### PR TITLE
Fallback to `doc.id` if `questionPart.id` doesn't exist on cloze question quiz previews

### DIFF
--- a/src/app/components/content/IsaacClozeQuestion.tsx
+++ b/src/app/components/content/IsaacClozeQuestion.tsx
@@ -99,7 +99,7 @@ export function IsaacClozeQuestion({doc, questionId, readonly}: {doc: IsaacCloze
     const pageQuestions = useSelector(selectors.questions.getQuestions);
     const questionPart = selectQuestionPart(pageQuestions, questionId);
     const currentAttempt = questionPart?.currentAttempt as (ItemChoiceDTO | undefined);
-    const cssFriendlyQuestionPartId = questionPart?.id?.replace(/\|/g, '-') ?? ""; // Maybe we should clean up IDs more?
+    const cssFriendlyQuestionPartId = (questionPart?.id || doc.id)?.replace(/\|/g, '-') ?? ""; // Maybe we should clean up IDs more?
     const questionContentRef = useRef<HTMLDivElement>(null);
     const withReplacement = doc.withReplacement ?? false;
 
@@ -255,7 +255,7 @@ export function IsaacClozeQuestion({doc, questionId, readonly}: {doc: IsaacCloze
                         ref={provided.innerRef} {...provided.droppableProps} id="non-selected-items"
                         className={`d-flex overflow-auto rounded p-2 mb-3 bg-grey ${snapshot.isDraggingOver ? "border border-dark" : ""}`}
                     >
-                        {nonSelectedItems.map((item, i) => <Draggable key={item.replacementId} draggableId={item.replacementId || `${i}`} index={i}>
+                        {nonSelectedItems.map((item, i) => <Draggable key={item.replacementId} isDragDisabled={readonly} draggableId={item.replacementId || `${i}`} index={i}>
                             {(provided) =>
                                 <div className={"cloze-draggable"} ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps}>
                                     <Item item={item} />

--- a/src/app/components/content/IsaacClozeQuestion.tsx
+++ b/src/app/components/content/IsaacClozeQuestion.tsx
@@ -99,7 +99,7 @@ export function IsaacClozeQuestion({doc, questionId, readonly}: {doc: IsaacCloze
     const pageQuestions = useSelector(selectors.questions.getQuestions);
     const questionPart = selectQuestionPart(pageQuestions, questionId);
     const currentAttempt = questionPart?.currentAttempt as (ItemChoiceDTO | undefined);
-    const cssFriendlyQuestionPartId = (questionPart?.id || doc.id)?.replace(/\|/g, '-') ?? ""; // Maybe we should clean up IDs more?
+    const cssFriendlyQuestionPartId = questionId?.replace(/\|/g, '-') ?? ""; // Maybe we should clean up IDs more?
     const questionContentRef = useRef<HTMLDivElement>(null);
     const withReplacement = doc.withReplacement ?? false;
 


### PR DESCRIPTION
Prior to the fix (on `/test/preview/quiz_alevel_boolean_01/page/1?examBoard=all&stage=all`):
![image](https://user-images.githubusercontent.com/33040507/161098336-6d3814a5-1b7a-4424-8315-8fb301df5f0f.png)

This fix works by falling back to the `doc.id` if `questionPart.id` is `undefined`. Whether this is the right move or whether the question part id should be defined is something I'm not sure about.