### PR TITLE
Remove hyperbolic functions from trig functions menu.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6501,6 +6501,15 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
@@ -7242,6 +7251,7 @@
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -11054,6 +11064,12 @@
         "schema-utils": "^1.0.0"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "filesize": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
@@ -12736,6 +12752,8 @@
     },
     "isaac-graph-sketcher": {
       "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/isaac-graph-sketcher/-/isaac-graph-sketcher-0.9.3.tgz",
+      "integrity": "sha512-Bp3PXIC2MV2of6zurLDRyOTUZ/xFbLku33PuPSuChPDH5qk/UK442E2xw+dPHfUbvwzklLNOpHtY0QBys9Dcsw==",
       "requires": {
         "lodash": "^4.17.19",
         "p5": "1.0.0"
@@ -19629,6 +19647,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         }

--- a/src/app/components/elements/modals/InequalityModal.tsx
+++ b/src/app/components/elements/modals/InequalityModal.tsx
@@ -98,7 +98,7 @@ export class InequalityModal extends React.Component<InequalityModalProps> {
     private _lowerCaseGreekLetters = ["alpha", "beta", "gamma", "delta", "varepsilon", "zeta", "eta", "theta", "iota", "kappa", "lambda", "mu", "nu", "xi", "omicron", "pi", "rho", "sigma", "tau", "upsilon", "phi", "chi", "psi", "omega"];
     private _upperCaseGreekLetters = ["Gamma", "Delta", "Theta", "Lambda", "Xi", "Pi", "Sigma", "Upsilon", "Phi", "Psi", "Omega"];
 
-    private _trigFunctionNames = ["sin", "cos", "tan", "arcsin", "arccos", "arctan", "sinh", "cosh", "tanh", "cosec", "sec", "cot", "arccosec", "arcsec", "arccot"];
+    private _trigFunctionNames = ["sin", "cos", "tan", "cosec", "sec", "cot", "arcsin", "arccos", "arctan", "arccosec", "arcsec", "arccot"];
     private _hypFunctionsNames = ["sinh", "cosh", "tanh", "cosech", "sech", "coth", "arccosech", "arcsech", "arccoth", "arcsinh", "arccosh", "arctanh"];
     private _logFunctionNames = ["ln", "log"];
 


### PR DESCRIPTION
For some reason, some of the hyperbolic functions were in the trig functions list, and so would get included in the wrong menu tab as well as in the correct menu tab.

This fixes this mistake.