### PR TITLE
Focus last focused element on modal close

### DIFF
--- a/src/app/state/modalFocusMiddleware.ts
+++ b/src/app/state/modalFocusMiddleware.ts
@@ -1,24 +1,27 @@
 import {Dispatch, Middleware, MiddlewareAPI} from "redux";
 import {ACTION_TYPE} from "../services/constants";
 
-let lastFocused: Element | null = null;
+const lastFocusedStack: Element[] = [];
 
 // When a modal is closed, this tries to focus the last element that was focused before it opened. If no element exists,
 // we try to focus the page title. This is for accessibility, mostly to help when navigating the site with a screen-reader.
 export const modalFocusMiddleware: Middleware = (api: MiddlewareAPI) => (next: Dispatch) => action => {
+    const state = api.getState();
+
     switch (action.type) {
         case ACTION_TYPE.ACTIVE_MODAL_OPEN:
             // Before modal open, record the element that is currently focused
-            lastFocused = document.activeElement;
+            if (document.activeElement) lastFocusedStack.push(document.activeElement);
             break;
-        case ACTION_TYPE.ACTIVE_MODAL_CLOSE:
+        case ACTION_TYPE.ACTIVE_MODAL_CLOSE: {
+            const lastFocusedElement = lastFocusedStack.pop() as HTMLElement;
             // Before modal close, try to focus the last focused element, otherwise focus the main heading (if it exists)
-            if (lastFocused !== null && typeof (lastFocused as HTMLElement)?.focus === "function") {
-                (lastFocused as HTMLElement)?.focus();
-                lastFocused = null;
+            if (lastFocusedElement && typeof lastFocusedElement.focus === "function") {
+                lastFocusedElement.focus();
             } else {
-                document.getElementById("main")?.focus();
+                document.getElementById(state?.mainContentId || "main")?.focus();
             }
+        }
     }
 
     return next(action);

--- a/src/app/state/modalFocusMiddleware.ts
+++ b/src/app/state/modalFocusMiddleware.ts
@@ -17,7 +17,7 @@ export const modalFocusMiddleware: Middleware = (api: MiddlewareAPI) => (next: D
                 (lastFocused as HTMLElement)?.focus();
                 lastFocused = null;
             } else {
-                document.getElementById("main-heading")?.focus();
+                document.getElementById("main")?.focus();
             }
     }
 

--- a/src/app/state/modalFocusMiddleware.ts
+++ b/src/app/state/modalFocusMiddleware.ts
@@ -1,7 +1,7 @@
 import {Dispatch, Middleware, MiddlewareAPI} from "redux";
 import {ACTION_TYPE} from "../services/constants";
 
-const lastFocusedStack: Element[] = [];
+let lastFocusedStack: Element[] = [];
 
 // When a modal is closed, this tries to focus the last element that was focused before it opened. If no element exists,
 // we try to focus the page title. This is for accessibility, mostly to help when navigating the site with a screen-reader.
@@ -16,9 +16,10 @@ export const modalFocusMiddleware: Middleware = (api: MiddlewareAPI) => (next: D
         case ACTION_TYPE.ACTIVE_MODAL_CLOSE: {
             const lastFocusedElement = lastFocusedStack.pop() as HTMLElement;
             // Before modal close, try to focus the last focused element, otherwise focus the main heading (if it exists)
-            if (lastFocusedElement && typeof lastFocusedElement.focus === "function") {
+            if (lastFocusedElement && lastFocusedElement.isConnected && typeof lastFocusedElement.focus === "function") {
                 lastFocusedElement.focus();
             } else {
+                lastFocusedStack = [];
                 document.getElementById(state?.mainContentId || "main")?.focus();
             }
         }

--- a/src/app/state/modalFocusMiddleware.ts
+++ b/src/app/state/modalFocusMiddleware.ts
@@ -1,0 +1,25 @@
+import {Dispatch, Middleware, MiddlewareAPI} from "redux";
+import {ACTION_TYPE} from "../services/constants";
+
+let lastFocused: Element | null = null;
+
+// When a modal is closed, this tries to focus the last element that was focused before it opened. If no element exists,
+// we try to focus the page title. This is for accessibility, mostly to help when navigating the site with a screen-reader.
+export const modalFocusMiddleware: Middleware = (api: MiddlewareAPI) => (next: Dispatch) => action => {
+    switch (action.type) {
+        case ACTION_TYPE.ACTIVE_MODAL_OPEN:
+            // Before modal open, record the element that is currently focused
+            lastFocused = document.activeElement;
+            break;
+        case ACTION_TYPE.ACTIVE_MODAL_CLOSE:
+            // Before modal close, try to focus the last focused element, otherwise focus the main heading (if it exists)
+            if (lastFocused !== null && typeof (lastFocused as HTMLElement)?.focus === "function") {
+                (lastFocused as HTMLElement)?.focus();
+                lastFocused = null;
+            } else {
+                document.getElementById("main-heading")?.focus();
+            }
+    }
+
+    return next(action);
+};

--- a/src/app/state/store.tsx
+++ b/src/app/state/store.tsx
@@ -4,6 +4,7 @@ import * as reduxLogger from "redux-logger";
 import {AppState, rootReducer} from "./reducers";
 import {userConsistencyCheckerMiddleware} from "./userConsistencyChecker";
 import {notificationCheckerMiddleware} from "../services/notificationManager";
+import {modalFocusMiddleware} from "./modalFocusMiddleware";
 
 // @ts-ignore
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
@@ -11,6 +12,7 @@ const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 export const middleware: Middleware[] = [
     userConsistencyCheckerMiddleware,
     notificationCheckerMiddleware,
+    modalFocusMiddleware,
     thunk,
 ];
 


### PR DESCRIPTION
This fixes an accessibility issue where a modal popping up resets the focused element. It adds Redux middleware that records the last focused element before a modal opens, and restores it on modal close (or resets focus to the top of the main content if no element exists).

When this is tested, the team that does might want to try navigating the teacher gameboard builder with a screen-reader to make sure it is as accessible as needed.