### PR TITLE
Avoid showing "Careful!" when the errors array is empty

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "isaac-react-app",
       "version": "1.6.22-SNAPSHOT",
       "dependencies": {
         "@babel/core": "^7.9.0",
@@ -56539,8 +56538,7 @@
       "integrity": "sha512-eVyv5rrK6qY9bG60bboRY78In7OpdRRg+hxp4QMLIjC/UJaFSU7exTYd0764GtXvBqh+b+faYGzren5/ffRYKw==",
       "requires": {
         "@babel/runtime": "^7.2.0",
-        "invariant": "^2.2.4",
-        "prop-types": "^15.5.7"
+        "invariant": "^2.2.4"
       }
     },
     "react-test-renderer": {

--- a/src/app/components/content/IsaacSymbolicLogicQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicLogicQuestion.tsx
@@ -260,7 +260,7 @@ const IsaacSymbolicLogicQuestionComponent = (props: IsaacSymbolicLogicQuestionPr
                         </UncontrolledTooltip>
                     </InputGroupAddon>
                 </InputGroup>
-                {errors && errors.length > 0 && <div className="eqn-editor-input-errors"><strong>Careful!</strong><ul>
+                {isDefined(errors) && Array.isArray(errors) && errors.length > 0 && <div className="eqn-editor-input-errors"><strong>Careful!</strong><ul>
                     {errors.map(e => (<li key={e}>{e}</li>))}
                 </ul></div>}
                 {symbolList && <div className="eqn-editor-symbols">

--- a/src/app/components/content/IsaacSymbolicQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicQuestion.tsx
@@ -251,7 +251,7 @@ const IsaacSymbolicQuestionComponent = (props: IsaacSymbolicQuestionProps) => {
                         </RS.UncontrolledTooltip>
                     </RS.InputGroupAddon>
                 </RS.InputGroup>
-                {errors && <div className="eqn-editor-input-errors"><strong>Careful!</strong><ul>
+                {isDefined(errors) && Array.isArray(errors) && errors.length > 0 && <div className="eqn-editor-input-errors"><strong>Careful!</strong><ul>
                     {errors.map(e => (<li key={e}>{e}</li>))}
                 </ul></div>}
                 {symbolList && <div className="eqn-editor-symbols">

--- a/src/app/components/pages/Equality.tsx
+++ b/src/app/components/pages/Equality.tsx
@@ -259,7 +259,7 @@ export const Equality = withRouter(({location}: RouteComponentProps<{}, {}, {boa
                                 </UncontrolledTooltip>}
                             </InputGroupAddon>
                         </InputGroup>
-                        {errors && errors.length > 0 && <div className="eqn-editor-input-errors"><strong>Careful!</strong><ul>
+                        {isDefined(errors) && Array.isArray(errors) && errors.length > 0 && <div className="eqn-editor-input-errors"><strong>Careful!</strong><ul>
                             {errors.map(e => (<li key={e}>{e}</li>))}
                         </ul></div>}
                     </div>}


### PR DESCRIPTION
Apparently, we had already fixed this in other components but the phy/math one was stilly bugged.