### PR TITLE
Hide "Coming soon" hexagon tag on Safari

### DIFF
--- a/src/scss/phy/filter.scss
+++ b/src/scss/phy/filter.scss
@@ -109,3 +109,23 @@ svg {
     border: solid 1px $phy_chemistry;
   }
 }
+
+/* Taken from https://www.browserstack.com/guide/create-browser-specific-css */
+
+/* Safari 11+ */
+@media not all and (min-resolution:.001dpcm) {
+  @supports (-webkit-appearance:none) and (stroke-color:transparent) {
+    .hexagon-coming-soon {
+      visibility: hidden !important;
+    }
+  }
+}
+
+/* Safari 10.1 */
+@media not all and (min-resolution:.001dpcm) {
+  @supports (-webkit-appearance:none) and (not (stroke-color:transparent)) {
+    .hexagon-coming-soon {
+      visibility: hidden !important;
+    }
+  }
+}


### PR DESCRIPTION
This is because it doesn't work and is rendered weirdly. Nicki would like it fixed properly but said this was okay for now, since actually fixing it will be extremely difficult. 
I've tested on Chrome, Edge, Firefox and Safari and only on Safari is it hidden.