### PR TITLE
Upgrade highlightjs to 11.0.0 and reduce bundle size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11820,9 +11820,9 @@
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
     },
     "highlight.js": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.6.0.tgz",
-      "integrity": "sha512-8mlRcn5vk/r4+QcqerapwBYTe+iPL5ih6xrNylxrnBdHQiijDETfXX7VIxC3UiCRiINBJfANBAsPzAvRQj8RpQ=="
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.0.0.tgz",
+      "integrity": "sha512-ByaTMfsSuoqerTwemOgpIhfULEIaK52JJYhky/sK7/Yqc0+t7Uh5DHay9vIC94YXSupnQ1Vqfc9VXrYP4eXW3Q=="
     },
     "history": {
       "version": "4.10.1",
@@ -27284,8 +27284,7 @@
         "normalize-path": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-          "optional": true
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
         },
         "readdirp": {
           "version": "3.4.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "file-loader": "2.0.0",
     "fs-extra": "7.0.1",
     "he": "^1.2.0",
-    "highlight.js": "^10.6.0",
+    "highlight.js": "^11.0.0",
     "history": "^4.9.0",
     "html-webpack-plugin": "4.0.0-alpha.2",
     "identity-obj-proxy": "3.0.0",

--- a/src/app/components/content/IsaacCodeSnippet.tsx
+++ b/src/app/components/content/IsaacCodeSnippet.tsx
@@ -2,7 +2,7 @@ import {CodeSnippetDTO} from "../../../IsaacApiTypes";
 import React, {useEffect, useRef} from "react";
 import {Col, Row} from "reactstrap";
 
-import hljs from 'highlight.js';
+import hljs from 'highlight.js/lib/core';
 
 interface IsaacCodeProps {
     doc: CodeSnippetDTO;
@@ -13,7 +13,7 @@ export const IsaacCodeSnippet = ({doc}: IsaacCodeProps) => {
 
     useEffect(() => {
         if (codeSnippetRef.current) {
-            hljs.highlightBlock(codeSnippetRef.current);
+            hljs.highlightElement(codeSnippetRef.current);
         }
     }, [doc]);
 

--- a/src/app/services/highlightJsConfig.ts
+++ b/src/app/services/highlightJsConfig.ts
@@ -1,12 +1,14 @@
-import hljs from "highlight.js";
+import hljs from "highlight.js/lib/core";
 import javascript from 'highlight.js/lib/languages/javascript';
 import python from 'highlight.js/lib/languages/python'
 import php from 'highlight.js/lib/languages/php'
 import csharp from 'highlight.js/lib/languages/csharp'
+import plaintext from 'highlight.js/lib/languages/plaintext'
 
 export function registerLanguages() {
     hljs.registerLanguage('javascript', javascript);
     hljs.registerLanguage('python', python);
     hljs.registerLanguage('php', php);
     hljs.registerLanguage('csharp', csharp);
+    hljs.registerLanguage('plaintext', plaintext);
 }


### PR DESCRIPTION
highlightBlock has been deprecated and replaced with highlightElement
