### PR TITLE
Fix oversized teacher features images caused by IsaacCard introduction

### DIFF
--- a/src/app/components/content/IsaacCard.tsx
+++ b/src/app/components/content/IsaacCard.tsx
@@ -6,8 +6,12 @@ import {Link} from "react-router-dom";
 import {isAppLink} from "../../services/navigation";
 import {IsaacCardDTO} from "../../../IsaacApiTypes";
 
+interface IsaacCardProps {
+    doc: IsaacCardDTO,
+    imageClassName?: string
+}
 
-export const IsaacCard = ({doc}: {doc: IsaacCardDTO}) => {
+export const IsaacCard = ({doc, imageClassName}: IsaacCardProps) => {
     const {title, subtitle, image, clickUrl, disabled, verticalContent} = doc;
     const classes = classNames({"menu-card": true, "disabled": disabled, "isaac-card-vertical": verticalContent});
     const imgSrc = image?.src && apiHelper.determineImageUrl(image.src);
@@ -19,7 +23,7 @@ export const IsaacCard = ({doc}: {doc: IsaacCardDTO}) => {
         <Card className={classes}>
             {image && <Row>
                 <Col className="justify-content-md-center">
-                    <img className={classes} src={imgSrc} alt=""/>
+                    <img className={[classes, imageClassName].join(" ")} src={imgSrc} alt={image.altText}/>
                 </Col>
             </Row>}
             <CardTitle className="px-3">

--- a/src/app/components/pages/TeacherFeatures.tsx
+++ b/src/app/components/pages/TeacherFeatures.tsx
@@ -41,19 +41,25 @@ export const TeacherFeatures = () => {
                 title: "1. Create a Group",
                 disabled: isDisabled,
                 verticalContent: true,
-                subtitle: "Create and manage class groups, and share them with colleagues."}}/>
+                subtitle: "Create and manage class groups, and share them with colleagues."}}
+                       imageClassName="teacher-features"
+            />
             <IsaacCard doc={{ clickUrl: "/set_assignments",
                 image: {src: "/assets/phy/teacher_features_sprite.svg#set-assignments"},
                 title: "2. Set Assignments",
                 disabled: isDisabled,
                 verticalContent: true,
-                subtitle: "Set assignments from our skills books, pre-made boards or create your own."}}/>
+                subtitle: "Set assignments from our skills books, pre-made boards or create your own."}}
+                       imageClassName="teacher-features"
+            />
             <IsaacCard doc={{ clickUrl: "/assignment_progress",
                 image: {src: "/assets/phy/teacher_features_sprite.svg#track-progress"},
                 title: "3. Assignment Progress",
                 disabled: isDisabled,
                 verticalContent: true,
-                subtitle: "View your students’ progress through their assignments."}}/>
+                subtitle: "View your students’ progress through their assignments."}}
+                       imageClassName="teacher-features"
+            />
         </Row>
         <Row className="my-4">
             <Col>
@@ -65,17 +71,23 @@ export const TeacherFeatures = () => {
                 image: {src: "/assets/phy/teacher_features_sprite.svg#teacher-forum"},
                 title: "Teacher FAQ",
                 verticalContent: true,
-                subtitle: "Answers to your questions and how-to guides."}}/>
+                subtitle: "Answers to your questions and how-to guides."}}
+                       imageClassName="teacher-features"
+            />
             <IsaacCard doc={{ clickUrl: "/pages/teacher_mentoring",
                 image: {src: "/assets/phy/teacher_features_sprite.svg#use-with-class"},
                 title: "Teacher Mentoring",
                 verticalContent: true,
-                subtitle: isLoggedIn(user) ? "Fortnightly support for Physics teachers." : "Fortnightly support for teachers of Physics."}}/>
+                subtitle: isLoggedIn(user) ? "Fortnightly support for Physics teachers." : "Fortnightly support for teachers of Physics."}}
+                       imageClassName="teacher-features"
+            />
             <IsaacCard doc={{ clickUrl: "/pages/isaac_embedded_schools",
                 image: {src: "/assets/phy/teacher_features_sprite.svg#groups"},
                 title: "Teacher Ambassadors",
                 verticalContent: true,
-                subtitle: isLoggedIn(user) ? "Learn from real teachers how they have embedded Isaac Physics. " : "Learn from practising teachers how they have embedded Isaac Physics."}}/>
+                subtitle: isLoggedIn(user) ? "Learn from real teachers how they have embedded Isaac Physics. " : "Learn from practising teachers how they have embedded Isaac Physics."}}
+                       imageClassName="teacher-features"
+            />
         </Row>
         <Row className="my-4">
             <Col>
@@ -87,17 +99,23 @@ export const TeacherFeatures = () => {
                 image: {src: "/assets/phy/teacher_features_sprite.svg#skills-book-cover"},
                 title: "Isaac Physics Books",
                 verticalContent: true,
-                subtitle: "Buy one of our Skills Mastery books at cost."}}/>
+                subtitle: "Buy one of our Skills Mastery books at cost."}}
+                       imageClassName="teacher-features"
+            />
             <IsaacCard doc={{ clickUrl: "/pages/pre_made_gameboards",
                 image: {src: "/assets/phy/key_stage_sprite.svg#triple"},
                 title: "Boards for Lessons",
                 verticalContent: true,
-                subtitle: isLoggedIn(user) ?  "A selection of our questions organised by topic." : "A selection of our questions organised by lesson topic."}}/>
+                subtitle: isLoggedIn(user) ?  "A selection of our questions organised by topic." : "A selection of our questions organised by lesson topic."}}
+                       imageClassName="teacher-features"
+            />
             <IsaacCard doc={{ clickUrl: "/events?types=teacher",
                 image: {src: "/assets/phy/teacher_features_sprite.svg#calendar"},
                 title: "Events",
                 verticalContent: true,
-                subtitle: "Attend FREE face-to-face or virtual CPDs."}}/>
+                subtitle: "Attend FREE face-to-face or virtual CPDs."}}
+                       imageClassName="teacher-features"
+            />
         </Row>
     </Container>
 };

--- a/src/scss/phy/menu-page-phy.scss
+++ b/src/scss/phy/menu-page-phy.scss
@@ -166,6 +166,10 @@
       margin-right: auto !important;
       margin-left: auto !important;
       display: block;
+
+      &.teacher-features {
+        width: 90px;
+      }
     }
 
     &.disabled {

--- a/src/scss/phy/menu-page-phy.scss
+++ b/src/scss/phy/menu-page-phy.scss
@@ -168,7 +168,7 @@
       display: block;
 
       &.teacher-features {
-        width: 90px;
+        width: 150px;
       }
     }
 


### PR DESCRIPTION
Adds a imageClassName parameter to the IsaacCard type.
Add CSS using the class name to restore the teacher features images to their original size.