### PR TITLE
Checks for canvas before trying to remove it

### DIFF
--- a/src/app/components/elements/modals/InequalityModal.tsx
+++ b/src/app/components/elements/modals/InequalityModal.tsx
@@ -464,8 +464,9 @@ class InequalityModalComponent extends React.Component<InequalityModalProps> {
             }));
             this.setState({ sketch: null });
         }
-        if (inequalityElement) {
-            inequalityElement.removeChild(inequalityElement.getElementsByTagName('canvas')[0]);
+        const canvas = inequalityElement?.getElementsByTagName('canvas')[0];
+        if (canvas) {
+            inequalityElement.removeChild(canvas);
         }
 
         document.documentElement.style.width = '';


### PR DESCRIPTION
We have been seeing front-end errors reporting:

TypeError: Failed to execute 'removeChild' on 'Node': parameter 1 is not of type 'Node'.
  at.componentWillUnmount (https://isaacphysics.org/...

This should fix that but I have not determined the true cause to reproduce.