### PR TITLE
Override default modal handing of escape key and backdrop click

### DIFF
--- a/src/app/components/elements/modals/ActiveModal.tsx
+++ b/src/app/components/elements/modals/ActiveModal.tsx
@@ -34,17 +34,26 @@ export const ActiveModal = ({activeModal}: ActiveModalProps) => {
             // @ts-ignore
             modalRef.current.handleEscape = (e) => {
                 // @ts-ignore
-                const backdrop = modalRef.current._dialog ? modalRef.current._dialog.parentNode : null;
-                if (backdrop && e.target === backdrop) {
-                    dispatch(closeActiveModal());
+                if (modalRef.current.props.keyboard && e.keyCode === 27) { // 27 is the key code for esc
+                    e.preventDefault();
+                    e.stopPropagation();
+                    // @ts-ignore
+                    const backdrop = modalRef.current._dialog ? modalRef.current._dialog.parentNode : null;
+                    if (backdrop && e.target === backdrop) {
+                        dispatch(closeActiveModal());
+                    }
                 }
             }
             // @ts-ignore
             modalRef.current.handleBackdropClick = (e) => {
                 // @ts-ignore
-                const backdrop = modalRef.current._dialog ? modalRef.current._dialog.parentNode : null;
-                if (backdrop && e.target === backdrop) {
-                    dispatch(closeActiveModal());
+                if (e.target === modalRef.current._mouseDownElement) {
+                    e.stopPropagation();
+                    // @ts-ignore
+                    const backdrop = modalRef.current._dialog ? modalRef.current._dialog.parentNode : null;
+                    if (backdrop && e.target === backdrop) {
+                        dispatch(closeActiveModal());
+                    }
                 }
             };
         }


### PR DESCRIPTION
This is to make sure the scrollbar is unlocked on close.

This feels like a patch on top of an issue with how 'toggle' works, since that is what gets called in the Reactstrap `Modal` class component. It works now but there should be a shorter and neater (but probably more complicated) solution?