### PR TITLE
Remove invisible encoding character from cookie banner which converts…

### DIFF
--- a/src/app/components/navigation/CookieBanner.tsx
+++ b/src/app/components/navigation/CookieBanner.tsx
@@ -26,7 +26,7 @@ export const CookieBanner = () => {
             <RS.Row style={{alignItems: "center"}}>
                 <RS.Col xs={12} sm={2} md={1}>
                     <h3 className="text-center">
-                        <span role="presentation" aria-labelledby="cookies-heading">ℹ</span>️
+                        <span role="presentation" aria-labelledby="cookies-heading">ℹ</span>
                         <span id="cookies-heading" className="d-inline-block d-sm-none">&nbsp;Cookies</span>
                     </h3>
                 </RS.Col>


### PR DESCRIPTION
… it into an emoji

Invisible variation selector 16 was causing the i symbol to be rendered as an emoji.