### PR TITLE
Improvement/cs search tweaks

### DIFF
--- a/src/app/components/elements/list-groups/ContentSummaryListGroupItem.tsx
+++ b/src/app/components/elements/list-groups/ContentSummaryListGroupItem.tsx
@@ -73,11 +73,17 @@ export const ContentSummaryListGroupItem = ({item, search, displayTopicTitle}: {
             icon = questionIcon;
             iconLabel = item.correct ? "Completed question icon" : "Question icon";
             audienceViews = filterAudienceViewsByProperties(determineAudienceViews(item.audience), AUDIENCE_DISPLAY_FIELDS);
+            if (SITE_SUBJECT === SITE.CS) {
+                typeLabel = "Question";
+            }
             break;
         case (DOCUMENT_TYPE.CONCEPT):
             linkDestination = `/${documentTypePathPrefix[DOCUMENT_TYPE.CONCEPT]}/${item.id}`;
             icon = <img src="/assets/concept.svg" alt="Concept page"/>;
             iconLabel = "Concept page icon";
+            if (SITE_SUBJECT === SITE.CS) {
+                typeLabel = "Concept";
+            }
             break;
         case (DOCUMENT_TYPE.EVENT):
             linkDestination = `/${documentTypePathPrefix[DOCUMENT_TYPE.EVENT]}/${item.id}`;
@@ -111,7 +117,7 @@ export const ContentSummaryListGroupItem = ({item, search, displayTopicTitle}: {
                 <div className={"align-self-center " + titleClasses}>
                     <div className="d-flex">
                         <LaTeX className={titleTextClass} markup={title ?? ""} />
-                        {typeLabel && <span className={"small text-muted align-self-end d-none d-md-inline ml-2"}>
+                        {typeLabel && <span className={"small text-muted align-self-end d-none d-md-inline ml-2 mb-1"}>
                             ({typeLabel})
                         </span>}
                     </div>

--- a/src/app/components/pages/Search.tsx
+++ b/src/app/components/pages/Search.tsx
@@ -59,12 +59,15 @@ export const Search = withRouter((props: RouteComponentProps) => {
     const userContext = useUserContext();
     const [urlQuery, urlFilters] = parseLocationSearch(location.search);
     const [queryState, setQueryState] = useState(urlQuery);
-    const [filtersState, setFiltersState] = useState<Item<DOCUMENT_TYPE>[]>(urlFilters.map(itemise))
+
+    let initialFilters = urlFilters;
+    if (SITE_SUBJECT === SITE.CS && urlFilters.length === 0) {
+        initialFilters = [DOCUMENT_TYPE.CONCEPT, DOCUMENT_TYPE.EVENT, DOCUMENT_TYPE.TOPIC_SUMMARY, DOCUMENT_TYPE.GENERIC];
+    }
+    const [filtersState, setFiltersState] = useState<Item<DOCUMENT_TYPE>[]>(initialFilters.map(itemise));
 
     useEffect(function triggerSearchOnUrlChange() {
-        setQueryState(urlQuery);
-        setFiltersState(urlFilters.map(itemise));
-        dispatch(fetchSearch(urlQuery || "", urlFilters.length ? urlFilters.join(",") : undefined));
+        dispatch(fetchSearch(queryState ?? "", filtersState.length ? filtersState.map(deitemise).join(",") : undefined));
     }, [dispatch, location.search]);
 
     function updateSearchUrl(e?: FormEvent<HTMLFormElement>) {

--- a/src/app/services/search.ts
+++ b/src/app/services/search.ts
@@ -9,12 +9,12 @@ import queryString from "query-string";
 export const pushSearchToHistory = function(history: History, searchQuery: string, typesFilter: DOCUMENT_TYPE[]) {
     const previousQuery = queryString.parse(history.location.search);
     const newQueryOptions = {
-        query: searchQuery,
-        types: typesFilter.join(",") || undefined,
+        query: encodeURI(searchQuery),
+        types: typesFilter.map(encodeURI).join(",") || undefined,
     };
     history.push({
         pathname: "/search",
-        search: queryString.stringify({...previousQuery, ...newQueryOptions}),
+        search: queryString.stringify({...previousQuery, ...newQueryOptions}, {encode: false}),
     });
 };
 


### PR DESCRIPTION
This PR:
 - Adds a "type label" to question and concept search results for CS, to look consistent with topic summary results.
 - For CS will make the default search response exclude question results.
 - Stop escaping the commas in the search URL's page type filters.

A separately merged PR bumped the priority of topic summary pages in results.