### PR TITLE
Generate MathML for any LaTeX currently unsupported by katex-a11y

### DIFF
--- a/src/IsaacAppTypes.tsx
+++ b/src/IsaacAppTypes.tsx
@@ -546,9 +546,7 @@ export interface ShortcutResponse extends ContentSummaryDTO {
     hash?: string;
 }
 
-export interface UserBetaFeaturePreferences {
-    SCREENREADER_HOVERTEXT?: boolean;
-}
+export interface UserBetaFeaturePreferences {}
 
 export interface UserEmailPreferences {
     NEWS_AND_UPDATES?: boolean;

--- a/src/app/components/elements/LaTeX.tsx
+++ b/src/app/components/elements/LaTeX.tsx
@@ -101,7 +101,6 @@ const customKatexOptions: KatexOptions = {
     throwOnError: false,
     strict: false,
     colorIsTextColor: true,
-    output: "html"
 };
 
 function patternQuote(s: string) {
@@ -275,30 +274,42 @@ export function katexify(html: string, user: PotentialUser | null, booleanNotati
                         const reference = args[0].reverse().map((t: {text: string}) => t.text).join("");
                         return "\\text{" + REF + reference + ENDREF + "}";
                     }};
-                let katexOptions = {...customKatexOptions, displayMode: search.mode == "display", macros: macrosToUse} as KatexOptions;
+                const katexOptions = {...customKatexOptions, displayMode: search.mode == "display", macros: macrosToUse, output: "html"} as KatexOptions;
                 let katexRenderResult = katex.renderToString(latexMunged, katexOptions);
                 katexRenderResult = katexRenderResult.replace(REF_REGEXP, (_, match) => {
                     return createReference(match, "unknown reference " + match);
                 });
 
-                let screenreaderText;
+                let screenReaderText;
                 try {
-                    let pauseChars = katexOptions.displayMode ? ". &nbsp;" : ",";  // trailing comma/full-stop for pause in speaking
-                    screenreaderText = `${renderA11yString(latexMunged, katexOptions)}${pauseChars}`;
-                    screenreaderText = screenreaderText.replace(SR_REF_REGEXP, (_, match) => {
+                    const pauseChars = katexOptions.displayMode ? ". &nbsp;" : ",";  // trailing comma/full-stop for pause in speaking
+                    screenReaderText = `${renderA11yString(latexMunged, katexOptions)}${pauseChars}`;
+                    screenReaderText = screenReaderText.replace(SR_REF_REGEXP, (_, match) => {
                         return createReference(match, "unknown reference " + match, false);
                     });
-                } catch (e) {
-                    // eslint-disable-next-line no-console
-                    console.warn(`Unsupported equation for screenreader text: '${latexMunged}'`, e);
-                    screenreaderText = "[[Unsupported equation]]";
+                } catch {
+                    screenReaderText = undefined;
                 }
-                katexRenderResult = katexRenderResult.replace('<span class="katex">',
-                    `<span class="katex"><span class="sr-only">${screenreaderText}</span>`);
+
+                // If katex-a11y fails, generate MathML using KaTeX for accessibility
+                if (screenReaderText) {
+                    katexRenderResult = katexRenderResult.replace('<span class="katex">',
+                        `<span class="katex"><span class="sr-only">${screenReaderText}</span>`);
+                } else {
+                    const katexMathML = katex.renderToString(latexMunged, {...katexOptions, output: "mathml"})
+                        .replace(`class="katex"`, `class="katex-mathml"`);
+                    katexRenderResult = katexRenderResult.replace('<span class="katex">',
+                        `<span class="katex">${katexMathML}`);
+                }
 
                 if (screenReaderHoverText) {
-                    katexRenderResult = katexRenderResult.replace('<span class="katex">',
-                        `<span class="katex" title="${screenreaderText.replace(/,/g, "").replace(/\s\s+/g, " ")}">`);
+                    katexRenderResult = katexRenderResult.replace(
+                        '<span class="katex-html"',
+                        `<span class="katex-html" title="${
+                            screenReaderText ? 
+                                "Screenreader text: " + screenReaderText.replace(/,/g, "").replace(/\s\s+/g, " ") : 
+                                "Accessible with a screenreader that supports MathML"
+                        }"`);
                 }
 
                 output += katexRenderResult;
@@ -325,13 +336,12 @@ export function katexify(html: string, user: PotentialUser | null, booleanNotati
 
 export function LaTeX({markup, className}: {markup: string, className?: string}) {
     const user = useSelector(selectors.user.orNull);
+    const segueEnvironment = useSelector(selectors.segue.environmentOrUnknown);
     const booleanNotation = useSelector((state: AppState) => state?.userPreferences?.BOOLEAN_NOTATION || null);
-    const screenReaderHoverText = useSelector((state: AppState) => state && state.userPreferences &&
-        state.userPreferences.BETA_FEATURE && state.userPreferences.BETA_FEATURE.SCREENREADER_HOVERTEXT || false);
     const figureNumbers = useContext(FigureNumberingContext);
 
     const escapedMarkup = utils.escapeHtml(markup);
-    const katexHtml = katexify(escapedMarkup, user, booleanNotation, screenReaderHoverText, figureNumbers);
+    const katexHtml = katexify(escapedMarkup, user, booleanNotation, segueEnvironment === "DEV", figureNumbers);
 
     return <span dangerouslySetInnerHTML={{__html: katexHtml}} className={className} />
 }

--- a/src/app/components/elements/TrustedHtml.tsx
+++ b/src/app/components/elements/TrustedHtml.tsx
@@ -105,10 +105,8 @@ const Table = ({id, html, classes, rootElement}: TableData & {rootElement: HTMLE
 
 export const TrustedHtml = ({html, span, className}: {html: string; span?: boolean; className?: string;}) => {
     const user = useSelector(selectors.user.orNull);
+    const segueEnvironment = useSelector(selectors.segue.environmentOrUnknown);
     const booleanNotation = useSelector((state: AppState) => state?.userPreferences?.BOOLEAN_NOTATION || null);
-    const screenReaderHoverText = useSelector((state: AppState) => state && state.userPreferences &&
-        state.userPreferences.BETA_FEATURE && state.userPreferences.BETA_FEATURE.SCREENREADER_HOVERTEXT || false);
-
     const figureNumbers = useContext(FigureNumberingContext);
 
     const [ htmlRef, setHtmlRef ] = useState<HTMLDivElement>();
@@ -118,7 +116,7 @@ export const TrustedHtml = ({html, span, className}: {html: string; span?: boole
         }
     }, []);
 
-    const {manipulatedHtml, tableData} = manipulateHtml(katexify(html, user, booleanNotation, screenReaderHoverText, figureNumbers));
+    const {manipulatedHtml, tableData} = manipulateHtml(katexify(html, user, booleanNotation, segueEnvironment === "DEV", figureNumbers));
     html = useClozeDropRegionsInHtml(manipulatedHtml);
 
     const ElementType = span ? "span" : "div";

--- a/src/test/components/TrustedHtml.test.tsx
+++ b/src/test/components/TrustedHtml.test.tsx
@@ -34,6 +34,10 @@ describe('TrustedHtml LaTeX locator', () => {
             const callArgs = katex.renderToString.mock.calls.pop();
             expect(callArgs[0]).toBe(math[0]);
             expect(callArgs[1]).toMatchObject({"displayMode": displayMode});
+            // @ts-ignore katex.__parse is mocked, so katex-a11y can't generate screenreader text - this means
+            // katex.renderToString is called again to generate MathML, so we need to pop a second call off of the
+            // call stack
+            katex.renderToString.mock.calls.pop();
         });
     });
 
@@ -58,6 +62,10 @@ describe('TrustedHtml LaTeX locator', () => {
                 const callArgs = katex.renderToString.mock.calls.pop();
                 expect(callArgs[0]).toBe(dollarMath);
                 expect(callArgs[1]).toMatchObject({"displayMode": displayMode});
+                // @ts-ignore katex.__parse is mocked, so katex-a11y can't generate screenreader text - this means
+                // katex.renderToString is called again to generate MathML, so we need to pop a second call off of the
+                // call stack
+                katex.renderToString.mock.calls.pop();
             });
         });
     });
