### PR TITLE
Add Boolean logic notation preference to My account page 

### DIFF
--- a/src/IsaacAppTypes.tsx
+++ b/src/IsaacAppTypes.tsx
@@ -533,6 +533,7 @@ export interface ShortcutResponse {
 export interface UserBetaFeaturePreferences {
     SCREENREADER_HOVERTEXT?: boolean;
     AUDIENCE_CONTEXT?: boolean;
+    BOOLEAN_NOTATION?: boolean;
 }
 
 export interface UserEmailPreferences {

--- a/src/IsaacAppTypes.tsx
+++ b/src/IsaacAppTypes.tsx
@@ -533,7 +533,6 @@ export interface ShortcutResponse {
 export interface UserBetaFeaturePreferences {
     SCREENREADER_HOVERTEXT?: boolean;
     AUDIENCE_CONTEXT?: boolean;
-    BOOLEAN_NOTATION?: boolean;
 }
 
 export interface UserEmailPreferences {
@@ -563,8 +562,7 @@ export interface SubjectInterests {
 
 export interface BooleanNotation {
     ENG?: boolean,
-    MATH?: boolean,
-    BOARD_SPECIFIC?: boolean
+    MATH?: boolean
 }
 
 export interface UserPreferencesDTO {

--- a/src/IsaacAppTypes.tsx
+++ b/src/IsaacAppTypes.tsx
@@ -560,10 +560,17 @@ export interface SubjectInterests {
     ENGINEERING_UNI?: boolean;
 }
 
+export interface BooleanNotation {
+    ENG?: boolean,
+    MATH?: boolean,
+    BOARD_SPECIFIC?: boolean
+}
+
 export interface UserPreferencesDTO {
     BETA_FEATURE?: UserBetaFeaturePreferences;
     EMAIL_PREFERENCE?: UserEmailPreferences | null;
     SUBJECT_INTEREST?: SubjectInterests;
+    BOOLEAN_NOTATION?: BooleanNotation;
 }
 
 export interface ValidatedChoice<C extends ApiTypes.ChoiceDTO> {

--- a/src/app/components/elements/LaTeX.tsx
+++ b/src/app/components/elements/LaTeX.tsx
@@ -267,7 +267,7 @@ export function katexify(html: string, user: PotentialUser | null, examBoard: EX
                 const latexMunged = munge(latexUnEntitied);
                 let macrosToUse;
                 if (SITE_SUBJECT == SITE.CS) {
-                    if (user?.loggedIn && booleanNotation && !booleanNotation.BOARD_SPECIFIC) {
+                    if (user?.loggedIn && booleanNotation) {
                         macrosToUse = booleanNotation?.ENG ? KatexMacrosWithEngineeringBool : KatexMacrosWithMathsBool;
                     } else {
                         macrosToUse = examBoard == EXAM_BOARD.AQA ? KatexMacrosWithEngineeringBool : KatexMacrosWithMathsBool;
@@ -330,7 +330,7 @@ export function katexify(html: string, user: PotentialUser | null, examBoard: EX
 
 export function LaTeX({markup}: {markup: string}) {
     const user = useSelector(selectors.user.orNull);
-    const booleanNotation = useSelector((state: AppState) => (state?.userPreferences?.BETA_FEATURE?.BOOLEAN_NOTATION &&
+    const booleanNotation = useSelector((state: AppState) => (state?.userPreferences?.BETA_FEATURE?.AUDIENCE_CONTEXT &&
         state?.userPreferences?.BOOLEAN_NOTATION) || null);
     const screenReaderHoverText = useSelector((state: AppState) => state && state.userPreferences &&
         state.userPreferences.BETA_FEATURE && state.userPreferences.BETA_FEATURE.SCREENREADER_HOVERTEXT || false);

--- a/src/app/components/elements/LaTeX.tsx
+++ b/src/app/components/elements/LaTeX.tsx
@@ -3,7 +3,7 @@ import {useSelector} from "react-redux";
 import {selectors} from "../../state/selectors";
 import {AppState} from "../../state/reducers";
 import {useUserContext} from "../../services/userContext";
-import {FigureNumberingContext, FigureNumbersById, PotentialUser} from "../../../IsaacAppTypes";
+import {FigureNumberingContext, FigureNumbersById, PotentialUser, UserPreferencesDTO} from "../../../IsaacAppTypes";
 import {EXAM_BOARD} from "../../services/constants";
 import he from "he";
 import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
@@ -225,7 +225,7 @@ const ENDREF = "==ENDREF==";
 const REF_REGEXP = new RegExp(REF + "(.*?)" + ENDREF, "g");
 const SR_REF_REGEXP = new RegExp("start text, " + REF_REGEXP.source + ", end text,", "g");
 
-export function katexify(html: string, user: PotentialUser | null, examBoard: EXAM_BOARD | null, screenReaderHoverText: boolean, figureNumbers: FigureNumbersById) {
+export function katexify(html: string, user: PotentialUser | null, userPreferences : UserPreferencesDTO | null, examBoard: EXAM_BOARD | null, screenReaderHoverText: boolean, figureNumbers: FigureNumbersById) {
     start.lastIndex = 0;
     let match: RegExpExecArray | null;
     let output = "";
@@ -262,7 +262,11 @@ export function katexify(html: string, user: PotentialUser | null, examBoard: EX
                 const latexMunged = munge(latexUnEntitied);
                 let macrosToUse;
                 if (SITE_SUBJECT == SITE.CS) {
-                    macrosToUse = examBoard == EXAM_BOARD.AQA ? KatexMacrosWithEngineeringBool : KatexMacrosWithMathsBool;
+                    if (user?.loggedIn && !userPreferences?.BOOLEAN_NOTATION?.BOARD_SPECIFIC) {
+                        macrosToUse = userPreferences?.BOOLEAN_NOTATION?.ENG ? KatexMacrosWithEngineeringBool : KatexMacrosWithMathsBool;
+                    } else {
+                        macrosToUse = examBoard == EXAM_BOARD.AQA ? KatexMacrosWithEngineeringBool : KatexMacrosWithMathsBool;
+                    }
                 } else {
                     macrosToUse = KatexBaseMacros;
                 }
@@ -321,13 +325,14 @@ export function katexify(html: string, user: PotentialUser | null, examBoard: EX
 
 export function LaTeX({markup}: {markup: string}) {
     const user = useSelector(selectors.user.orNull);
+    const userPreferences = useSelector(selectors.userPreferences.orNull);
     const screenReaderHoverText = useSelector((state: AppState) => state && state.userPreferences &&
         state.userPreferences.BETA_FEATURE && state.userPreferences.BETA_FEATURE.SCREENREADER_HOVERTEXT || false);
     const {examBoard} = useUserContext();
     const figureNumbers = useContext(FigureNumberingContext);
 
     const escapedMarkup = escapeHtml(markup);
-    const katexHtml = katexify(escapedMarkup, user, examBoard, screenReaderHoverText, figureNumbers);
+    const katexHtml = katexify(escapedMarkup, user, userPreferences, examBoard, screenReaderHoverText, figureNumbers);
 
     return <span dangerouslySetInnerHTML={{__html: katexHtml}} />
 }

--- a/src/app/components/elements/LaTeX.tsx
+++ b/src/app/components/elements/LaTeX.tsx
@@ -7,8 +7,7 @@ import {
     BooleanNotation,
     FigureNumberingContext,
     FigureNumbersById,
-    PotentialUser,
-    UserPreferencesDTO
+    PotentialUser
 } from "../../../IsaacAppTypes";
 import {EXAM_BOARD} from "../../services/constants";
 import he from "he";

--- a/src/app/components/elements/LaTeX.tsx
+++ b/src/app/components/elements/LaTeX.tsx
@@ -270,7 +270,7 @@ export function katexify(html: string, user: PotentialUser | null, examBoard: EX
                     if (user?.loggedIn && booleanNotation) {
                         macrosToUse = booleanNotation?.ENG ? KatexMacrosWithEngineeringBool : KatexMacrosWithMathsBool;
                     } else {
-                        macrosToUse = examBoard == EXAM_BOARD.AQA ? KatexMacrosWithEngineeringBool : KatexMacrosWithMathsBool;
+                        macrosToUse = KatexMacrosWithMathsBool;
                     }
                 } else {
                     macrosToUse = KatexBaseMacros;

--- a/src/app/components/elements/TrustedHtml.tsx
+++ b/src/app/components/elements/TrustedHtml.tsx
@@ -36,14 +36,15 @@ function manipulateHtml(html: string) {
 
 export const TrustedHtml = ({html, span}: {html: string; span?: boolean}) => {
     const user = useSelector(selectors.user.orNull);
-    const userPreferences = useSelector(selectors.userPreferences.orNull)
+    const booleanNotation = useSelector((state: AppState) => (state?.userPreferences?.BETA_FEATURE?.BOOLEAN_NOTATION &&
+        state?.userPreferences?.BOOLEAN_NOTATION) || null);
     const screenReaderHoverText = useSelector((state: AppState) => state && state.userPreferences &&
         state.userPreferences.BETA_FEATURE && state.userPreferences.BETA_FEATURE.SCREENREADER_HOVERTEXT || false);
     const {examBoard} = useUserContext();
 
     const figureNumbers = useContext(FigureNumberingContext);
 
-    html = manipulateHtml(katexify(html, user, userPreferences, examBoard, screenReaderHoverText, figureNumbers));
+    html = manipulateHtml(katexify(html, user, examBoard, booleanNotation, screenReaderHoverText, figureNumbers));
 
     const ElementType = span ? "span" : "div";
     return <ElementType dangerouslySetInnerHTML={{__html: html}} />;

--- a/src/app/components/elements/TrustedHtml.tsx
+++ b/src/app/components/elements/TrustedHtml.tsx
@@ -36,7 +36,7 @@ function manipulateHtml(html: string) {
 
 export const TrustedHtml = ({html, span}: {html: string; span?: boolean}) => {
     const user = useSelector(selectors.user.orNull);
-    const booleanNotation = useSelector((state: AppState) => (state?.userPreferences?.BETA_FEATURE?.BOOLEAN_NOTATION &&
+    const booleanNotation = useSelector((state: AppState) => (state?.userPreferences?.BETA_FEATURE?.AUDIENCE_CONTEXT &&
         state?.userPreferences?.BOOLEAN_NOTATION) || null);
     const screenReaderHoverText = useSelector((state: AppState) => state && state.userPreferences &&
         state.userPreferences.BETA_FEATURE && state.userPreferences.BETA_FEATURE.SCREENREADER_HOVERTEXT || false);

--- a/src/app/components/elements/TrustedHtml.tsx
+++ b/src/app/components/elements/TrustedHtml.tsx
@@ -36,13 +36,14 @@ function manipulateHtml(html: string) {
 
 export const TrustedHtml = ({html, span}: {html: string; span?: boolean}) => {
     const user = useSelector(selectors.user.orNull);
+    const userPreferences = useSelector(selectors.userPreferences.orNull)
     const screenReaderHoverText = useSelector((state: AppState) => state && state.userPreferences &&
         state.userPreferences.BETA_FEATURE && state.userPreferences.BETA_FEATURE.SCREENREADER_HOVERTEXT || false);
     const {examBoard} = useUserContext();
 
     const figureNumbers = useContext(FigureNumberingContext);
 
-    html = manipulateHtml(katexify(html, user, examBoard, screenReaderHoverText, figureNumbers));
+    html = manipulateHtml(katexify(html, user, userPreferences, examBoard, screenReaderHoverText, figureNumbers));
 
     const ElementType = span ? "span" : "div";
     return <ElementType dangerouslySetInnerHTML={{__html: html}} />;

--- a/src/app/components/elements/inputs/BooleanNotationInput.tsx
+++ b/src/app/components/elements/inputs/BooleanNotationInput.tsx
@@ -8,10 +8,12 @@ interface BooleanNotationInputProps {
     booleanNotation: BooleanNotation;
     setBooleanNotation: (bn: BooleanNotation) => void;
     submissionAttempted: boolean;
+    isRequired?: boolean;
 }
-export const BooleanNotationInput = ({booleanNotation, setBooleanNotation, submissionAttempted} : BooleanNotationInputProps) => {
+export const BooleanNotationInput = ({booleanNotation, setBooleanNotation, submissionAttempted, isRequired = false} : BooleanNotationInputProps) => {
+
     return <FormGroup>
-        <Label className="d-inline-block pr-2 form-required" htmlFor="boolean-notation-preference">
+        <Label className={`d-inline-block pr-2 ${isRequired ? "form-required" : ""}`} htmlFor="boolean-notation-preference">
             Boolean logic notation
         </Label>
         <Input
@@ -19,15 +21,22 @@ export const BooleanNotationInput = ({booleanNotation, setBooleanNotation, submi
             value={
                 // This chooses the last string in this list that (when used as a key)
                 // is mapped to true in the current value of booleanNotation
-                Object.keys(BOOLEAN_NOTATION).reduce((val: string | undefined, key) => booleanNotation[key as keyof BooleanNotation] === true ? key : val, undefined)
+                Object.keys(BOOLEAN_NOTATION).reduce((val: string, key) => booleanNotation[key as keyof BooleanNotation] === true ? key : val, BOOLEAN_NOTATION.NONE)
             }
             onChange={(event: ChangeEvent<HTMLInputElement>) => {
-                setBooleanNotation({[event.target.value]: true})
-            }
+                    // Makes a new object, with all the boolean notation flags being false apart
+                    // from those that are set in the newBooleanNotation parameter
+                    const newBooleanNotation = {ENG: false, MATH: false}
+                    if (event.target.value !== BOOLEAN_NOTATION.NONE) {
+                        newBooleanNotation[event.target.value as keyof BooleanNotation] = true;
+                    }
+                    setBooleanNotation(Object.assign({}, newBooleanNotation));
+                }
             }
             invalid={submissionAttempted && !validateBooleanNotation(booleanNotation)}
+            required={isRequired}
         >
-            <option value={undefined}></option>
+            <option value={BOOLEAN_NOTATION.NONE}>No preference</option>
             <option value={BOOLEAN_NOTATION.MATH}>And (&and;) Or (&or;) Not (&not;)</option>
             <option value={BOOLEAN_NOTATION.ENG}>And (&middot;) Or (+) Not (bar)</option>
         </Input>

--- a/src/app/components/elements/inputs/BooleanNotationInput.tsx
+++ b/src/app/components/elements/inputs/BooleanNotationInput.tsx
@@ -21,7 +21,7 @@ export const BooleanNotationInput = ({booleanNotation, setBooleanNotation, submi
             value={
                 // This chooses the last string in this list that (when used as a key)
                 // is mapped to true in the current value of booleanNotation
-                Object.keys(BOOLEAN_NOTATION).reduce((val: string, key) => booleanNotation[key as keyof BooleanNotation] === true ? key : val, BOOLEAN_NOTATION.NONE)
+                Object.keys(BOOLEAN_NOTATION).reduce((val: string, key) => booleanNotation[key as keyof BooleanNotation] ? key : val, BOOLEAN_NOTATION.NONE)
             }
             onChange={(event: ChangeEvent<HTMLInputElement>) => {
                     // Makes a new object, with all the boolean notation flags being false apart

--- a/src/app/components/elements/inputs/BooleanNotationInput.tsx
+++ b/src/app/components/elements/inputs/BooleanNotationInput.tsx
@@ -1,0 +1,35 @@
+import {FormGroup, Input, Label} from "reactstrap";
+import {BOOLEAN_NOTATION} from "../../../services/constants";
+import {BooleanNotation, SubjectInterests} from "../../../../IsaacAppTypes";
+import React, {ChangeEvent} from "react";
+import {validateBooleanNotation} from "../../../services/validation";
+
+interface BooleanNotationInputProps {
+    booleanNotation: BooleanNotation;
+    setBooleanNotation: (bn: BooleanNotation) => void;
+    submissionAttempted: boolean;
+}
+export const BooleanNotationInput = ({booleanNotation, setBooleanNotation, submissionAttempted} : BooleanNotationInputProps) => {
+    return <FormGroup>
+        <Label className="d-inline-block pr-2 form-required" htmlFor="boolean-notation-preference">
+            Boolean logic notation
+        </Label>
+        <Input
+            type="select" name="select" id="boolean-notation-preference"
+            value={
+                // This chooses the last string in this list that (when used as a key)
+                // is mapped to true in the current value of booleanNotation
+                Object.keys(BOOLEAN_NOTATION).reduce((val: string | undefined, key) => booleanNotation[key as keyof BooleanNotation] === true ? key : val, undefined)
+            }
+            onChange={(event: ChangeEvent<HTMLInputElement>) => {
+                setBooleanNotation({[event.target.value]: true})
+            }
+            }
+            invalid={submissionAttempted && !validateBooleanNotation(booleanNotation)}
+        >
+            <option value={undefined}></option>
+            <option value={BOOLEAN_NOTATION.MATH}>And (&and;) Or (&or;) Not (&not;)</option>
+            <option value={BOOLEAN_NOTATION.ENG}>And (&middot;) Or (+) Not (bar)</option>
+        </Input>
+    </FormGroup>
+}

--- a/src/app/components/elements/inputs/BooleanNotationInput.tsx
+++ b/src/app/components/elements/inputs/BooleanNotationInput.tsx
@@ -1,6 +1,6 @@
 import {FormGroup, Input, Label} from "reactstrap";
 import {BOOLEAN_NOTATION} from "../../../services/constants";
-import {BooleanNotation, SubjectInterests} from "../../../../IsaacAppTypes";
+import {BooleanNotation} from "../../../../IsaacAppTypes";
 import React, {ChangeEvent} from "react";
 import {validateBooleanNotation} from "../../../services/validation";
 

--- a/src/app/components/elements/modals/RequiredAccountInformationModal.tsx
+++ b/src/app/components/elements/modals/RequiredAccountInformationModal.tsx
@@ -7,6 +7,7 @@ import {useDispatch, useSelector} from "react-redux";
 import {AppState} from "../../../state/reducers";
 import {
     allRequiredInformationIsPresent,
+    validateBooleanNotation,
     validateEmailPreferences,
     validateExamBoard,
     validateSubjectInterests,
@@ -21,6 +22,7 @@ import {GenderInput} from "../inputs/GenderInput";
 import {EXAM_BOARD} from "../../../services/constants";
 import {SITE, SITE_SUBJECT} from "../../../services/siteConstants";
 import {selectors} from "../../../state/selectors";
+import {BooleanNotationInput} from "../inputs/BooleanNotationInput";
 
 const RequiredAccountInfoBody = () => {
     // Redux state
@@ -41,9 +43,13 @@ const RequiredAccountInfoBody = () => {
     const initialEmailPreferencesValue = (userPreferences && userPreferences.EMAIL_PREFERENCE) ? Object.assign({}, userPreferences.EMAIL_PREFERENCE): {};
     const [emailPreferences, setEmailPreferences] = useState<UserEmailPreferences>(initialEmailPreferencesValue);
 
+    const initialBooleanNotationValue = (userPreferences && userPreferences.BOOLEAN_NOTATION) ? Object.assign({}, userPreferences.BOOLEAN_NOTATION): {};
+    const [booleanNotation, setBooleanNotation] = useState(initialBooleanNotationValue);
+
     const userPreferencesToUpdate = {
         EMAIL_PREFERENCE: emailPreferences,
-        SUBJECT_INTEREST: subjectInterests
+        SUBJECT_INTEREST: subjectInterests,
+        BOOLEAN_NOTATION: booleanNotation
     };
 
     // Form submission
@@ -59,7 +65,8 @@ const RequiredAccountInfoBody = () => {
 
     const allUserFieldsAreValid = SITE_SUBJECT !== SITE.CS ||
         validateUserSchool(initialUserValue) && validateUserGender(initialUserValue) &&
-        validateExamBoard(initialUserValue) && validateSubjectInterests(initialSubjectInterestsValue);
+        validateExamBoard(initialUserValue) && validateSubjectInterests(initialSubjectInterestsValue) &&
+        validateBooleanNotation(initialBooleanNotationValue);
 
     return <RS.Form onSubmit={formSubmission}>
         {!allUserFieldsAreValid && <RS.CardBody className="py-0">
@@ -98,12 +105,23 @@ const RequiredAccountInfoBody = () => {
                         </RS.FormGroup>
                     </div>}
                 </RS.Col>}
-                {!validateUserSchool(initialUserValue) && <RS.Col>
-                    <SchoolInput
-                        userToUpdate={userToUpdate} setUserToUpdate={setUserToUpdate}
-                        submissionAttempted={submissionAttempted} idPrefix="modal"
-                        required
-                    />
+                {!(validateUserSchool(initialUserValue) &&
+                    (userPreferences?.BETA_FEATURE?.AUDIENCE_CONTEXT === null ||
+                        (userPreferences?.BETA_FEATURE?.AUDIENCE_CONTEXT && validateBooleanNotation(initialBooleanNotationValue))
+                    )
+                  ) && <RS.Col>
+                    {!validateUserSchool(initialUserValue) &&
+                        <SchoolInput
+                            userToUpdate={userToUpdate} setUserToUpdate={setUserToUpdate}
+                            submissionAttempted={submissionAttempted} idPrefix="modal"
+                            required
+                        />
+                    }
+                    {userPreferences?.BETA_FEATURE?.AUDIENCE_CONTEXT && !validateBooleanNotation(initialBooleanNotationValue) &&
+                        <BooleanNotationInput booleanNotation={booleanNotation} setBooleanNotation={setBooleanNotation}
+                                              submissionAttempted={submissionAttempted}
+                        />
+                    }
                 </RS.Col>}
             </RS.Row>
             {!validateSubjectInterests(initialSubjectInterestsValue) && <RS.Row className="d-flex flex-wrap my-1">

--- a/src/app/components/elements/modals/RequiredAccountInformationModal.tsx
+++ b/src/app/components/elements/modals/RequiredAccountInformationModal.tsx
@@ -66,7 +66,7 @@ const RequiredAccountInfoBody = () => {
     const allUserFieldsAreValid = SITE_SUBJECT !== SITE.CS ||
         validateUserSchool(initialUserValue) && validateUserGender(initialUserValue) &&
         validateExamBoard(initialUserValue) && validateSubjectInterests(initialSubjectInterestsValue) &&
-        validateBooleanNotation(initialBooleanNotationValue);
+        (userPreferences?.BETA_FEATURE?.AUDIENCE_CONTEXT !== true || validateBooleanNotation(initialBooleanNotationValue));
 
     return <RS.Form onSubmit={formSubmission}>
         {!allUserFieldsAreValid && <RS.CardBody className="py-0">
@@ -106,9 +106,7 @@ const RequiredAccountInfoBody = () => {
                     </div>}
                 </RS.Col>}
                 {!(validateUserSchool(initialUserValue) &&
-                    (userPreferences?.BETA_FEATURE?.AUDIENCE_CONTEXT === null ||
-                        (userPreferences?.BETA_FEATURE?.AUDIENCE_CONTEXT && validateBooleanNotation(initialBooleanNotationValue))
-                    )
+                    (userPreferences?.BETA_FEATURE?.AUDIENCE_CONTEXT !== true || validateBooleanNotation(initialBooleanNotationValue))
                   ) && <RS.Col>
                     {!validateUserSchool(initialUserValue) &&
                         <SchoolInput

--- a/src/app/components/elements/modals/RequiredAccountInformationModal.tsx
+++ b/src/app/components/elements/modals/RequiredAccountInformationModal.tsx
@@ -7,7 +7,6 @@ import {useDispatch, useSelector} from "react-redux";
 import {AppState} from "../../../state/reducers";
 import {
     allRequiredInformationIsPresent,
-    validateBooleanNotation,
     validateEmailPreferences,
     validateExamBoard,
     validateSubjectInterests,
@@ -22,7 +21,6 @@ import {GenderInput} from "../inputs/GenderInput";
 import {EXAM_BOARD} from "../../../services/constants";
 import {SITE, SITE_SUBJECT} from "../../../services/siteConstants";
 import {selectors} from "../../../state/selectors";
-import {BooleanNotationInput} from "../inputs/BooleanNotationInput";
 
 const RequiredAccountInfoBody = () => {
     // Redux state
@@ -43,13 +41,9 @@ const RequiredAccountInfoBody = () => {
     const initialEmailPreferencesValue = (userPreferences && userPreferences.EMAIL_PREFERENCE) ? Object.assign({}, userPreferences.EMAIL_PREFERENCE): {};
     const [emailPreferences, setEmailPreferences] = useState<UserEmailPreferences>(initialEmailPreferencesValue);
 
-    const initialBooleanNotationValue = (userPreferences && userPreferences.BOOLEAN_NOTATION) ? Object.assign({}, userPreferences.BOOLEAN_NOTATION): {};
-    const [booleanNotation, setBooleanNotation] = useState(initialBooleanNotationValue);
-
     const userPreferencesToUpdate = {
         EMAIL_PREFERENCE: emailPreferences,
-        SUBJECT_INTEREST: subjectInterests,
-        BOOLEAN_NOTATION: booleanNotation
+        SUBJECT_INTEREST: subjectInterests
     };
 
     // Form submission
@@ -65,8 +59,7 @@ const RequiredAccountInfoBody = () => {
 
     const allUserFieldsAreValid = SITE_SUBJECT !== SITE.CS ||
         validateUserSchool(initialUserValue) && validateUserGender(initialUserValue) &&
-        validateExamBoard(initialUserValue) && validateSubjectInterests(initialSubjectInterestsValue) &&
-        (userPreferences?.BETA_FEATURE?.AUDIENCE_CONTEXT !== true || validateBooleanNotation(initialBooleanNotationValue));
+        validateExamBoard(initialUserValue) && validateSubjectInterests(initialSubjectInterestsValue);
 
     return <RS.Form onSubmit={formSubmission}>
         {!allUserFieldsAreValid && <RS.CardBody className="py-0">
@@ -105,21 +98,12 @@ const RequiredAccountInfoBody = () => {
                         </RS.FormGroup>
                     </div>}
                 </RS.Col>}
-                {!(validateUserSchool(initialUserValue) &&
-                    (userPreferences?.BETA_FEATURE?.AUDIENCE_CONTEXT !== true || validateBooleanNotation(initialBooleanNotationValue))
-                  ) && <RS.Col>
-                    {!validateUserSchool(initialUserValue) &&
+                {!validateUserSchool(initialUserValue) && <RS.Col>
                         <SchoolInput
                             userToUpdate={userToUpdate} setUserToUpdate={setUserToUpdate}
                             submissionAttempted={submissionAttempted} idPrefix="modal"
                             required
                         />
-                    }
-                    {userPreferences?.BETA_FEATURE?.AUDIENCE_CONTEXT && !validateBooleanNotation(initialBooleanNotationValue) &&
-                        <BooleanNotationInput booleanNotation={booleanNotation} setBooleanNotation={setBooleanNotation}
-                                              submissionAttempted={submissionAttempted}
-                        />
-                    }
                 </RS.Col>}
             </RS.Row>
             {!validateSubjectInterests(initialSubjectInterestsValue) && <RS.Row className="d-flex flex-wrap my-1">

--- a/src/app/components/elements/panels/UserDetails.tsx
+++ b/src/app/components/elements/panels/UserDetails.tsx
@@ -44,7 +44,7 @@ export const UserDetails = (props: UserDetailsProps) => {
     };
 
     const allRequiredFieldsValid = userToUpdate && userToUpdate.email &&
-        allRequiredInformationIsPresent(userToUpdate, {SUBJECT_INTEREST: subjectInterests, EMAIL_PREFERENCE: null, BOOLEAN_NOTATION: booleanNotation});
+        allRequiredInformationIsPresent(userToUpdate, {SUBJECT_INTEREST: subjectInterests, EMAIL_PREFERENCE: null});
 
     return <CardBody className="pt-0">
         <Row>

--- a/src/app/components/elements/panels/UserDetails.tsx
+++ b/src/app/components/elements/panels/UserDetails.tsx
@@ -24,6 +24,7 @@ interface UserDetailsProps {
     setSubjectInterests: (si: SubjectInterests) => void;
     booleanNotation: BooleanNotation;
     setBooleanNotation: (bn: BooleanNotation) => void;
+    allowBooleanNotationOption: boolean;
     submissionAttempted: boolean;
     editingOtherUser: boolean;
     userAuthSettings: UserAuthenticationSettingsDTO | null;
@@ -33,7 +34,7 @@ export const UserDetails = (props: UserDetailsProps) => {
     const {
         userToUpdate, setUserToUpdate,
         subjectInterests, setSubjectInterests,
-        booleanNotation, setBooleanNotation,
+        booleanNotation, setBooleanNotation, allowBooleanNotationOption,
         submissionAttempted, editingOtherUser
     } = props;
 
@@ -148,7 +149,7 @@ export const UserDetails = (props: UserDetailsProps) => {
                     <StudyingCsInput subjectInterests={subjectInterests} setSubjectInterests={setSubjectInterests} submissionAttempted={submissionAttempted} />
                 </div>
             </Col>}
-            {SITE_SUBJECT === SITE.CS && <Col md={6}>
+            {SITE_SUBJECT === SITE.CS && allowBooleanNotationOption && <Col md={6}>
                 <FormGroup>
                     <Label className="d-inline-block pr-2 form-required" htmlFor="boolean-notation-preference">
                         Boolean logic notation

--- a/src/app/components/elements/panels/UserDetails.tsx
+++ b/src/app/components/elements/panels/UserDetails.tsx
@@ -1,10 +1,9 @@
 import {CardBody, Col, FormFeedback, FormGroup, Input, Label, Row} from "reactstrap";
 import {BooleanNotation, SubjectInterests, ValidationUser} from "../../../../IsaacAppTypes";
-import {BOOLEAN_NOTATION, EXAM_BOARD, UserFacingRole} from "../../../services/constants";
+import {EXAM_BOARD, UserFacingRole} from "../../../services/constants";
 import React, {ChangeEvent} from "react";
 import {
     allRequiredInformationIsPresent,
-    validateBooleanNotation,
     validateEmail,
     validateExamBoard,
 } from "../../../services/validation";

--- a/src/app/components/elements/panels/UserDetails.tsx
+++ b/src/app/components/elements/panels/UserDetails.tsx
@@ -1,8 +1,13 @@
 import {CardBody, Col, FormFeedback, FormGroup, Input, Label, Row} from "reactstrap";
-import {SubjectInterests, ValidationUser} from "../../../../IsaacAppTypes";
+import {BooleanNotation, SubjectInterests, ValidationUser} from "../../../../IsaacAppTypes";
 import {EXAM_BOARD, UserFacingRole} from "../../../services/constants";
 import React, {ChangeEvent} from "react";
-import {allRequiredInformationIsPresent, validateEmail, validateExamBoard,} from "../../../services/validation";
+import {
+    allRequiredInformationIsPresent,
+    validateBooleanNotation,
+    validateEmail,
+    validateExamBoard,
+} from "../../../services/validation";
 import {SchoolInput} from "../inputs/SchoolInput";
 import {DobInput} from "../inputs/DobInput";
 import {StudyingCsInput} from "../inputs/StudyingCsInput";
@@ -17,6 +22,8 @@ interface UserDetailsProps {
     setUserToUpdate: (user: any) => void;
     subjectInterests: SubjectInterests;
     setSubjectInterests: (si: SubjectInterests) => void;
+    booleanNotation: BooleanNotation;
+    setBooleanNotation: (bn: BooleanNotation) => void;
     submissionAttempted: boolean;
     editingOtherUser: boolean;
     userAuthSettings: UserAuthenticationSettingsDTO | null;
@@ -26,6 +33,7 @@ export const UserDetails = (props: UserDetailsProps) => {
     const {
         userToUpdate, setUserToUpdate,
         subjectInterests, setSubjectInterests,
+        booleanNotation, setBooleanNotation,
         submissionAttempted, editingOtherUser
     } = props;
 
@@ -35,7 +43,7 @@ export const UserDetails = (props: UserDetailsProps) => {
     };
 
     const allRequiredFieldsValid = userToUpdate && userToUpdate.email &&
-        allRequiredInformationIsPresent(userToUpdate, {SUBJECT_INTEREST: subjectInterests, EMAIL_PREFERENCE: null});
+        allRequiredInformationIsPresent(userToUpdate, {SUBJECT_INTEREST: subjectInterests, EMAIL_PREFERENCE: null, BOOLEAN_NOTATION: booleanNotation});
 
     return <CardBody className="pt-0">
         <Row>
@@ -139,6 +147,31 @@ export const UserDetails = (props: UserDetailsProps) => {
                 <div className="mt-2 mb-2 pt-1">
                     <StudyingCsInput subjectInterests={subjectInterests} setSubjectInterests={setSubjectInterests} submissionAttempted={submissionAttempted} />
                 </div>
+            </Col>}
+            {SITE_SUBJECT === SITE.CS && <Col md={6}>
+                <FormGroup>
+                    <Label className="d-inline-block pr-2 form-required" htmlFor="boolean-notation-preference">
+                        Boolean logic notation
+                    </Label>
+                    <Input
+                        type="select" name="select" id="boolean-notation-preference"
+                        value={
+                            // This chooses the last string in this list that (when used as a key)
+                            // is mapped to true in the current value of booleanNotation
+                            ["ENG", "MATH", "BOARD_SPECIFIC"].reduce((val : string | undefined, key) => booleanNotation[key as keyof BooleanNotation] === true ? key : val, undefined)
+                        }
+                        onChange={(event: ChangeEvent<HTMLInputElement>) => {
+                                setBooleanNotation({[event.target.value]: true})
+                            }
+                        }
+                        invalid={submissionAttempted && !validateBooleanNotation(booleanNotation)}
+                    >
+                        <option value={undefined}></option>
+                        <option value={"BOARD_SPECIFIC"}>Exam board specific</option>
+                        <option value={"MATH"}>And (&and;) Or (&or;) Not (&not;)</option>
+                        <option value={"ENG"}>And (&middot;) Or (+) Not (bar)</option>
+                    </Input>
+                </FormGroup>
             </Col>}
         </Row>
         {SITE_SUBJECT === SITE.PHY && !editingOtherUser && <Row className="mt-3">

--- a/src/app/components/elements/panels/UserDetails.tsx
+++ b/src/app/components/elements/panels/UserDetails.tsx
@@ -1,6 +1,6 @@
 import {CardBody, Col, FormFeedback, FormGroup, Input, Label, Row} from "reactstrap";
 import {BooleanNotation, SubjectInterests, ValidationUser} from "../../../../IsaacAppTypes";
-import {EXAM_BOARD, UserFacingRole} from "../../../services/constants";
+import {BOOLEAN_NOTATION, EXAM_BOARD, UserFacingRole} from "../../../services/constants";
 import React, {ChangeEvent} from "react";
 import {
     allRequiredInformationIsPresent,
@@ -16,6 +16,7 @@ import {UserAuthenticationSettingsDTO} from "../../../../IsaacApiTypes";
 import {SITE, SITE_SUBJECT} from "../../../services/siteConstants";
 import {SubjectInterestTableInput} from "../inputs/SubjectInterestTableInput";
 import {Link} from "react-router-dom";
+import {BooleanNotationInput} from "../inputs/BooleanNotationInput";
 
 interface UserDetailsProps {
     userToUpdate: ValidationUser;
@@ -150,29 +151,7 @@ export const UserDetails = (props: UserDetailsProps) => {
                 </div>
             </Col>}
             {SITE_SUBJECT === SITE.CS && allowBooleanNotationOption && <Col md={6}>
-                <FormGroup>
-                    <Label className="d-inline-block pr-2 form-required" htmlFor="boolean-notation-preference">
-                        Boolean logic notation
-                    </Label>
-                    <Input
-                        type="select" name="select" id="boolean-notation-preference"
-                        value={
-                            // This chooses the last string in this list that (when used as a key)
-                            // is mapped to true in the current value of booleanNotation
-                            ["ENG", "MATH", "BOARD_SPECIFIC"].reduce((val : string | undefined, key) => booleanNotation[key as keyof BooleanNotation] === true ? key : val, undefined)
-                        }
-                        onChange={(event: ChangeEvent<HTMLInputElement>) => {
-                                setBooleanNotation({[event.target.value]: true})
-                            }
-                        }
-                        invalid={submissionAttempted && !validateBooleanNotation(booleanNotation)}
-                    >
-                        <option value={undefined}></option>
-                        <option value={"BOARD_SPECIFIC"}>Exam board specific</option>
-                        <option value={"MATH"}>And (&and;) Or (&or;) Not (&not;)</option>
-                        <option value={"ENG"}>And (&middot;) Or (+) Not (bar)</option>
-                    </Input>
-                </FormGroup>
+                <BooleanNotationInput booleanNotation={booleanNotation} setBooleanNotation={setBooleanNotation} submissionAttempted={submissionAttempted} />
             </Col>}
         </Row>
         {SITE_SUBJECT === SITE.PHY && !editingOtherUser && <Row className="mt-3">

--- a/src/app/components/pages/MyAccount.tsx
+++ b/src/app/components/pages/MyAccount.tsx
@@ -166,9 +166,8 @@ const AccountPageComponent = ({user, updateCurrentUser, getChosenUserAuthSetting
 
     function setBooleanNotation(newBooleanNotation: BooleanNotation) {
         // Makes a new object, with all the boolean notation flags being false apart
-        // from those that are set as true in the newBooleanNotation parameter
-        const fullNewBooleanNotation = ["ENG", "MATH", "BOARD_SPECIFIC"]
-            .reduce((acc, key) => acc[key as keyof BooleanNotation] ? acc : {...acc, [key]: false}, newBooleanNotation);
+        // from those that are set in the newBooleanNotation parameter
+        const fullNewBooleanNotation = {ENG: false, MATH: false, ...newBooleanNotation};
 
         // fullNewBooleanNotation might contain more than one true flag, but this is
         // checked in the validation step
@@ -262,7 +261,7 @@ const AccountPageComponent = ({user, updateCurrentUser, getChosenUserAuthSetting
                                     setSubjectInterests={setSubjectInterests}
                                     booleanNotation={myUserPreferences.BOOLEAN_NOTATION || {}}
                                     setBooleanNotation={setBooleanNotation}
-                                    allowBooleanNotationOption={userPreferences?.BETA_FEATURE?.BOOLEAN_NOTATION || false}
+                                    allowBooleanNotationOption={userPreferences?.BETA_FEATURE?.AUDIENCE_CONTEXT || false}
                                     submissionAttempted={attemptedAccountUpdate} editingOtherUser={editingOtherUser}
                                     userAuthSettings={userAuthSettings}
                                 />

--- a/src/app/components/pages/MyAccount.tsx
+++ b/src/app/components/pages/MyAccount.tsx
@@ -19,6 +19,7 @@ import {UserAuthenticationSettingsDTO} from "../../../IsaacApiTypes";
 import {AppState} from "../../state/reducers";
 import {adminUserGet, getChosenUserAuthSettings, resetPassword, updateCurrentUser} from "../../state/actions";
 import {
+    BooleanNotation,
     PotentialUser,
     SubjectInterests,
     UserEmailPreferences,
@@ -134,9 +135,11 @@ const AccountPageComponent = ({user, updateCurrentUser, getChosenUserAuthSetting
     useEffect(() => {
         const currentEmailPreferences = (userPreferences && userPreferences.EMAIL_PREFERENCE) ? userPreferences.EMAIL_PREFERENCE : {};
         const currentSubjectInterests = (userPreferences && userPreferences.SUBJECT_INTEREST) ? userPreferences.SUBJECT_INTEREST: {};
+        const currentBooleanNotation = (userPreferences && userPreferences.BOOLEAN_NOTATION) ? userPreferences.BOOLEAN_NOTATION: {};
         const currentUserPreferences = {
             EMAIL_PREFERENCE: currentEmailPreferences,
             SUBJECT_INTEREST: currentSubjectInterests,
+            BOOLEAN_NOTATION: currentBooleanNotation
         };
 
         setEmailPreferences(currentEmailPreferences);
@@ -159,6 +162,17 @@ const AccountPageComponent = ({user, updateCurrentUser, getChosenUserAuthSetting
 
     function setSubjectInterests(newSubjectInterests: SubjectInterests) {
         setMyUserPreferences({...myUserPreferences, SUBJECT_INTEREST: newSubjectInterests});
+    }
+
+    function setBooleanNotation(newBooleanNotation: BooleanNotation) {
+        // Makes a new object, with all the boolean notation flags being false apart
+        // from those that are set as true in the newBooleanNotation parameter
+        const fullNewBooleanNotation = ["ENG", "MATH", "BOARD_SPECIFIC"]
+            .reduce((acc, key) => acc[key as keyof BooleanNotation] ? acc : {...acc, [key]: false}, newBooleanNotation);
+
+        // fullNewBooleanNotation might contain more than one true flag, but this is
+        // checked in the validation step
+        setMyUserPreferences({...myUserPreferences, BOOLEAN_NOTATION: fullNewBooleanNotation});
     }
 
     // Form's submission method
@@ -246,6 +260,8 @@ const AccountPageComponent = ({user, updateCurrentUser, getChosenUserAuthSetting
                                     userToUpdate={userToUpdate} setUserToUpdate={setUserToUpdate}
                                     subjectInterests={myUserPreferences.SUBJECT_INTEREST || {}}
                                     setSubjectInterests={setSubjectInterests}
+                                    booleanNotation={myUserPreferences.BOOLEAN_NOTATION || {}}
+                                    setBooleanNotation={setBooleanNotation}
                                     submissionAttempted={attemptedAccountUpdate} editingOtherUser={editingOtherUser}
                                     userAuthSettings={userAuthSettings}
                                 />

--- a/src/app/components/pages/MyAccount.tsx
+++ b/src/app/components/pages/MyAccount.tsx
@@ -165,13 +165,7 @@ const AccountPageComponent = ({user, updateCurrentUser, getChosenUserAuthSetting
     }
 
     function setBooleanNotation(newBooleanNotation: BooleanNotation) {
-        // Makes a new object, with all the boolean notation flags being false apart
-        // from those that are set in the newBooleanNotation parameter
-        const fullNewBooleanNotation = {ENG: false, MATH: false, ...newBooleanNotation};
-
-        // fullNewBooleanNotation might contain more than one true flag, but this is
-        // checked in the validation step
-        setMyUserPreferences({...myUserPreferences, BOOLEAN_NOTATION: fullNewBooleanNotation});
+        setMyUserPreferences({...myUserPreferences, BOOLEAN_NOTATION: newBooleanNotation});
     }
 
     // Form's submission method

--- a/src/app/components/pages/MyAccount.tsx
+++ b/src/app/components/pages/MyAccount.tsx
@@ -262,6 +262,7 @@ const AccountPageComponent = ({user, updateCurrentUser, getChosenUserAuthSetting
                                     setSubjectInterests={setSubjectInterests}
                                     booleanNotation={myUserPreferences.BOOLEAN_NOTATION || {}}
                                     setBooleanNotation={setBooleanNotation}
+                                    allowBooleanNotationOption={userPreferences?.BETA_FEATURE?.BOOLEAN_NOTATION || false}
                                     submissionAttempted={attemptedAccountUpdate} editingOtherUser={editingOtherUser}
                                     userAuthSettings={userAuthSettings}
                                 />

--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -564,6 +564,12 @@ export const examBoardTagMap: {[examBoard: string]: string} = {
     [EXAM_BOARD.WJEC]: "examboard_wjec",
 };
 
+// BOOLEAN LOGIC NOTATION OPTIONS
+export enum BOOLEAN_NOTATION {
+    ENG = "ENG",
+    MATH = "MATH"
+}
+
 // STAGES
 export enum STAGE {
     GCSE = "gcse",

--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -567,7 +567,8 @@ export const examBoardTagMap: {[examBoard: string]: string} = {
 // BOOLEAN LOGIC NOTATION OPTIONS
 export enum BOOLEAN_NOTATION {
     ENG = "ENG",
-    MATH = "MATH"
+    MATH = "MATH",
+    NONE = "NONE"
 }
 
 // STAGES

--- a/src/app/services/validation.ts
+++ b/src/app/services/validation.ts
@@ -78,9 +78,10 @@ export const validateUserGender = (user?: ValidationUser | null) => {
 };
 
 export const validateBooleanNotation = (booleanNotation? : BooleanNotation | null) => {
-    // Make sure only one of the possible keys are true at a time
-    return booleanNotation &&
-        Object.keys(BOOLEAN_NOTATION).filter(key => (booleanNotation[key as keyof BooleanNotation] || false)).length === 1;
+    // Make sure at most one of the possible keys are true at a time
+    return booleanNotation && Object.keys(BOOLEAN_NOTATION)
+        .filter(key => (key !== BOOLEAN_NOTATION.NONE && (booleanNotation[key as keyof BooleanNotation] || false)))
+        .length <= 1;
 }
 
 const withinLastNMinutes = (nMinutes: number, dateOfAction: string | null) => {
@@ -99,8 +100,7 @@ export function allRequiredInformationIsPresent(user?: ValidationUser | null, us
     return user && userPreferences &&
         (SITE_SUBJECT !== SITE.CS || (validateUserSchool(user) && validateUserGender(user) && validateExamBoard(user))) &&
         (userPreferences.EMAIL_PREFERENCE === null || validateEmailPreferences(userPreferences.EMAIL_PREFERENCE)) &&
-        (SITE_SUBJECT !== SITE.CS || validateSubjectInterests(userPreferences.SUBJECT_INTEREST)) &&
-        (SITE_SUBJECT !== SITE.CS || (userPreferences?.BETA_FEATURE?.AUDIENCE_CONTEXT !== true || validateBooleanNotation(userPreferences.BOOLEAN_NOTATION)));
+        (SITE_SUBJECT !== SITE.CS || validateSubjectInterests(userPreferences.SUBJECT_INTEREST));
 }
 
 export function validateBookingSubmission(event: AugmentedEvent, user: UserSummaryWithEmailAddressDTO, additionalInformation: AdditionalInformation) {

--- a/src/app/services/validation.ts
+++ b/src/app/services/validation.ts
@@ -10,7 +10,7 @@ import {
 } from "../../IsaacAppTypes";
 import {UserSummaryWithEmailAddressDTO} from "../../IsaacApiTypes";
 import {FAILURE_TOAST} from "../components/navigation/Toasts";
-import {EXAM_BOARD, NOT_FOUND} from "./constants";
+import {BOOLEAN_NOTATION, EXAM_BOARD, NOT_FOUND} from "./constants";
 import {SITE_SUBJECT, SITE} from "./siteConstants";
 
 export function atLeastOne(possibleNumber?: number): boolean {return possibleNumber !== undefined && possibleNumber > 0}
@@ -80,7 +80,7 @@ export const validateUserGender = (user?: ValidationUser | null) => {
 export const validateBooleanNotation = (booleanNotation? : BooleanNotation | null) => {
     // Make sure only one of the possible keys are true at a time
     return booleanNotation &&
-        ["ENG", "MATH", "BOARD_SPECIFIC"].filter(key => (booleanNotation[key as keyof BooleanNotation] || false)).length === 1;
+        Object.keys(BOOLEAN_NOTATION).filter(key => (booleanNotation[key as keyof BooleanNotation] || false)).length === 1;
 }
 
 const withinLastNMinutes = (nMinutes: number, dateOfAction: string | null) => {
@@ -100,7 +100,7 @@ export function allRequiredInformationIsPresent(user?: ValidationUser | null, us
         (SITE_SUBJECT !== SITE.CS || (validateUserSchool(user) && validateUserGender(user) && validateExamBoard(user))) &&
         (userPreferences.EMAIL_PREFERENCE === null || validateEmailPreferences(userPreferences.EMAIL_PREFERENCE)) &&
         (SITE_SUBJECT !== SITE.CS || validateSubjectInterests(userPreferences.SUBJECT_INTEREST)) &&
-        (SITE_SUBJECT !== SITE.CS || (userPreferences.BETA_FEATURE?.BOOLEAN_NOTATION === null || validateBooleanNotation(userPreferences.BOOLEAN_NOTATION)));
+        (SITE_SUBJECT !== SITE.CS || (userPreferences.BETA_FEATURE?.AUDIENCE_CONTEXT === null || validateBooleanNotation(userPreferences.BOOLEAN_NOTATION)));
 }
 
 export function validateBookingSubmission(event: AugmentedEvent, user: UserSummaryWithEmailAddressDTO, additionalInformation: AdditionalInformation) {

--- a/src/app/services/validation.ts
+++ b/src/app/services/validation.ts
@@ -79,7 +79,6 @@ export const validateUserGender = (user?: ValidationUser | null) => {
 
 export const validateBooleanNotation = (booleanNotation? : BooleanNotation | null) => {
     // Make sure only one of the possible keys are true at a time
-    console.log(booleanNotation)
     return booleanNotation &&
         ["ENG", "MATH", "BOARD_SPECIFIC"].filter(key => (booleanNotation[key as keyof BooleanNotation] || false)).length === 1;
 }

--- a/src/app/services/validation.ts
+++ b/src/app/services/validation.ts
@@ -1,6 +1,7 @@
 import {
     AdditionalInformation,
-    AugmentedEvent, BooleanNotation,
+    AugmentedEvent,
+    BooleanNotation,
     NOT_FOUND_TYPE,
     SubjectInterests,
     UserEmailPreferences,

--- a/src/app/services/validation.ts
+++ b/src/app/services/validation.ts
@@ -100,7 +100,7 @@ export function allRequiredInformationIsPresent(user?: ValidationUser | null, us
         (SITE_SUBJECT !== SITE.CS || (validateUserSchool(user) && validateUserGender(user) && validateExamBoard(user))) &&
         (userPreferences.EMAIL_PREFERENCE === null || validateEmailPreferences(userPreferences.EMAIL_PREFERENCE)) &&
         (SITE_SUBJECT !== SITE.CS || validateSubjectInterests(userPreferences.SUBJECT_INTEREST)) &&
-        (SITE_SUBJECT !== SITE.CS || (userPreferences.BETA_FEATURE?.AUDIENCE_CONTEXT === null || validateBooleanNotation(userPreferences.BOOLEAN_NOTATION)));
+        (SITE_SUBJECT !== SITE.CS || (userPreferences?.BETA_FEATURE?.AUDIENCE_CONTEXT !== true || validateBooleanNotation(userPreferences.BOOLEAN_NOTATION)));
 }
 
 export function validateBookingSubmission(event: AugmentedEvent, user: UserSummaryWithEmailAddressDTO, additionalInformation: AdditionalInformation) {

--- a/src/app/services/validation.ts
+++ b/src/app/services/validation.ts
@@ -99,7 +99,7 @@ export function allRequiredInformationIsPresent(user?: ValidationUser | null, us
         (SITE_SUBJECT !== SITE.CS || (validateUserSchool(user) && validateUserGender(user) && validateExamBoard(user))) &&
         (userPreferences.EMAIL_PREFERENCE === null || validateEmailPreferences(userPreferences.EMAIL_PREFERENCE)) &&
         (SITE_SUBJECT !== SITE.CS || validateSubjectInterests(userPreferences.SUBJECT_INTEREST)) &&
-        (SITE_SUBJECT !== SITE.CS || validateBooleanNotation(userPreferences.BOOLEAN_NOTATION));
+        (SITE_SUBJECT !== SITE.CS || (userPreferences.BETA_FEATURE?.BOOLEAN_NOTATION === null || validateBooleanNotation(userPreferences.BOOLEAN_NOTATION)));
 }
 
 export function validateBookingSubmission(event: AugmentedEvent, user: UserSummaryWithEmailAddressDTO, additionalInformation: AdditionalInformation) {

--- a/src/app/services/validation.ts
+++ b/src/app/services/validation.ts
@@ -1,6 +1,6 @@
 import {
     AdditionalInformation,
-    AugmentedEvent,
+    AugmentedEvent, BooleanNotation,
     NOT_FOUND_TYPE,
     SubjectInterests,
     UserEmailPreferences,
@@ -11,6 +11,7 @@ import {UserSummaryWithEmailAddressDTO} from "../../IsaacApiTypes";
 import {FAILURE_TOAST} from "../components/navigation/Toasts";
 import {EXAM_BOARD, NOT_FOUND} from "./constants";
 import {SITE_SUBJECT, SITE} from "./siteConstants";
+import {convertExamBoardToOption} from "./gameboardBuilder";
 
 export function atLeastOne(possibleNumber?: number): boolean {return possibleNumber !== undefined && possibleNumber > 0}
 export function zeroOrLess(possibleNumber?: number): boolean {return possibleNumber !== undefined && possibleNumber <= 0}
@@ -76,6 +77,13 @@ export const validateUserGender = (user?: ValidationUser | null) => {
     return user && user.gender && user.gender !== "UNKNOWN";
 };
 
+export const validateBooleanNotation = (booleanNotation? : BooleanNotation | null) => {
+    // Make sure only one of the possible keys are true at a time
+    console.log(booleanNotation)
+    return booleanNotation &&
+        ["ENG", "MATH", "BOARD_SPECIFIC"].filter(key => (booleanNotation[key as keyof BooleanNotation] || false)).length === 1;
+}
+
 const withinLastNMinutes = (nMinutes: number, dateOfAction: string | null) => {
     if (dateOfAction) {
         const now = new Date();
@@ -92,7 +100,8 @@ export function allRequiredInformationIsPresent(user?: ValidationUser | null, us
     return user && userPreferences &&
         (SITE_SUBJECT !== SITE.CS || (validateUserSchool(user) && validateUserGender(user) && validateExamBoard(user))) &&
         (userPreferences.EMAIL_PREFERENCE === null || validateEmailPreferences(userPreferences.EMAIL_PREFERENCE)) &&
-        (SITE_SUBJECT !== SITE.CS || validateSubjectInterests(userPreferences.SUBJECT_INTEREST));
+        (SITE_SUBJECT !== SITE.CS || validateSubjectInterests(userPreferences.SUBJECT_INTEREST)) &&
+        (SITE_SUBJECT !== SITE.CS || validateBooleanNotation(userPreferences.BOOLEAN_NOTATION));
 }
 
 export function validateBookingSubmission(event: AugmentedEvent, user: UserSummaryWithEmailAddressDTO, additionalInformation: AdditionalInformation) {

--- a/src/app/services/validation.ts
+++ b/src/app/services/validation.ts
@@ -11,7 +11,6 @@ import {UserSummaryWithEmailAddressDTO} from "../../IsaacApiTypes";
 import {FAILURE_TOAST} from "../components/navigation/Toasts";
 import {EXAM_BOARD, NOT_FOUND} from "./constants";
 import {SITE_SUBJECT, SITE} from "./siteConstants";
-import {convertExamBoardToOption} from "./gameboardBuilder";
 
 export function atLeastOne(possibleNumber?: number): boolean {return possibleNumber !== undefined && possibleNumber > 0}
 export function zeroOrLess(possibleNumber?: number): boolean {return possibleNumber !== undefined && possibleNumber <= 0}

--- a/src/app/state/selectors.tsx
+++ b/src/app/state/selectors.tsx
@@ -122,6 +122,10 @@ export const selectors = {
         orNull: (state: AppState) => state?.user || null,
     },
 
+    userPreferences:  {
+        orNull: (state: AppState) => state?.userPreferences || null,
+    },
+
     mainContentId: {
         orDefault: (state: AppState) => state?.mainContentId || "main",
     },

--- a/src/app/state/selectors.tsx
+++ b/src/app/state/selectors.tsx
@@ -122,10 +122,6 @@ export const selectors = {
         orNull: (state: AppState) => state?.user || null,
     },
 
-    userPreferences:  {
-        orNull: (state: AppState) => state?.userPreferences || null,
-    },
-
     mainContentId: {
         orDefault: (state: AppState) => state?.mainContentId || "main",
     },

--- a/src/test/components/TrustedHtml.test.tsx
+++ b/src/test/components/TrustedHtml.test.tsx
@@ -27,7 +27,7 @@ describe('TrustedHtml LaTeX locator', () => {
     it('can find basic delimiters', () => {
         delimiters.forEach(([open, displayMode, close]) => {
             const testcase = html[0] + wrapIn(open, math[0], close) + html[1];
-            const result = katexify(testcase, null, null, false, {});
+            const result = katexify(testcase, null, null, null, false, {});
 
             expect(result).toEqual(html[0] + LATEX + html[1]);
             // @ts-ignore
@@ -40,7 +40,7 @@ describe('TrustedHtml LaTeX locator', () => {
     it("unbalanced delimiters don't break everything but instead are just skipped", () => {
         delimiters.forEach(([open, , ]) => {
             const testcase = html[0] + wrapIn(open, math[0], "") + html[1];
-            const result = katexify(testcase, null, null, false, {});
+            const result = katexify(testcase, null, null, null, false, {});
 
             expect(result).toEqual(html[0] + open + math[0] + html[1]);
             expect(katex.renderToString).not.toHaveBeenCalled();
@@ -51,7 +51,7 @@ describe('TrustedHtml LaTeX locator', () => {
         nestedDollars.forEach((dollarMath) => {
             delimiters.forEach(([open, displayMode, close]) => {
                 const testcase = html[0] + wrapIn(open, dollarMath, close) + html[1];
-                const result = katexify(testcase, null, null, false, {});
+                const result = katexify(testcase, null, null, null, false, {});
 
                 expect(result).toEqual(html[0] + LATEX + html[1]);
                 // @ts-ignore
@@ -65,7 +65,7 @@ describe('TrustedHtml LaTeX locator', () => {
     it('can render environments', () => {
         const env = "\\begin{aligned}" + math[0] + "\\end{aligned}";
         const testcase = html[0] + env + html[1];
-        const result = katexify(testcase, null, null, false, {});
+        const result = katexify(testcase, null, null, null, false, {});
 
         expect(result).toEqual(html[0] + LATEX + html[1]);
         // @ts-ignore
@@ -77,7 +77,7 @@ describe('TrustedHtml LaTeX locator', () => {
     it('missing refs show an inline error', () => {
         const ref = "\\ref{foo[234o89tdgfiuno34£\"$%^Y}";
         const testcase = html[0] + ref + html[1];
-        const result = katexify(testcase, null, null, false, {});
+        const result = katexify(testcase, null, null, null, false, {});
 
         expect(result).toEqual(html[0] + "unknown reference " + ref + html[1]);
         expect(katex.renderToString).not.toHaveBeenCalled();
@@ -86,7 +86,7 @@ describe('TrustedHtml LaTeX locator', () => {
     it('found refs show their figure number', () => {
         const ref = "\\ref{foo}";
         const testcase = html[0] + ref + html[1];
-        const result = katexify(testcase, null, null, false, {foo: 42});
+        const result = katexify(testcase, null, null, null, false, {foo: 42});
 
         const expectedFigureRef = "Figure" + "&nbsp;" + "42";
         const expectedFigureRefWithFormatting = `<strong class="text-secondary figure-reference">${expectedFigureRef}</strong>`;
@@ -98,7 +98,7 @@ describe('TrustedHtml LaTeX locator', () => {
         const escapedDollar = "\\$";
         const unescapedDollar = "$";
         const testcase = html[0] + escapedDollar + html[1];
-        const result = katexify(testcase, null, null, false, {});
+        const result = katexify(testcase, null, null, null, false, {});
 
         expect(result).toEqual(html[0] + unescapedDollar + html[1]);
         expect(katex.renderToString).not.toHaveBeenCalled();


### PR DESCRIPTION
Backend change [here](https://github.com/isaacphysics/isaac-api/pull/375).

This adds an option on the "My account" page to change how Boolean logic is displayed - either using engineering, maths, or exam board specific notation.

The choice is stored as a map from each option to a Boolean value. In the case of multiple `true` values, the option occurring last (in the order they are listed above) is selected. I also added a `userPreferences` selector to neaten things a bit (removed in the latest commit for name clash and relative uselessness compared to other ways of accessing preferences).

The user needs to have the `BOOLEAN_NOTATION` beta feature enabled to see the "My account" option, and for their selection to affect which katex macros are used.

I'm wondering if line 162 in `UserDetails.tsx` (`value = ["ENG", ...`) gets run more times than needed, and if so whether it matters/could be changed?