### PR TITLE
Add TitleAndBreadcrumb parameter to optionally disable LaTeX rendering

### DIFF
--- a/src/app/components/elements/PageTitle.tsx
+++ b/src/app/components/elements/PageTitle.tsx
@@ -35,12 +35,13 @@ function AudienceViewer({audienceViews}: {audienceViews: ViewingContext[]}) {
 export interface PageTitleProps {
     currentPageTitle: string;
     subTitle?: string;
+    disallowLaTeX?: boolean;
     help?: ReactElement;
     className?: string;
     audienceViews?: ViewingContext[];
     modalId?: string;
 }
-export const PageTitle = ({currentPageTitle, subTitle, help, className, audienceViews, modalId}: PageTitleProps) => {
+export const PageTitle = ({currentPageTitle, subTitle, disallowLaTeX, help, className, audienceViews, modalId}: PageTitleProps) => {
     const dispatch = useDispatch();
     const openModal = useSelector((state: AppState) => Boolean(state?.activeModals?.length));
     const headerRef = useRef<HTMLHeadingElement>(null);
@@ -75,7 +76,7 @@ export const PageTitle = ({currentPageTitle, subTitle, help, className, audience
 
     return <h1 id="main-heading" tabIndex={-1} ref={headerRef} className={`h-title h-secondary d-sm-flex ${className ? className : ""}`}>
         <div className="mr-auto">
-            <LaTeX markup={currentPageTitle} />
+            {formatPageTitle(currentPageTitle, disallowLaTeX)}
             {subTitle && <span className="h-subtitle d-none d-sm-block">{subTitle}</span>}
         </div>
         <Helmet>
@@ -91,3 +92,7 @@ export const PageTitle = ({currentPageTitle, subTitle, help, className, audience
         </React.Fragment>}
     </h1>
 };
+
+export const formatPageTitle = (currentPageTitle: string, disallowLaTeX?: boolean) => {
+   return  disallowLaTeX ? <span> {currentPageTitle} </span> : <LaTeX markup={currentPageTitle} />
+}

--- a/src/app/components/elements/TitleAndBreadcrumb.tsx
+++ b/src/app/components/elements/TitleAndBreadcrumb.tsx
@@ -8,6 +8,7 @@ import {LaTeX} from "./LaTeX";
 
 interface BreadcrumbTrailProps {
     currentPageTitle: string;
+    disallowLaTeX?: boolean;
     intermediateCrumbs?: LinkInfo[];
     collectionType?: CollectionType;
 }
@@ -16,7 +17,8 @@ interface BreadcrumbTrailProps {
 // If you want to use it elsewhere, that is fine but you must consider the implications on the "Skip to main content"
 // link which needs to skip all static navigational elements (i.e. breadcrumbs).
 // We manage the ID of the "main content" with the mainContentId reducer.
-const BreadcrumbTrail = ({currentPageTitle, intermediateCrumbs = [], collectionType}: BreadcrumbTrailProps) => {
+const BreadcrumbTrail = ({currentPageTitle, intermediateCrumbs = [], collectionType, disallowLaTeX}:
+                             BreadcrumbTrailProps) => {
     const breadcrumbHistory = [HOME_CRUMB as LinkInfo, ...intermediateCrumbs];
 
     // Copy and mask collection type title
@@ -27,20 +29,28 @@ const BreadcrumbTrail = ({currentPageTitle, intermediateCrumbs = [], collectionT
     }
 
     return <Breadcrumb className="py-md-2 px-md-0 mb-3 mb-md-0 bread">
-        {breadcrumbHistory.map((breadcrumb) => (
-            <BreadcrumbItem key={breadcrumb.title}>
-                {breadcrumb.to ?
-                    <Link to={breadcrumb.to} replace={breadcrumb.replace}><LaTeX markup={breadcrumb.title} /></Link>
-                    :
-                    <LaTeX markup={breadcrumb.title} />
-                }
-            </BreadcrumbItem>
-        ))}
-        <BreadcrumbItem active>
-            <LaTeX markup={currentPageTitle} />
-        </BreadcrumbItem>
+        {breadcrumbHistory.map((breadcrumb) => formatBreadcrumbHistoryItem(breadcrumb, disallowLaTeX))}
+        {formatBreadcrumbItem(currentPageTitle, disallowLaTeX)}
     </Breadcrumb>;
 };
+
+export const formatBreadcrumbItemTitle = (title: string, disallowLaTeX?: boolean) => {
+    return disallowLaTeX ? <span> {title} </span> : <LaTeX markup={title} />
+}
+
+export const formatBreadcrumbHistoryItem = (breadcrumb: LinkInfo, disallowLaTeX?: boolean) => {
+    const titleElement = formatBreadcrumbItemTitle(breadcrumb.title, disallowLaTeX)
+
+    return <BreadcrumbItem key={breadcrumb.title}>
+        {breadcrumb.to ? <Link to={breadcrumb.to} replace={breadcrumb.replace}>{titleElement}</Link> : titleElement}
+    </BreadcrumbItem>
+}
+
+export const formatBreadcrumbItem = (currentPageTitle: string, disallowLaTeX?: boolean) => {
+    return <BreadcrumbItem active>
+        {formatBreadcrumbItemTitle(currentPageTitle, disallowLaTeX)}
+    </BreadcrumbItem>
+}
 
 type TitleAndBreadcrumbProps = BreadcrumbTrailProps & PageTitleProps & {
     breadcrumbTitleOverride?: string;

--- a/src/app/components/pages/MyProgress.tsx
+++ b/src/app/components/pages/MyProgress.tsx
@@ -87,7 +87,7 @@ export const MyProgress = withRouter(({user, match: {params: {userIdOfInterest}}
     const pageTitle = viewingOwnData ? "My progress" : `Progress for ${userName || "user"}`;
 
     return <RS.Container id="my-progress" className="mb-5">
-        <TitleAndBreadcrumb currentPageTitle={pageTitle} />
+        <TitleAndBreadcrumb currentPageTitle={pageTitle} disallowLaTeX={true} />
         <RS.Card className="mt-4">
             <RS.CardBody>
                 <Tabs>{{

--- a/src/test/components/elements/TitleAndBreadcrumb.test.tsx
+++ b/src/test/components/elements/TitleAndBreadcrumb.test.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import {LaTeX} from "../../../app/components/elements/LaTeX";
+import {formatPageTitle} from "../../../app/components/elements/PageTitle";
+import {formatBreadcrumbItemTitle} from "../../../app/components/elements/TitleAndBreadcrumb";
+
+describe("Parameter to disallow LaTeX rendering is observed by PageTitle", () => {
+    it("Uses a LaTeX component for title by default",
+        () => {
+            // Act
+            const pageTitleElement = formatPageTitle('\\(x^2 + y^2 = z^2\\)')
+
+            // Assert
+            expect(pageTitleElement.type).toBe(LaTeX)
+        }
+    )
+    it("Uses a plain span element for title when LaTeX is disallowed",
+        () => {
+            // Act
+            const pageTitleElement = formatPageTitle('\\(x^2 + y^2 = z^2\\)', true)
+
+            // Assert
+            expect(pageTitleElement.type).toBe("span")
+        }
+    )
+})
+describe("Parameter to disallow LaTeX rendering is observed by Breadcrumbs", () => {
+    it("Uses a LaTeX component for breadcrumb title by default",
+        () => {
+            // Act
+            const breadcrumbTitleElement = formatBreadcrumbItemTitle('\\(x^2 + y^2 = z^2\\)')
+
+            // Assert
+            expect(breadcrumbTitleElement.type).toBe(LaTeX)
+        }
+    )
+    it("Uses a plain span element for breadcrumb title when LaTeX is disallowed",
+        () => {
+            // Act
+            const breadcrumbTitleElement = formatBreadcrumbItemTitle('\\(x^2 + y^2 = z^2\\)', true)
+
+            // Assert
+            expect(breadcrumbTitleElement.type).toBe("span")
+        }
+    )
+})
+


### PR DESCRIPTION
With this change a new optional `disallowLaTeX` parameter is used by the My Progress page to prevent LaTeX in student names from rendering in the page title or breadcrumb trail.

Other pages using TitleAndBreadcrumb are unaffected (can be tested with this [test page](https://editor.isaaccomputerscience.org/#!/edit/master/content/_test/_latex_title_test.json)).