### PR TITLE
Potentially fix Windows 10 centering bug when OS UI is zoomed.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "isaac-react-app",
-  "version": "1.2.4-SNAPSHOT",
+  "version": "1.2.5-SNAPSHOT",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2610,11 +2610,6 @@
       "version": "11.11.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.0.tgz",
       "integrity": "sha512-D5Rt+HXgEywr3RQJcGlZUCTCx1qVbCZpVk3/tOOA6spLNZdGm8BU+zRgdRYDoF1pO3RuXLxADzMrF903JlQXqg=="
-    },
-    "@types/p5": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@types/p5/-/p5-0.9.0.tgz",
-      "integrity": "sha512-GhI0ctGdKlnf1oUEYqE+sTWuGHhjQCZXQPxazdI9Lx2eE6z7qO6T55FGFenOY3wpL8jSzLWRmt83RHGblr4AWg=="
     },
     "@types/prop-types": {
       "version": "15.7.2",
@@ -8074,7 +8069,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8094,11 +8090,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8112,15 +8110,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8236,7 +8237,8 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8247,6 +8249,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8260,17 +8263,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "1.2.5",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -8288,6 +8294,7 @@
         "mkdirp": {
           "version": "0.5.3",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -8348,7 +8355,8 @@
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "npm-packlist": {
           "version": "1.4.8",
@@ -8375,7 +8383,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8386,6 +8395,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8462,7 +8472,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8497,6 +8508,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8515,6 +8527,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8557,11 +8570,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -9374,21 +9389,12 @@
       "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
     },
     "inequality": {
-      "version": "0.9.21",
-      "resolved": "https://registry.npmjs.org/inequality/-/inequality-0.9.21.tgz",
-      "integrity": "sha512-sTAEf6HSQ9Envxu9MLN2l7C4WLh6BFkjbE6GK9bbTWZqnKGXUpjr/yIWJpOYxjyCS5JRXNMeF1tAHA8kogXRFg==",
+      "version": "0.9.22",
+      "resolved": "https://registry.npmjs.org/inequality/-/inequality-0.9.22.tgz",
+      "integrity": "sha512-MYADkCU7T0F+iJ1mDRsll+c6AWbV3DrgbvFUpDJzNDTRMiIBqrmhsajvrhXv4yVSu1uWCaJmJToEH35dokwjlw==",
       "requires": {
-        "@types/lodash": "^4.14.149",
-        "@types/p5": "^0.9.0",
         "lodash": "^4.17.15",
         "p5": "1.0.0"
-      },
-      "dependencies": {
-        "@types/lodash": {
-          "version": "4.14.150",
-          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.150.tgz",
-          "integrity": "sha512-kMNLM5JBcasgYscD9x/Gvr6lTAv2NVgsKtet/hm93qMyf/D1pt+7jeEZklKJKxMVmXjxbRVQQGfqDSfipYCO6w=="
-        }
       }
     },
     "inequality-grammar": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "history": "^4.9.0",
     "html-webpack-plugin": "4.0.0-alpha.2",
     "identity-obj-proxy": "3.0.0",
-    "inequality": "^0.9.21",
+    "inequality": "^0.9.22",
     "inequality-grammar": "^0.9.10",
     "jest": "^24.7.1",
     "jest-pnp-resolver": "1.0.2",

--- a/src/app/components/elements/modals/InequalityModal.tsx
+++ b/src/app/components/elements/modals/InequalityModal.tsx
@@ -162,8 +162,8 @@ export class InequalityModal extends React.Component<InequalityModalProps> {
         const inequalityElement = document.getElementById('inequality-modal') as HTMLElement;
         const { sketch, p } = makeInequality(
             inequalityElement,
-            window.innerWidth * Math.ceil(window.devicePixelRatio),
-            window.innerHeight * Math.ceil(window.devicePixelRatio),
+            window.innerWidth,
+            window.innerHeight,
             this.props.initialEditorSymbols,
             {
                 editorMode: this.props.editorMode || 'logic',


### PR DESCRIPTION
Upgrades `inequality` to 0.9.22 which includes a bug fix. Apparently Windows 10 now reports `window.innerWidth` correctly so we don't need the crazy trick with the device pixel ratio. Who knew…

Needs checking that this doesn't break it for every other platform. Works for me on macOS with Chrome and Firefox.