### PR TITLE
Add rel=canonical meta tags to pages with many URL parameters

### DIFF
--- a/src/app/components/navigation/CanonicalHrefElement.tsx
+++ b/src/app/components/navigation/CanonicalHrefElement.tsx
@@ -1,0 +1,14 @@
+import {history} from "../../services/history";
+import {Helmet} from "react-helmet";
+import React from "react";
+
+export const CanonicalHrefElement = () => {
+    let canonicalPath = "";
+    if (history.location.pathname !== "/") {
+        canonicalPath = history.location.pathname;
+    }
+    const canonicalHref = `${window.location.origin}${canonicalPath}`;
+    return <Helmet>
+        <link rel="canonical" href={canonicalHref}/>
+    </Helmet>
+};

--- a/src/app/components/pages/Concept.tsx
+++ b/src/app/components/pages/Concept.tsx
@@ -24,6 +24,7 @@ import {IntendedAudienceWarningBanner} from "../navigation/IntendedAudienceWarni
 import {SupersededDeprecatedWarningBanner} from "../navigation/SupersededDeprecatedWarningBanner";
 import {Helmet} from "react-helmet";
 import {generateQuestionTitle} from "../../services/questions";
+import {CanonicalHrefElement} from "../navigation/CanonicalHrefElement";
 
 interface ConceptPageProps {
     conceptIdOverride?: string;
@@ -52,6 +53,7 @@ export const Concept = withRouter(({match: {params}, location: {search}, concept
                     collectionType={navigation.collectionType}
                     subTitle={doc.subtitle as string}
                 />
+                <CanonicalHrefElement />
                 <div className="no-print d-flex align-items-center">
                     <EditContentButton doc={doc} />
                     <div className="mt-3 mr-sm-1 ml-auto">

--- a/src/app/components/pages/GameboardFilter.tsx
+++ b/src/app/components/pages/GameboardFilter.tsx
@@ -36,6 +36,7 @@ import {History} from "history";
 import {Dispatch} from "redux";
 import {IsaacSpinner} from "../handlers/IsaacSpinner";
 import {siteSpecific} from "../../services/miscUtils";
+import {CanonicalHrefElement} from "../navigation/CanonicalHrefElement";
 
 function itemiseByValue<R extends {value: string}>(values: string[], options: R[]) {
     return options.filter(option => values.includes(option.value));
@@ -480,6 +481,7 @@ export const GameboardFilter = withRouter(({location}: {location: Location}) => 
 
     return <RS.Container id="gameboard-generator" className="mb-5">
         <TitleAndBreadcrumb currentPageTitle={siteSpecific("Choose your Questions", "Question Finder")} help={pageHelp} modalId="gameboard_filter_help"/>
+        <CanonicalHrefElement />
 
         <RS.Card id="filter-panel" className="mt-4 px-2 py-3 p-sm-4 pb-5">
             {/* Filter Summary */}

--- a/src/app/components/pages/Question.tsx
+++ b/src/app/components/pages/Question.tsx
@@ -28,6 +28,7 @@ import {IntendedAudienceWarningBanner} from "../navigation/IntendedAudienceWarni
 import {determineAudienceViews} from "../../services/userContext";
 import {SupersededDeprecatedWarningBanner} from "../navigation/SupersededDeprecatedWarningBanner";
 import {generateQuestionTitle} from "../../services/questions";
+import {CanonicalHrefElement} from "../navigation/CanonicalHrefElement";
 
 interface QuestionPageProps {
     questionIdOverride?: string;
@@ -76,6 +77,7 @@ export const Question = withRouter(({questionIdOverride, match, location}: Quest
                 >
                     {isFastTrack && fastTrackProgressEnabledBoards.includes(gameboardId || "") && <FastTrackProgress doc={doc} search={location.search} />}
                 </TitleAndBreadcrumb>
+                <CanonicalHrefElement />
                 <div className="no-print d-flex align-items-center mt-3">
                     <EditContentButton doc={doc} />
                     <div className="question-actions ml-auto">

--- a/src/app/components/pages/Topic.tsx
+++ b/src/app/components/pages/Topic.tsx
@@ -14,6 +14,7 @@ import {UserContextPicker} from "../elements/inputs/UserContextPicker";
 import {atLeastOne} from "../../services/validation";
 import {selectors} from '../../state/selectors';
 import {TopicSummaryLinks} from "../elements/list-groups/TopicSummaryLinks";
+import {CanonicalHrefElement} from "../navigation/CanonicalHrefElement";
 
 export const Topic = withRouter(({match: {params: {topicName}}}: {match: {params: {topicName: TAG_ID}}}) => {
     const dispatch = useDispatch();
@@ -34,6 +35,7 @@ export const Topic = withRouter(({match: {params: {topicName}}}: {match: {params
     return <ShowLoading until={topicPage} thenRender={topicPage =>
         <Container id="topic-page">
             <TitleAndBreadcrumb intermediateCrumbs={[ALL_TOPICS_CRUMB]} currentPageTitle={topicPage.title as string}/>
+            <CanonicalHrefElement />
             <Row>
                 <Col md={{size: 8, offset: 2}} className="py-3">
                     <div className="d-flex justify-content-end">


### PR DESCRIPTION
When a search engine indexes these pages, we only care about the full versions of the pages (I think!) and not the exam board or stage specific versions. This strips out all URL parameters and hashes and leaves just the bare URL as "canonical".
The new element is designed to work on any page so it can be reused.

I can't see why the component correctly rerenders when the page changes (it feels like it needs a prop or something so React knows to re-render it?!), but it seems to work for the places it is currently in!

---
The aim is to reduce the number of duplicate search results caused by the explosion of possible combinations of URL parameters on each page, and we can always roll it back if it doesn't work.