### PR TITLE
Simplify and update My Progress page activity graph

### DIFF
--- a/src/app/components/elements/DateString.ts
+++ b/src/app/components/elements/DateString.ts
@@ -16,6 +16,13 @@ export function formatDate(date: number | Date | undefined) {
     return NUMERIC_DATE.format(dateObject);
 }
 
+// 2020-01-22
+export function formatISODateOnly(date: number | Date) {
+    const dateObject = new Date(date);
+    // ISO String looks like 2020-01-22T13:00:00.000Z so remove the time:
+    return dateObject.toISOString().split("T")[0];
+}
+
 export const DateString = ({children, defaultValue, formatter=FRIENDLY_DATE_AND_TIME}: {children: any; defaultValue?: any; formatter?: any}) => {
     const fallback = defaultValue || "NOT A VALID DATE";
     try {

--- a/src/app/components/elements/views/ActivityGraph.tsx
+++ b/src/app/components/elements/views/ActivityGraph.tsx
@@ -49,7 +49,8 @@ export const ActivityGraph = ({answeredQuestionsByDate}: {answeredQuestionsByDat
             zoom: {enabled: true},
             legend: {show: false},
             spline: {interpolation: {type: "monotone-x"}},
-            bindto: "#activityGraph"
+            bindto: "#activityGraph",
+            padding: {top: 0, right: 20, bottom: 0, left: 20}  // Pad sides to avoid tick labels being truncated!
         });
     }, [answeredQuestionsByDate, selectedDates]);
 

--- a/src/app/components/elements/views/ActivityGraph.tsx
+++ b/src/app/components/elements/views/ActivityGraph.tsx
@@ -4,38 +4,17 @@ import {NUMERIC_DATE} from "../DateString";
 import {AnsweredQuestionsByDate} from "../../../../IsaacApiTypes";
 
 export const ActivityGraph = ({answeredQuestionsByDate}: {answeredQuestionsByDate: AnsweredQuestionsByDate}) => {
-    const generateDateArray = (min: Date, max: Date) => {
-        const current = new Date(min);
-        const dates = [];
-        while (current <= max) {
-            dates.push(new Date(current));
-            current.setMonth(current.getMonth() + 1);
+
+    let selectedDates: string[] = [];
+    const foundDates = answeredQuestionsByDate ? Object.keys(answeredQuestionsByDate) : [];
+    if (foundDates && foundDates.length > 0) {
+        const nonZeroDates = foundDates.filter((date) => answeredQuestionsByDate && answeredQuestionsByDate[date] > 0);
+        if (nonZeroDates.length > 0) {
+            selectedDates = foundDates.sort().map((date) => NUMERIC_DATE.format(new Date(date)).split("/").reverse().join("-"));
         }
-        return dates;
-    };
+    }
 
     useEffect(() => {
-        const foundDates = answeredQuestionsByDate ? Object.keys(answeredQuestionsByDate) : [];
-        let selectedDates: string[] = [];
-        let minTime;
-        let maxTime;
-        if (foundDates && foundDates.length > 0) {
-            const nonZeroDates = foundDates.filter((date) => answeredQuestionsByDate && answeredQuestionsByDate[date] > 0);
-            if (nonZeroDates.length > 0) {
-                const minNonZeroDate = new Date(nonZeroDates.reduce((min, date) => date < min ? date : min));
-                const maxDate = new Date(foundDates.reduce((max, date) => date > max ? date : max));
-                let tempMinTime = new Date(minNonZeroDate.getTime());
-                let tempMaxTime = new Date(maxDate.getTime());
-                if (minNonZeroDate.getFullYear() == maxDate.getFullYear() && minNonZeroDate.getMonth() == maxDate.getMonth()) {
-                    tempMinTime.setMonth(minNonZeroDate.getMonth() - 1);
-                    tempMaxTime.setMonth(maxDate.getMonth() + 1);
-                }
-                minTime = Date.parse(tempMinTime.toString());
-                maxTime = Date.parse(tempMaxTime.toString());
-                selectedDates = generateDateArray(minNonZeroDate, maxDate)
-                    .map((date) => NUMERIC_DATE.format(date).split("/").reverse().join("-"));
-            }
-        }
         bb.generate({
             data: {
                 x: "x",
@@ -47,13 +26,13 @@ export const ActivityGraph = ({answeredQuestionsByDate}: {answeredQuestionsByDat
                 colors: {activity: "#ffb53f"},
                 xFormat: "%Y-%m-%d"
             },
-            axis: {x: {type: "timeseries", tick: {fit: false, count: 8}, min: minTime, max: maxTime}},
+            axis: {x: {type: "timeseries", tick: {fit: false, count: 8}}},
             zoom: {enabled: true},
             legend: {show: false},
             spline: {interpolation: {type: "monotone-x"}},
             bindto: "#activityGraph"
         });
-    }, [answeredQuestionsByDate]);
+    }, [answeredQuestionsByDate, selectedDates]);
 
     return <div id="activityGraph"/>
 };

--- a/src/app/components/elements/views/ActivityGraph.tsx
+++ b/src/app/components/elements/views/ActivityGraph.tsx
@@ -15,6 +15,9 @@ export const ActivityGraph = ({answeredQuestionsByDate}: {answeredQuestionsByDat
     }
 
     useEffect(() => {
+        if (selectedDates.length === 0) {
+            return;
+        }
         bb.generate({
             data: {
                 x: "x",
@@ -34,5 +37,5 @@ export const ActivityGraph = ({answeredQuestionsByDate}: {answeredQuestionsByDat
         });
     }, [answeredQuestionsByDate, selectedDates]);
 
-    return <div id="activityGraph"/>
+    return selectedDates.length > 0 ? <div id="activityGraph"/> : <div className="text-center-width"><strong>No data</strong></div>;
 };

--- a/src/app/components/elements/views/ActivityGraph.tsx
+++ b/src/app/components/elements/views/ActivityGraph.tsx
@@ -26,7 +26,7 @@ export const ActivityGraph = ({answeredQuestionsByDate}: {answeredQuestionsByDat
                 colors: {activity: "#ffb53f"},
                 xFormat: "%Y-%m-%d"
             },
-            axis: {x: {type: "timeseries", tick: {fit: false, count: 8}}},
+            axis: {x: {type: "timeseries", tick: {fit: false, format: '%b %Y', count: Math.min(8, selectedDates.length)}}},
             zoom: {enabled: true},
             legend: {show: false},
             spline: {interpolation: {type: "monotone-x"}},


### PR DESCRIPTION
This replaces #332, and simplifies the code dramatically. The only real difference is that this assumes that the API will provide zero values for months with no activity, and that it will only provide months when activity is meaningful. Currently this is all handled by Postgres, so it seems unlikely that this will go away even if the API changes dramatically.
It also now includes the months that were zero from registration as it used to, which may not actually be desired?