### PR TITLE
Manage Tests / Assignment Progress (tests): student performance overflows window, doesn't scroll

### DIFF
--- a/src/app/components/elements/quiz/QuizProgressCommon.tsx
+++ b/src/app/components/elements/quiz/QuizProgressCommon.tsx
@@ -117,7 +117,7 @@ export function ResultRow({pageSettings, row, assignment}: ResultRowProps) {
     }
     const valid = message === undefined;
     return <tr className={`${row.user?.authorisedFullAccess ? "" : " not-authorised"}`} title={`${row.user?.givenName + " " + row.user?.familyName}`}>
-        <th className="student-name">
+        <td className="student-name">
             {valid ?
                 <>
                     <Button color="link" onClick={toggle} disabled={working}>
@@ -143,7 +143,7 @@ export function ResultRow({pageSettings, row, assignment}: ResultRowProps) {
                     <span className="d-none d-lg-inline"> {row.user?.familyName}</span>
                 </>
             }
-        </th>
+        </td>
         {!valid && <td colSpan={sections.map(questionsInSection).flat().length + 1}>{message}</td>}
         {valid && <>
             {sections.map(section => {
@@ -160,9 +160,9 @@ export function ResultRow({pageSettings, row, assignment}: ResultRowProps) {
                     </td>
                 }).flat()
             })}
-            <td className="total-column">
+            <th className="total-column">
                 {formatMark(row.feedback?.overallMark?.correct as number, quiz?.total as number, pageSettings.formatAsPercentage)}
-            </td>
+            </th>
         </>}
     </tr>;
 }
@@ -170,24 +170,25 @@ export function ResultRow({pageSettings, row, assignment}: ResultRowProps) {
 export function ResultsTable({assignment, pageSettings}: ResultsTableProps) {
     const sections: IsaacQuizSectionDTO[] = assignment.quiz?.children || [];
 
-    return <table className="progress-table w-100 mb-5 border">
-        <tbody>
-            <tr className="bg-white">
-                <th>&nbsp;</th>
-                {sections.map(section => <th key={section.id} colSpan={questionsInSection(section).length} className="border font-weight-bold">
-                    {section.title}
-                </th>)}
-                <th rowSpan={2} className="border-bottom">Overall</th>
-            </tr>
-            <tr className="bg-white">
-                <th className="bg-white border-bottom">&nbsp;</th>
-                {sections.map(section => questionsInSection(section).map((question, index) => <th key={question.id} className="border">
-                    {`Q${index + 1}`}
-                </th>)).flat()}
-            </tr>
-            {assignment.userFeedback?.map(row =>
-                <ResultRow key={row.user?.id} pageSettings={pageSettings} row={row} assignment={assignment} />
-            )}
-        </tbody>
-    </table>;
+    return <div className={"progress-table-container mb-5"}>
+        <table className="progress-table border">
+            <tbody>
+                <tr className="bg-white">
+                    <th rowSpan={2} className="bg-white border-bottom student-name">&nbsp;</th>
+                    {sections.map(section => <th key={section.id} colSpan={questionsInSection(section).length} className="border font-weight-bold">
+                        {section.title}
+                    </th>)}
+                    <th rowSpan={2} className="border-bottom total-column">Overall</th>
+                </tr>
+                <tr className="bg-white">
+                    {sections.map(section => questionsInSection(section).map((question, index) => <th key={question.id} className="border">
+                        {`Q${index + 1}`}
+                    </th>)).flat()}
+                </tr>
+                {assignment.userFeedback?.map(row =>
+                    <ResultRow key={row.user?.id} pageSettings={pageSettings} row={row} assignment={assignment} />
+                )}
+            </tbody>
+        </table>
+    </div> ;
 }

--- a/src/app/components/pages/AssignmentProgress.tsx
+++ b/src/app/components/pages/AssignmentProgress.tsx
@@ -52,7 +52,7 @@ function selectGroups(state: AppState) {
         if (isDefined(state.boards) && isDefined(state.boards.boards)) {
             for (const board of state.boards.boards.boards) {
                 gameboards[board.id as string] = board;
-            };
+            }
         }
 
         const assignmentsProgress = selectors.assignments.progress(state);
@@ -72,7 +72,7 @@ function selectGroups(state: AppState) {
                 } else {
                     assignments[groupId] = [enhancedAssignment];
                 }
-            };
+            }
         }
 
         const quizAssignments: { [id: number]: QuizAssignmentDTO[] } = {};
