### PR TITLE
Only give a link to a quiz section if feedbackMode is set to detailed

### DIFF
--- a/src/app/components/elements/quiz/QuizAttemptComponent.tsx
+++ b/src/app/components/elements/quiz/QuizAttemptComponent.tsx
@@ -58,7 +58,10 @@ function QuizContents({attempt, sections, questions, pageLink}: QuizAttemptProps
                     {Object.keys(sections).map((k, index) => {
                         const section = sections[k];
                         return <tr key={k}>
-                            <td><Link replace to={pageLink(attempt, index + 1)}>{section.title}</Link></td>
+                            {attempt.feedbackMode === 'DETAILED_FEEDBACK' ?
+                                <td><Link replace to={pageLink(attempt, index + 1)}>{section.title}</Link></td> :
+                                <td>{section.title}</td>
+                            }
                             <td>
                                 {attempt.quiz?.individualFeedback?.sectionMarks?.[section.id as string]?.correct}
                                 {" / "}


### PR DESCRIPTION
This doesn't interfere with previewing or doing a quiz, it now only sets the section title to be a link if detailed feedback is selected.