### PR TITLE
Improvement/video end time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27272,8 +27272,7 @@
         "normalize-path": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-          "optional": true
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
         },
         "readdirp": {
           "version": "3.4.0",

--- a/src/app/components/content/IsaacVideo.tsx
+++ b/src/app/components/content/IsaacVideo.tsx
@@ -14,11 +14,13 @@ interface IsaacVideoProps {
 function rewrite(src: string) {
     const possibleVideoId = /(v=|\/embed\/|\/)([^?&/.]{11})/.exec(src);
     const possibleStartTime = /[?&]t=([0-9]+)/.exec(src);
+    const possibleEndTime = /[?&]end=([0-9]+)/.exec(src);
     if (possibleVideoId) {
         const videoId = possibleVideoId[2];
         const optionalStart = possibleStartTime ? `&start=${possibleStartTime[1]}` : "";
+        const optionalEnd = possibleEndTime ? `&end=${possibleEndTime[1]}` : "";
         return `https://www.youtube-nocookie.com/embed/${videoId}?enablejsapi=1&rel=0&fs=1&modestbranding=1` +
-               `${optionalStart}&origin=${window.location.origin}`
+               `${optionalStart}${optionalEnd}&origin=${window.location.origin}`
     }
 }
 

--- a/src/app/components/content/IsaacVideo.tsx
+++ b/src/app/components/content/IsaacVideo.tsx
@@ -13,11 +13,11 @@ interface IsaacVideoProps {
 
 function rewrite(src: string) {
     const possibleVideoId = /(v=|\/embed\/|\/)([^?&/.]{11})/.exec(src);
-    const possibleStartTime = /[?&]t=([0-9]+)/.exec(src);
+    const possibleStartTime = /[?&](t|start)=([0-9]+)/.exec(src);
     const possibleEndTime = /[?&]end=([0-9]+)/.exec(src);
     if (possibleVideoId) {
         const videoId = possibleVideoId[2];
-        const optionalStart = possibleStartTime ? `&start=${possibleStartTime[1]}` : "";
+        const optionalStart = possibleStartTime ? `&start=${possibleStartTime[2]}` : "";
         const optionalEnd = possibleEndTime ? `&end=${possibleEndTime[1]}` : "";
         return `https://www.youtube-nocookie.com/embed/${videoId}?enablejsapi=1&rel=0&fs=1&modestbranding=1` +
                `${optionalStart}${optionalEnd}&origin=${window.location.origin}`


### PR DESCRIPTION
- Requires content teams to add (?/&)end=[number in seconds] for a video to automatically stop at that point