### PR TITLE
Allow the compose scripts to manage both physics and CS containers

### DIFF
--- a/compose
+++ b/compose
@@ -1,76 +1,74 @@
 #!/bin/bash
 
-if [ $# -eq 0 ]
-  then
-    echo "Usage: compose [dev|staging|test] VERSION"
-    exit 1
-fi
+# Fail on error, so this script can be chained safely:
+set -e
 
-ENV=$1
-APP_VERSION=$2
-
-if [ $2 = "dev" ] || [ $2 = "staging" ] || [ $2 = "test" ] || [ $2 = "live" ]; then
-  echo "Environment is now first argument to this script. Sorry James."
-  echo "Usage: compose [dev|staging|test] VERSION"
+# Cannot manage live deployment with the script!
+if [ "$2" == "live" ]; then
+  echo "Cannot manage live deployment with this script any more. Please use ./compose-live"
   exit 1
 fi
-shift 2
 
-if [ $1 = "create" ] || [ $1 = "exec" ] || [ $1 = "pull" ] || [ $1 = "push" ] || [ $1 = "run" ] || [ $1 = "start" ] || [ $1 = "up" ]; then
-  docker pull docker.isaacscience.org/isaac-cs-app:$APP_VERSION
-  API_VERSION=`docker inspect -f '{{.Config.Labels.apiVersion}}' docker.isaacscience.org/isaac-cs-app:$APP_VERSION`
+# Need at least four args and the first argument to be the site:
+if [ $# -lt 4 ] || ! { [ $1 = "cs" ] || [ $1 = "phy" ]; } || ! { [ $2 = "dev" ] || [ $2 = "staging" ] || [ $2 = "test" ]; } ; then
+  echo "Usage: compose [cs|phy] [ENVIRONMENT] [APP_VERSION] [DOCKER_ARGS]..."
+  exit 1
+fi
+
+# Extract args:
+SITE=$1
+ENV=$2
+APP_VERSION=$3
+# We're done with the first three args. The remainder will be passed to docker-compose:
+shift 3
+
+
+# Use the app image to find the correct API version to use:
+if [ $1 = "create" ] || [ $1 = "pull" ] || [ $1 = "push" ] || [ $1 = "run" ] || [ $1 = "start" ] || [ $1 = "up" ]; then
+  # This will cause new containers or should update containers, so pull newer images if possible:
+  docker pull docker.isaacscience.org/isaac-$SITE-app:$APP_VERSION
+  API_VERSION=$(docker inspect -f '{{.Config.Labels.apiVersion}}' docker.isaacscience.org/isaac-$SITE-app:$APP_VERSION)
   docker pull docker.isaacscience.org/isaac-api:$API_VERSION
+
+elif [ $1 = "stop" ] || [ $1 = "restart" ] || [ $1 = "exec" ] || [ $1 = "config" ] || [ $1 = "logs" ] || [ $1 = "kill" ] || [ $1 = "ps" ]; then
+  # This affects existing containers, so don't pull newer images:
+  API_VERSION=$(docker inspect -f '{{.Config.Labels.apiVersion}}' docker.isaacscience.org/isaac-$SITE-app:$APP_VERSION)
+
 else
-  API_VERSION=`docker inspect -f '{{.Config.Labels.apiVersion}}' docker.isaacscience.org/isaac-cs-app:$APP_VERSION`
-fi
-
-API_NAME=cs-api-$ENV-$API_VERSION
-APP_NAME=cs-app-$ENV-$APP_VERSION
-
-# Define the Postgres YML. Note that when ENV is "test" an additional volume line is appended to the end!
-read -r -d '' PG_SERVICE << EOM
-cs-pg-$ENV:
-    container_name: cs-pg-$ENV
-    restart: unless-stopped
-    image: postgres:12
-    environment:
-      POSTGRES_USER: rutherford
-      POSTGRES_PASSWORD: rutherf0rd
-    volumes:
-      - cs-pg-$ENV:/var/lib/postgresql/data
-      - ../isaac-api/src/main/resources/db_scripts/postgres-rutherford-create-script.sql:/docker-entrypoint-initdb.d/00-isaac-create.sql:ro
-      - ../isaac-api/src/main/resources/db_scripts/postgres-rutherford-functions.sql:/docker-entrypoint-initdb.d/01-isaac-functions.sql:ro
-      - ../isaac-api/src/main/resources/db_scripts/quartz_scheduler_create_script.sql:/docker-entrypoint-initdb.d/02-isaac-quartz.sql:ro
-EOM
-
-
-if [ "$ENV" == "dev" ]; then
-  : # Continue
-elif [ "$ENV" == "staging" ]; then
-  : # Continue
-elif [ "$ENV" == "live" ]; then
-  echo "Cannot manage live deployment with this script any more. Please use compose-live."
-  exit 1
-elif [ "$ENV" == "test" ]; then
-  # Need to add the SQL script that loads the test data to pg-test:
-  TEST_INIT_DATA="      - /local/data/test-cs-db-schema.sql:/docker-entrypoint-initdb.d/test-db-schema.sql"
-  PG_SERVICE="$PG_SERVICE"$'\n'"$TEST_INIT_DATA"
-else
-  echo "Must set environment to dev, staging or test"
+  # This might not be a docker-compose operation. If it is, it could be added above to the correct branch.
+  echo "Error: Unsupported docker-compose operation '$1'!"
   exit 1
 fi
 
-cat << EOF | docker-compose -p dc-$APP_NAME -f - $@
+# Ensure we actually _have_ an API_VERSION before we continue, though the "set -e" might avoid this:
+if [ -z $API_VERSION ]; then
+  echo "Error: Cannot extract API version from APP image!"
+  exit 1
+fi
+
+API_NAME=$SITE-api-$ENV-$API_VERSION
+APP_NAME=$SITE-app-$ENV-$APP_VERSION
+PG_CONTAINER_NAME=$SITE-pg-$ENV
+ES_CONTAINER_NAME=$SITE-elasticsearch-live
+
+# The content repo is named differently for both sites in a non-standard way:
+if [ "$SITE" == "cs" ]; then
+  CONTENT_REPO="cs-content"
+elif [ "$SITE" == "phy" ]; then
+  CONTENT_REPO="rutherford-content"
+fi
+
+docker-compose -p dc-$APP_NAME -f - $@ << EOF
 version: '2'
 services:
   $APP_NAME:
     container_name: $APP_NAME
-    image: docker.isaacscience.org/isaac-cs-app:$APP_VERSION
+    image: docker.isaacscience.org/isaac-$SITE-app:$APP_VERSION
     restart: unless-stopped
     networks:
       default:
         aliases:
-          - cs-app-$ENV
+          - $SITE-app-$ENV
   $API_NAME:
     container_name: $API_NAME
     image: docker.isaacscience.org/isaac-api:$API_VERSION
@@ -78,36 +76,48 @@ services:
     extra_hosts:
       - local-smtp:$LOCAL_SMTP
     links:
-      - cs-pg-$ENV:postgres
+      - $PG_CONTAINER_NAME:postgres
     external_links:
-      - cs-elasticsearch-live:elasticsearch
+      - $ES_CONTAINER_NAME:elasticsearch
     environment:
       - SEGUE_CONFIG_LOCATION=/local/data/conf/segue-config.properties
       - JAVA_OPTIONS=-Dlog.path=/isaac-logs -Dsegue.version=$API_VERSION
     volumes:
       - /local/data/m2:/root/.m2:rw
-      - /local/data/isaac-config/cs/segue-config.$ENV.properties:/local/data/conf/segue-config.properties:ro
-      - /local/data/cs-content:/local/data/cs-content:rw
+      - /local/data/isaac-config/$SITE/segue-config.$ENV.properties:/local/data/conf/segue-config.properties:ro
+      - /local/data/$CONTENT_REPO:/local/data/$CONTENT_REPO:rw
       - /local/data/keys:/local/data/keys:ro
       - /local/data/school_list_2019.csv:/local/data/school_list_2019.csv:ro
-      - /var/log/isaac/cs-$ENV:/isaac-logs:rw
+      - /var/log/isaac/$SITE-$ENV:/isaac-logs:rw
     networks:
       default:
         aliases:
-          - cs-api-$ENV-any
+          - $SITE-api-$ENV-any
     logging:
       driver: journald
       options:
-        tag: cs-isaac-api-$ENV
-  $PG_SERVICE
+        tag: $SITE-isaac-api-$ENV
+  $PG_CONTAINER_NAME:
+    container_name: $PG_CONTAINER_NAME
+    restart: unless-stopped
+    image: postgres:12
+    environment:
+      POSTGRES_USER: rutherford
+      POSTGRES_PASSWORD: rutherf0rd
+    volumes:
+      - $PG_CONTAINER_NAME:/var/lib/postgresql/data
+      - /local/src/isaac-api/src/main/resources/db_scripts/postgres-rutherford-create-script.sql:/docker-entrypoint-initdb.d/00-isaac-create.sql:ro
+      - /local/src/isaac-api/src/main/resources/db_scripts/postgres-rutherford-functions.sql:/docker-entrypoint-initdb.d/01-isaac-functions.sql:ro
+      - /local/src/isaac-api/src/main/resources/db_scripts/quartz_scheduler_create_script.sql:/docker-entrypoint-initdb.d/02-isaac-quartz.sql:ro
+      # The initialisation for the test DB, which is ignored with non-empty database volumes anyway:
+      - /local/data/test-$SITE-db-schema.sql:/docker-entrypoint-initdb.d/99-test-db-schema.sql:ro
 networks:
   default:
     external:
       name: isaac
 volumes:
-  cs-pg-$ENV:
+  $PG_CONTAINER_NAME:
     external: true
-
 EOF
 
 exit 0

--- a/compose
+++ b/compose
@@ -11,7 +11,7 @@ fi
 
 # Need at least four args and the first argument to be the site:
 if [ $# -lt 4 ] || ! { [ $1 = "cs" ] || [ $1 = "phy" ]; } || ! { [ $2 = "dev" ] || [ $2 = "staging" ] || [ $2 = "test" ]; } ; then
-  echo "Usage: compose [cs|phy] [ENVIRONMENT] [APP_VERSION] [DOCKER_ARGS]..."
+  echo "Usage: compose [cs|phy] [staging|dev|test] [APP_VERSION] [DOCKER_ARGS]..."
   exit 1
 fi
 

--- a/compose-etl
+++ b/compose-etl
@@ -1,36 +1,59 @@
 #!/bin/bash
 
-if [ $# -eq 0 ]
-  then
-    echo "Usage: compose-etl VERSION"
-    echo "Note: VERSION is the *APP* version, not API."
-    exit 1
+# Fail on error, so this script can be chained safely:
+set -e
+
+# Need at least three args and the first argument to be the site:
+if [ $# -lt 3 ] || ! { [ $1 = "cs" ] || [ $1 = "phy" ]; }; then
+  echo "Usage: compose-etl [cs|phy] [APP_VERSION] [DOCKER_ARGS]..."
+  echo "Note this is the app version and not the API version!"
+  exit 1
 fi
 
-
-APP_VERSION=$1
+# Extract args:
+SITE=$1
+APP_VERSION=$2
 ENV=live
+# We're done with the first two args. The remainder will be passed to docker-compose:
+shift 2
 
-# We're done with the first argument. The remainder will be passed to docker-compose
-shift 1
-
-if [ $1 = "create" ] || [ $1 = "exec" ] || [ $1 = "pull" ] || [ $1 = "push" ] || [ $1 = "run" ] || [ $1 = "start" ] || [ $1 = "up" ]; then
-  docker pull docker.isaacscience.org/isaac-cs-app:$APP_VERSION
-  API_VERSION=`docker inspect -f '{{.Config.Labels.apiVersion}}' docker.isaacscience.org/isaac-cs-app:$APP_VERSION`
+# Use the app image to find the correct API version to use:
+if [ $1 = "create" ] || [ $1 = "pull" ] || [ $1 = "push" ] || [ $1 = "run" ] || [ $1 = "start" ] || [ $1 = "up" ]; then
+  # This will cause new containers or should update containers, so pull newer images if possible:
+  docker pull docker.isaacscience.org/isaac-$SITE-app:$APP_VERSION
+  API_VERSION=$(docker inspect -f '{{.Config.Labels.apiVersion}}' docker.isaacscience.org/isaac-$SITE-app:$APP_VERSION)
   docker pull docker.isaacscience.org/isaac-etl:$API_VERSION
+
+elif [ $1 = "stop" ] || [ $1 = "restart" ] || [ $1 = "exec" ] || [ $1 = "config" ] || [ $1 = "logs" ] || [ $1 = "kill" ] || [ $1 = "ps" ]; then
+  # This affects existing containers, so don't pull newer images:
+  API_VERSION=$(docker inspect -f '{{.Config.Labels.apiVersion}}' docker.isaacscience.org/isaac-$SITE-app:$APP_VERSION)
+
 else
-  API_VERSION=`docker inspect -f '{{.Config.Labels.apiVersion}}' docker.isaacscience.org/isaac-cs-app:$APP_VERSION`
+  # This might not be a docker-compose operation. If it is, it could be added above to the correct branch.
+  echo "Error: Unsupported docker-compose operation '$1'!"
+  exit 1
 fi
 
-docker pull docker.isaacscience.org/isaac-etl:$API_VERSION
+# Ensure we actually _have_ an API_VERSION before we continue, though the "set -e" might avoid this:
+if [ -z $API_VERSION ]; then
+  echo "Error: Cannot extract API version from APP image!"
+  exit 1
+fi
 
+ETL_NAME=$SITE-etl-$API_VERSION
+ES_CONTAINER=$SITE-elasticsearch-live
 
-ETL_NAME=cs-etl-$API_VERSION
+# The content repo is named differently for both sites in a non-standard way:
+if [ "$SITE" == "cs" ]; then
+  CONTENT_REPO="cs-content"
+elif [ "$SITE" == "phy" ]; then
+  CONTENT_REPO="rutherford-content"
+fi
 
-cat << EOF | docker-compose -p dc-cs-etl -f - $@
+docker-compose -p dc-$SITE-etl -f - $@ << EOF
 version: '2'
 services:
-  cs-etl:
+  $SITE-etl:
     container_name: $ETL_NAME
     image: docker.isaacscience.org/isaac-etl:$API_VERSION
     environment:
@@ -38,22 +61,22 @@ services:
       - JAVA_OPTIONS=-Dlog.path=/isaac-logs -Dsegue.version=$API_VERSION -Djetty.port=8090
     volumes:
       - /local/data/m2:/root/.m2:rw
-      - /local/data/isaac-config/cs/segue-config.$ENV.properties:/local/data/conf/segue-config.properties:ro
-      - /local/data/isaac-config/cs/content_indices.properties:/local/data/conf/content_indices.properties:rw
-      - /local/data/cs-content:/local/data/cs-content:rw
+      - /local/data/isaac-config/$SITE/segue-config.$ENV.properties:/local/data/conf/segue-config.properties:ro
+      - /local/data/isaac-config/$SITE/content_indices.properties:/local/data/conf/content_indices.properties:rw
+      - /local/data/$CONTENT_REPO:/local/data/$CONTENT_REPO:rw
       - /local/data/keys:/local/data/keys:ro
       - /local/data/school_list_2019.csv:/local/data/school_list_2019.csv:ro
-      - /var/log/isaac/cs-etl:/isaac-logs:rw
+      - /var/log/isaac/$SITE-etl:/isaac-logs:rw
     external_links:
-      - cs-elasticsearch-live:elasticsearch
+      - $ES_CONTAINER:elasticsearch
     networks:
       default:
         aliases:
-          - cs-etl
+          - $SITE-etl
     logging:
       driver: journald
       options:
-        tag: cs-isaac-etl
+        tag: $SITE-isaac-etl
 networks:
   default:
     external:

--- a/compose-live
+++ b/compose-live
@@ -1,46 +1,68 @@
 #!/bin/bash
 
-if [ $# -eq 0 ]
-  then
-    echo "Usage: compose-live VERSION"
-    exit 1
+# Fail on error, so this script can be chained safely:
+set -e
+
+# Need at least three args and the first argument to be the site:
+if [ $# -lt 3 ] || ! { [ $1 = "cs" ] || [ $1 = "phy" ]; }; then
+  echo "Usage: compose-live [cs|phy] [APP_VERSION] [DOCKER_ARGS]..."
+  exit 1
 fi
 
-# Arg: app version
-
-APP_VERSION=$1
+# Extract args:
+SITE=$1
+APP_VERSION=$2
 ENV=live
-# We're done with the first argument. The remainder will be passed to docker-compose
-shift 1
+# We're done with the first two args. The remainder will be passed to docker-compose:
+shift 2
 
 
-# Pull the correct App image, inspect it to find the required API version, pull that.
-
-if [ $1 = "create" ] || [ $1 = "exec" ] || [ $1 = "pull" ] || [ $1 = "push" ] || [ $1 = "run" ] || [ $1 = "start" ] || [ $1 = "up" ]; then
-  docker pull docker.isaacscience.org/isaac-cs-app:$APP_VERSION
-  API_VERSION=`docker inspect -f '{{.Config.Labels.apiVersion}}' docker.isaacscience.org/isaac-cs-app:$APP_VERSION`
+# Use the app image to find the correct API version to use:
+if [ $1 = "create" ] || [ $1 = "pull" ] || [ $1 = "push" ] || [ $1 = "run" ] || [ $1 = "start" ] || [ $1 = "up" ]; then
+  # This will cause new containers or should update containers, so pull newer images if possible:
+  docker pull docker.isaacscience.org/isaac-$SITE-app:$APP_VERSION
+  API_VERSION=$(docker inspect -f '{{.Config.Labels.apiVersion}}' docker.isaacscience.org/isaac-$SITE-app:$APP_VERSION)
   docker pull docker.isaacscience.org/isaac-api:$API_VERSION
+
+elif [ $1 = "stop" ] || [ $1 = "restart" ] || [ $1 = "exec" ] || [ $1 = "config" ] || [ $1 = "logs" ] || [ $1 = "kill" ] || [ $1 = "ps" ]; then
+  # This affects existing containers, so don't pull newer images:
+  API_VERSION=$(docker inspect -f '{{.Config.Labels.apiVersion}}' docker.isaacscience.org/isaac-$SITE-app:$APP_VERSION)
+
 else
-  API_VERSION=`docker inspect -f '{{.Config.Labels.apiVersion}}' docker.isaacscience.org/isaac-cs-app:$APP_VERSION`
+  # This might not be a docker-compose operation. If it is, it could be added above to the correct branch.
+  echo "Error: Unsupported docker-compose operation '$1'!"
+  exit 1
 fi
 
-API_NAME=cs-api-$ENV-$API_VERSION
-APP_NAME=cs-app-$ENV-$APP_VERSION
+# Ensure we actually _have_ an API_VERSION before we continue, though the "set -e" might avoid this:
+if [ -z $API_VERSION ]; then
+  echo "Error: Cannot extract API version from APP image!"
+  exit 1
+fi
 
-PG=cs-pg-live
-CONTENT=live
+API_NAME=$SITE-api-$ENV-$API_VERSION
+APP_NAME=$SITE-app-$ENV-$APP_VERSION
+PG_CONTAINER=$SITE-pg-$ENV
+ES_CONTAINER=$SITE-elasticsearch-live
 
-cat << EOF | docker-compose -p dc-$APP_NAME -f - $@
+# The content repo is named differently for both sites in a non-standard way:
+if [ "$SITE" == "cs" ]; then
+  CONTENT_REPO="cs-content"
+elif [ "$SITE" == "phy" ]; then
+  CONTENT_REPO="rutherford-content"
+fi
+
+docker-compose -p dc-$APP_NAME -f - $@ << EOF
 version: '2'
 services:
   $APP_NAME:
     container_name: $APP_NAME
-    image: docker.isaacscience.org/isaac-cs-app:$APP_VERSION
+    image: docker.isaacscience.org/isaac-$SITE-app:$APP_VERSION
     restart: unless-stopped
     networks:
       default:
         aliases:
-          - cs-app-$ENV
+          - $SITE-app-$ENV
   $API_NAME:
     container_name: $API_NAME
     image: docker.isaacscience.org/isaac-api:$API_VERSION
@@ -48,26 +70,26 @@ services:
     extra_hosts:
       - local-smtp:$LOCAL_SMTP
     external_links:
-      - cs-pg-live:postgres
-      - cs-elasticsearch-live:elasticsearch
+      - $PG_CONTAINER:postgres
+      - $ES_CONTAINER:elasticsearch
     environment:
       - SEGUE_CONFIG_LOCATION=/local/data/conf/segue-config.properties
       - JAVA_OPTIONS=-Dlog.path=/isaac-logs -Dsegue.version=$API_VERSION
     volumes:
       - /local/data/m2:/root/.m2:rw
-      - /local/data/isaac-config/cs/segue-config.$ENV.properties:/local/data/conf/segue-config.properties:ro
-      - /local/data/cs-content:/local/data/cs-content:rw
+      - /local/data/isaac-config/$SITE/segue-config.$ENV.properties:/local/data/conf/segue-config.properties:ro
+      - /local/data/$CONTENT_REPO:/local/data/$CONTENT_REPO:rw
       - /local/data/keys:/local/data/keys:ro
       - /local/data/school_list_2019.csv:/local/data/school_list_2019.csv:ro
-      - /var/log/isaac/cs-$ENV:/isaac-logs:rw
+      - /var/log/isaac/$SITE-$ENV:/isaac-logs:rw
     networks:
       default:
         aliases:
-          - cs-api-$ENV-any
+          - $SITE-api-$ENV-any
     logging:
       driver: journald
       options:
-        tag: isaac-cs-api-$ENV
+        tag: isaac-$SITE-api-$ENV
 networks:
   default:
     external:


### PR DESCRIPTION
This also improves the validation of inputs initially and before they get passed into docker-compose, which seemed sensible.

It also removes the "special-case" nature of the test database initialisation; since the Docker Postgres image will not use the init
scripts if the data directory is blank, it ought to be safe to include the test scheme for all non-prod databases. Doing this dramatically simplifies the compose script.

This also restricts the types of docker-compose commands that can be run, to prevent passing unexpected things into it. If any commands have been missed, they can easily be added and a helpful error is printed.