### PR TITLE
Fix lost account change information

### DIFF
--- a/src/app/components/pages/MyAccount.tsx
+++ b/src/app/components/pages/MyAccount.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useMemo, useState} from 'react';
 import {connect} from "react-redux";
 import classnames from "classnames";
 import {
@@ -62,7 +62,7 @@ const stateToProps = (state: AppState, props: any) => {
         hashAnchor: hash?.slice(1) ?? null,
         authToken: searchParams?.authToken as string ?? null,
         userOfInterest: searchParams?.userId as string ?? null,
-        userToEdit: state && {...state.adminUserGet, loggedIn: true} || {loggedIn: false}
+        adminUserToEdit: state?.adminUserGet
     }
 };
 
@@ -91,10 +91,16 @@ interface AccountPageProps {
     authToken: string | null;
     userOfInterest: string | null;
     adminUserGet: (userid: number | undefined) => void;
-    userToEdit: AdminUserGetState;
+    adminUserToEdit?: AdminUserGetState;
 }
 
-const AccountPageComponent = ({user, updateCurrentUser, getChosenUserAuthSettings, errorMessage, userAuthSettings, userPreferences, adminUserGet, hashAnchor, authToken, userOfInterest, userToEdit}: AccountPageProps) => {
+const AccountPageComponent = ({user, updateCurrentUser, getChosenUserAuthSettings, errorMessage, userAuthSettings, userPreferences, adminUserGet, hashAnchor, authToken, userOfInterest, adminUserToEdit}: AccountPageProps) => {
+    // Memoising this derived field is necessary so that it can be used used as a dependency to a useEffect later.
+    // Otherwise, it is a new object on each re-render and the useEffect is constantly re-triggered.
+    const userToEdit = useMemo(function wrapUserWithLoggedInStatus() {
+        return adminUserToEdit ? {...adminUserToEdit, loggedIn: true} : {loggedIn: false}
+    }, [adminUserToEdit]);
+
     useEffect(() => {
         if (userOfInterest) {
             adminUserGet(Number(userOfInterest));
@@ -112,7 +118,8 @@ const AccountPageComponent = ({user, updateCurrentUser, getChosenUserAuthSetting
             {...user, password: ""}
     );
 
-    useEffect(() => {
+    // This is necessary for updating the user when the user updates fields from the required account info modal, for example.
+    useEffect(function keepUserInSyncWithChangesElsewhere() {
         if (editingOtherUser && userToEdit) {
             setUserToUpdate({...userToEdit, loggedIn: true});
         } else if (user) {


### PR DESCRIPTION
This is not a nice bug!
On the account page sometimes edits which were "saved" were not being persisted.

The main object that we are altering from the account page forms is the `userToUpdate`.
`userToUpdate` can either be the `user` themselves or `userToEdit` if it is an admin that is using the page to alter someone else's details.
To accomodate changes from the Required Account Information modal being visible in `userToUpdate` we have a `useEffect` which updates `userToUpdate` to be either `user` or `userToEdit` whenever either of them change.
`userToEdit` gets wrapped to include a `loggedIn` field in a rather hacky way so that it looks like a normal user when it is being validated.
That wrapping created a new instance of `userToEdit` each time any part of redux state was changed, which in turn triggered the `useEffect` that keeps `userToUpdate` in sync - overwriting `userToUpdate` with the value in `user` or `userToEdit`.
The redux state is uppdated whenever there is a websocket update, for example, which is once per minute.
Because we don't use controlled components on the My Account page (probably the only place that we don't) the value changes do not get reflected in the input fields so the user thinks their old changes are still there but `userToUpdate` has been rewritten to whatever it used to be. When they eventually press save it is only the changes since the last redux state change / websocket snapshot that got sent to the server to be persisted.






