### PR TITLE
Improved meta descriptions

### DIFF
--- a/src/app/components/elements/MetaDescription.tsx
+++ b/src/app/components/elements/MetaDescription.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import {Helmet} from "react-helmet";
+import {isDefined} from "../../services/miscUtils";
+import {RenderNothing} from "./RenderNothing";
+
+export function MetaDescription(props: { description?: string }) {
+    if (isDefined(props.description)) {
+        return <Helmet>
+            <meta name="description" content={props.description} />
+            <meta property="og:description" content={props.description} />
+        </Helmet>;
+    }
+    return RenderNothing;
+}

--- a/src/app/components/elements/PageTitle.tsx
+++ b/src/app/components/elements/PageTitle.tsx
@@ -11,6 +11,7 @@ import {AUDIENCE_DISPLAY_FIELDS, filterAudienceViewsByProperties, useUserContext
 import {STAGE, stageLabelMap} from "../../services/constants";
 import {DifficultyIcons} from "./svg/DifficultyIcons";
 import classnames from "classnames";
+import {Helmet} from "react-helmet";
 
 function AudienceViewer({audienceViews}: {audienceViews: ViewingContext[]}) {
     const userContext = useUserContext();
@@ -77,6 +78,9 @@ export const PageTitle = ({currentPageTitle, subTitle, help, className, audience
             <LaTeX markup={currentPageTitle} />
             {subTitle && <span className="h-subtitle d-none d-sm-block">{subTitle}</span>}
         </div>
+        <Helmet>
+            <meta property="og:title" content={currentPageTitle} />
+        </Helmet>
         {audienceViews && <AudienceViewer audienceViews={audienceViews} />}
         {help && !showModal && <React.Fragment>
             <div id="title-help" className="title-help">Help</div>

--- a/src/app/components/pages/AllTopics.tsx
+++ b/src/app/components/pages/AllTopics.tsx
@@ -14,7 +14,7 @@ import {useQueryParams} from "../../services/reactRouterExtension";
 import {useUserContext} from "../../services/userContext";
 import {RenderNothing} from "../elements/RenderNothing";
 import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
-import {Helmet} from "react-helmet";
+import {MetaDescription} from "../elements/MetaDescription";
 
 export function AllTopicsWithoutAStage() {
     const history = useHistory();
@@ -129,10 +129,7 @@ export const AllTopics = ({stage}: {stage: STAGE.A_LEVEL | STAGE.GCSE}) => {
     return <div className="pattern-02">
         <Container>
             <TitleAndBreadcrumb currentPageTitle={stage === STAGE.A_LEVEL ? "A level topics" : "GCSE topics"}/>
-            {SITE_SUBJECT === SITE.CS && <Helmet>
-                <meta name="description" content={metaDescriptionMap[stage]} />
-                <meta property="og:description" content={metaDescriptionMap[stage]} />
-            </Helmet>}
+            {SITE_SUBJECT === SITE.CS && <MetaDescription description={metaDescriptionMap[stage]} />}
 
             <Tabs className="pt-3" tabContentClass="pt-3" activeTabOverride={activeTab} refreshHash={stage} onActiveTabChange={setActiveTab}>
                 {

--- a/src/app/components/pages/Concept.tsx
+++ b/src/app/components/pages/Concept.tsx
@@ -19,12 +19,11 @@ import {EditContentButton} from "../elements/EditContentButton";
 import {ShareLink} from "../elements/ShareLink";
 import {PrintButton} from "../elements/PrintButton";
 import {TrustedMarkdown} from "../elements/TrustedMarkdown";
-import {SITE, SITE_SUBJECT, SITE_SUBJECT_TITLE} from "../../services/siteConstants";
+import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
 import {IntendedAudienceWarningBanner} from "../navigation/IntendedAudienceWarningBanner";
 import {SupersededDeprecatedWarningBanner} from "../navigation/SupersededDeprecatedWarningBanner";
-import {Helmet} from "react-helmet";
-import {generateQuestionTitle} from "../../services/questions";
 import {CanonicalHrefElement} from "../navigation/CanonicalHrefElement";
+import {MetaDescription} from "../elements/MetaDescription";
 
 interface ConceptPageProps {
     conceptIdOverride?: string;
@@ -42,17 +41,13 @@ export const Concept = withRouter(({match: {params}, location: {search}, concept
         const doc = supertypedDoc as IsaacQuestionPageDTO & DocumentSubject;
         return <div className={doc.subjectId || ""}>
             <Container>
-                <Helmet>
-                    <meta property="og:title" content={generateQuestionTitle(doc) + " — Isaac " + SITE_SUBJECT_TITLE} />
-                    {doc.summary && <meta name="description" content={doc.summary}/>}
-                    {doc.summary && <meta property="og:description" content={doc.summary}/>}
-                </Helmet>
                 <TitleAndBreadcrumb
                     intermediateCrumbs={navigation.breadcrumbHistory}
                     currentPageTitle={doc.title as string}
                     collectionType={navigation.collectionType}
                     subTitle={doc.subtitle as string}
                 />
+                <MetaDescription description={doc.summary} />
                 <CanonicalHrefElement />
                 <div className="no-print d-flex align-items-center">
                     <EditContentButton doc={doc} />

--- a/src/app/components/pages/Contact.tsx
+++ b/src/app/components/pages/Contact.tsx
@@ -23,7 +23,7 @@ import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
 import {SITE, SITE_SUBJECT, SITE_SUBJECT_TITLE, WEBMASTER_EMAIL} from "../../services/siteConstants";
 import {PageFragment} from "../elements/PageFragment";
 import {selectors} from "../../state/selectors";
-import {Helmet} from "react-helmet";
+import {MetaDescription} from "../elements/MetaDescription";
 
 const determineUrlQueryPresets = (user?: PotentialUser | null) => {
     const urlQuery = queryString.parse(location.search);
@@ -91,10 +91,7 @@ export const Contact = () => {
 
     return <Container id="contact-page" className="pb-5">
         <TitleAndBreadcrumb currentPageTitle="Contact us" />
-        {SITE_SUBJECT === SITE.CS && <Helmet>
-            <meta name="description" content={metaDescriptionCS} />
-            <meta property="og:description" content={metaDescriptionCS} />
-        </Helmet>}
+        {SITE_SUBJECT === SITE.CS && <MetaDescription description={metaDescriptionCS}/>}
         <div className="pt-4">
             <Row>
                 <Col size={12} md={{size: 3, order: 1}} xs={{order: 2}} className="mt-4 mt-md-0">

--- a/src/app/components/pages/Events.tsx
+++ b/src/app/components/pages/Events.tsx
@@ -16,7 +16,7 @@ import {isTeacher} from "../../services/user";
 import {RenderNothing} from "../elements/RenderNothing";
 import {CoronavirusWarningBanner} from "../navigation/CoronavirusWarningBanner";
 import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
-import {Helmet} from "react-helmet";
+import {MetaDescription} from "../elements/MetaDescription";
 
 
 interface EventsPageQueryParams {
@@ -62,10 +62,7 @@ export const Events = withRouter(({history, location}: {history: History; locati
             <TitleAndBreadcrumb currentPageTitle={"Events"} help={pageHelp} />
             {SITE_SUBJECT === SITE.CS && <>
                 <CoronavirusWarningBanner />
-                <Helmet>
-                    <meta name="description" content={metaDescriptionCS} />
-                    <meta property="og:description" content={metaDescriptionCS} />
-                </Helmet>
+                <MetaDescription description={metaDescriptionCS} />
             </>}
             <div className="my-4">
                 {/* Filters */}

--- a/src/app/components/pages/GameboardFilter.tsx
+++ b/src/app/components/pages/GameboardFilter.tsx
@@ -2,17 +2,17 @@ import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {useDispatch, useSelector} from "react-redux";
 import * as RS from "reactstrap";
 import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
-import {Link, withRouter} from "react-router-dom";
+import {Link, useHistory, withRouter} from "react-router-dom";
 import tags from '../../services/tags';
 import {
+    DIFFICULTY_ICON_ITEM_OPTIONS,
     DIFFICULTY_ITEM_OPTIONS,
     EXAM_BOARD_ITEM_OPTIONS,
     NOT_FOUND,
     QUESTION_CATEGORY_ITEM_OPTIONS,
-    STAGE,
-    TAG_ID,
     QUESTION_FINDER_CONCEPT_LABEL_PLACEHOLDER,
-    DIFFICULTY_ICON_ITEM_OPTIONS
+    STAGE,
+    TAG_ID
 } from '../../services/constants';
 import {Tag} from "../../../IsaacAppTypes";
 import {GameboardViewer} from './Gameboard';
@@ -20,9 +20,8 @@ import {fetchConcepts, generateTemporaryGameboard, loadGameboard} from '../../st
 import {ShowLoading} from "../handlers/ShowLoading";
 import {selectors} from "../../state/selectors";
 import queryString from "query-string";
-import {useHistory} from "react-router-dom";
 import {HierarchyFilterHexagonal, HierarchyFilterSummary, Tier} from "../elements/svg/HierarchyFilter";
-import {Item, unwrapValue, isItemEqual} from "../../services/select";
+import {isItemEqual, Item, unwrapValue} from "../../services/select";
 import {useDeviceSize} from "../../services/device";
 import Select, {GroupedOptionsType} from "react-select";
 import {getFilteredExamBoardOptions, getFilteredStageOptions, useUserContext} from "../../services/userContext";
@@ -37,7 +36,7 @@ import {Dispatch} from "redux";
 import {IsaacSpinner} from "../handlers/IsaacSpinner";
 import {siteSpecific} from "../../services/miscUtils";
 import {CanonicalHrefElement} from "../navigation/CanonicalHrefElement";
-import {Helmet} from "react-helmet";
+import {MetaDescription} from "../elements/MetaDescription";
 
 function itemiseByValue<R extends {value: string}>(values: string[], options: R[]) {
     return options.filter(option => values.includes(option.value));
@@ -258,10 +257,7 @@ const CSFilter = ({selections, setSelections, stages, setStages, difficulties, s
 
     return <>
         {/* CS-specific metadata: */}
-        <Helmet>
-            <meta name="description" content={metaDescriptionCS} />
-            <meta property="og:description" content={metaDescriptionCS} />
-        </Helmet>
+        <MetaDescription description={metaDescriptionCS} />
         <RS.Row>
             <RS.Col md={6}>
                 <RS.Label className={`mt-2 mt-lg-0`} htmlFor="stage-selector">

--- a/src/app/components/pages/Generic.tsx
+++ b/src/app/components/pages/Generic.tsx
@@ -16,7 +16,7 @@ import {ShareLink} from "../elements/ShareLink";
 import {PrintButton} from "../elements/PrintButton";
 import {WithFigureNumbering} from "../elements/WithFigureNumbering";
 import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
-import {Helmet} from "react-helmet";
+import {MetaDescription} from "../elements/MetaDescription";
 
 interface GenericPageComponentProps {
     pageIdOverride?: string;
@@ -35,10 +35,7 @@ export const Generic = withRouter(({pageIdOverride, match: {params}}: GenericPag
         return <div className={doc.subjectId || ""}>
             <Container>
                 <TitleAndBreadcrumb currentPageTitle={doc.title as string} />
-                <Helmet>
-                    {doc.summary && <meta name="description" content={doc.summary}/>}
-                    {doc.summary && <meta property="og:description" content={doc.summary}/>}
-                </Helmet>
+                <MetaDescription description={doc.summary} />
                 <div className="no-print d-flex align-items-center">
                     <EditContentButton doc={doc} />
                     <div className="question-actions question-actions-leftmost mt-3">

--- a/src/app/components/pages/Glossary.tsx
+++ b/src/app/components/pages/Glossary.tsx
@@ -18,7 +18,7 @@ import {useUserContext} from "../../services/userContext";
 import {useUrlHashValue} from "../../services/reactRouterExtension";
 import {Item} from "../../services/select";
 import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
-import {Helmet} from "react-helmet";
+import {MetaDescription} from "../elements/MetaDescription";
 
 /*
     This hook waits for `waitingFor` to be populated, returning:
@@ -195,10 +195,7 @@ export const Glossary = () => {
     const thenRender = <div className="glossary-page">
         <Container>
             <TitleAndBreadcrumb currentPageTitle="Glossary" />
-            {SITE_SUBJECT === SITE.CS && <Helmet>
-                <meta name="description" content={metaDescriptionCS} />
-                <meta property="og:description" content={metaDescriptionCS} />
-            </Helmet>}
+            {SITE_SUBJECT === SITE.CS && <MetaDescription description={metaDescriptionCS} />}
 
             <div className="no-print d-flex align-items-center">
                 <div className="question-actions question-actions-leftmost mt-3">

--- a/src/app/components/pages/LogIn.tsx
+++ b/src/app/components/pages/LogIn.tsx
@@ -8,7 +8,7 @@ import {history} from "../../services/history";
 import {Redirect} from "react-router";
 import {selectors} from "../../state/selectors";
 import {SITE, SITE_SUBJECT, SITE_SUBJECT_TITLE} from "../../services/siteConstants";
-import {Helmet} from "react-helmet";
+import {MetaDescription} from "../elements/MetaDescription";
 
 export const LogIn = () => {
     const headingRef = useRef<HTMLHeadingElement>(null);
@@ -83,10 +83,7 @@ export const LogIn = () => {
     const metaDescriptionCS = "Log in to your account. Access free GCSE and A level Computer Science resources. Use our materials to learn and revise for your exams.";
 
     return <Container id="login-page" className="my-4">
-        {SITE_SUBJECT === SITE.CS && <Helmet>
-            <meta name="description" content={metaDescriptionCS} />
-            <meta property="og:description" content={metaDescriptionCS} />
-        </Helmet>}
+        {SITE_SUBJECT === SITE.CS && <MetaDescription description={metaDescriptionCS} />}
         <Row>
             <Col md={{offset: 1, size: 10}} lg={{offset: 2, size: 8}} xl={{offset: 3, size: 6}}>
                 <Card>

--- a/src/app/components/pages/Registration.tsx
+++ b/src/app/components/pages/Registration.tsx
@@ -28,7 +28,7 @@ import {FIRST_LOGIN_STATE} from "../../services/firstLogin";
 import {Redirect, RouteComponentProps, withRouter} from "react-router";
 import {SITE, SITE_SUBJECT, SITE_SUBJECT_TITLE} from "../../services/siteConstants";
 import {selectors} from "../../state/selectors";
-import {Helmet} from "react-helmet";
+import {MetaDescription} from "../elements/MetaDescription";
 
 export const Registration = withRouter(({location}:  RouteComponentProps<{}, {}, {email?: string; password?: string}>) => {
     const dispatch = useDispatch();
@@ -95,10 +95,7 @@ export const Registration = withRouter(({location}:  RouteComponentProps<{}, {},
     return <Container id="registration-page" className="mb-5">
 
         <TitleAndBreadcrumb currentPageTitle="Registration" className="mb-4" />
-        {SITE_SUBJECT === SITE.CS && <Helmet>
-            <meta name="description" content={metaDescriptionCS} />
-            <meta property="og:description" content={metaDescriptionCS} />
-        </Helmet>}
+        {SITE_SUBJECT === SITE.CS && <MetaDescription description={metaDescriptionCS} />}
 
         <Card>
             <CardBody>

--- a/src/app/components/pages/Support.tsx
+++ b/src/app/components/pages/Support.tsx
@@ -9,8 +9,8 @@ import {fromPairs} from "lodash";
 import {PageFragment} from "../elements/PageFragment";
 import {NotFound} from "./NotFound";
 import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
-import {Helmet} from "react-helmet";
 import {isDefined} from "../../services/miscUtils";
+import {MetaDescription} from "../elements/MetaDescription";
 
 type SupportType = "student" | "teacher";
 
@@ -119,10 +119,7 @@ export const SupportPageComponent = ({match: {params: {type, category}}}: RouteC
         <Row>
             <Col>
                 <TitleAndBreadcrumb currentPageTitle={section.title} />
-                {SITE_SUBJECT === SITE.CS && isDefined(type) && <Helmet>
-                    <meta name="description" content={metaDescriptionMap[type]} />
-                    <meta property="og:description" content={metaDescriptionMap[type]} />
-                </Helmet>}
+                {SITE_SUBJECT === SITE.CS && isDefined(type) && <MetaDescription description={metaDescriptionMap[type]} />}
             </Col>
         </Row>
         <Row>


### PR DESCRIPTION
As suggested by Meurig in #523, use a single element for the meta description tags.

Also set the `og:title` (used by Facebook and Twitter, but only if set without JavaScript I fear) in the same way that page titles are set, so that it matches the title on all pages. This may not do anything.