### PR TITLE
Add a warning for users typing unclear function calls in text entry

### DIFF
--- a/src/app/components/content/IsaacSymbolicQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicQuestion.tsx
@@ -180,7 +180,12 @@ const IsaacSymbolicQuestionComponent = (props: IsaacSymbolicQuestionProps) => {
                 }
                 setErrors(errors);
             } else {
-                setErrors(undefined);
+                if (/[A-Zbd-z](sin|cos|tan|log|ln|sqrt)\(/.test(pycode)) {
+                    // A warning about a common mistake naive users may make (no warning for asin or arcsin though):
+                    setErrors(["Make sure to use spaces or * signs before function names like 'sin' or 'sqrt'!"])
+                } else {
+                    setErrors(undefined);
+                }
                 if (pycode === '') {
                     const state = {result: {tex: "", python: "", mathml: ""}};
                     setCurrentAttempt(questionId, { type: 'formula', value: JSON.stringify(sanitiseInequalityState(state)), pythonExpression: ""});


### PR DESCRIPTION
If a user types "Tsin(theta)" this will be parsed as "T\*s\*i\*n\*theta", which is not what the user intended. Whilst this is visible, in the fact that the result has italic and not upright letters for the sin in the preview, this fact is not obvious to most users. Instead add a warning underneath.
We have to allow "a" and "c" as characters before to allow "asin(x)" or "arcsin(x)", and this seems the simplest regex to achieve this.