@@ -155,23 +155,23 @@ export const ProgressDetails = (props: ProgressDetailsProps | SingleProgressDeta
     const [singleQuestionSort, setSingleQuestionSort] = useState(false);
 
     // Calculate 'class average', which isn't an average at all, it's the percentage of ticks per question.
-    let questions = assignment.gameboard.contents;
+    const questions = assignment.gameboard.contents;
     const assignmentAverages: number[] = [];
     let assignmentTotalQuestionParts = 0;
 
-    for (let i in questions) {
-        let q = questions[i];
+    for (const i in questions) {
+        const q = questions[i];
         let tickCount = 0;
 
         for (let j = 0; j < progress.length; j++) {
-            let studentResults = progress[j].results;
+            const studentResults = progress[j].results;
 
-            if (studentResults[i] == "PASSED" || studentResults[i] == "PERFECT") {
+            if (studentResults[i] === "PASSED" || studentResults[i] === "PERFECT") {
                 tickCount++;
             }
         }
 
-        let tickPercent = Math.round(100 * (tickCount / progress.length));
+        const tickPercent = Math.round(100 * (tickCount / progress.length));
         assignmentAverages.push(tickPercent);
         assignmentTotalQuestionParts += q.questionPartsTotal;
     }
@@ -180,7 +180,7 @@ export const ProgressDetails = (props: ProgressDetailsProps | SingleProgressDeta
     let studentsCorrect = 0;
     for (let j = 0; j < progress.length; j++) {
 
-        let studentProgress = progress[j];
+        const studentProgress = progress[j];
 
         if (progress[j].user.authorisedFullAccess) {
 
@@ -189,8 +189,8 @@ export const ProgressDetails = (props: ProgressDetailsProps | SingleProgressDeta
             studentProgress.incorrectQuestionPartsCount = 0;
             studentProgress.notAttemptedPartResults = [];
 
-            for (let i in studentProgress.results) {
-                if (studentProgress.results[i] == "PASSED" || studentProgress.results[i] == "PERFECT") {
+            for (const i in studentProgress.results) {
+                if (studentProgress.results[i] === "PASSED" || studentProgress.results[i] === "PERFECT") {
                     studentProgress.tickCount++;
                 }
                 studentProgress.correctQuestionPartsCount += studentProgress.correctPartResults[i];
@@ -251,7 +251,7 @@ export const ProgressDetails = (props: ProgressDetailsProps | SingleProgressDeta
         const {itemOrder, ...rest} = props;
         const className = (props.className || "") + " " + sortClasses(itemOrder);
         const clickToSelect = typeof itemOrder === "number" ? (() => setSelectedQuestion(itemOrder)) : undefined;
-        const sortArrows = (typeof itemOrder !== "number" || itemOrder == selectedQuestionNumber) ?
+        const sortArrows = (typeof itemOrder !== "number" || itemOrder === selectedQuestionNumber) ?
             <button className="sort" onClick={() => {toggleSort(itemOrder);}}>
                 <span className="up" >▲</span>
                 <span className="down">▼</span>
@@ -272,11 +272,11 @@ export const ProgressDetails = (props: ProgressDetailsProps | SingleProgressDeta
     function markClassesInternal(studentProgress: AppAssignmentProgress, status: GameboardItemState | null, correctParts: number, incorrectParts: number, totalParts: number) {
         if (!studentProgress.user.authorisedFullAccess) {
             return "revoked";
-        } else if (correctParts == totalParts) {
+        } else if (correctParts === totalParts) {
             return "completed";
-        } else if (status == "PASSED" || (correctParts / totalParts) >= passMark) {
+        } else if (status === "PASSED" || (correctParts / totalParts) >= passMark) {
             return "passed";
-        } else if (status == "FAILED" || (incorrectParts / totalParts) > (1 - passMark)) {
+        } else if (status === "FAILED" || (incorrectParts / totalParts) > (1 - passMark)) {
             return "failed";
         } else if (correctParts > 0 || incorrectParts > 0) {
             return "in-progress";
@@ -286,9 +286,9 @@ export const ProgressDetails = (props: ProgressDetailsProps | SingleProgressDeta
     }
 
     function markClasses(studentProgress: AppAssignmentProgress, totalParts: number) {
-        let correctParts = studentProgress.correctQuestionPartsCount;
-        let incorrectParts = studentProgress.incorrectQuestionPartsCount;
-        let status = null;
+        const correctParts = studentProgress.correctQuestionPartsCount;
+        const incorrectParts = studentProgress.incorrectQuestionPartsCount;
+        const status = null;
 
         return markClassesInternal(studentProgress, status, correctParts, incorrectParts, totalParts);
     }
@@ -297,9 +297,9 @@ export const ProgressDetails = (props: ProgressDetailsProps | SingleProgressDeta
         const question = questions[index];
 
         const totalParts = question.questionPartsTotal;
-        let correctParts = studentProgress.correctPartResults[index];
-        let incorrectParts = studentProgress.incorrectPartResults[index];
-        let status = studentProgress.results[index];
+        const correctParts = studentProgress.correctPartResults[index];
+        const incorrectParts = studentProgress.incorrectPartResults[index];
+        const status = studentProgress.results[index];
 
         return isSelected(question) + " " + markClassesInternal(studentProgress, status, correctParts, incorrectParts, totalParts);
     }
@@ -339,7 +339,7 @@ export const ProgressDetails = (props: ProgressDetailsProps | SingleProgressDeta
         <div className="progress-header">
             <strong>{studentsCorrect}</strong> of <strong>{progress.length}</strong> students have completed the gameboard <Link to={`/gameboards#${assignment.gameboardId}`}>{assignment.gameboard.title}</Link> correctly.
         </div>
-        {progress.length > 0 && <React.Fragment>
+        {progress.length > 0 && <>
             <div className="progress-questions">
                 <Button color="tertiary" disabled={selectedQuestionNumber == 0}
                     onClick={() => setSelectedQuestion(selectedQuestionNumber - 1)}>◄</Button>
@@ -393,7 +393,7 @@ export const ProgressDetails = (props: ProgressDetailsProps | SingleProgressDeta
                     </tfoot>
                 </table>
             </div>
-        </React.Fragment>}
+        </>}
     </div>;
 };
 
@@ -440,7 +440,7 @@ const AssignmentDetails = (props: AssignmentDetailsProps) => {
                 <span className="d-none d-md-inline">,</span>
                 <Button className="d-none d-md-inline" color="link" tag="a" href={getAssignmentCSVDownloadLink(assignment._id)} onClick={openAssignmentDownloadLink}>Download CSV</Button>
                 <span className="d-none d-md-inline">or</span>
-                < Button className="d-none d-md-inline" color="link" tag="a" href={`/${assignmentPath}/${assignment._id}`} onClick={openSingleAssignment}>View individual assignment</Button>
+                <Button className="d-none d-md-inline" color="link" tag="a" href={`/${assignmentPath}/${assignment._id}`} onClick={openSingleAssignment}>View individual assignment</Button>
             </div>
         </div>
         {isExpanded && <ProgressLoader {...props} />}
@@ -642,7 +642,7 @@ const GroupAssignmentProgress = (props: GroupDetailsProps) => {
         dispatch(openActiveModal(downloadLinkModal(event.currentTarget.href)));
     }
 
-return <React.Fragment>
+    return <>
         <div onClick={() => setExpanded(!isExpanded)} className={isExpanded ? "assignment-progress-group active align-items-center" : "assignment-progress-group align-items-center"}>
             <div className="group-name"><span className="icon-group"/><span>{group.groupName}</span></div>
             <div className="flex-grow-1" />
@@ -655,7 +655,7 @@ return <React.Fragment>
             </Button>
         </div>
         {isExpanded && <GroupDetails {...props} />}
-    </React.Fragment>;
+    </>;
 };
 
 export function AssignmentProgress(props: AssignmentProgressPageProps) {
@@ -687,7 +687,7 @@ export function AssignmentProgress(props: AssignmentProgressPageProps) {
         Click on your groups to see the assignments you have set. View your students' progress by question.
     </span>;
 
-    return <React.Fragment>
+    return <>
         <Container>
             <TitleAndBreadcrumb
                 currentPageTitle={{[SITE.PHY]: "Assignment Progress", [SITE.CS]: "My markbook"}[SITE_SUBJECT]}
@@ -721,5 +721,5 @@ export function AssignmentProgress(props: AssignmentProgressPageProps) {
                 </Container>}
             </ShowLoading>
         </div>
-    </React.Fragment>;
+    </>;
 }

--- a/src/scss/common/assignment-progress.scss
+++ b/src/scss/common/assignment-progress.scss
@@ -344,18 +344,20 @@ $failed-bg-size: 25%;
 
 @mixin table-sticky() {
   position: sticky !important;
+  position: -webkit-sticky !important;
   background-clip:  padding-box !important;
   background: $gray-103;
   z-index: 2;
 }
 
 @mixin after-border() {
-  content:'';
-  position:absolute;
-  left: 0px;
-  top: 0px;
-  right: 0px;
-  bottom: 0px;
+  content: '';
+  position: absolute;
+  margin: -0.5px -0.5px;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
 }
 
 .single-download {
@@ -363,18 +365,29 @@ $failed-bg-size: 25%;
   text-align: right;
 }
 
-.progress-table {
+.progress-table-container {
+  width: 100% !important;
+  display: block;
+  overflow-y: auto;
   overflow-x: auto;
-  overflow-y: visible;
+  -webkit-overflow-scrolling: touch;
+}
+
+// Safari 10.1+
+// https://stackoverflow.com/questions/16348489/is-there-a-css-hack-for-safari-only-not-chrome
+@media not all and (min-resolution:.001dpcm)
+{ @supports (-webkit-appearance:none) {
+  .progress-table-container {
+    overflow-x: scroll !important;
+  }
+}}
+
+.progress-table {
   padding-bottom: 1px; // Fixes odd broswer bugs around the magic :after borders
 
   th.selected {
     // Fixes Firefox bug with position: relative table cells: https://bugzilla.mozilla.org/show_bug.cgi?id=688556
     background-clip: padding-box !important;
-  }
-
-  table {
-    width: 100%;
   }
 
   tbody tr:nth-of-type(even) {
@@ -394,6 +407,7 @@ $failed-bg-size: 25%;
   font-size: 12px;
   tbody td, tbody th {
     min-width: 40px;
+    z-index: 1;
   }
   .total-column.left {
     right: 40px;
@@ -485,15 +499,21 @@ $failed-bg-size: 25%;
     font-weight: bold;
   }
 
-  th:first-child {
+  .student-name {
+    font-weight: bold;
+    color: $text-muted;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    min-width: 130px;
+
     @include table-sticky;
     left: 0;
     top: 0;
     width: 195px;
-
     &:after {
       @include after-border;
       border-right: 1px solid $gray-118;
+      border-left: 1px solid $gray-118;
       pointer-events: none; // don't intercept clicks as we want links in the th element
     }
   }
@@ -503,21 +523,12 @@ $failed-bg-size: 25%;
     width: 65px;
     right: 0;
     top: 0;
-    button {
-      z-index: 2;
-    }
-    &.left:after{
+    &:after {
       @include after-border;
+      border-right: 1px solid $gray-118;
       border-left: 1px solid $gray-118;
+      pointer-events: none; // don't intercept clicks as we want links in the th element
     }
-  }
-
-  .student-name {
-    font-weight: bold;
-    color: $text-muted;
-    padding-top: 5px;
-    padding-bottom: 5px;
-    min-width: 130px;
   }
 }
 


### PR DESCRIPTION
It does now! Plus the overall mark column is now sticky to the right of the table (which seemed to be what the old CSS was trying to do anyway)

A lot of the diff is cleaning up old code to make the linter happy (turning `let` into `const`, that kind of thing) 