### PR TITLE
Add displayUnit support for numeric questions

### DIFF
--- a/src/IsaacApiTypes.tsx
+++ b/src/IsaacApiTypes.tsx
@@ -127,6 +127,7 @@ export interface IsaacNumericQuestionDTO extends IsaacQuestionBaseDTO {
     requireUnits?: boolean;
     availableUnits?: string[];
     knownUnits?: string[];
+    displayUnit?: string;
 }
 
 export interface IsaacParsonsQuestionDTO extends IsaacItemQuestionDTO {

--- a/src/app/components/content/IsaacNumericQuestion.tsx
+++ b/src/app/components/content/IsaacNumericQuestion.tsx
@@ -137,6 +137,8 @@ export const IsaacNumericQuestion = ({doc, questionId, validationResponse, reado
 
     const helpTooltipId = useMemo(() => `numeric-input-help-${uuid.v4()}`, []);
 
+    const noDisplayUnit = doc.displayUnit == null || doc.displayUnit === ""
+
     return (
         <div className="numeric-question">
             <div className="question-content">
@@ -166,14 +168,14 @@ export const IsaacNumericQuestion = ({doc, questionId, validationResponse, reado
                             </InputGroup>
                         </Label>
                     </div>
-                    {doc.requireUnits && <div className="unit-selection w-100 w-sm-50 w-md-100 w-lg-25">
+                    {(doc.requireUnits || doc.displayUnit) && <div className="unit-selection w-100 w-sm-50 w-md-100 w-lg-25">
                         <Label className="w-100 ml-sm-2 ml-md-0 ml-lg-5">
                             Units <br/>
-                            <Dropdown disabled={readonly} isOpen={isOpen} toggle={() => {setIsOpen(!isOpen);}}>
-                                <DropdownToggle caret disabled={readonly} className="px-2 py-1" color={currentAttemptUnitsWrong ? "danger" : undefined}>
-                                    <LaTeX markup={wrapUnitForSelect(currentAttemptUnits)}/>
+                            <Dropdown disabled={readonly} isOpen={isOpen && noDisplayUnit} toggle={() => {setIsOpen(!isOpen);}}>
+                                <DropdownToggle caret={noDisplayUnit} disabled={readonly} className={`${noDisplayUnit ? "" : "border-dark"} px-2 py-1`} color={noDisplayUnit ? (currentAttemptUnitsWrong ? "danger" : undefined) : "white"}>
+                                    <LaTeX markup={wrapUnitForSelect(noDisplayUnit ? currentAttemptUnits : doc.displayUnit)}/>
                                 </DropdownToggle>
-                                <DropdownMenu right>
+                                {noDisplayUnit && <DropdownMenu right>
                                     {selectedUnits.map((unit) =>
                                         <DropdownItem key={wrapUnitForSelect(unit)}
                                             data-unit={unit || 'None'}
@@ -182,7 +184,7 @@ export const IsaacNumericQuestion = ({doc, questionId, validationResponse, reado
                                             <LaTeX markup={wrapUnitForSelect(unit)}/>
                                         </DropdownItem>
                                     )}
-                                </DropdownMenu>
+                                </DropdownMenu>}
                             </Dropdown>
                         </Label>
                     </div>}

--- a/src/app/components/content/IsaacNumericQuestion.tsx
+++ b/src/app/components/content/IsaacNumericQuestion.tsx
@@ -137,7 +137,7 @@ export const IsaacNumericQuestion = ({doc, questionId, validationResponse, reado
 
     const helpTooltipId = useMemo(() => `numeric-input-help-${uuid.v4()}`, []);
 
-    const noDisplayUnit = doc.displayUnit == null || doc.displayUnit === ""
+    const noDisplayUnit = doc.displayUnit == null || doc.displayUnit === "";
 
     return (
         <div className="numeric-question">
@@ -170,7 +170,7 @@ export const IsaacNumericQuestion = ({doc, questionId, validationResponse, reado
                     </div>
                     {(doc.requireUnits || doc.displayUnit) && <div className="unit-selection w-100 w-sm-50 w-md-100 w-lg-25">
                         <Label className="w-100 ml-sm-2 ml-md-0 ml-lg-5">
-                            Units <br/>
+                            Unit{noDisplayUnit && "s"} <br/>
                             <Dropdown disabled={readonly} isOpen={isOpen && noDisplayUnit} toggle={() => {setIsOpen(!isOpen);}}>
                                 <DropdownToggle disabled={readonly || !noDisplayUnit} className={`${noDisplayUnit ? "" : "border-dark display-unit"} px-2 py-1`} color={noDisplayUnit ? (currentAttemptUnitsWrong ? "danger" : undefined) : "white"}>
                                     <LaTeX markup={wrapUnitForSelect(noDisplayUnit ? currentAttemptUnits : doc.displayUnit)}/>

--- a/src/app/components/content/IsaacNumericQuestion.tsx
+++ b/src/app/components/content/IsaacNumericQuestion.tsx
@@ -172,10 +172,10 @@ export const IsaacNumericQuestion = ({doc, questionId, validationResponse, reado
                         <Label className="w-100 ml-sm-2 ml-md-0 ml-lg-5">
                             Units <br/>
                             <Dropdown disabled={readonly} isOpen={isOpen && noDisplayUnit} toggle={() => {setIsOpen(!isOpen);}}>
-                                <DropdownToggle caret={noDisplayUnit} disabled={readonly} className={`${noDisplayUnit ? "" : "border-dark"} px-2 py-1`} color={noDisplayUnit ? (currentAttemptUnitsWrong ? "danger" : undefined) : "white"}>
+                                <DropdownToggle disabled={readonly || !noDisplayUnit} className={`${noDisplayUnit ? "" : "border-dark display-unit"} px-2 py-1`} color={noDisplayUnit ? (currentAttemptUnitsWrong ? "danger" : undefined) : "white"}>
                                     <LaTeX markup={wrapUnitForSelect(noDisplayUnit ? currentAttemptUnits : doc.displayUnit)}/>
                                 </DropdownToggle>
-                                {noDisplayUnit && <DropdownMenu right>
+                                <DropdownMenu right>
                                     {selectedUnits.map((unit) =>
                                         <DropdownItem key={wrapUnitForSelect(unit)}
                                             data-unit={unit || 'None'}
@@ -184,7 +184,7 @@ export const IsaacNumericQuestion = ({doc, questionId, validationResponse, reado
                                             <LaTeX markup={wrapUnitForSelect(unit)}/>
                                         </DropdownItem>
                                     )}
-                                </DropdownMenu>}
+                                </DropdownMenu>
                             </Dropdown>
                         </Label>
                     </div>}

--- a/src/scss/phy/subjects.scss
+++ b/src/scss/phy/subjects.scss
@@ -69,6 +69,9 @@
 
   /* unit dropdown */
   .numeric-question .unit-selection {
+    .display-unit {
+      opacity: 1 !important;
+    }
     .dropdown-item {
       &:active {
         @include button-variant($color, $color);


### PR DESCRIPTION
In line with James' API pull request, the existence of a non-null/non-empty `displayUnit` overrides `requireUnits`

If the question has a `displayUnit`, the unit dropdown is *essentially* disabled - it's default value is set to the `displayUnit`,
the colour is changed so the dropdown doesn't stand out as much, the caret is removed, it is permanently closed etc.

When there is a `displayUnit` the dropdown is still registered as clickable. This isn't ideal but the same can be said for the
numeric modal help button thingy (nothing happens when it gets clicked, but changes the mouse pointer etc.), so unless 
there's an easy fix I don't think it matters that much. 