### PR TITLE
Implement UI for additional managers to remove themselves from groups

### DIFF
--- a/src/app/components/elements/modals/GroupsModalCreators.tsx
+++ b/src/app/components/elements/modals/GroupsModalCreators.tsx
@@ -25,6 +25,48 @@ interface CurrentGroupInviteModalProps {
     firstTime: boolean;
 }
 
+interface AdditionalManagerRemovalModalProps {
+    groupToModify: AppGroup;
+    user: RegisteredUserDTO;
+    showArchived: boolean;
+}
+
+const AdditionalManagerRemovalModalBody = ({groupToModify}: AdditionalManagerRemovalModalProps) => {
+    return <React.Fragment>
+        <p>You are about to remove yourself as a manager from &apos;{groupToModify.groupName}&apos;.  The group will not appear any more on your
+            Assignment Progress page or on the Manage Groups page.  You will still have student connections with the
+            students who agreed to share data with you.  The group owner will <strong>not</strong> be notified.</p>
+    </React.Fragment>
+};
+
+export const additionalManagerRemovalModal = ({groupToModify, user, showArchived}: AdditionalManagerRemovalModalProps) => {
+    return {
+        closeAction: () => {store.dispatch(closeActiveModal())},
+        title: "Additional manager self removal",
+        body: <AdditionalManagerRemovalModalBody groupToModify={groupToModify} user={user} showArchived={showArchived}/>,
+        buttons: [
+            <RS.Row key={0}>
+                <RS.Col>
+                    <RS.Button block key={2} color="secondary" onClick={() => {
+                        store.dispatch(closeActiveModal());
+                    }}>
+                        Cancel
+                    </RS.Button>
+                </RS.Col>
+                <RS.Col>
+                    <RS.Button block key={1} color="secondary" onClick={() => {
+                        store.dispatch(deleteGroupManager(groupToModify, user, showArchived));
+                        store.dispatch(closeActiveModal());
+                        store.dispatch(selectGroup(null));
+                    }}>
+                        Confirm
+                    </RS.Button>
+                </RS.Col>
+            </RS.Row>
+        ]
+    }
+};
+
 const CurrentGroupInviteModal = ({firstTime}: CurrentGroupInviteModalProps) => {
     const group = useSelector(selectors.groups.current);
     return group && <React.Fragment>

--- a/src/app/components/pages/Groups.tsx
+++ b/src/app/components/pages/Groups.tsx
@@ -32,6 +32,7 @@ import {
     loadGroups,
     resetMemberPassword,
     selectGroup,
+    showAdditionalManagerSelfRemovalModal,
     showGroupEmailModal,
     showGroupInvitationModal,
     showGroupManagersModal,
@@ -42,7 +43,7 @@ import {AppState} from "../../state/reducers";
 import {sortBy} from "lodash";
 import {AppGroup, AppGroupMembership} from "../../../IsaacAppTypes";
 import {selectors} from "../../state/selectors";
-import {UserGroupDTO} from "../../../IsaacApiTypes";
+import {RegisteredUserDTO, UserGroupDTO} from "../../../IsaacApiTypes";
 import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
 import {ifKeyIsEnter} from "../../services/navigation";
 import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
@@ -51,13 +52,15 @@ import {isStaff} from "../../services/user";
 const stateFromProps = (state: AppState) => (state && {
     groups: selectors.groups.groups(state),
     group: selectors.groups.current(state),
+    user: state.user as RegisteredUserDTO
 });
 
-const dispatchFromProps = {loadGroups, selectGroup, createGroup, deleteGroup, updateGroup, getGroupInfo, resetMemberPassword, deleteMember, showGroupInvitationModal, showGroupManagersModal, showGroupEmailModal};
+const dispatchFromProps = {loadGroups, selectGroup, createGroup, deleteGroup, updateGroup, getGroupInfo, resetMemberPassword, deleteMember, showGroupInvitationModal, showGroupManagersModal, showGroupEmailModal, showAdditionalManagerSelfRemovalModal};
 
 interface GroupsPageProps {
     groups: {active: AppGroup[] | null; archived: AppGroup[] | null};
     group: AppGroup | null;
+    user: RegisteredUserDTO;
     loadGroups: (getArchived: boolean) => void;
     selectGroup: (group: UserGroupDTO | null) => void;
     createGroup: (groupName: string) => Promise<AppGroup>;
@@ -69,6 +72,7 @@ interface GroupsPageProps {
     showGroupInvitationModal: (firstTime: boolean) => void;
     showGroupManagersModal: () => void;
     showGroupEmailModal: (users?: number[]) => void;
+    showAdditionalManagerSelfRemovalModal: (groupToModify: AppGroup, user: RegisteredUserDTO, showArchived: boolean) => void;
 }
 
 enum SortOrder {
@@ -168,13 +172,14 @@ const MemberInfo = ({member, resetMemberPassword, deleteMember}: MemberInfoProps
     </div>;
 };
 
-const GroupEditor = ({group, selectGroup, updateGroup, createNewGroup, groupNameRef, resetMemberPassword, deleteMember, showGroupInvitationModal, showGroupManagersModal, showGroupEmailModal}: GroupEditorProps) => {
+const GroupEditor = ({group, selectGroup, updateGroup, createNewGroup, groupNameRef, resetMemberPassword, deleteMember, showGroupInvitationModal, showGroupManagersModal, showGroupEmailModal, showArchived, showAdditionalManagerSelfRemovalModal}: GroupEditorProps & {showArchived: boolean}) => {
     const [isExpanded, setExpanded] = useState(false);
 
     const initialGroupName = group ? group.groupName : "";
     const [newGroupName, setNewGroupName] = useState(initialGroupName);
 
     const user = useSelector((state: AppState) => state && state.user || null);
+    const isUserGroupOwner = user?.loggedIn && user.id === group?.ownerId;
 
     useEffect(() => {
         setExpanded(false);
@@ -220,10 +225,10 @@ const GroupEditor = ({group, selectGroup, updateGroup, createNewGroup, groupName
     return <Card>
         <CardBody>
             <Row className="mt-2">
-                <Col xs={5} sm={6} md={3} lg={3}><h4>{group ? "Edit group" : "Create group"}</h4></Col>
+                <Col xs={5} sm={6} md={group ? 3 : 12} lg={group ? 3 : 12}><h4>{group ? "Edit group" : "Create group"}</h4></Col>
                 {group && <Col xs={7} sm={6} md={9} lg={9} className="text-right">
                     <Button className="d-none d-sm-inline" size="sm" color="tertiary" onClick={() => showGroupManagersModal()}>
-                        Edit<span className="d-none d-xl-inline">{" "}group</span>{" "}managers
+                        {isUserGroupOwner ? "Edit" : "View"}<span className="d-none d-xl-inline">{" "}group</span>{" "}managers
                     </Button>
                     <span className="d-none d-lg-inline-block">&nbsp;or&nbsp;</span>
                     <span className="d-inline-block d-md-none">&nbsp;</span>
@@ -250,9 +255,9 @@ const GroupEditor = ({group, selectGroup, updateGroup, createNewGroup, groupName
                 <InputGroup className="w-100">
                     <Input
                         innerRef={groupNameRef} length={50} placeholder="Group name" value={newGroupName}
-                        onChange={e => setNewGroupName(e.target.value)} aria-label="Group Name"
+                        onChange={e => setNewGroupName(e.target.value)} aria-label="Group Name" disabled={!isUserGroupOwner && group !== null}
                     />
-                    <InputGroupAddon addonType="append">
+                    {(isUserGroupOwner || group === null) && <InputGroupAddon addonType="append">
                         <Button
                             color={{[SITE.PHY]: "secondary", [SITE.CS]: "primary"}[SITE_SUBJECT]}
                             className="p-0 border-dark" disabled={newGroupName == "" || initialGroupName == newGroupName}
@@ -260,7 +265,7 @@ const GroupEditor = ({group, selectGroup, updateGroup, createNewGroup, groupName
                         >
                             {group ? "Update" : "Create"}
                         </Button>
-                    </InputGroupAddon>
+                    </InputGroupAddon>}
                 </InputGroup>
             </Form>
             <Row className="pt-1 mb-3">
@@ -271,9 +276,12 @@ const GroupEditor = ({group, selectGroup, updateGroup, createNewGroup, groupName
             {group && <React.Fragment>
                 <Row>
                     <Col>
-                        <Button block color="tertiary" onClick={toggleArchived}>
+                        {isUserGroupOwner ? <Button block color="tertiary" onClick={toggleArchived}>
                             {group.archived ? "Unarchive this group" : "Archive this group"}
-                        </Button>
+                        </Button> :
+                        <Button block color="tertiary" onClick={() => user?.loggedIn && showAdditionalManagerSelfRemovalModal(group, user, showArchived)}>
+                            Remove self as additional manager
+                        </Button>}
                     </Col>
                 </Row>
                 <Row className="mt-4">
@@ -331,7 +339,7 @@ const MobileGroupCreatorComponent = ({createNewGroup, ...props}: GroupCreatorPro
 };
 
 const GroupsPageComponent = (props: GroupsPageProps) => {
-    const {group, groups, loadGroups, getGroupInfo, selectGroup, createGroup, deleteGroup, showGroupInvitationModal} = props;
+    const {group, groups, user, loadGroups, getGroupInfo, selectGroup, createGroup, deleteGroup, showGroupInvitationModal, showAdditionalManagerSelfRemovalModal} = props;
 
     const [showArchived, setShowArchived] = useState(false);
 
@@ -376,10 +384,16 @@ const GroupsPageComponent = (props: GroupsPageProps) => {
     };
 
     const confirmDeleteGroup = (groupToDelete: AppGroup) => {
-        if (confirm("Are you sure you want to permanently delete the group '" + groupToDelete.groupName + "' and remove all associated assignments?\n\nTHIS ACTION CANNOT BE UNDONE!")) {
-            deleteGroup(groupToDelete);
-            if (group && group.id == groupToDelete.id) {
-                selectGroup(null);
+        if (user.id === groupToDelete.ownerId) {
+            if (confirm("Are you sure you want to permanently delete the group '" + groupToDelete.groupName + "' and remove all associated assignments?\n\nTHIS ACTION CANNOT BE UNDONE!")) {
+                deleteGroup(groupToDelete);
+                if (group && group.id == groupToDelete.id) {
+                    selectGroup(null);
+                }
+            }
+        } else {
+            if (confirm("You cannot delete this group, because you are not the group owner.  Do you want to remove yourself as a manager of '" + groupToDelete.groupName + "'?")) {
+                showAdditionalManagerSelfRemovalModal(groupToDelete, user, showArchived);
             }
         }
     };
@@ -474,7 +488,7 @@ const GroupsPageComponent = (props: GroupsPageProps) => {
                                                             </button>
                                                         </div>
                                                         {group && group.id == g.id && <div className="d-md-none py-2">
-                                                            <GroupEditor {...props} createNewGroup={createNewGroup} />
+                                                            <GroupEditor {...props} createNewGroup={createNewGroup} showArchived={showArchived}/>
                                                         </div>}
                                                     </div>
                                                 )}
@@ -488,7 +502,7 @@ const GroupsPageComponent = (props: GroupsPageProps) => {
                 </ShowLoading>
             </Col>
             <Col md={8} className="d-none d-md-block">
-                <GroupEditor {...props} createNewGroup={createNewGroup} groupNameRef={groupNameRef} />
+                <GroupEditor {...props} createNewGroup={createNewGroup} groupNameRef={groupNameRef} showArchived={showArchived} />
             </Col>
         </Row>
     </Container>;

--- a/src/app/state/actions.tsx
+++ b/src/app/state/actions.tsx
@@ -62,7 +62,11 @@ import {
 } from "../components/elements/modals/TeacherConnectionModalCreators";
 import * as persistence from "../services/localStorage";
 import {KEY} from "../services/localStorage";
-import {groupInvitationModal, groupManagersModal} from "../components/elements/modals/GroupsModalCreators";
+import {
+    additionalManagerRemovalModal,
+    groupInvitationModal,
+    groupManagersModal
+} from "../components/elements/modals/GroupsModalCreators";
 import {ThunkDispatch} from "redux-thunk";
 import {selectors} from "./selectors";
 import {isFirstLoginInPersistence} from "../services/firstLogin";
@@ -1424,11 +1428,14 @@ export const addGroupManager = (group: AppGroup, managerEmail: string) => async 
     }
 };
 
-export const deleteGroupManager = (group: AppGroup, manager: UserSummaryWithEmailAddressDTO) => async (dispatch: Dispatch<Action>) => {
+export const deleteGroupManager = (group: AppGroup, manager: UserSummaryWithEmailAddressDTO, showArchived?: boolean) => async (dispatch: Dispatch<Action>) => {
     dispatch({type: ACTION_TYPE.GROUPS_MANAGER_DELETE_REQUEST, group, manager});
     try {
         await api.groups.deleteManager(group, manager);
         dispatch({type: ACTION_TYPE.GROUPS_MANAGER_DELETE_RESPONSE_SUCCESS, group, manager});
+        if (typeof showArchived === "boolean") {
+            dispatch(loadGroups(showArchived) as any);
+        }
     } catch (e) {
         dispatch({type: ACTION_TYPE.GROUPS_MANAGER_DELETE_RESPONSE_FAILURE, group, manager});
         dispatch(showErrorToastIfNeeded("Group manager removal failed", e));
@@ -1441,6 +1448,10 @@ export const showGroupEmailModal = (users?: number[]) => async (dispatch: Dispat
 
 export const showGroupInvitationModal = (firstTime: boolean) => async (dispatch: Dispatch<Action>) => {
     dispatch(openActiveModal(groupInvitationModal(firstTime)) as any);
+};
+
+export const showAdditionalManagerSelfRemovalModal = (groupToModify: AppGroup, user: RegisteredUserDTO, showArchived: boolean) => async (dispatch: Dispatch<Action>) => {
+    dispatch(openActiveModal(additionalManagerRemovalModal({groupToModify, user, showArchived})) as any);
 };
 
 export const showGroupManagersModal = () => async (dispatch: Dispatch<Action>, getState: () => AppState) => {


### PR DESCRIPTION
- When trying to delete a group as one of it's additional managers, instead opens the 'additional manager self removal options'.
- When a group you are an additional manager of is selected, a 'remove self as additional manager' button is shown instead of the 'archive group'.
- When a group you are an additional manager of is selected, instead of showing the 'edit additional managers' button, it is altered to 'view additional managers'.
- When a group you are an additional manager of is selected, the group name is shown in a disabled input box, without the update button, to make it more obvious you can't edit the name of a group you don't own.