### PR TITLE
Alter logic to show waiting list button

### DIFF
--- a/src/app/components/pages/EventDetails.tsx
+++ b/src/app/components/pages/EventDetails.tsx
@@ -91,8 +91,7 @@ export const EventDetails = ({match: {params: {eventId}}, location: {pathname}}:
             !canMakeABooking &&
             event.isNotClosed &&
             !event.hasExpired &&
-            ((isDefined(event.userBookingStatus) && !["WAITING_LIST", "CONFIRMED", "RESERVED"].includes(event.userBookingStatus)) ||
-                (event.eventStatus === "WAITING_LIST_ONLY" && !isDefined(event.userBookingStatus))) &&
+            (event.userBookingStatus === undefined || !["WAITING_LIST", "CONFIRMED", "RESERVED"].includes(event.userBookingStatus)) &&
             studentOnlyRestrictionSatisfied;
 
         const canReserveSpaces =

--- a/src/app/components/pages/EventDetails.tsx
+++ b/src/app/components/pages/EventDetails.tsx
@@ -91,7 +91,8 @@ export const EventDetails = ({match: {params: {eventId}}, location: {pathname}}:
             !canMakeABooking &&
             event.isNotClosed &&
             !event.hasExpired &&
-            isDefined(event.userBookingStatus) && !["WAITING_LIST", "CONFIRMED", "RESERVED"].includes(event.userBookingStatus) &&
+            ((isDefined(event.userBookingStatus) && !["WAITING_LIST", "CONFIRMED", "RESERVED"].includes(event.userBookingStatus)) ||
+                (event.eventStatus === "WAITING_LIST_ONLY" && !isDefined(event.userBookingStatus))) &&
             studentOnlyRestrictionSatisfied;
 
         const canReserveSpaces =


### PR DESCRIPTION
The previously added check (which I have overwritten) correctly hid the `book a place` button when a user already had a booking with an allowed status to see it. However it stopped the button showing for events with wait_list_only as their status for users that don't have a booking already, phy extensively make use of this to validate students before promoting them to a full booking.

I have tested this as a student and a teacher, on events with and without wait lists and the `book a place` button (dis)appears correctly