### PR TITLE
Add a button to allow previewing of content version changes

### DIFF
--- a/src/app/components/pages/Admin.tsx
+++ b/src/app/components/pages/Admin.tsx
@@ -6,8 +6,9 @@ import {AppState, ContentVersionState} from "../../state/reducers";
 import {RegisteredUserDTO} from "../../../IsaacApiTypes";
 import {getContentVersion, requestConstantsSegueVersion, setContentVersion} from "../../state/actions";
 import {ShowLoading} from "../handlers/ShowLoading";
-import {ContentVersionUpdatingStatus} from "../../services/constants";
+import {ContentVersionUpdatingStatus, EDITOR_COMPARE_URL} from "../../services/constants";
 import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
+import classnames from "classnames";
 
 const stateToProps = (state: AppState) => ({
     segueVersion: state && state.constants && state.constants.segueVersion || "unknown",
@@ -94,6 +95,18 @@ const AdminPageComponent = ({user, getContentVersion, setContentVersion, content
                                             onChange={e => setNewVersion(e.target.value)}
                                             placeholder="Enter commit SHA"
                                         />
+                                        <RS.InputGroupAddon addonType="append">
+                                            <a
+                                                className={classnames({
+                                                    "p-1 border-dark btn btn-secondary": true,
+                                                    "disabled": displayVersion === contentVersion.liveVersion
+                                                })}
+                                                href={`${EDITOR_COMPARE_URL}/${contentVersion?.liveVersion}/${displayVersion}`}
+                                                target="_blank" rel="noopener"
+                                            >
+                                                Preview Changes
+                                            </a>
+                                        </RS.InputGroupAddon>
                                         <RS.InputGroupAddon addonType="append">
                                             <RS.Button
                                                 type="button" className="p-0 border-dark"

--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -22,10 +22,14 @@ export const isTest = document.location.hostname.startsWith("test.");
 
 export const API_PATH: string = apiPath;
 
-export const EDITOR_URL = {
+const EDITOR_BASE_URL = {
     [SITE.PHY]: "https://editor.isaacphysics.org",
     [SITE.CS]: "https://editor.isaaccomputerscience.org",
-}[SITE_SUBJECT] + "/#!/edit/master/";
+}[SITE_SUBJECT];
+
+export const EDITOR_URL = EDITOR_BASE_URL + "/#!/edit/master/";
+export const EDITOR_COMPARE_URL = EDITOR_BASE_URL + "/#!/compare";
+
 
 export const API_REQUEST_FAILURE_MESSAGE = "There may be an error connecting to the Isaac platform.";
 


### PR DESCRIPTION
This uses the editor as a redirect proxy to GitHub; but the editor is already configured with the correct GitHub repo to use in all cases, and so this prevents duplicated configuration.