### PR TITLE
Force physics filter to specify problem solving questions

### DIFF
--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -1,5 +1,5 @@
 import axios, {AxiosPromise} from "axios";
-import {API_PATH, EventTypeFilter, MEMBERSHIP_STATUS, TAG_ID} from "./constants";
+import {API_PATH, EventTypeFilter, MEMBERSHIP_STATUS, QUESTION_CATEGORY, TAG_ID} from "./constants";
 import * as ApiTypes from "../../IsaacApiTypes";
 import {AuthenticationProvider, EventBookingDTO, GameboardDTO, TestCaseDTO} from "../../IsaacApiTypes";
 import * as AppTypes from "../../IsaacAppTypes";
@@ -20,6 +20,7 @@ import {
 import {handleApiGoneAway, handleServerError} from "../state/actions";
 import {EventOverviewFilter} from "../components/elements/panels/EventOverviews";
 import {securePadCredentials, securePadPasswordReset} from "./credentialPadding";
+import {SITE, SITE_SUBJECT} from "./siteConstants";
 
 export const endpoint = axios.create({
     baseURL: API_PATH,
@@ -307,6 +308,10 @@ export const api = {
             return endpoint.get(`gameboards/wildcards`);
         },
         generateTemporary: (params: {[key: string]: string}): AxiosPromise<ApiTypes.GameboardDTO> => {
+            // TODO FILTER: Temporarily force physics to search for problem solving questions
+            if (SITE_SUBJECT === SITE.PHY) {
+                params['questionCategories'] = QUESTION_CATEGORY.PROBLEM_SOLVING;
+            }
             return endpoint.get(`/gameboards`, {params});
         }
     },

--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -791,6 +791,11 @@ for(let entry of Object.entries(GREEK_LETTERS_MAP)) {
 _REVERSE_GREEK_LETTERS_MAP["ε"] = "epsilon"; // Take this one in preference!
 export const REVERSE_GREEK_LETTERS_MAP = _REVERSE_GREEK_LETTERS_MAP;
 
+
+export enum QUESTION_CATEGORY {
+    PROBLEM_SOLVING = "problem_solving"
+}
+
 export const specificDoughnutColours: { [key: string]: string } = {
     [SITE.PHY]: {
         "Physics": "#944cbe",


### PR DESCRIPTION
This PR has an accompanying backend PR.

This will allow the content team to safely tag Maths questions as both `book` and `problem_solving` questions.
In the future, the filter will surface a question category selection (for Physics at least).
