### PR TITLE
Add figure numbering to page fragments

### DIFF
--- a/src/app/components/elements/PageFragment.tsx
+++ b/src/app/components/elements/PageFragment.tsx
@@ -4,6 +4,7 @@ import {ShowLoading} from "../handlers/ShowLoading";
 import {IsaacContent} from "../content/IsaacContent";
 import {useDispatch, useSelector} from "react-redux";
 import {fetchFragment} from "../../state/actions";
+import {WithFigureNumbering} from "./WithFigureNumbering";
 
 
 interface PageFragmentComponentProps {
@@ -33,7 +34,9 @@ export const PageFragment = ({fragmentId, renderFragmentNotFound}: PageFragmentC
     return <React.Fragment>
         {!(fragment == 404 && !showFragment) && <ShowLoading
             until={fragment}
-            thenRender={fragment => <IsaacContent doc={fragment} />}
+            thenRender={fragment => <WithFigureNumbering doc={fragment}>
+                <IsaacContent doc={fragment} />
+            </WithFigureNumbering>}
             ifNotFound={notFoundComponent}
         />}
     </React.Fragment>;

--- a/src/app/components/elements/WithFigureNumbering.tsx
+++ b/src/app/components/elements/WithFigureNumbering.tsx
@@ -1,6 +1,6 @@
+import {useContext} from "react";
 import {ContentDTO} from "../../../IsaacApiTypes";
 import {FigureNumberingContext} from "../../../IsaacAppTypes";
-import React, {useContext} from "react";
 import {extractFigureId} from "../content/IsaacFigure";
 
 interface WithFigureNumberingProps {

--- a/src/app/components/elements/WithFigureNumbering.tsx
+++ b/src/app/components/elements/WithFigureNumbering.tsx
@@ -1,6 +1,6 @@
 import {ContentDTO} from "../../../IsaacApiTypes";
-import {FigureNumberingContext, FigureNumbersById} from "../../../IsaacAppTypes";
-import React from "react";
+import {FigureNumberingContext} from "../../../IsaacAppTypes";
+import React, {useContext} from "react";
 import {extractFigureId} from "../content/IsaacFigure";
 
 interface WithFigureNumberingProps {
@@ -9,15 +9,18 @@ interface WithFigureNumberingProps {
 }
 
 export const WithFigureNumbering = ({doc, children}: WithFigureNumberingProps) => {
-    let figureNumbers: FigureNumbersById = {};
+    const figureNumbers = useContext(FigureNumberingContext);
 
-    let n = 1;
-    let walk = (d: any) => {
+    let n = Object.keys(figureNumbers).length + 1;
+    function walk(d: any) {
         if (!d) {
             // Nothing to see here. Move along.
             return;
         } else if (d.type == "figure" && d.id) {
-            figureNumbers[extractFigureId(d.id)] = n++;
+            const figureId = extractFigureId(d.id)
+            if (!Object.keys(figureNumbers).includes(figureId)) {
+                figureNumbers[figureId] = n++;
+            }
         } else {
             // Walk all the things that might possibly contain figures. Doesn't blow up if they don't exist.
             for (let c of d.children || []) {
@@ -30,11 +33,9 @@ export const WithFigureNumbering = ({doc, children}: WithFigureNumberingProps) =
 
             // If we find that some figures aren't getting numbers, add additional walks here to find them.
         }
-    };
+    }
 
     walk(doc);
 
-    return <FigureNumberingContext.Provider value={figureNumbers}>
-        {children}
-    </FigureNumberingContext.Provider>
+    return children;
 };

--- a/src/app/components/navigation/TrackedRoute.tsx
+++ b/src/app/components/navigation/TrackedRoute.tsx
@@ -1,7 +1,7 @@
 import React, {useEffect} from "react";
 import {Redirect, Route, RouteComponentProps, RouteProps} from "react-router";
 import ReactGA, {FieldsObject} from "react-ga";
-import {PotentialUser} from "../../../IsaacAppTypes";
+import {FigureNumberingContext, PotentialUser} from "../../../IsaacAppTypes";
 import {ShowLoading} from "../handlers/ShowLoading";
 import {useSelector} from "react-redux";
 import * as persistence from "../../services/localStorage";
@@ -33,7 +33,9 @@ const WrapperComponent = function({component: Component, trackingOptions, ...pro
     useEffect(() => {
         trackPage(props.location.pathname, trackingOptions);
     }, [props.location.pathname, trackingOptions]);
-    return <Component {...props} />;
+    return <FigureNumberingContext.Provider value={{}}> {/* Create a figure numbering scope for each page */}
+        <Component {...props} />
+    </FigureNumberingContext.Provider>;
 };
 
 export const TrackedRoute = function({component, trackingOptions, componentProps, ...rest}: TrackedRouteProps) {


### PR DESCRIPTION
The main problem with supporting figure numbering is that you can have multiple page fragments on a single page and the figure numbers should not restart from 1 for each fragment.
We now create a figure numbering "scope" for each page - unfortunately implemented by piggy-backing on the already overloaded TrackedRoute component.
I believe that it would be possible for a page with two page fragments to load out of order so that Figure 2 appears before Figure 1 on the final rendered page but that did not happen in my constructed page. Even then, each reference would still at least be unique.
No examples exist in the wild so I constructed a page with two page fragments each containing a unique Figure and figure reference (details to reproduce in last paragraph).
It certainly isn't perfect but it does the right thing in more cases than it used to.

My temporary unpublished page fragment can be found at: `/master/content/general_pages/support/unpublished_temp_support_for_teachers_general.json`
I suggest adding a page fragment pointing to its ID in the support page component then visiting `/support/teacher/general` and inspecting the figure numbering for the section titled: "How do I connect to my students?" in both fragments. They should contain a fig 1 and fig 2 because I gave them unique figure numbers. Please delete the temporary editor file after the PR is merged, if we eventually add a real world case it can be added to our regression tests.