### PR TITLE
Improvement/glossary term hidden by index

### DIFF
--- a/src/app/components/content/IsaacGlossaryTerm.tsx
+++ b/src/app/components/content/IsaacGlossaryTerm.tsx
@@ -1,66 +1,41 @@
-import React, {useEffect} from 'react';
-import {withRouter} from "react-router-dom";
+import React, {Ref} from 'react';
 import {Col, Row} from "reactstrap";
 import {GlossaryTermDTO} from "../../../IsaacApiTypes";
 import {IsaacContent} from "./IsaacContent";
-import {scrollVerticallyIntoView} from "../../services/scrollManager";
-import {useUserContext} from "../../services/userContext";
 import tags from "../../services/tags";
 import { isDefined } from '../../services/miscUtils';
 import { SITE, SITE_SUBJECT } from '../../services/siteConstants';
 import { TAG_ID } from '../../services/constants';
 import { Tag } from '../../../IsaacAppTypes';
+import {formatGlossaryTermId} from "../pages/Glossary";
 
 interface IsaacGlossaryTermProps {
     doc: GlossaryTermDTO;
-    location: {hash: string};
-    linkToGlossary: boolean;
+    linkToGlossary?: boolean;
 }
 
-const IsaacGlossaryTermComponent = ({doc, location: {hash}, linkToGlossary = false}: IsaacGlossaryTermProps) => {
-    let anchorId = '';
-    const idRegexp = new RegExp('([a-z0-9-_]+)\\|?(?:(aqa|ocr)\\|?)?([a-z0-9-_~]+)?');
-    const parsedAnchorId = doc.id && idRegexp.exec(doc.id.split('|').slice(1).join('|'));
-    if (parsedAnchorId) {
-        anchorId = parsedAnchorId.slice(1,3).filter(i => typeof i === 'string').join('|').toLowerCase().replace(/[^a-z0-9]/g, '-');
-    }
-    const {examBoard} = useUserContext();
-
-    useEffect(() => {
-        if (hash.includes("#")) {
-            const hashAnchor = hash.slice(1).toLowerCase().replace(/[^a-z0-9]/g, '-');
-            const element = document.getElementById(hashAnchor);
-            if (element && anchorId) { // exists on page
-                if (anchorId.indexOf(hashAnchor) === 0) {
-                    scrollVerticallyIntoView(element);
-                }
-            }
-        }
-    }, [hash, anchorId]);
-
+const IsaacGlossaryTermComponent = ({doc, linkToGlossary}: IsaacGlossaryTermProps, ref: Ref<any>) => {
     let _tags: Tag[] = [];
     if (SITE_SUBJECT === SITE.CS && doc.tags) {
         _tags = doc.tags.map(id => tags.getById(id as TAG_ID)).filter(tag => isDefined(tag));
     }
 
-    return <React.Fragment>
-        {(!isDefined(doc.examBoard) || doc.examBoard === '' || examBoard === doc.examBoard) && <Col><Row className="glossary_term">
-            <Col md={3} className="glossary_term_name">
-                <p id={anchorId}>
-                    {linkToGlossary && <a href={location.origin + location.pathname + '#' + anchorId}>
-                        <img src="/assets/link-variant.png" className="pr-2" alt="direct link" />
-                        <strong>{doc.value}</strong>
-                    </a>}
-                    {!linkToGlossary && <strong>{doc.value}</strong>}
-                    <span className="only-print">: </span>
-                </p>
-            </Col>
-            <Col>
-                {doc.explanation && <IsaacContent doc={doc.explanation} />}
-                {/* {_tags && _tags.length > 0 && <p className="topics">Used in: {_tags.map(tag => tag.title).join(', ')}</p>} */}
-            </Col>
-        </Row></Col>}
-    </React.Fragment>;
+    return <Row className="glossary_term" key={doc.id}>
+        <Col md={3} className="glossary_term_name">
+            <p ref={ref}>
+                {linkToGlossary && <a href={`#${(doc.id && formatGlossaryTermId(doc.id)) ?? ""}`}>
+                    <img src="/assets/link-variant.png" className="pr-2" alt="direct link" />
+                    <strong>{doc.value}</strong>
+                </a>}
+                {!linkToGlossary && <strong>{doc.value}</strong>}
+                <span className="only-print">: </span>
+            </p>
+        </Col>
+        <Col md={7}>
+            {doc.explanation && <IsaacContent doc={doc.explanation} />}
+            {/* {_tags && _tags.length > 0 && <p className="topics">Used in: {_tags.map(tag => tag.title).join(', ')}</p>} */}
+        </Col>
+    </Row>;
 };
 
-export const IsaacGlossaryTerm = withRouter(IsaacGlossaryTermComponent);
+export const IsaacGlossaryTerm = React.forwardRef(IsaacGlossaryTermComponent);

--- a/src/app/components/pages/Glossary.tsx
+++ b/src/app/components/pages/Glossary.tsx
@@ -189,9 +189,6 @@ export const Glossary = withRouter(({ location: { hash } }: GlossaryProps) => {
                     <div id="stickyalphabetlist" className="alphabetlist pb-4">
                         {alphabetList}
                     </div>
-                    <div className="alphabetlist pb-4">
-                        {alphabetList}
-                    </div>
                 </div>
                 {Object.entries(glossaryTerms).map(([key, terms]) => <Row key={key} className="pb-5">
                     <Col md={{size: 1, offset: 1}} id={`key-${key}`}><h2 style={{position: 'sticky', top: '1em'}}>{key}</h2></Col>

--- a/src/app/components/pages/Glossary.tsx
+++ b/src/app/components/pages/Glossary.tsx
@@ -232,7 +232,7 @@ export const Glossary = () => {
             </Row>}
             {glossaryTerms && Object.keys(glossaryTerms).length > 0 && <Col className="pt-2 pb-4">
                 <div className="no-print">
-                    <div id="sentinel" className={"sentinel"} ref={alphabetScrollerSentinel}>&nbsp;</div>
+                    <div id="sentinel" ref={alphabetScrollerSentinel}>&nbsp;</div>
                     <div ref={alphabetListContainer} id="stickyalphabetlist" className="alphabetlist pb-4">
                         {alphabetList}
                     </div>

--- a/src/app/components/pages/Glossary.tsx
+++ b/src/app/components/pages/Glossary.tsx
@@ -52,10 +52,7 @@ export function useUntilFound<T, U>(waitingFor: T | NOT_FOUND_TYPE | null | unde
 export function formatGlossaryTermId(rawTermId: string) {
     const idRegExp = new RegExp('([a-z0-9-_]+)\\|?(?:(aqa|ocr)\\|?)?([a-z0-9-_~]+)?');
     const simplifiedTermId = idRegExp.exec(rawTermId.split('|').slice(1).join('|'));
-    if (simplifiedTermId) {
-        return simplifiedTermId.slice(1,3).filter(i => typeof i === 'string').join('|').toLowerCase().replace(/[^a-z0-9]/g, '-');
-    }
-    return undefined;
+    return simplifiedTermId?.slice(1,3).filter(i => typeof i === 'string').join('|').toLowerCase().replace(/[^a-z0-9]/g, '-');
 }
 
 /* An offset applied when scrolling to a glossary term, so the term isn't hidden under the alphabet header */

--- a/src/app/components/pages/Glossary.tsx
+++ b/src/app/components/pages/Glossary.tsx
@@ -189,6 +189,9 @@ export const Glossary = withRouter(({ location: { hash } }: GlossaryProps) => {
                     <div id="stickyalphabetlist" className="alphabetlist pb-4">
                         {alphabetList}
                     </div>
+                    <div className="alphabetlist pb-4">
+                        {alphabetList}
+                    </div>
                 </div>
                 {Object.entries(glossaryTerms).map(([key, terms]) => <Row key={key} className="pb-5">
                     <Col md={{size: 1, offset: 1}} id={`key-${key}`}><h2 style={{position: 'sticky', top: '1em'}}>{key}</h2></Col>

--- a/src/app/components/pages/Glossary.tsx
+++ b/src/app/components/pages/Glossary.tsx
@@ -168,11 +168,11 @@ export const Glossary = () => {
 
     const alphabetList = glossaryTerms && '#ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('').map(k => {
         if (glossaryTerms.hasOwnProperty(k)) {
-            return <div id={`alphascroller-key-${k}`} className="key" data-key={k} role="button" tabIndex={0} onKeyUp={onKeyUpScrollTo} onClick={() => scrollToKey(k)}>
+            return <div id={`alphascroller-key-${k}`} className="key" data-key={k} key={k} role="button" tabIndex={0} onKeyUp={onKeyUpScrollTo} onClick={() => scrollToKey(k)}>
                 {k}
             </div>
         } else {
-            return <div className="key unavailable" data-key={k}>
+            return <div className="key unavailable" data-key={k} key={k}>
                 {k}
             </div>
         }

--- a/src/app/components/pages/Glossary.tsx
+++ b/src/app/components/pages/Glossary.tsx
@@ -83,13 +83,14 @@ export const Glossary = () => {
         }
 
         const regex = new RegExp(searchText.split(' ').join('|'), 'gi');
-        const sortedTerms =
+        const sortedAndFilteredTerms =
             (searchText === ''
                 ? rawGlossaryTerms
                 : rawGlossaryTerms?.filter(e => e.value?.match(regex))
-            )?.sort((a, b) => (a?.value && b?.value && a.value.localeCompare(b.value)) || 0);
+            )?.sort((a, b) => (a?.value && b?.value && a.value.localeCompare(b.value)) || 0)
+             ?.filter(t => t.examBoard === "" || t.examBoard === examBoard);
 
-        return groupTerms(sortedTerms?.filter(t => t.examBoard === "" || t.examBoard === examBoard));
+        return groupTerms(sortedAndFilteredTerms);
     }, [rawGlossaryTerms, filterTopic, searchText, examBoard]);
 
     const scrollToKey = (k: string) => {

--- a/src/app/components/pages/Glossary.tsx
+++ b/src/app/components/pages/Glossary.tsx
@@ -51,8 +51,16 @@ export function useUntilFound<T, U>(waitingFor: T | NOT_FOUND_TYPE | null | unde
 /* Gets rid of glossary page and exam board information from a glossary term id, just to keep the URL hash looking nice */
 export function formatGlossaryTermId(rawTermId: string) {
     const idRegExp = new RegExp('([a-z0-9-_]+)\\|?(?:(aqa|ocr)\\|?)?([a-z0-9-_~]+)?');
-    const simplifiedTermId = idRegExp.exec(rawTermId.split('|').slice(1).join('|'));
-    return simplifiedTermId?.slice(1,3).filter(i => typeof i === 'string').join('|').toLowerCase().replace(/[^a-z0-9]/g, '-');
+    const simplifiedTermId = idRegExp.exec(
+        rawTermId.split('|')
+            .slice(1)
+            .join('|')
+    );
+    return simplifiedTermId?.slice(1,3)
+        .filter(i => typeof i === 'string')
+        .join('|')
+        .toLowerCase()
+        .replace(/[^a-z0-9]/g, '-');
 }
 
 /* An offset applied when scrolling to a glossary term, so the term isn't hidden under the alphabet header */

--- a/src/app/components/site/cs/RoutesCS.tsx
+++ b/src/app/components/site/cs/RoutesCS.tsx
@@ -43,8 +43,6 @@ export const RoutesCS = [
     <TrackedRoute key={key++} exact path="/topics/gcse" component={AllTopics} componentProps={{stage: STAGE.GCSE}} />,
     <TrackedRoute key={key++} exact path="/topics/a_level" component={AllTopics} componentProps={{stage: STAGE.A_LEVEL}} />,
     <TrackedRoute key={key++} exact path="/topics/:topicName" component={Topic} />,
-    <TrackedRoute key={key++} exact path="/glossary" component={Glossary} />,
-
 
     // Books:
     <TrackedRoute key={key++} exact path="/books/workbook_20_aqa" component={Workbook20AQA}/>,

--- a/src/app/services/scrollManager.ts
+++ b/src/app/services/scrollManager.ts
@@ -15,8 +15,8 @@ history.listen((location, action) => {
     }
 });
 
-export function scrollVerticallyIntoView(element: Element, offset: number = 0): void {
-    const yPosition = element.getBoundingClientRect().top + pageYOffset + offset;
+export function scrollVerticallyIntoView(element: Element, offset = 0): void {
+    const yPosition = element.getBoundingClientRect().top + window.scrollY + offset;
     if (isDefined(yPosition)) {
         window.scrollTo(0, yPosition);
     }

--- a/src/scss/common/glossary.scss
+++ b/src/scss/common/glossary.scss
@@ -108,27 +108,23 @@
   }
 
   .glossary_term_name {
+    position: relative;
+
     img {
+      position: absolute;
+      top: 0.4em;
       left: 0;
+      height: 1em;
+      display: block;
+    }
+
+    strong {
+      text-decoration: underline;
+      display: block;
+      float: left;
+      top: 0;
+      left: 2em;
     }
   }
 }
 
-.glossary_term_name {
-  position: relative;
-
-  img {
-    position: absolute;
-    top: 0.4em;
-    height: 1em;
-    display: block;
-  }
-
-  strong {
-    text-decoration: underline;
-    display: block;
-    float: left;
-    top: 0;
-    left: 2em;
-  }
-}

--- a/src/scss/common/glossary.scss
+++ b/src/scss/common/glossary.scss
@@ -14,18 +14,17 @@
     background: transparent;
   }
 
-  .alphabetlist {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-evenly;
+  #stickyalphabetlist {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    background: white;
+    z-index: 255;
+    display: none;
 
     &.active {
-      position: fixed;
-      top: 0;
-      left: 0;
-      width: 100%;
-      background: white;
-      z-index: 255;
+      display: flex;
       @include make-col(12);
       box-shadow: 0px 5px 20px rgba(0,0,0,0.1);
       padding-top: 0;
@@ -35,37 +34,27 @@
         display: block;
         margin-bottom: 0;
         line-height: 3em;
+        cursor: pointer;
 
         &.unavailable {
           cursor: default;
         }
       }
-    }
 
-    div.key {
-      line-height: 1.2em;
-      width: 2em;
-      text-align: center;
-      vertical-align: bottom;
-      margin-bottom: 0.8em;
-      cursor: pointer;
-
-      &.unavailable {
-        color: $gray-120;
-        cursor: default;
+      @include respond-below(sm) {
+        display: none;
       }
     }
   }
 
-  // IMPORTANT - all CSS below overrides that of the class above (when used on the same
-  // element) because of *specificity*
-  // This is needed to make sure the three different responsive versions of the alphabet list
-  // can use the same elements.
-  #stickyalphabetlist {
+  .alphabetlist {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-evenly;
+
     @include respond-below(sm) {
       flex-direction: column;
       position: fixed;
-      left: unset;
       right: 0vw;
       top: 10vh;
       z-index: 255;
@@ -82,7 +71,8 @@
         font-weight: bold;
         display: block;
         line-height: 1em;
-        text-align: center !important;
+        width: 1.2em;
+        text-align: center!important;
         padding-left: 0.6em;
         margin: 0 !important;
 
@@ -99,6 +89,20 @@
         &.unavailable {
           display: none;
         }
+      }
+    }
+
+    div.key {
+      line-height: 1.2em;
+      width: 2em;
+      text-align: center;
+      vertical-align: bottom;
+      margin-bottom: 0.8em;
+      cursor: pointer;
+
+      &.unavailable {
+        color: $gray-120;
+        cursor: default;
       }
     }
   }

--- a/src/scss/common/glossary.scss
+++ b/src/scss/common/glossary.scss
@@ -14,17 +14,18 @@
     background: transparent;
   }
 
-  #stickyalphabetlist {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    background: white;
-    z-index: 255;
-    display: none;
+  .alphabetlist {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-evenly;
 
     &.active {
-      display: flex;
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      background: white;
+      z-index: 255;
       @include make-col(12);
       box-shadow: 0px 5px 20px rgba(0,0,0,0.1);
       padding-top: 0;
@@ -34,27 +35,37 @@
         display: block;
         margin-bottom: 0;
         line-height: 3em;
-        cursor: pointer;
 
         &.unavailable {
           cursor: default;
         }
       }
+    }
 
-      @include respond-below(sm) {
-        display: none;
+    div.key {
+      line-height: 1.2em;
+      width: 2em;
+      text-align: center;
+      vertical-align: bottom;
+      margin-bottom: 0.8em;
+      cursor: pointer;
+
+      &.unavailable {
+        color: $gray-120;
+        cursor: default;
       }
     }
   }
 
-  .alphabetlist {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-evenly;
-
+  // IMPORTANT - all CSS below overrides that of the class above (when used on the same
+  // element) because of *specificity*
+  // This is needed to make sure the three different responsive versions of the alphabet list
+  // can use the same elements.
+  #stickyalphabetlist {
     @include respond-below(sm) {
       flex-direction: column;
       position: fixed;
+      left: unset;
       right: 0vw;
       top: 10vh;
       z-index: 255;
@@ -71,8 +82,7 @@
         font-weight: bold;
         display: block;
         line-height: 1em;
-        width: 1.2em;
-        text-align: center!important;
+        text-align: center !important;
         padding-left: 0.6em;
         margin: 0 !important;
 
@@ -89,20 +99,6 @@
         &.unavailable {
           display: none;
         }
-      }
-    }
-
-    div.key {
-      line-height: 1.2em;
-      width: 2em;
-      text-align: center;
-      vertical-align: bottom;
-      margin-bottom: 0.8em;
-      cursor: pointer;
-
-      &.unavailable {
-        color: $gray-120;
-        cursor: default;
       }
     }
   }

--- a/src/scss/common/glossary.scss
+++ b/src/scss/common/glossary.scss
@@ -109,6 +109,7 @@
 
   .glossary_term_name {
     position: relative;
+    margin-left: 15px;
 
     img {
       position: absolute;


### PR DESCRIPTION
Apart from fixing the scrolling to glossary term sometimes getting caught in the header, this PR Reactifies the code a bit more, using refs instead of `document.getElementById` for example.
To fix the scrolling I had to add a lot of new code, and tear up big chunks of the old code, so it's quite a substantial change for a small-ish bug.
I tried to change/fix the fact there the alphabet header is duplicated for a couple of reasons (in the related commit), but it's much harder to get right than I thought! 😅 

