### PR TITLE
Sort older assignments only by latest creation date first

### DIFF
--- a/src/app/services/assignments.ts
+++ b/src/app/services/assignments.ts
@@ -45,7 +45,7 @@ export const filterAssignmentsByStatus = (assignments: AssignmentDTO[] | null) =
             }
         });
         myAssignments.inProgressRecent = orderBy(myAssignments.inProgressRecent, ["dueDate", "creationDate"], ["asc", "desc"]);
-        myAssignments.inProgressOld = orderBy(myAssignments.inProgressOld, ["dueDate", "creationDate"], ["asc", "desc"]);
+        myAssignments.inProgressOld = orderBy(myAssignments.inProgressOld, ["creationDate"], ["desc"]);
         myAssignments.completed = orderBy(myAssignments.completed, ["creationDate"], ["desc"]);
     }
 


### PR DESCRIPTION
This just removes filtering by due date, as proposed and preferred by Physics content team