### PR TITLE
Remove link from unauthorised users viewing progress

### DIFF
--- a/src/app/components/pages/AssignmentProgress.tsx
+++ b/src/app/components/pages/AssignmentProgress.tsx
@@ -331,12 +331,16 @@ export const ProgressDetails = (props: ProgressDetailsProps | SingleProgressDeta
                     <tbody>
                         {sortedProgress.map((studentProgress) => {
                             const fullAccess = studentProgress.user.authorisedFullAccess;
-                            return <tr key={studentProgress.user.id} className={`${markClasses(studentProgress, assignmentTotalQuestionParts)}${fullAccess ? "" : " revoked"}`} title={`${studentProgress.user.givenName + " " + studentProgress.user.familyName}`}>
+                            return <tr key={studentProgress.user.id} className={`${markClasses(studentProgress, assignmentTotalQuestionParts)}${fullAccess ? "" : " not-authorised"}`} title={`${studentProgress.user.givenName + " " + studentProgress.user.familyName}`}>
                                 <th className="student-name">
-                                    <Link to={`/progress/${studentProgress.user.id}`} target="_blank">
-                                        {studentProgress.user.givenName}
-                                        <span className="d-none d-lg-inline"> {studentProgress.user.familyName}</span>
-                                    </Link>
+                                    {fullAccess ?
+                                        <Link to={`/progress/${studentProgress.user.id}`} target="_blank">
+                                            {studentProgress.user.givenName}
+                                            <span
+                                                className="d-none d-lg-inline"> {studentProgress.user.familyName}</span>
+                                        </Link> :
+                                        <span>{studentProgress.user.givenName} {studentProgress.user.familyName}</span>
+                                    }
                                 </th>
                                 {questions.map((q, index) =>
                                     <td key={q.id} className={markQuestionClasses(studentProgress, index)} onClick={() => setSelectedQuestion(index)}>

--- a/src/app/components/pages/Groups.tsx
+++ b/src/app/components/pages/Groups.tsx
@@ -139,7 +139,7 @@ const MemberInfo = ({member, resetMemberPassword, deleteMember}: MemberInfoProps
                           className={"align-text-top d-flex align-items-stretch"}>
                         <span className="pl-1">{member.givenName} {member.familyName}</span>
                     </Link> :
-                    <span className="not-authorised"><span className="pl-1 struck-out">{member.givenName} {member.familyName}</span> (not sharing)</span>
+                    <span className="not-authorised"><span className="pl-1 struck-out">{member.givenName} {member.familyName}</span> (Not Sharing)</span>
                 }
             </div>
             <div>

--- a/src/app/components/pages/Groups.tsx
+++ b/src/app/components/pages/Groups.tsx
@@ -134,9 +134,13 @@ const MemberInfo = ({member, resetMemberPassword, deleteMember}: MemberInfoProps
                 <span className="icon-group-table-person mt-2" />
             </div>
             <div>
-                <Link to={`/progress/${member.groupMembershipInformation.userId}`} className="align-text-top d-flex align-items-stretch">
-                    <span className="pl-1">{member.givenName} {member.familyName}</span>
-                </Link>
+                {member.authorisedFullAccess ?
+                    <Link to={`/progress/${member.groupMembershipInformation.userId}`}
+                          className={"align-text-top d-flex align-items-stretch"}>
+                        <span className="pl-1">{member.givenName} {member.familyName}</span>
+                    </Link> :
+                    <span className="not-authorised"><span className="pl-1 struck-out">{member.givenName} {member.familyName}</span> (not sharing)</span>
+                }
             </div>
             <div>
                 {member.emailVerificationStatus == "DELIVERY_FAILED" &&

--- a/src/scss/common/groups.scss
+++ b/src/scss/common/groups.scss
@@ -20,3 +20,14 @@
     border-top: $gray-107 solid 1px;
   }
 }
+
+.not-authorised {
+  -webkit-filter: grayscale(100%);
+  -webkit-filter: grayscale(1);
+  filter: grayscale(100%);
+  filter:gray;
+  opacity: .5;
+  .struck-out {
+    text-decoration: line-through;
+  }
+}


### PR DESCRIPTION
- Makes it more obvious if a teacher (with access revoked by student) is looking through their manage groups page
- Adds same greying out and removing of link to assignment progress page for unauthorised users