### PR TITLE
Link the maths text entry button help tooltip to the /solving_problems#symbolic_text page

### DIFF
--- a/src/app/components/content/IsaacSymbolicQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicQuestion.tsx
@@ -238,7 +238,7 @@ const IsaacSymbolicQuestionComponent = (props: IsaacSymbolicQuestionProps) => {
                     <RS.Input type="text" onChange={updateEquation} value={textInput}
                               placeholder="Type your formula here"/>
                     <RS.InputGroupAddon addonType="append">
-                        <RS.Button type="button" className="eqn-editor-help" id={helpTooltipId}>?</RS.Button>
+                        <RS.Button type="button" className="eqn-editor-help" id={helpTooltipId} tag="a" href="/solving_problems#symbolic_text">?</RS.Button>
                         <RS.UncontrolledTooltip placement="bottom" autohide={false} target={helpTooltipId}>
                             Here are some examples of expressions you can type:<br />
                             <br />

--- a/src/app/components/pages/Equality.tsx
+++ b/src/app/components/pages/Equality.tsx
@@ -237,7 +237,7 @@ export const Equality = withRouter(({location}: RouteComponentProps<{}, {}, {boa
                             <Input className="py-4" type="text" onChange={updateEquation} value={textInput}
                                 placeholder="Type your expression here"/>
                             <InputGroupAddon addonType="append">
-                                <Button type="button" className="eqn-editor-help" id='inequality-help' size="sm">?</Button>
+                                <Button type="button" className="eqn-editor-help pt-2" id='inequality-help' size="sm" tag="a" href="/solving_problems#symbolic_text">?</Button>
                                 {editorMode === 'maths' && <UncontrolledTooltip placement="bottom" autohide={false} target='inequality-help'>
                                     Here are some examples of expressions you can type:<br />
                                     <br />


### PR DESCRIPTION
From [this](https://trello.com/c/9ZIbsIK5/2394-make-the-equation-text-entry-button-clickable-for-further-help) content request.