### PR TITLE
Fix KaTeX fonts and Webpack bundling

### DIFF
--- a/config/webpack.config.common.js
+++ b/config/webpack.config.common.js
@@ -17,7 +17,7 @@ module.exports = (isProd) => {
         stats: {
             errorDetails: true
         },
-        
+
         mode: isProd ? "production" : "development",
 
         devServer: {
@@ -98,7 +98,12 @@ module.exports = (isProd) => {
                                 {
                                     loader: 'css-loader',
                                     options: {
-                                        url: false
+                                        url: {
+                                            filter: (url, resourcePath) => {
+                                                // Only rewrite URLs for KaTeX fonts or non-Isaac things:
+                                                return url.includes('KaTeX') || resourcePath.includes("node_modules");
+                                            }
+                                        }
                                     }
                                 },
                                 'sass-loader',
@@ -106,13 +111,16 @@ module.exports = (isProd) => {
                         },
                         {
                             test: /\.(png|gif|jpg|svg)$/,
-                            type: 'asset/resource'
-                        },
-                        {
-                            test: /\.(ttf|woff2?)$/,
                             type: 'asset/resource',
                             generator: {
-                                filename: isProd ? 'static/fonts/[name].[contenthash:8].[ext]' : 'static/fonts/[name].[ext]',
+                                filename: isProd ? 'static/assets/[name].[contenthash:8][ext]' : 'static/assets/[name][ext]',
+                            }
+                        },
+                        {
+                            test: /\.(ttf|woff2?|eot)$/,
+                            type: 'asset/resource',
+                            generator: {
+                                filename: isProd ? 'static/fonts/[name].[contenthash:8][ext]' : 'static/fonts/[name][ext]',
                             }
                         }
                     ],

--- a/config/webpack.config.common.js
+++ b/config/webpack.config.common.js
@@ -99,9 +99,9 @@ module.exports = (isProd) => {
                                     loader: 'css-loader',
                                     options: {
                                         url: {
-                                            filter: (url, resourcePath) => {
-                                                // Only rewrite URLs for KaTeX fonts or non-Isaac things:
-                                                return url.includes('KaTeX') || resourcePath.includes("node_modules");
+                                            filter: (url) => {
+                                                // The "/assets" directory is a special case and should be ignored:
+                                                return !url.startsWith("/assets");
                                             }
                                         }
                                     }


### PR DESCRIPTION
We were not bundling the KaTeX fonts correctly, because the `css-loader` being used to import them was ignoring all URL rewriting so sometimes they would not load correctly in a production build.

The problem is that we use the `create-react-app` folder `public` for all of our assets, both those Webpack wants to know about and those that really are static and not part of the bundle. So instead of using Webpack as it intended, we just bluntly copy the `public/assets` folder to the `/assets` path and we turned off URL rewriting so this would work. But the turning off affected things beyond our special assets folder. So this fix, which is a bit hacky, is just to treat the `/assets` URL as a special case and rewrite anything else.

(The only other changes are to give bundled images and fonts sensible names, noting that `[ext]` contains the leading dot character and so we didn't need it in our templated names).