@@ -72,6 +80,10 @@ describe('TrustedHtml LaTeX locator', () => {
         const callArgs = katex.renderToString.mock.calls.pop();
         expect(callArgs[0]).toBe(env);
         expect(callArgs[1]).toMatchObject({"displayMode": true});
+        // @ts-ignore katex.__parse is mocked, so katex-a11y can't generate screenreader text - this means
+        // katex.renderToString is called again to generate MathML, so we need to pop a second call off of the
+        // call stack
+        katex.renderToString.mock.calls.pop();
     });
 
     it('missing refs show an inline error', () => {


### PR DESCRIPTION
Also shows screenreader text when hovering over math on all `DEV` platforms, which may improve focus on accessible content.

As far as I can tell this is only a net benefit, although there may be equations where:

- `katex-a11y` can't support them
- The MathML generated as a fall-back is awful when parsed by a screenreader

In this edge case, probably quoting "Unsupported equation" is better than a long string of nonsense from the parsed MathML.

This change also requires users to have a screenreader that supports MathML (as well as anyone testing accessibility). The one I've been using is the [Access8Math addon for NVDA](https://addons.nvda-project.org/addons/access8math.en.html). I reckon that any visually impaired user who is seriously using platforms containing math content will have a screenreader that supports MathML, since it seems to be the recommended method of math accessibility on the web.

---

~After an hour or so I've got exactly nowhere with working out why the tests are failing - all the tests containing `expect(katex.renderToString).not.toHaveBeenCalled();` fail, but the only time my new line containing `katex.renderToString` is run is when the already existing line with `katex.renderToString` is run. I also haven't to my knowledge changed the conditions for when the initial call is made.~ Fixed!