### PR TITLE
Add simple filter to content errors

### DIFF
--- a/src/app/components/pages/AdminContentErrors.tsx
+++ b/src/app/components/pages/AdminContentErrors.tsx
@@ -1,11 +1,11 @@
-import React, {useEffect} from "react";
+import React, {useEffect, useState} from "react";
 import {AppState} from "../../state/reducers";
 import {getAdminContentErrors} from "../../state/actions";
 import {ShowLoading} from "../handlers/ShowLoading";
 import {useDispatch, useSelector} from "react-redux";
-import {Col, Container, Row, Table} from "reactstrap";
-import {EDITOR_URL} from "../../services/constants";
-import {ContentErrorItem} from "../../../IsaacAppTypes";
+import {Col, Container, Input, Label, Row, Table} from "reactstrap";
+import {EDITOR_URL, sortIcon} from "../../services/constants";
+import {BoardOrder, ContentErrorItem} from "../../../IsaacAppTypes";
 import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
 
 const contentErrorDetailsListItem = (errorDetailsListItem: string, index: number) => {
@@ -35,6 +35,9 @@ export const AdminContentErrors = () => {
     useEffect(() => {dispatch(getAdminContentErrors());}, [dispatch]);
     const errors = useSelector((state: AppState) => state?.adminContentErrors || null);
 
+    const [errorFilter, setErrorFilter] = useState<string>("");
+    const errorReducer = (show: boolean, errorStr: string) => show || errorStr.toLowerCase().includes(errorFilter.toLowerCase())
+
     return <Container>
         <Row>
             <Col>
@@ -56,6 +59,13 @@ export const AdminContentErrors = () => {
                     </Col>
                 </Row>
                 <Row>
+                    <Col lg={4} className="mb-2">
+                        <Label className="w-100">
+                            Filter error messages <Input type="text" onChange={(e) => setErrorFilter(e.target.value)} placeholder="Filter errors by error type"/>
+                        </Label>
+                    </Col>
+                </Row>
+                <Row>
                     <Col>
                         <Table responsive bordered>
                             <tbody>
@@ -65,7 +75,8 @@ export const AdminContentErrors = () => {
                                     <th title="Files with critical errors will not be available on Isaac!">Critical Error</th>
                                     <th>List of Error Messages</th>
                                 </tr>
-                                {errors.errorsList.map(ContentErrorRow)}
+                                {errors.errorsList.filter((error) => error.listOfErrors.reduce(errorReducer, false))
+                                    .map(ContentErrorRow)}
                             </tbody>
                         </Table>
                     </Col>

--- a/src/app/components/pages/AdminContentErrors.tsx
+++ b/src/app/components/pages/AdminContentErrors.tsx
@@ -4,8 +4,8 @@ import {getAdminContentErrors} from "../../state/actions";
 import {ShowLoading} from "../handlers/ShowLoading";
 import {useDispatch, useSelector} from "react-redux";
 import {Col, Container, Input, Label, Row, Table} from "reactstrap";
-import {EDITOR_URL, sortIcon} from "../../services/constants";
-import {BoardOrder, ContentErrorItem} from "../../../IsaacAppTypes";
+import {EDITOR_URL} from "../../services/constants";
+import {ContentErrorItem} from "../../../IsaacAppTypes";
 import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
 
 const contentErrorDetailsListItem = (errorDetailsListItem: string, index: number) => {

--- a/src/app/components/pages/AdminContentErrors.tsx
+++ b/src/app/components/pages/AdminContentErrors.tsx
@@ -61,7 +61,7 @@ export const AdminContentErrors = () => {
                 <Row>
                     <Col lg={4} className="mb-2">
                         <Label className="w-100">
-                            Filter error messages <Input type="text" onChange={(e) => setErrorFilter(e.target.value)} placeholder="Filter errors by error type"/>
+                            Filter errors <Input type="text" onChange={(e) => setErrorFilter(e.target.value)} placeholder="Filter errors by error message"/>
                         </Label>
                     </Col>
                 </Row>


### PR DESCRIPTION
A really small change to add a filter to the admin content errors page. The filter checks whether the search string is included in any of the error messages in the list inside each `ContentErrorItem`