### PR TITLE
Drastically reduce the amount of re-renders while using Inequality

### DIFF
--- a/src/app/components/elements/modals/InequalityModal.tsx
+++ b/src/app/components/elements/modals/InequalityModal.tsx
@@ -854,10 +854,14 @@ export class InequalityModal extends React.Component<InequalityModalProps> {
             const trashCanRect = trashCan.getBoundingClientRect();
             if (trashCanRect && x >= trashCanRect.left && x <= trashCanRect.right && y >= trashCanRect.top && y <= trashCanRect.bottom) {
                 trashCan.classList.add('active');
-                this.setState({ trashActive: true });
+                if (!this.state.trashActive) {
+                    this.setState({ trashActive: true });
+                }
             } else {
                 trashCan.classList.remove('active');
-                this.setState({ trashActive: false });
+                if (this.state.trashActive) {
+                    this.setState({ trashActive: false });
+                }
             }
         }
 


### PR DESCRIPTION
State was being set even though no actual change was present. Odd that React wouldn't detect that, but hey.