### PR TITLE
Render 5 most recent and oldest question attempts on the progress page

### DIFF
--- a/src/IsaacAppTypes.tsx
+++ b/src/IsaacAppTypes.tsx
@@ -7,11 +7,13 @@ import {
     ContentBase,
     ContentSummaryDTO,
     GameboardDTO,
-    GameboardItem, QuizFeedbackMode,
+    GameboardItem,
+    QuizFeedbackMode,
     RegisteredUserDTO,
     ResultsWrapper,
     TestCaseDTO,
-    TOTPSharedSecretDTO, UserSummaryForAdminUsersDTO
+    TOTPSharedSecretDTO,
+    UserSummaryForAdminUsersDTO
 } from "./IsaacApiTypes";
 import {ACTION_TYPE, DOCUMENT_TYPE, EXAM_BOARD, MEMBERSHIP_STATUS, TAG_ID, TAG_LEVEL} from "./app/services/constants";
 
@@ -827,6 +829,8 @@ export interface UserProgress {
     totalQuestionsAttemptedThisAcademicYear?: number;
     totalQuestionPartsCorrectThisAcademicYear?: number;
     totalQuestionPartsAttemptedThisAcademicYear?: number;
+    mostRecentQuestions?: ContentSummaryDTO[];
+    oldestIncompleteQuestions?: ContentSummaryDTO[];
     attemptsByType?: { [type: string]: number };
     correctByType?: { [type: string]: number };
     attemptsByTag?: { [tag: string]: number };

--- a/src/app/components/pages/MyProgress.tsx
+++ b/src/app/components/pages/MyProgress.tsx
@@ -180,7 +180,7 @@ export const MyProgress = withRouter(({user, match: {params: {userIdOfInterest}}
                         </div>}
                         <RS.Row id="progress-questions">
                             {progress?.mostRecentQuestions && progress?.mostRecentQuestions.length > 0 && <RS.Col md={12} lg={6} className="mt-4">
-                                <h4>Most recently attempted questions</h4>
+                                <h4>Most recently answered questions</h4>
                                 <LinkToContentSummaryList items={progress.mostRecentQuestions}/>
                             </RS.Col>}
                             {progress?.oldestIncompleteQuestions && progress?.oldestIncompleteQuestions.length > 0 && <RS.Col md={12} lg={6} className="mt-4">

--- a/src/app/components/pages/MyProgress.tsx
+++ b/src/app/components/pages/MyProgress.tsx
@@ -23,6 +23,7 @@ import {ProgressBar} from "../elements/views/ProgressBar";
 import {safePercentage} from "../../services/validation";
 import {TeacherAchievement} from "../elements/TeacherAchievement";
 import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
+import {LinkToContentSummaryList} from "../elements/list-groups/ContentSummaryListGroupItem";
 
 export const siteSpecific = {
     [SITE.PHY]: {
@@ -177,6 +178,16 @@ export const MyProgress = withRouter(({user, match: {params: {userIdOfInterest}}
                                 <ActivityGraph answeredQuestionsByDate={answeredQuestionsByDate} />
                             </div>
                         </div>}
+                        <RS.Row id="progress-questions">
+                            {progress?.mostRecentQuestions && <RS.Col md={12} lg={6} className="mt-4">
+                                <h4>Most recently attempted questions</h4>
+                                <LinkToContentSummaryList items={progress.mostRecentQuestions}/>
+                            </RS.Col>}
+                            {progress?.oldestIncompleteQuestions && <RS.Col md={12} lg={6} className="mt-4">
+                                <h4>Oldest unsolved questions</h4>
+                                <LinkToContentSummaryList items={progress.oldestIncompleteQuestions}/>
+                            </RS.Col>}
+                        </RS.Row>
                     </div>,
                     ...(viewingOwnData && isTeacher(user) && SITE_SUBJECT == SITE.PHY && {"Teacher Activity": <div>
                         <TeacherAchievement

--- a/src/app/components/pages/MyProgress.tsx
+++ b/src/app/components/pages/MyProgress.tsx
@@ -179,11 +179,11 @@ export const MyProgress = withRouter(({user, match: {params: {userIdOfInterest}}
                             </div>
                         </div>}
                         <RS.Row id="progress-questions">
-                            {progress?.mostRecentQuestions && <RS.Col md={12} lg={6} className="mt-4">
+                            {progress?.mostRecentQuestions && progress?.mostRecentQuestions.length > 0 && <RS.Col md={12} lg={6} className="mt-4">
                                 <h4>Most recently attempted questions</h4>
                                 <LinkToContentSummaryList items={progress.mostRecentQuestions}/>
                             </RS.Col>}
-                            {progress?.oldestIncompleteQuestions && <RS.Col md={12} lg={6} className="mt-4">
+                            {progress?.oldestIncompleteQuestions && progress?.oldestIncompleteQuestions.length > 0 && <RS.Col md={12} lg={6} className="mt-4">
                                 <h4>Oldest unsolved questions</h4>
                                 <LinkToContentSummaryList items={progress.oldestIncompleteQuestions}/>
                             </RS.Col>}

--- a/src/scss/common/search.scss
+++ b/src/scss/common/search.scss
@@ -1,7 +1,7 @@
 // ISAAC
 // Search page
 
-#search-page {
+#search-page, #progress-questions {
   .search-header {
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
- Data comes as a ContentSummaryDTO so can't simply show whether it's correct or not, just a list of the 5 most recently attempted questions and the 5 oldest incomplete/incorrect.