### PR TITLE
Allow gameboard filter to populate exam board from URL properly

### DIFF
--- a/src/app/components/pages/GameboardFilter.tsx
+++ b/src/app/components/pages/GameboardFilter.tsx
@@ -7,7 +7,6 @@ import tags from '../../services/tags';
 import {
     DIFFICULTY_ICON_ITEM_OPTIONS,
     DIFFICULTY_ITEM_OPTIONS,
-    EXAM_BOARD_ITEM_OPTIONS,
     NOT_FOUND,
     QUESTION_CATEGORY_ITEM_OPTIONS,
     QUESTION_FINDER_CONCEPT_LABEL_PLACEHOLDER,
@@ -76,8 +75,8 @@ function processQueryString(query: string): QueryStringResponse {
     const tagHierarchy = tags.getTagHierarchy();
 
     const stageItems = itemiseByValue(arrayFromPossibleCsv(stages), getFilteredStageOptions());
-    const difficultyItems = itemiseByValue(arrayFromPossibleCsv(difficulties), DIFFICULTY_ITEM_OPTIONS);
-    const examBoardItems = itemiseByValue(arrayFromPossibleCsv(examBoards), EXAM_BOARD_ITEM_OPTIONS);
+    const difficultyItems = itemiseByValue(arrayFromPossibleCsv(difficulties), siteSpecific(DIFFICULTY_ITEM_OPTIONS, DIFFICULTY_ICON_ITEM_OPTIONS));
+    const examBoardItems = itemiseByValue(arrayFromPossibleCsv(examBoards), getFilteredExamBoardOptions({byStages: stageItems.map(item => item.value as STAGE)}));
     const questionCategoryItems = itemiseByValue(arrayFromPossibleCsv(questionCategories), QUESTION_CATEGORY_ITEM_OPTIONS);
     const conceptItems = itemiseConcepts(arrayFromPossibleCsv(concepts))
 
@@ -387,7 +386,7 @@ export const GameboardFilter = withRouter(({location}: {location: Location}) => 
     // const [questionCategories, setQuestionCategories] = useState<Item<string>[]>(queryQuestionCategories);
 
     const [examBoards, setExamBoards] = useState<Item<string>[]>(
-        queryExamBoards.length > 0 ? queryStages : itemiseByValue([userContext.examBoard], getFilteredExamBoardOptions({byStages: stages.map(item => item.value as STAGE)})));
+        queryExamBoards.length > 0 ? queryExamBoards : itemiseByValue([userContext.examBoard], getFilteredExamBoardOptions({byStages: stages.map(item => item.value as STAGE)})));
     useEffect(function keepExamBoardsInSyncWithUserContext() {
         if (examBoards.length === 0) setExamBoards(itemiseByValue([userContext.examBoard], getFilteredExamBoardOptions({byStages: stages.map(item => item.value as STAGE)})));
     }, [userContext.examBoard]);


### PR DESCRIPTION
This doesn't necessarily address the possibility of the gameboard not showing up when the URL is loaded, but I haven't been able to reproduce that and can't see a reason for it happening if it does - I just need to ask CS content for examples I think.