### PR TITLE
Feature/2021 topic refactor

### DIFF
--- a/src/IsaacAppTypes.tsx
+++ b/src/IsaacAppTypes.tsx
@@ -849,6 +849,7 @@ export interface BaseTag {
     parent?: TAG_ID;
     comingSoon?: string;
     new?: boolean;
+    hidden?: boolean;
 }
 
 export interface Tag extends BaseTag {

--- a/src/app/components/elements/views/QuestionProgressCharts.tsx
+++ b/src/app/components/elements/views/QuestionProgressCharts.tsx
@@ -119,7 +119,7 @@ export const QuestionProgressCharts = (props: QuestionProgressChartsProps) => {
     const noCharts = {[SITE.CS]: 2, [SITE.PHY]: 3}[SITE_SUBJECT];
 
     return <RS.Row>
-        <RS.Col xl={12/noCharts} md={6} className="mt-4 d-flex flex-column">
+        {SITE_SUBJECT === SITE.PHY && <RS.Col xl={12/noCharts} md={6} className="mt-4 d-flex flex-column">
             <div className="height-40px text-flex-align mb-2">
                 Questions by {topTagLevel}
             </div>
@@ -128,7 +128,8 @@ export const QuestionProgressCharts = (props: QuestionProgressChartsProps) => {
                     <strong>{isAllZero(categoryColumns) ? "No data" : ""}</strong>
                 </div>
             </div>
-        </RS.Col>
+        </RS.Col>}
+        {SITE_SUBJECT === SITE.CS && <RS.Col md={3}/>}
         <RS.Col xl={12/noCharts} md={6} className="mt-4 d-flex flex-column">
             <div className="height-40px text-flex-align mb-2">
                 <Select
@@ -148,6 +149,7 @@ export const QuestionProgressCharts = (props: QuestionProgressChartsProps) => {
                 </div>
             </div>
         </RS.Col>
+        {SITE_SUBJECT === SITE.CS && <RS.Col md={3}/>}
         {SITE_SUBJECT === SITE.PHY && <RS.Col xl={4} className="mt-4 d-flex flex-column">
             <div className="height-40px text-flex-align mb-2">
                 Questions by level

--- a/src/app/components/pages/AllTopics.tsx
+++ b/src/app/components/pages/AllTopics.tsx
@@ -43,6 +43,33 @@ export const AllTopics = () => {
     const categoryDescendentIds = tags.getDescendents(TAG_ID.computerScience).map(t => t.id);
     const subcategoryTags = tags.getSubcategoryTags(categoryDescendentIds);
 
+    const firstColTags = subcategoryTags.filter(function (subcategory) {return subcategory.title.charAt(0) < "H"});
+    const secondColTags = subcategoryTags.filter(function (subcategory) {return subcategory.title.charAt(0) > "H"});
+
+    const topicColumn = (subTags: Tag[]) => {
+        return <Col key={TAG_ID.computerScience + "_" + subTags[0].id} md={6}>
+            {subTags.sort((a, b) => (a.title > b.title) ? 1 : -1).map((subcategory) => {
+                const subcategoryDescendentIds = tags.getDescendents(subcategory.id).map(t => t.id);
+                const topicTags = tags.getTopicTags(subcategoryDescendentIds);
+                if (!subcategory.hidden) {
+                    return <React.Fragment key={subcategory.id}>
+                        <h3>{subcategory.title}</h3>
+                        <ul className="list-unstyled mb-3 link-list">
+                            {topicTags.map((topic) =>
+                                <li
+                                    className="border-0 px-0 py-0 pb-1 bg-transparent"
+                                    key={topic.id}
+                                >
+                                    {renderTopic(topic)}
+                                </li>
+                            )}
+                        </ul>
+                    </React.Fragment>
+                }
+            })}
+        </Col>
+    };
+
     return <div className="pattern-02">
         <Container>
             <TitleAndBreadcrumb currentPageTitle="All topics"/>
@@ -51,49 +78,8 @@ export const AllTopics = () => {
 
             <Row>
                 <Col lg={{size: 8, offset: 2}} className="bg-light-grey py-md-4 d-md-flex">
-                    <Col key={TAG_ID.computerScience} md={6}>
-                    {subcategoryTags.sort((a, b) => (a.title > b.title) ? 1 : -1).map((subcategory) => {
-                        const subcategoryDescendentIds = tags.getDescendents(subcategory.id).map(t => t.id);
-                        const topicTags = tags.getTopicTags(subcategoryDescendentIds);
-                        console.log(topicTags);
-                        if (subcategory.title.charAt(0) < "H" && !subcategory.hidden) {
-                            return <React.Fragment key={subcategory.id}>
-                                <h3>{subcategory.title}</h3>
-                                <ul className="list-unstyled mb-3 link-list">
-                                    {topicTags.map((topic) =>
-                                        <li
-                                            className="border-0 px-0 py-0 pb-1 bg-transparent"
-                                            key={topic.id}
-                                        >
-                                            {renderTopic(topic)}
-                                        </li>
-                                    )}
-                                </ul>
-                            </React.Fragment>
-                        }
-                    })}
-                    </Col>
-                    <Col key={TAG_ID.computerScience + "_2"} md={6}>
-                        {subcategoryTags.sort((a, b) => (a.title > b.title) ? 1 : -1).map((subcategory) => {
-                                const subcategoryDescendentIds = tags.getDescendents(subcategory.id).map(t => t.id);
-                                const topicTags = tags.getTopicTags(subcategoryDescendentIds);
-                                if (subcategory.title.charAt(0) > "H" && !subcategory.hidden) {
-                                    return <React.Fragment key={subcategory.id}>
-                                        <h3>{subcategory.title}</h3>
-                                        <ul className="list-unstyled mb-3 link-list">
-                                            {topicTags.map((topic) =>
-                                                <li
-                                                    className="border-0 px-0 py-0 pb-1 bg-transparent"
-                                                    key={topic.id}
-                                                >
-                                                    {renderTopic(topic)}
-                                                </li>
-                                            )}
-                                        </ul>
-                                    </React.Fragment>
-                                }
-                            })}
-                    </Col>
+                    {topicColumn(firstColTags)}
+                    {topicColumn(secondColTags)}
                 </Col>
             </Row>
         </Container>

--- a/src/app/components/pages/AllTopics.tsx
+++ b/src/app/components/pages/AllTopics.tsx
@@ -9,23 +9,12 @@ import {TAG_ID} from "../../services/constants";
 
 export const AllTopics = () => {
 
-    // This points the relevant new tags to existing topic summary pages
-    const topicSummaryMap: {[topicId: string]: string} = {
-        [TAG_ID.proceduralProgramming]: "procedural_and_structured_programming",
-        [TAG_ID.eventDrivenProgramming]: "guis",
-        [TAG_ID.searching]: "searching_sorting_pathfinding",
-        [TAG_ID.modelsOfComputation]: "theory_of_computation",
-        [TAG_ID.operatingSystems]: "operating_systems_and_software",
-        [TAG_ID.numberRepresentation]: "number_bases",
-        [TAG_ID.stringHandling]: "string_manipulation",
-    };
-
     const renderTopic = (topic: Tag) => {
         const TextTag = topic.comingSoon ? "span" : "strong";
         if (!topic.hidden) {
             return <React.Fragment>
                 <Link
-                    to={topic.comingSoon ? "/coming_soon" : `/topics/${topicSummaryMap[topic.id] || topic.id}`}
+                    to={topic.comingSoon ? "/coming_soon" : `/topics/${topic.id}`}
                     className={topic.comingSoon ? "text-muted" : ""}
                 >
                     <TextTag>

--- a/src/app/components/pages/AllTopics.tsx
+++ b/src/app/components/pages/AllTopics.tsx
@@ -5,25 +5,43 @@ import "../../services/tagsPhy";
 import tags from "../../services/tags";
 import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
 import {Tag} from "../../../IsaacAppTypes";
+import {TAG_ID} from "../../services/constants";
 
 export const AllTopics = () => {
 
+    // This points the relevant new tags to existing topic summary pages
+    const topicSummaryMap: {[topicId: string]: string} = {
+        [TAG_ID.proceduralProgramming]: "procedural_and_structured_programming",
+        [TAG_ID.eventDrivenProgramming]: "guis",
+        [TAG_ID.searching]: "searching_sorting_pathfinding",
+        [TAG_ID.modelsOfComputation]: "theory_of_computation",
+        [TAG_ID.operatingSystems]: "operating_systems_and_software",
+        [TAG_ID.numberRepresentation]: "number_bases",
+        [TAG_ID.stringHandling]: "string_manipulation",
+    };
+
     const renderTopic = (topic: Tag) => {
         const TextTag = topic.comingSoon ? "span" : "strong";
-        return <React.Fragment>
-            <Link
-                to={topic.comingSoon ? "/coming_soon" : `/topics/${topic.id}`}
-                className={topic.comingSoon ? "text-muted" : ""}
-            >
-                <TextTag>
-                    {topic.title}
-                </TextTag>
-            </Link>
-            {" "}
-            {topic.comingSoon && !topic.new && <Badge color="light" className="border bg-white">Coming {topic.comingSoon}</Badge>}
-            {topic.new && !topic.comingSoon && <Badge color="secondary">New</Badge>}
-        </React.Fragment>;
+        if (!topic.hidden) {
+            return <React.Fragment>
+                <Link
+                    to={topic.comingSoon ? "/coming_soon" : `/topics/${topicSummaryMap[topic.id] || topic.id}`}
+                    className={topic.comingSoon ? "text-muted" : ""}
+                >
+                    <TextTag>
+                        {topic.title}
+                    </TextTag>
+                </Link>
+                {" "}
+                {topic.comingSoon && !topic.new &&
+                <Badge color="light" className="border bg-white">Coming {topic.comingSoon}</Badge>}
+                {topic.new && !topic.comingSoon && <Badge color="secondary">New</Badge>}
+            </React.Fragment>;
+        }
     };
+
+    const categoryDescendentIds = tags.getDescendents(TAG_ID.computerScience).map(t => t.id);
+    const subcategoryTags = tags.getSubcategoryTags(categoryDescendentIds);
 
     return <div className="pattern-02">
         <Container>
@@ -33,30 +51,49 @@ export const AllTopics = () => {
 
             <Row>
                 <Col lg={{size: 8, offset: 2}} className="bg-light-grey py-md-4 d-md-flex">
-                    {tags.allCategoryTags.map((category) => {
-                        const categoryDescendentIds = tags.getDescendents(category.id).map(t => t.id);
-                        const subcategoryTags = tags.getSubcategoryTags(categoryDescendentIds);
-                        return <Col key={category.id} md={6}>
-                            <h2>{category.title}</h2>
-                            {subcategoryTags.map((subcategory) => {
+                    <Col key={TAG_ID.computerScience} md={6}>
+                    {subcategoryTags.sort((a, b) => (a.title > b.title) ? 1 : -1).map((subcategory) => {
+                        const subcategoryDescendentIds = tags.getDescendents(subcategory.id).map(t => t.id);
+                        const topicTags = tags.getTopicTags(subcategoryDescendentIds);
+                        console.log(topicTags);
+                        if (subcategory.title.charAt(0) < "H" && !subcategory.hidden) {
+                            return <React.Fragment key={subcategory.id}>
+                                <h3>{subcategory.title}</h3>
+                                <ul className="list-unstyled mb-3 link-list">
+                                    {topicTags.map((topic) =>
+                                        <li
+                                            className="border-0 px-0 py-0 pb-1 bg-transparent"
+                                            key={topic.id}
+                                        >
+                                            {renderTopic(topic)}
+                                        </li>
+                                    )}
+                                </ul>
+                            </React.Fragment>
+                        }
+                    })}
+                    </Col>
+                    <Col key={TAG_ID.computerScience + "_2"} md={6}>
+                        {subcategoryTags.sort((a, b) => (a.title > b.title) ? 1 : -1).map((subcategory) => {
                                 const subcategoryDescendentIds = tags.getDescendents(subcategory.id).map(t => t.id);
                                 const topicTags = tags.getTopicTags(subcategoryDescendentIds);
-                                return <React.Fragment key={subcategory.id}>
-                                    <h3>{subcategory.title}</h3>
-                                    <ul className="list-unstyled mb-3 link-list">
-                                        {topicTags.map((topic) =>
-                                            <li
-                                                className="border-0 px-0 py-0 pb-1 bg-transparent"
-                                                key={topic.id}
-                                            >
-                                                {renderTopic(topic)}
-                                            </li>
-                                        )}
-                                    </ul>
-                                </React.Fragment>
+                                if (subcategory.title.charAt(0) > "H" && !subcategory.hidden) {
+                                    return <React.Fragment key={subcategory.id}>
+                                        <h3>{subcategory.title}</h3>
+                                        <ul className="list-unstyled mb-3 link-list">
+                                            {topicTags.map((topic) =>
+                                                <li
+                                                    className="border-0 px-0 py-0 pb-1 bg-transparent"
+                                                    key={topic.id}
+                                                >
+                                                    {renderTopic(topic)}
+                                                </li>
+                                            )}
+                                        </ul>
+                                    </React.Fragment>
+                                }
                             })}
-                        </Col>
-                    })}
+                    </Col>
                 </Col>
             </Row>
         </Container>

--- a/src/app/components/site/cs/RoutesCS.tsx
+++ b/src/app/components/site/cs/RoutesCS.tsx
@@ -30,9 +30,17 @@ export const RoutesCS = [
     // <TrackedRoute key={key++} exact path="/group_progress/:groupId" ifUser={isTeacher} component={SingleGroupProgress} />,
 
     // Topics
+    <Redirect key={key++} from="/topics/procedural_and_structured_programming" to="/topics/procedural_programming" />,
+    <Redirect key={key++} from="/topics/guis" to="/topics/event_driven_programming" />,
+    <Redirect key={key++} from="/topics/searching_sorting_pathfinding" to="/topics/searching" />,
+    <Redirect key={key++} from="/topics/theory_of_computation" to="/topics/models_of_computation" />,
+    <Redirect key={key++} from="/topics/operating_systems_and_software" to="/topics/operating_systems" />,
+    <Redirect key={key++} from="/topics/number_bases" to="/topics/number_representation" />,
+    <Redirect key={key++} from="/topics/string_manipulation" to="/topics/string_handling" />,
     <TrackedRoute key={key++} exact path="/topics/:topicName" component={Topic} />,
     <TrackedRoute key={key++} exact path="/topics" component={AllTopics} />,
     <TrackedRoute key={key++} exact path="/glossary" component={Glossary} />,
+
 
     // Books:
     <TrackedRoute key={key++} exact path="/books/workbook_20_aqa" component={Workbook20AQA}/>,

--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -563,68 +563,101 @@ export const tagExamBoardMap: {[tag: string]: string} = invert(examBoardTagMap);
 export enum TAG_ID {
     // CS ----
     // Categories
-    theory = "theory",
-    programming = "programming",
+    computerScience = "computer_science",
 
-    // Theory sub-categories
-    gcseToALevel = "gcse_to_a_level",
-    dataStructuresAndAlgorithms = "data_structures_and_algorithms",
+    // Strands
     computerNetworks = "computer_networks",
     computerSystems = "computer_systems",
+    cyberSecurity = "cyber_security",
     dataAndInformation = "data_and_information",
-    // Programming sub-categories
-    programmingParadigms = "programming_paradigms",
+    dataStructuresAndAlgorithms = "data_structures_and_algorithms",
+    gcseToALevel = "gcse_to_a_level",
+    impactsOfTechnology = "impact_of_tech",
+    machineLearningAi = "machine_learning_ai",
+    mathsForCs = "maths_for_cs",
     programmingFundamentals = "programming_fundamentals",
-    computingPracticalProject = "computing_practical_project",
+    programmingParadigms = "programming_paradigms",
+    softwareEngineering = "software_engineering",
+    theoryOfComputation = "theory_of_computation",
 
+    // Computer networks topics
+    networking = "networking",
+    networkHardware = "network_hardware",
+    communication = "communication",
+    theInternet = "the_internet",
+    webTechnologies = "web_technologies",
+    // Computer systems topics
+    booleanLogic = "boolean_logic",
+    architecture = "architecture",
+    memoryAndStorage = "memory_and_storage",
+    hardware = "hardware",
+    software = "software",
+    operatingSystems = "operating_systems",
+    translators = "translators",
+    programmingLanguages = "programming_languages",
+    // Cyber security
+    security = "security",
+    socialEngineering = "social_engineering",
+    maliciousCode = "malicious_code",
+    identificationPrevention = "identification_prevention",
+    // Data and information topics
+    numberRepresentation = "number_representation",
+    textRepresentation = "text_representation",
+    imageRepresentation = "image_representation",
+    soundRepresentation = "sound_representation",
+    compression = "compression",
+    encryption = "encryption",
+    databases = "databases",
+    sql = "sql",
+    bigData = "big_data",
+    // Data structures and algorithms topics
+    searching = "searching",
+    sorting = "sorting",
+    pathfinding = "pathfinding",
+    complexity = "complexity",
+    dataStructures = "data_structures",
     // GCSE to A level transition topics
     gcseBooleanLogic = "gcse_boolean_logic",
     gcseProgrammingConcepts = "gcse_programming_concepts",
     gcseNetworking = "gcse_networking",
     gcseDataRepresentation = "gcse_data_representation",
     gcseSystems = "gcse_systems",
-    // Data structures and algorithms topics
-    searchingSortingPathfinding = "searching_sorting_pathfinding",
-    complexity = "complexity",
-    theoryOfComputation = "theory_of_computation",
-    computationalThinking = "computational_thinking",
-    dataStructures = "data_structures",
-    // Computer networks topics
-    security = "security",
-    networking = "networking",
-    networkHardware = "network_hardware",
-    communication = "communication",
-    theInternet = "the_internet",
-    // Computer systems topics
-    booleanLogic = "boolean_logic",
-    architecture = "architecture",
-    hardware = "hardware",
-    operatingSystemsAndSoftware = "operating_systems_and_software",
-    translators = "translators",
-    programmingLanguages = "programming_languages",
-    // Data and information topics
+    // Impacts of technology
+    legal = "legal",
+    ethical = "ethical",
+    cultural = "cultural",
+    environmental = "environmental",
+    moral = "moral",
+    trends = "trends",
+    // Maths for CS
     numberSystems = "number_systems",
-    numberBases = "number_bases",
-    representation = "representation",
-    databases = "databases",
-    bigData = "big_data",
-    compression = "compression",
-    encryption = "encryption",
-
+    mathsFunctions = "functions",
+    // Machine learning and ai
+    graphsForAi = "graphs_for_ai",
+    neuralNetworks = "neural_networks",
+    machineLearning = "machine_learning",
+    backpropagationAndRegression = "backpropogation_and_regression",
     // Programming fundamentals topics
     programmingConcepts = "programming_concepts",
     subroutines = "subroutines",
     files = "files",
     recursion = "recursion",
-    stringManipulation = "string_manipulation",
-    guis = "guis",
-    softwareEngineeringPrinciples = "software_engineering_principles",
+    stringHandling = "string_handling",
+    ide = "ide",
     // Programming paradigms topics
     objectOrientedProgramming = "object_oriented_programming",
     functionalProgramming = "functional_programming",
-    proceduralAndStructuredProgramming = "procedural_and_structured_programming",
-    // Computing practical project topics
+    eventDrivenProgramming = "event_driven_programming",
+    declarativeProgramming = "declarative_programming",
+    proceduralProgramming = "procedural_programming",
+    // Software engineering
+    softwareEngineeringPrinciples = "software_engineering_principles",
+    programDesign = "program_design",
+    testing = "testing",
     softwareProject = "software_project",
+    //Theory of computation
+    computationalThinking = "computational_thinking",
+    modelsOfComputation = "models_of_computation",
 
     // PHY ----
     // Subjects

--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -572,7 +572,7 @@ export enum TAG_ID {
     dataAndInformation = "data_and_information",
     dataStructuresAndAlgorithms = "data_structures_and_algorithms",
     gcseToALevel = "gcse_to_a_level",
-    impactsOfTechnology = "impact_of_tech",
+    impactsOfDigitalTechnology = "impacts_of_digital_tech",
     machineLearningAi = "machine_learning_ai",
     mathsForCs = "maths_for_cs",
     programmingFundamentals = "programming_fundamentals",
@@ -622,13 +622,9 @@ export enum TAG_ID {
     gcseNetworking = "gcse_networking",
     gcseDataRepresentation = "gcse_data_representation",
     gcseSystems = "gcse_systems",
-    // Impacts of technology
-    legal = "legal",
-    ethical = "ethical",
-    cultural = "cultural",
-    environmental = "environmental",
-    moral = "moral",
-    trends = "trends",
+    // Impacts of digital technology
+    legislation = "legislation",
+    impactsOfTech = "impacts_of_tech",
     // Maths for CS
     numberSystems = "number_systems",
     mathsFunctions = "functions",
@@ -636,7 +632,7 @@ export enum TAG_ID {
     graphsForAi = "graphs_for_ai",
     neuralNetworks = "neural_networks",
     machineLearning = "machine_learning",
-    backpropagationAndRegression = "backpropogation_and_regression",
+    backpropagationAndRegression = "regression",
     // Programming fundamentals topics
     programmingConcepts = "programming_concepts",
     subroutines = "subroutines",

--- a/src/app/services/tagsCS.ts
+++ b/src/app/services/tagsCS.ts
@@ -7,68 +7,102 @@ export class CsTagService extends AbstractBaseTagService {
     private static readonly tagHierarchy = [TAG_LEVEL.category, TAG_LEVEL.subcategory, TAG_LEVEL.topic];
     private static readonly baseTags: BaseTag[] = [
         // Categories
-        {id: TAG_ID.theory, title: "Theory"},
-        {id: TAG_ID.programming, title: "Programming"},
+        {id: TAG_ID.computerScience, title: "Computer Science"},
 
-        // Theory sub-categories
-        {id: TAG_ID.gcseToALevel, title: "GCSE to A level transition", parent: TAG_ID.theory},
-        {id: TAG_ID.dataAndInformation, title: "Data and information", parent: TAG_ID.theory},
-        {id: TAG_ID.dataStructuresAndAlgorithms, title: "Data structures and algorithms", parent: TAG_ID.theory},
-        {id: TAG_ID.computerNetworks, title: "Computer networks", parent: TAG_ID.theory},
-        {id: TAG_ID.computerSystems, title: "Computer systems", parent: TAG_ID.theory},
-        // Programming sub-categories
-        {id: TAG_ID.programmingFundamentals, title: "Programming fundamentals", parent: TAG_ID.programming},
-        {id: TAG_ID.programmingParadigms, title: "Programming paradigms", parent: TAG_ID.programming},
-        {id: TAG_ID.computingPracticalProject, title: "Computing practical project", parent: TAG_ID.programming},
+        // Computer science strands
+        {id: TAG_ID.gcseToALevel, title: "GCSE to A level", parent: TAG_ID.computerScience},
+        {id: TAG_ID.dataAndInformation, title: "Data and information", parent: TAG_ID.computerScience},
+        {id: TAG_ID.dataStructuresAndAlgorithms, title: "Data structures and algorithms", parent: TAG_ID.computerScience},
+        {id: TAG_ID.computerNetworks, title: "Computer networks", parent: TAG_ID.computerScience},
+        {id: TAG_ID.computerSystems, title: "Computer systems", parent: TAG_ID.computerScience},
+        {id: TAG_ID.programmingFundamentals, title: "Programming fundamentals", parent: TAG_ID.computerScience},
+        {id: TAG_ID.programmingParadigms, title: "Programming paradigms", parent: TAG_ID.computerScience},
+        {id: TAG_ID.cyberSecurity, title: "Cyber security", parent: TAG_ID.computerScience},
+        {id: TAG_ID.impactsOfTechnology, title: "Impacts of technology", parent: TAG_ID.computerScience},
+        {id: TAG_ID.machineLearningAi, title: "Machine learning and AI", parent: TAG_ID.computerScience, hidden: true},
+        {id: TAG_ID.mathsForCs, title: "Maths for Computer Science", parent: TAG_ID.computerScience},
+        {id: TAG_ID.softwareEngineering, title: "Software Engineering", parent: TAG_ID.computerScience},
+        {id: TAG_ID.theoryOfComputation, title: "Theory of Computation", parent: TAG_ID.computerScience},
 
+        // Computer networks topics
+        {id: TAG_ID.networking, title: "Network fundamentals", parent: TAG_ID.computerNetworks},
+        {id: TAG_ID.theInternet, title: "The internet", parent: TAG_ID.computerNetworks},
+        {id: TAG_ID.networkHardware, title: "Network hardware", parent: TAG_ID.computerNetworks},
+        {id: TAG_ID.communication, title: "Communication", parent: TAG_ID.computerNetworks},
+        {id: TAG_ID.webTechnologies, title: "Web technologies", parent: TAG_ID.computerNetworks},
+        // Computer systems topics
+        {id: TAG_ID.booleanLogic, title: "Boolean logic", parent: TAG_ID.computerSystems},
+        {id: TAG_ID.architecture, title: "Systems architecture", parent: TAG_ID.computerSystems},
+        {id: TAG_ID.memoryAndStorage, title: "Memory and storage", parent: TAG_ID.computerSystems},
+        {id: TAG_ID.hardware, title: "Hardware", parent: TAG_ID.computerSystems},
+        {id: TAG_ID.software, title: "Software", parent: TAG_ID.computerSystems},
+        {id: TAG_ID.operatingSystems, title: "Operating systems", parent: TAG_ID.computerSystems},
+        {id: TAG_ID.programmingLanguages, title: "High and low level languages", parent: TAG_ID.computerSystems},
+        {id: TAG_ID.translators, title: "Translators", parent: TAG_ID.computerSystems},
+        // Cyber security topics
+        {id: TAG_ID.socialEngineering, title: "Social engineering", parent: TAG_ID.cyberSecurity},
+        {id: TAG_ID.maliciousCode, title: "Malicious code", parent: TAG_ID.cyberSecurity},
+        {id: TAG_ID.security, title: "Network security", parent: TAG_ID.cyberSecurity},
+        {id: TAG_ID.identificationPrevention, title: "Identification and prevention", parent: TAG_ID.cyberSecurity},
+        // Data and information topics
+        {id: TAG_ID.numberRepresentation, title: "Representation of numbers", parent: TAG_ID.dataAndInformation},
+        {id: TAG_ID.textRepresentation, title: "Representation of text", parent: TAG_ID.dataAndInformation},
+        {id: TAG_ID.imageRepresentation, title: "Representation of images", parent: TAG_ID.dataAndInformation},
+        {id: TAG_ID.soundRepresentation, title: "Representation of sound", parent: TAG_ID.dataAndInformation},
+        {id: TAG_ID.compression, title: "Compression", parent: TAG_ID.dataAndInformation},
+        {id: TAG_ID.encryption, title: "Encryption", parent: TAG_ID.dataAndInformation},
+        {id: TAG_ID.databases, title: "Database concepts", parent: TAG_ID.dataAndInformation},
+        {id: TAG_ID.sql, title: "SQL", parent: TAG_ID.dataAndInformation},
+        {id: TAG_ID.bigData, title: "Big Data", parent: TAG_ID.dataAndInformation},
+        // Data structures and algorithms topics
+        {id: TAG_ID.dataStructures, title: "Data structures", parent: TAG_ID.dataStructuresAndAlgorithms},
+        {id: TAG_ID.searching, title: "Searching algorithms", parent: TAG_ID.dataStructuresAndAlgorithms},
+        {id: TAG_ID.sorting, title: "Sorting algorithms", parent: TAG_ID.dataStructuresAndAlgorithms},
+        {id: TAG_ID.pathfinding, title: "Pathfinding algorithms", parent: TAG_ID.dataStructuresAndAlgorithms},
+        {id: TAG_ID.complexity, title: "Complexity", parent: TAG_ID.dataStructuresAndAlgorithms},
         // GCSE to A level transition topics
         {id: TAG_ID.gcseProgrammingConcepts, title: "GCSE Programming concepts", parent: TAG_ID.gcseToALevel},
         {id: TAG_ID.gcseDataRepresentation, title: "GCSE Data representation", parent: TAG_ID.gcseToALevel},
         {id: TAG_ID.gcseBooleanLogic, title: "GCSE Boolean logic", parent: TAG_ID.gcseToALevel},
         {id: TAG_ID.gcseSystems, title: "GCSE Systems", parent: TAG_ID.gcseToALevel},
         {id: TAG_ID.gcseNetworking, title: "GCSE Networking", parent: TAG_ID.gcseToALevel},
-        // Data structures and algorithms topics
-        {id: TAG_ID.dataStructures, title: "Data structures", parent: TAG_ID.dataStructuresAndAlgorithms},
-        {id: TAG_ID.searchingSortingPathfinding, title: "Searching, sorting & pathfinding", parent: TAG_ID.dataStructuresAndAlgorithms},
-        {id: TAG_ID.complexity, title: "Complexity", parent: TAG_ID.dataStructuresAndAlgorithms},
-        {id: TAG_ID.theoryOfComputation, title: "Theory of computation (AQA)", parent: TAG_ID.dataStructuresAndAlgorithms},
-        // Computer networks topics
-        {id: TAG_ID.networking, title: "Networking", parent: TAG_ID.computerNetworks},
-        {id: TAG_ID.networkHardware, title: "Network hardware", parent: TAG_ID.computerNetworks},
-        {id: TAG_ID.theInternet, title: "The internet", parent: TAG_ID.computerNetworks},
-        {id: TAG_ID.security, title: "Security", parent: TAG_ID.computerNetworks},
-        {id: TAG_ID.communication, title: "Communication (AQA)", parent: TAG_ID.computerNetworks},
-        // Computer systems topics
-        {id: TAG_ID.booleanLogic, title: "Boolean logic", parent: TAG_ID.computerSystems},
-        {id: TAG_ID.architecture, title: "Architecture", parent: TAG_ID.computerSystems},
-        {id: TAG_ID.hardware, title: "Hardware", parent: TAG_ID.computerSystems},
-        {id: TAG_ID.operatingSystemsAndSoftware, title: "Operating systems and software", parent: TAG_ID.computerSystems},
-        {id: TAG_ID.translators, title: "Translators", parent: TAG_ID.computerSystems},
-        {id: TAG_ID.programmingLanguages, title: "Types of programming languages", parent: TAG_ID.computerSystems},
-        // Data and information topics
-        {id: TAG_ID.numberSystems, title: "Number systems (AQA)", parent: TAG_ID.dataAndInformation},
-        {id: TAG_ID.numberBases, title: "Number bases", parent: TAG_ID.dataAndInformation},
-        {id: TAG_ID.representation, title: "Representation", parent: TAG_ID.dataAndInformation},
-        {id: TAG_ID.compression, title: "Compression", parent: TAG_ID.dataAndInformation},
-        {id: TAG_ID.encryption, title: "Encryption", parent: TAG_ID.dataAndInformation},
-        {id: TAG_ID.databases, title: "Databases", parent: TAG_ID.dataAndInformation},
-        {id: TAG_ID.bigData, title: "Big Data (AQA)", parent: TAG_ID.dataAndInformation},
-
-        // Procedural programming topics
+        // Impacts of technology topics
+        {id: TAG_ID.legal, title: "Legal", parent: TAG_ID.impactsOfTechnology},
+        {id: TAG_ID.moral, title: "Moral", parent: TAG_ID.impactsOfTechnology, hidden: true},
+        {id: TAG_ID.ethical, title: "Ethical", parent: TAG_ID.impactsOfTechnology},
+        {id: TAG_ID.cultural, title: "Cultural", parent: TAG_ID.impactsOfTechnology},
+        {id: TAG_ID.environmental, title: "Environmental", parent: TAG_ID.impactsOfTechnology},
+        {id: TAG_ID.trends, title: "Trends", parent: TAG_ID.impactsOfTechnology, hidden: true},
+        //Machine learning topics
+        {id: TAG_ID.graphsForAi, title: "Graphs to aid AI", parent: TAG_ID.machineLearningAi},
+        {id: TAG_ID.neuralNetworks, title: "Artificial neural networks", parent: TAG_ID.machineLearningAi},
+        {id: TAG_ID.machineLearning, title: "Types of machine learning", parent: TAG_ID.machineLearningAi},
+        {id: TAG_ID.backpropagationAndRegression, title: "Backpropagation and regression", parent: TAG_ID.machineLearningAi},
+        // Maths for cs topics
+        {id: TAG_ID.numberSystems, title: "Number systems and sets", parent: TAG_ID.mathsForCs},
+        {id: TAG_ID.mathsFunctions, title: "Functions", parent: TAG_ID.mathsForCs},
+        // Programming  fundamentals topics
         {id: TAG_ID.programmingConcepts, title: "Programming concepts", parent: TAG_ID.programmingFundamentals},
-        {id: TAG_ID.stringManipulation, title: "String manipulation", parent: TAG_ID.programmingFundamentals},
+        {id: TAG_ID.stringHandling, title: "String handling", parent: TAG_ID.programmingFundamentals},
         {id: TAG_ID.subroutines, title: "Subroutines", parent: TAG_ID.programmingFundamentals},
-        {id: TAG_ID.files, title: "Files", parent: TAG_ID.programmingFundamentals},
+        {id: TAG_ID.files, title: "File handling", parent: TAG_ID.programmingFundamentals},
         {id: TAG_ID.recursion, title: "Recursion", parent: TAG_ID.programmingFundamentals},
-        {id: TAG_ID.guis, title: "Web technologies and GUIs (OCR)", parent: TAG_ID.programmingFundamentals},
-        {id: TAG_ID.computationalThinking, title: "Computational thinking", parent: TAG_ID.dataStructuresAndAlgorithms},
-        {id: TAG_ID.softwareEngineeringPrinciples, title: "Software engineering principles", parent: TAG_ID.programmingFundamentals},
+        {id: TAG_ID.ide, title: "IDEs", parent: TAG_ID.programmingFundamentals},
         // Programming paradigms topics:
-        {id: TAG_ID.proceduralAndStructuredProgramming, title: "Procedural and structured programming", parent: TAG_ID.programmingParadigms},
+        {id: TAG_ID.proceduralProgramming, title: "Procedural programming", parent: TAG_ID.programmingParadigms},
         {id: TAG_ID.objectOrientedProgramming, title: "Object-oriented programming", parent: TAG_ID.programmingParadigms},
-        {id: TAG_ID.functionalProgramming, title: "Functional programming (AQA)", parent: TAG_ID.programmingParadigms},
-        // Software project topics
-        {id: TAG_ID.softwareProject, title: "Software project", parent: TAG_ID.computingPracticalProject},
+        {id: TAG_ID.functionalProgramming, title: "Functional programming", parent: TAG_ID.programmingParadigms},
+        {id: TAG_ID.eventDrivenProgramming, title: "Event-driven programming", parent: TAG_ID.programmingParadigms},
+        {id: TAG_ID.declarativeProgramming, title: "Declarative programming", parent: TAG_ID.programmingParadigms, hidden: true},
+        // Software engineering topics
+        {id: TAG_ID.programDesign, title: "Program design", parent: TAG_ID.softwareEngineering},
+        {id: TAG_ID.testing, title: "Testing", parent: TAG_ID.softwareEngineering},
+        {id: TAG_ID.softwareEngineeringPrinciples, title: "Software engineering principles", parent: TAG_ID.softwareEngineering},
+        {id: TAG_ID.softwareProject, title: "Programming project / NEA", parent: TAG_ID.softwareEngineering},
+        // Theory of computation topics
+        {id: TAG_ID.computationalThinking, title: "Computational thinking", parent: TAG_ID.theoryOfComputation},
+        {id: TAG_ID.modelsOfComputation, title: "Models of computation", parent: TAG_ID.theoryOfComputation}
+
     ];
     public getTagHierarchy() {return CsTagService.tagHierarchy;}
     public getBaseTags() {return CsTagService.baseTags;}

--- a/src/app/services/tagsCS.ts
+++ b/src/app/services/tagsCS.ts
@@ -10,18 +10,18 @@ export class CsTagService extends AbstractBaseTagService {
         {id: TAG_ID.computerScience, title: "Computer Science"},
 
         // Computer science strands
-        {id: TAG_ID.gcseToALevel, title: "GCSE to A level", parent: TAG_ID.computerScience},
-        {id: TAG_ID.dataAndInformation, title: "Data and information", parent: TAG_ID.computerScience},
-        {id: TAG_ID.dataStructuresAndAlgorithms, title: "Data structures and algorithms", parent: TAG_ID.computerScience},
         {id: TAG_ID.computerNetworks, title: "Computer networks", parent: TAG_ID.computerScience},
         {id: TAG_ID.computerSystems, title: "Computer systems", parent: TAG_ID.computerScience},
-        {id: TAG_ID.programmingFundamentals, title: "Programming fundamentals", parent: TAG_ID.computerScience},
-        {id: TAG_ID.programmingParadigms, title: "Programming paradigms", parent: TAG_ID.computerScience},
-        {id: TAG_ID.cyberSecurity, title: "Cyber security", parent: TAG_ID.computerScience},
+        {id: TAG_ID.cyberSecurity, title: "Cybersecurity", parent: TAG_ID.computerScience},
+        {id: TAG_ID.dataAndInformation, title: "Data and information", parent: TAG_ID.computerScience},
+        {id: TAG_ID.dataStructuresAndAlgorithms, title: "Data structures and algorithms", parent: TAG_ID.computerScience},
+        {id: TAG_ID.gcseToALevel, title: "GCSE to A level transition", parent: TAG_ID.computerScience},
         {id: TAG_ID.impactsOfTechnology, title: "Impacts of technology", parent: TAG_ID.computerScience},
         {id: TAG_ID.machineLearningAi, title: "Machine learning and AI", parent: TAG_ID.computerScience, hidden: true},
-        {id: TAG_ID.mathsForCs, title: "Maths for Computer Science", parent: TAG_ID.computerScience},
-        {id: TAG_ID.softwareEngineering, title: "Software Engineering", parent: TAG_ID.computerScience},
+        {id: TAG_ID.mathsForCs, title: "Maths for computer science", parent: TAG_ID.computerScience},
+        {id: TAG_ID.programmingFundamentals, title: "Programming fundamentals", parent: TAG_ID.computerScience},
+        {id: TAG_ID.programmingParadigms, title: "Programming paradigms", parent: TAG_ID.computerScience},
+        {id: TAG_ID.softwareEngineering, title: "Software engineering", parent: TAG_ID.computerScience},
         {id: TAG_ID.theoryOfComputation, title: "Theory of Computation", parent: TAG_ID.computerScience},
 
         // Computer networks topics
@@ -37,7 +37,7 @@ export class CsTagService extends AbstractBaseTagService {
         {id: TAG_ID.hardware, title: "Hardware", parent: TAG_ID.computerSystems},
         {id: TAG_ID.software, title: "Software", parent: TAG_ID.computerSystems},
         {id: TAG_ID.operatingSystems, title: "Operating systems", parent: TAG_ID.computerSystems},
-        {id: TAG_ID.programmingLanguages, title: "High and low level languages", parent: TAG_ID.computerSystems},
+        {id: TAG_ID.programmingLanguages, title: "High- and low-level languages", parent: TAG_ID.computerSystems},
         {id: TAG_ID.translators, title: "Translators", parent: TAG_ID.computerSystems},
         // Cyber security topics
         {id: TAG_ID.socialEngineering, title: "Social engineering", parent: TAG_ID.cyberSecurity},
@@ -80,7 +80,7 @@ export class CsTagService extends AbstractBaseTagService {
         {id: TAG_ID.backpropagationAndRegression, title: "Backpropagation and regression", parent: TAG_ID.machineLearningAi},
         // Maths for cs topics
         {id: TAG_ID.numberSystems, title: "Number systems and sets", parent: TAG_ID.mathsForCs},
-        {id: TAG_ID.mathsFunctions, title: "Functions", parent: TAG_ID.mathsForCs},
+        {id: TAG_ID.mathsFunctions, title: "Mathematical functions", parent: TAG_ID.mathsForCs},
         // Programming  fundamentals topics
         {id: TAG_ID.programmingConcepts, title: "Programming concepts", parent: TAG_ID.programmingFundamentals},
         {id: TAG_ID.stringHandling, title: "String handling", parent: TAG_ID.programmingFundamentals},
@@ -98,7 +98,7 @@ export class CsTagService extends AbstractBaseTagService {
         {id: TAG_ID.programDesign, title: "Program design", parent: TAG_ID.softwareEngineering},
         {id: TAG_ID.testing, title: "Testing", parent: TAG_ID.softwareEngineering},
         {id: TAG_ID.softwareEngineeringPrinciples, title: "Software engineering principles", parent: TAG_ID.softwareEngineering},
-        {id: TAG_ID.softwareProject, title: "Programming project / NEA", parent: TAG_ID.softwareEngineering},
+        {id: TAG_ID.softwareProject, title: "A level programming project / NEA", parent: TAG_ID.softwareEngineering},
         // Theory of computation topics
         {id: TAG_ID.computationalThinking, title: "Computational thinking", parent: TAG_ID.theoryOfComputation},
         {id: TAG_ID.modelsOfComputation, title: "Models of computation", parent: TAG_ID.theoryOfComputation}

--- a/src/app/services/tagsCS.ts
+++ b/src/app/services/tagsCS.ts
@@ -16,7 +16,7 @@ export class CsTagService extends AbstractBaseTagService {
         {id: TAG_ID.dataAndInformation, title: "Data and information", parent: TAG_ID.computerScience},
         {id: TAG_ID.dataStructuresAndAlgorithms, title: "Data structures and algorithms", parent: TAG_ID.computerScience},
         {id: TAG_ID.gcseToALevel, title: "GCSE to A level transition", parent: TAG_ID.computerScience},
-        {id: TAG_ID.impactsOfTechnology, title: "Impacts of technology", parent: TAG_ID.computerScience},
+        {id: TAG_ID.impactsOfDigitalTechnology, title: "Impacts of digital technology", parent: TAG_ID.computerScience},
         {id: TAG_ID.machineLearningAi, title: "Machine learning and AI", parent: TAG_ID.computerScience, hidden: true},
         {id: TAG_ID.mathsForCs, title: "Maths for computer science", parent: TAG_ID.computerScience},
         {id: TAG_ID.programmingFundamentals, title: "Programming fundamentals", parent: TAG_ID.computerScience},
@@ -67,12 +67,8 @@ export class CsTagService extends AbstractBaseTagService {
         {id: TAG_ID.gcseSystems, title: "GCSE Systems", parent: TAG_ID.gcseToALevel},
         {id: TAG_ID.gcseNetworking, title: "GCSE Networking", parent: TAG_ID.gcseToALevel},
         // Impacts of technology topics
-        {id: TAG_ID.legal, title: "Legal", parent: TAG_ID.impactsOfTechnology},
-        {id: TAG_ID.moral, title: "Moral", parent: TAG_ID.impactsOfTechnology, hidden: true},
-        {id: TAG_ID.ethical, title: "Ethical", parent: TAG_ID.impactsOfTechnology},
-        {id: TAG_ID.cultural, title: "Cultural", parent: TAG_ID.impactsOfTechnology},
-        {id: TAG_ID.environmental, title: "Environmental", parent: TAG_ID.impactsOfTechnology},
-        {id: TAG_ID.trends, title: "Trends", parent: TAG_ID.impactsOfTechnology, hidden: true},
+        {id: TAG_ID.legislation, title: "Legislation", parent: TAG_ID.impactsOfDigitalTechnology},
+        {id: TAG_ID.impactsOfTech, title: "Impacts of technology", parent: TAG_ID.impactsOfDigitalTechnology},
         //Machine learning topics
         {id: TAG_ID.graphsForAi, title: "Graphs to aid AI", parent: TAG_ID.machineLearningAi},
         {id: TAG_ID.neuralNetworks, title: "Artificial neural networks", parent: TAG_ID.machineLearningAi},


### PR DESCRIPTION
Requires the relevant 'isaac-content-2' branch, https://github.com/isaacphysics/isaac-content-2/pull/5.

- Adds new CS category/subcategory/topic (subject/strand/topic) tags and removes old ones.
- Adds 'hidden' property to tags to completely hide either the subcategory (strand) or topic at the request of the CS content team. Currently the only subcategory hidden is 'machine_learning_ai'
- Alters All topics page to match the requested new ordering and layout.
- comments out the progress by category (subject) graph on the 'My progress' page on CS.