### PR TITLE
Re-request FastTrack concept state on page change

### DIFF
--- a/src/app/components/elements/FastTrackProgress.tsx
+++ b/src/app/components/elements/FastTrackProgress.tsx
@@ -118,12 +118,12 @@ export function FastTrackProgress({doc, search}: {doc: IsaacFastTrackQuestionPag
             : null;
 
     useEffect(() => {
-        if (conceptQuestions === null && gameboardMaybeNull) {
+        if (gameboardMaybeNull) {
             const uppers = questionHistory.filter(e => /upper/i.test(e));
             const upper = uppers.pop() || "";
             dispatch(fetchFasttrackConcepts(gameboardMaybeNull.id as string, doc.title as string, upper));
         }
-    }, [dispatch, gameboardMaybeNull, doc, conceptQuestions]);
+    }, [dispatch, gameboardMaybeNull, doc]);
 
     if (gameboardMaybeNull === null && conceptQuestions === null) return null;
 

--- a/src/app/state/actions.tsx
+++ b/src/app/state/actions.tsx
@@ -1887,8 +1887,6 @@ export const fetchConcepts = () => async (dispatch: Dispatch<Action>) => {
 
 // Fasttrack concepts
 export const fetchFasttrackConcepts = (gameboardId: string, concept: string, upperQuestionId: string) => async (dispatch: Dispatch<Action>, getState: () => AppState) => {
-    const state = getState();
-    if (state && state.fasttrackConcepts && state.fasttrackConcepts.gameboardId === gameboardId && state.fasttrackConcepts.concept === concept) return;
     dispatch({type: ACTION_TYPE.FASTTRACK_CONCEPTS_REQUEST});
     try {
         const concepts = await api.fasttrack.concepts(gameboardId, concept, upperQuestionId);


### PR DESCRIPTION
Progress within the session on concept questions was not being maintained between page changes.
A refresh used to be needed to get the concept progress of other quesitons, now we reload it on page change.