### PR TITLE
Prevent tooltip crashing the page and causing a memory leak.

### DIFF
--- a/src/app/components/elements/panels/TeacherConnections.tsx
+++ b/src/app/components/elements/panels/TeacherConnections.tsx
@@ -220,8 +220,9 @@ export const TeacherConnections = ({user, authToken}: TeacherConnectionsProps) =
                                             }>
                                                 Leave group
                                             </RS.Button>
-                                            <span id="leave-group-action" className="icon-help" />
-                                            <RS.UncontrolledTooltip placement="bottom" target="leave-group-action">
+                                            <span id={`leave-group-action-${membership.group.id}`} className="icon-help" />
+                                            <RS.UncontrolledTooltip placement="bottom" target={`leave-group-action-${membership.group.id}`}
+                                                                    modifiers={{preventOverflow: {boundariesElement: "viewport"}}}>
                                                 If you leave a group you will no longer receive notifications of new assignments.
                                             </RS.UncontrolledTooltip>
                                         </React.Fragment>}
@@ -232,8 +233,9 @@ export const TeacherConnections = ({user, authToken}: TeacherConnectionsProps) =
                                             }>
                                                 Rejoin group
                                             </RS.Button>
-                                            <span id="rejoin-group-action" className="icon-help" />
-                                            <RS.UncontrolledTooltip placement="bottom" target="rejoin-group-action">
+                                            <span id={`rejoin-group-action-${membership.group.id}`} className="icon-help" />
+                                            <RS.UncontrolledTooltip placement="bottom" target={`rejoin-group-action-${membership.group.id}`}
+                                                                    modifiers={{preventOverflow: {boundariesElement: "viewport"}}}>
                                                 If you rejoin a group you will see all the assignments set since the group was created.
                                             </RS.UncontrolledTooltip>
                                         </React.Fragment>}


### PR DESCRIPTION
The tooltip per default isn't allowed to exceed the bounds of it's scroll parent (the table).
The first row would break the tooltip if one or two groups were present as there wasn't enough space for the tooltip to be placed.