### PR TITLE
Add link to events safeguarding page in navbar

### DIFF
--- a/src/app/components/site/cs/NavigationBarCS.tsx
+++ b/src/app/components/site/cs/NavigationBarCS.tsx
@@ -41,6 +41,7 @@ export const NavigationBarCS = () => {
             <LinkItem to="/events?types=student">Student events</LinkItem>
             <LinkItem to="/events?types=teacher">Teacher events</LinkItem>
             <LinkItem to="/pages/2020_teacher_mentoring_cohort2">Teacher mentoring</LinkItem>
+            <LinkItem to="/safeguarding">Safeguarding</LinkItem>
         </NavigationSection>
 
         <NavigationSection title={<React.Fragment>

--- a/src/app/components/site/cs/RoutesCS.tsx
+++ b/src/app/components/site/cs/RoutesCS.tsx
@@ -51,6 +51,7 @@ export const RoutesCS = [
 
     // Static pages:
     <StaticPageRoute key={key++} exact path="/about" pageId="about_us" />,
+    <StaticPageRoute key={key++} exact path="/safeguarding" pageId="events_safeguarding" />,
     <StaticPageRoute key={key++} exact path="/teaching_order" pageId="teaching_order" />,
     <StaticPageRoute key={key++} exact path="/student_rewards" pageId="student_rewards_programme" />,
 


### PR DESCRIPTION
I don't think anything else needs changing here, and it works seemingly as intended locally