### PR TITLE
Soft limit search character length to 255

### DIFF
--- a/src/app/components/elements/MainSearch.tsx
+++ b/src/app/components/elements/MainSearch.tsx
@@ -4,6 +4,7 @@ import {pushSearchToHistory} from "../../services/search";
 import {History} from "history";
 import {withRouter} from "react-router";
 import {Collapse, Form, FormGroup, Input, Label, Nav, Navbar, NavbarToggler, NavItem} from "reactstrap";
+import {SEARCH_CHAR_LENGTH_LIMIT} from "../../services/constants";
 
 interface MainSearchProps {
     history: History;
@@ -41,7 +42,7 @@ const MainSearchComponent = ({history}: MainSearchProps) => {
                             <Label for='header-search' className='sr-only'>Search</Label>
                             <Input
                                 id="header-search" type="search" name="query" placeholder="Search" aria-label="Search"
-                                value={searchText} onChange={setSearchTextAsValue} innerRef={searchInputRef}
+                                value={searchText} onChange={setSearchTextAsValue} innerRef={searchInputRef} maxLength={SEARCH_CHAR_LENGTH_LIMIT}
                             />
                             <SearchButton />
                             <input type="hidden" name="types" value="isaacQuestionPage,isaacConceptPage" />

--- a/src/app/components/pages/Search.tsx
+++ b/src/app/components/pages/Search.tsx
@@ -10,7 +10,7 @@ import {AppState} from "../../state/reducers";
 import {ContentSummaryDTO} from "../../../IsaacApiTypes";
 import {History} from "history";
 import {LinkToContentSummaryList} from "../elements/list-groups/ContentSummaryListGroupItem";
-import {DOCUMENT_TYPE, documentDescription} from "../../services/constants";
+import {DOCUMENT_TYPE, documentDescription, SEARCH_CHAR_LENGTH_LIMIT} from "../../services/constants";
 import {pushSearchToHistory, searchResultIsPublic} from "../../services/search";
 import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
 import {shortcuts} from "../../services/searchResults";
@@ -112,6 +112,7 @@ export const Search = withRouter((props: {history: History; location: Location})
                             type="search" value={queryState}
                             placeholder="Search"
                             onChange={(e: ChangeEvent<HTMLInputElement>) => setQueryState(e.target.value)}
+                            maxLength={SEARCH_CHAR_LENGTH_LIMIT}
                         />
                     </Form>
                 </Col>

--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -831,3 +831,5 @@ export const progressColour = {
 }[SITE_SUBJECT];
 
 export const GRAY_120 = '#c9cad1';
+
+export const SEARCH_CHAR_LENGTH_LIMIT = 255;


### PR DESCRIPTION
Adds a 255 character limit to the search boxes, before a user hits the 1000 character backend bad request