### PR TITLE
Format dates for recurring events differently

### DIFF
--- a/src/IsaacAppTypes.tsx
+++ b/src/IsaacAppTypes.tsx
@@ -544,6 +544,7 @@ export interface AugmentedEvent extends ApiTypes.IsaacEventPageDTO {
     teacher?: boolean;
     student?: boolean;
     virtual?: boolean;
+    recurring?: boolean;
     field?: "physics" | "maths";
 }
 

--- a/src/app/components/elements/cards/EventCard.tsx
+++ b/src/app/components/elements/cards/EventCard.tsx
@@ -3,10 +3,11 @@ import * as RS from "reactstrap";
 import classnames from "classnames";
 import {Link} from "react-router-dom";
 import {AugmentedEvent} from "../../../../IsaacAppTypes";
-import {DateString, FRIENDLY_DATE, TIME_ONLY} from "../DateString";
+import {DateString} from "../DateString";
+import {formatEventCardDate} from "../../../services/events";
 
 export const EventCard = ({event, pod = false}: {event: AugmentedEvent; pod?: boolean}) => {
-    const {id, title, subtitle, eventThumbnail, location, expired, date, endDate, multiDay} = event;
+    const {id, title, subtitle, eventThumbnail, location, expired, date} = event;
 
     return <RS.Card className={classnames({'card-neat': true, 'disabled text-muted': expired, 'm-4': pod, 'mb-4': !pod})}>
         {eventThumbnail && <div className={'event-card-image text-center'}>
@@ -19,17 +20,7 @@ export const EventCard = ({event, pod = false}: {event: AugmentedEvent; pod?: bo
                 <span className="d-block my-2">
                     <span className="font-weight-bold">When:</span>
                     <span className="d-block">
-                        {multiDay ?
-                            <React.Fragment>
-                                <DateString>{date}</DateString><br />
-                                <DateString>{endDate}</DateString>
-                            </React.Fragment>
-                            :
-                            <React.Fragment>
-                                <DateString formatter={FRIENDLY_DATE}>{endDate}</DateString>{pod ? " " : <br />}
-                                <DateString formatter={TIME_ONLY}>{date}</DateString> — <DateString formatter={TIME_ONLY}>{endDate}</DateString>
-                            </React.Fragment>
-                        }
+                        {formatEventCardDate(event, pod)}
                     </span>
                 </span>
                 {location && location.address && <span className='d-block my-2'>

--- a/src/app/components/pages/EventDetails.tsx
+++ b/src/app/components/pages/EventDetails.tsx
@@ -8,7 +8,7 @@ import {ShowLoading} from "../handlers/ShowLoading";
 import {EVENTS_CRUMB, NOT_FOUND} from "../../services/constants";
 import {AdditionalInformation} from "../../../IsaacAppTypes";
 import {addMyselfToWaitingList, bookMyselfOnEvent, cancelMyBooking, getEvent, showToast} from "../../state/actions";
-import {DateString, TIME_ONLY} from "../elements/DateString";
+import {DateString} from "../elements/DateString";
 import {IsaacContent} from "../content/IsaacContent";
 import {Link} from "react-router-dom";
 import {EventBookingForm} from "../elements/EventBookingForm";
@@ -18,6 +18,7 @@ import {history} from "../../services/history";
 import {atLeastOne, validateBookingSubmission, zeroOrLess} from "../../services/validation";
 import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
 import {isStaff, isTeacher} from "../../services/user";
+import {formatEventDetailsDate} from "../../services/events";
 
 
 function formatDate(date: Date|number) {
@@ -120,10 +121,7 @@ export const EventDetails = ({match: {params: {eventId}}, location: {pathname}}:
                                     <tr>
                                         <td>When:</td>
                                         <td>
-                                            {event.multiDay ?
-                                                <><DateString>{event.date}</DateString>{" — "}<DateString>{event.endDate}</DateString></> :
-                                                <><DateString>{event.date}</DateString>{" — "}<DateString formatter={TIME_ONLY}>{event.endDate}</DateString></>
-                                            }
+                                            {formatEventDetailsDate(event)}
                                             {event.expired && <div className="alert-danger text-center">This event is in the past.</div>}
                                         </td>
                                     </tr>

--- a/src/app/services/events.tsx
+++ b/src/app/services/events.tsx
@@ -1,6 +1,8 @@
 import {IsaacEventPageDTO} from "../../IsaacApiTypes";
 import {apiHelper} from "./api";
 import {AugmentedEvent} from "../../IsaacAppTypes";
+import {DateString, FRIENDLY_DATE, TIME_ONLY} from "../components/elements/DateString";
+import React from "react";
 
 export const augmentEvent = (event: IsaacEventPageDTO): AugmentedEvent => {
     const augmentedEvent: AugmentedEvent = Object.assign({}, event);
@@ -24,6 +26,7 @@ export const augmentEvent = (event: IsaacEventPageDTO): AugmentedEvent => {
         augmentedEvent.teacher = event.tags.includes("teacher");
         augmentedEvent.student = event.tags.includes("student");
         augmentedEvent.virtual = event.tags.includes("virtual");
+        augmentedEvent.recurring = event.tags.includes("recurring");
         augmentedEvent.field =
             (event.tags.includes("physics") && "physics") ||
             (event.tags.includes("maths") && "maths") ||
@@ -43,3 +46,31 @@ export const augmentEvent = (event: IsaacEventPageDTO): AugmentedEvent => {
 
     return augmentedEvent;
 };
+
+export const formatEventDetailsDate = (event: AugmentedEvent) => {
+    if (event.recurring) {
+        return <span>Series starts <DateString>{event.date}</DateString></span>;
+    } else if (event.multiDay) {
+        return <><DateString>{event.date}</DateString>{" — "}<DateString>{event.endDate}</DateString></>;
+    } else {
+        return <><DateString>{event.date}</DateString>{" — "}<DateString formatter={TIME_ONLY}>{event.endDate}</DateString></>;
+    }
+}
+
+export const formatEventCardDate = (event: AugmentedEvent, podView?: boolean) => {
+    if (event.recurring) {
+        return <span>Series starts <DateString formatter={FRIENDLY_DATE}>{event.date}</DateString><br />
+            <DateString formatter={TIME_ONLY}>{event.date}</DateString> — <DateString formatter={TIME_ONLY}>{event.endDate}</DateString>
+        </span>;
+    } else if (event.multiDay) {
+        return <>
+            <DateString>{event.date}</DateString><br/>
+            <DateString>{event.endDate}</DateString>
+        </>;
+    } else {
+        return <>
+            <DateString formatter={FRIENDLY_DATE}>{event.endDate}</DateString>{podView ? " " : <br />}
+            <DateString formatter={TIME_ONLY}>{event.date}</DateString> — <DateString formatter={TIME_ONLY}>{event.endDate}</DateString>
+        </>;
+    }
+}


### PR DESCRIPTION
We assume that the start time of the first in the series and the end time of the last event are the same for all events, at least when showing on the pods and pages.