### PR TITLE
Update based on package updates; tell opener/parent when ready

### DIFF
--- a/config/webpack.config.cs.renderer.js
+++ b/config/webpack.config.cs.renderer.js
@@ -3,11 +3,9 @@ const path = require('path');
 const BASE_DIRECTORY = path.resolve(__dirname, "..");
 const resolve = (p) => path.resolve(BASE_DIRECTORY, p);
 const configCS = require('./webpack.config.cs');
-const merge = require('webpack-merge');
+const {merge} = require('webpack-merge');
 
 module.exports = env => {
-
-    let isProd = env['prod'];
 
     let configCSrenderer = {
         entry: {
@@ -19,7 +17,7 @@ module.exports = env => {
         },
     };
 
-    const nearly = merge(configCS(isProd), configCSrenderer);
+    const nearly = merge(configCS(env), configCSrenderer);
 
     nearly.entry = configCSrenderer.entry;
 

--- a/config/webpack.config.phy.renderer.js
+++ b/config/webpack.config.phy.renderer.js
@@ -3,11 +3,9 @@ const path = require('path');
 const BASE_DIRECTORY = path.resolve(__dirname, "..");
 const resolve = (p) => path.resolve(BASE_DIRECTORY, p);
 const configPHY = require('./webpack.config.physics');
-const merge = require('webpack-merge');
+const {merge} = require('webpack-merge');
 
 module.exports = env => {
-
-    let isProd = env['prod'];
 
     let configPHYrenderer = {
         entry: {
@@ -19,7 +17,7 @@ module.exports = env => {
         },
     };
 
-    const nearly = merge(configPHY(isProd), configPHYrenderer);
+    const nearly = merge(configPHY(env), configPHYrenderer);
 
     nearly.entry = configPHYrenderer.entry;
 

--- a/package.json
+++ b/package.json
@@ -67,9 +67,9 @@
     "build-stats-cs": "webpack --env prod --config config/webpack.config.cs.js --profile --json > bundle-stats-cs.json",
     "analyse-bundle-cs": "webpack-bundle-analyzer bundle-stats-cs.json build-cs",
     "build-cs-renderer": "webpack --env prod --config config/webpack.config.cs.renderer.js",
-    "start-cs-renderer": "webpack-dev-server --hot --port 3001 --history-api-fallback --config config/webpack.config.cs.renderer.js --disableHostCheck=true",
+    "start-cs-renderer": "webpack-dev-server --hot --port 3001 --history-api-fallback --config config/webpack.config.cs.renderer.js --allowed-hosts=true",
     "build-phy-renderer": "webpack --env prod --config config/webpack.config.phy.renderer.js",
-    "start-phy-renderer": "webpack-dev-server --hot --port 3002 --history-api-fallback --config config/webpack.config.phy.renderer.js --disableHostCheck=true",
+    "start-phy-renderer": "webpack-dev-server --hot --port 3002 --history-api-fallback --config config/webpack.config.phy.renderer.js --allowed-hosts=true",
     "build-renderer": "yarn run build-cs-renderer && yarn run build-phy-renderer"
   },
   "eslintConfig": {

--- a/src/app/components/elements/EditorRenderer.tsx
+++ b/src/app/components/elements/EditorRenderer.tsx
@@ -35,6 +35,10 @@ function EditorListener() {
 
     useEffect(() => {
         window.addEventListener("message", listener);
+        const source = window.opener || window.parent;
+        if (source) {
+            source.postMessage({ready: true}, "*");
+        }
         return () => window.removeEventListener("message", listener);
     }, [listener]);
 


### PR DESCRIPTION
A couple of things needed changing, I think because the webpack version changed.

I also send a message in to the opener/parent, which makes it possible to co-ordinate when to send messages.