### PR TITLE
Purged `NONE` from `BOOLEAN_NOTATION` enum

### DIFF
--- a/src/app/components/elements/inputs/BooleanNotationInput.tsx
+++ b/src/app/components/elements/inputs/BooleanNotationInput.tsx
@@ -19,21 +19,18 @@ export const BooleanNotationInput = ({booleanNotation, setBooleanNotation, isReq
             value={
                 // This chooses the last string in this list that (when used as a key)
                 // is mapped to true in the current value of booleanNotation
-                Object.keys(BOOLEAN_NOTATION).reduce((val: string, key) => booleanNotation[key as keyof BooleanNotation] ? key : val, BOOLEAN_NOTATION.NONE)
+                Object.keys(BOOLEAN_NOTATION).reduce((val: string, key) => booleanNotation[key as keyof BooleanNotation] ? key : val, BOOLEAN_NOTATION.MATH)
             }
             onChange={(event: ChangeEvent<HTMLInputElement>) => {
                     // Makes a new object, with all the boolean notation flags being false apart
                     // from those that are set in the newBooleanNotation parameter
                     const newBooleanNotation: BooleanNotation = {...EMPTY_BOOLEAN_NOTATION_RECORD};
-                    if (event.target.value !== BOOLEAN_NOTATION.NONE) {
-                        newBooleanNotation[event.target.value as keyof BooleanNotation] = true;
-                    }
+                    newBooleanNotation[event.target.value as keyof BooleanNotation] = true;
                     setBooleanNotation(newBooleanNotation);
                 }
             }
             required={isRequired}
         >
-            <option value={BOOLEAN_NOTATION.NONE}></option>
             <option value={BOOLEAN_NOTATION.MATH}>And (&and;) Or (&or;) Not (&not;)</option>
             <option value={BOOLEAN_NOTATION.ENG}>And (&middot;) Or (+) Not (bar)</option>
         </Input>

--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -583,11 +583,10 @@ export const EXAM_BOARDS_CS_GCSE = new Set([EXAM_BOARD.AQA, EXAM_BOARD.OCR, EXAM
 // BOOLEAN LOGIC NOTATION OPTIONS
 export enum BOOLEAN_NOTATION {
     ENG = "ENG",
-    MATH = "MATH",
-    NONE = "NONE"
+    MATH = "MATH"
 }
 export const EMPTY_BOOLEAN_NOTATION_RECORD: {[bn in BOOLEAN_NOTATION]: false} & BooleanNotation = {
-    [BOOLEAN_NOTATION.ENG]: false, [BOOLEAN_NOTATION.MATH]: false, [BOOLEAN_NOTATION.NONE]: false
+    [BOOLEAN_NOTATION.ENG]: false, [BOOLEAN_NOTATION.MATH]: false
 }
 // STAGES
 export enum STAGE {


### PR DESCRIPTION
Then followed through and patched anywhere it was previously used.

Since the enum only has two inhabitants, all of the code for reducing over it etc. seems quite heavy, but it shouldn't really impact performance and at least it's very extensible.