### PR TITLE
Show the list of available symbols underneath the text entry box

### DIFF
--- a/src/app/components/content/IsaacSymbolicQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicQuestion.tsx
@@ -13,6 +13,7 @@ import {Inequality, makeInequality} from "inequality";
 import {parseExpression} from "inequality-grammar";
 
 import _flattenDeep from 'lodash/flatMapDeep';
+import {parsePseudoSymbolicAvailableSymbols} from "../../services/questions";
 
 // Magic starts here
 interface ChildrenMap {
@@ -195,6 +196,8 @@ const IsaacSymbolicQuestionComponent = (props: IsaacSymbolicQuestionProps) => {
     };
 
     const helpTooltipId = `eqn-editor-help-${(doc.id || "").split('|').pop()}`;
+    const symbolList = parsePseudoSymbolicAvailableSymbols(doc.availableSymbols)?.map(
+        function (str) {return str.trim().replace(/;/g, ',')}).sort().join(", ");
     return (
         <div className="symbolic-question">
             <div className="question-content">
@@ -239,6 +242,9 @@ const IsaacSymbolicQuestionComponent = (props: IsaacSymbolicQuestionProps) => {
                 {errors && <div className="eqn-editor-input-errors"><strong>Careful!</strong><ul>
                     {errors.map(e => (<li key={e}>{e}</li>))}
                 </ul></div>}
+                {symbolList && <div className="eqn-editor-symbols">
+                    The following symbols may be useful: <pre>{symbolList}</pre>
+                </div>}
             </div>
         </div>
     );

--- a/src/app/components/elements/modals/InequalityModal.tsx
+++ b/src/app/components/elements/modals/InequalityModal.tsx
@@ -4,6 +4,7 @@ import {Inequality, makeInequality, WidgetSpec} from "inequality";
 import katex from "katex";
 import _uniqWith from 'lodash/uniqWith';
 import _isEqual from 'lodash/isEqual';
+import {parsePseudoSymbolicAvailableSymbols} from "../../../services/questions";
 
 class MenuItem {
     public type: string;
@@ -111,7 +112,7 @@ export class InequalityModal extends React.Component<InequalityModalProps> {
     public constructor(props: InequalityModalProps) {
         super(props);
 
-        this._availableSymbols = Array.from(new Set(this.parsePseudoSymbols(props.availableSymbols)));
+        this._availableSymbols = Array.from(new Set(parsePseudoSymbolicAvailableSymbols(props.availableSymbols)));
 
         this.state = {
             sketch: props.sketch as Inequality,
@@ -270,6 +271,7 @@ export class InequalityModal extends React.Component<InequalityModalProps> {
                         customMenuItems.otherFunctions.push(this.makeMathsLogFunctionItem(functionName));
                     } else {
                         // What
+                        // eslint-disable-next-line no-console
                         console.warn(`Could not parse available symbol "${availableSymbol} as a function"`);
                     }
                 } else if (availableSymbol.startsWith('Derivative')) {
@@ -396,41 +398,6 @@ export class InequalityModal extends React.Component<InequalityModalProps> {
         document.body.style.height = '';
         document.body.style.overflow = '';
         document.body.style.touchAction = 'auto';
-    }
-
-    private parsePseudoSymbols(availableSymbols?: string[]) {
-        if (!availableSymbols) return;
-        let theseSymbols = availableSymbols.slice(0).map(s => s.trim());
-        let i = 0;
-
-        // Note: _no_alphabet is already taken care of in the constructor.
-        while (i < theseSymbols.length) {
-            if (theseSymbols[i] === '_trigs') {
-                theseSymbols.splice(i, 1, 'cos()', 'sin()', 'tan()');
-                i += 3;
-            } else if (theseSymbols[i] === '_1/trigs') {
-                theseSymbols.splice(i, 1, 'cosec()', 'sec()', 'cot()');
-                i += 3;
-            } else if (theseSymbols[i] === '_inv_trigs') {
-                theseSymbols.splice(i, 1, 'arccos()', 'arcsin()', 'arctan()');
-                i += 3;
-            } else if (theseSymbols[i] === '_inv_1/trigs') {
-                theseSymbols.splice(i, 1, 'arccosec()', 'arcsec()', 'arccot()');
-                i += 3;
-            } else if (theseSymbols[i] === '_hyp_trigs') {
-                theseSymbols.splice(i, 1, 'cosh()', 'sinh()', 'tanh()', 'cosech()', 'sech()', 'coth()');
-                i += 6;
-            } else if (theseSymbols[i] === '_inv_hyp_trigs') {
-                theseSymbols.splice(i, 1, 'arccosh()', 'arcsinh()', 'arctanh()', 'arccosech()', 'arcsech()', 'arccoth()');
-                i += 6;
-            } else if (theseSymbols[i] === '_logs') {
-                theseSymbols.splice(i, 1, 'log()', 'ln()');
-                i += 2;
-            } else {
-                i += 1;
-            }
-        }
-        return theseSymbols;
     }
 
     private convertToLatexIfGreek(s: string): string {

--- a/src/app/services/questions.ts
+++ b/src/app/services/questions.ts
@@ -34,3 +34,38 @@ export const HUMAN_QUESTION_TYPES = new Map([
     ["isaacSymbolicLogicQuestion", "Boolean logic"],
     ["default", "Multiple choice"]
 ]);
+
+export const parsePseudoSymbolicAvailableSymbols = (availableSymbols?: string[]) => {
+    if (!availableSymbols) return;
+    let theseSymbols = availableSymbols.slice(0).map(s => s.trim());
+    let i = 0;
+    while (i < theseSymbols.length) {
+        if (theseSymbols[i] === '_trigs') {
+            theseSymbols.splice(i, 1, 'cos()', 'sin()', 'tan()');
+            i += 3;
+        } else if (theseSymbols[i] === '_1/trigs') {
+            theseSymbols.splice(i, 1, 'cosec()', 'sec()', 'cot()');
+            i += 3;
+        } else if (theseSymbols[i] === '_inv_trigs') {
+            theseSymbols.splice(i, 1, 'arccos()', 'arcsin()', 'arctan()');
+            i += 3;
+        } else if (theseSymbols[i] === '_inv_1/trigs') {
+            theseSymbols.splice(i, 1, 'arccosec()', 'arcsec()', 'arccot()');
+            i += 3;
+        } else if (theseSymbols[i] === '_hyp_trigs') {
+            theseSymbols.splice(i, 1, 'cosh()', 'sinh()', 'tanh()', 'cosech()', 'sech()', 'coth()');
+            i += 6;
+        } else if (theseSymbols[i] === '_inv_hyp_trigs') {
+            theseSymbols.splice(i, 1, 'arccosh()', 'arcsinh()', 'arctanh()', 'arccosech()', 'arcsech()', 'arccoth()');
+            i += 6;
+        } else if (theseSymbols[i] === '_logs') {
+            theseSymbols.splice(i, 1, 'log()', 'ln()');
+            i += 2;
+        } else if (theseSymbols[i] === '_no_alphabet') {
+            theseSymbols.splice(i, 1);
+        } else {
+            i += 1;
+        }
+    }
+    return theseSymbols;
+}

--- a/src/scss/common/questions.scss
+++ b/src/scss/common/questions.scss
@@ -126,6 +126,20 @@ button {
   .eqn-editor-help {
     min-width: 0;
   }
+
+  .eqn-editor-symbols {
+    font-size: 0.75rem;
+    margin: 10px 0;
+
+    & pre {
+      font-size: 0.75rem;
+      display: inline;
+      white-space: pre-wrap;
+      background: inherit;
+      border: 0;
+      padding: 0;
+    }
+  }
 }
 
 @include media-breakpoint-up(md) {


### PR DESCRIPTION
This required moving the parse function out from inside the modal, since we also need to use it to sanitise the displayed list. Since we also now use it outside, we need to remove `_no_alphabet` too.