### PR TITLE
Render tables using old method if tables are inside a cloze question

### DIFF
--- a/src/app/components/content/IsaacClozeQuestion.tsx
+++ b/src/app/components/content/IsaacClozeQuestion.tsx
@@ -75,7 +75,6 @@ function InlineDropRegion({id, item, contentHolder, readonly, updateAttempt, sho
 
 // Matches: [drop-zone], [drop-zone|w-50], [drop-zone|h-50] or [drop-zone|w-50h-200]
 const dropZoneRegex = /\[drop-zone(?<params>\|(?<width>w-\d+?)?(?<height>h-\d+?)?)?]/g;
-
 export function useClozeDropRegionsInHtml(html: string): string {
     const dropRegionContext = useContext(ClozeDropRegionContext);
     if (dropRegionContext && dropRegionContext.questionPartId) {
@@ -87,6 +86,14 @@ export function useClozeDropRegionsInHtml(html: string): string {
             const minHeight = heightMatch ? heightMatch.slice("h-".length) + "px" : "auto";
             return `<div id="${dropId}" class="d-inline-block" style="min-width: ${minWidth}; min-height: ${minHeight}"></div>`;
         });
+        // Make sure all tables inside the cloze question exposition are ignored when being parsed as expandable
+        const htmlDom = document.createElement("html");
+        htmlDom.innerHTML = html;
+        const tableElements = htmlDom.getElementsByTagName("table");
+        for (let i = 0; i < tableElements.length; i++) {
+            tableElements[i].setAttribute("data-ignore", "true");
+        }
+        html = htmlDom.innerHTML;
     }
     return html;
 }

--- a/src/app/components/content/IsaacClozeQuestion.tsx
+++ b/src/app/components/content/IsaacClozeQuestion.tsx
@@ -76,7 +76,8 @@ function InlineDropRegion({id, item, contentHolder, readonly, updateAttempt, sho
 export type ClozeQuestionDropRegionContext = {register: (id: string, index: number) => void, questionPartId: string};
 // Matches: [drop-zone], [drop-zone|w-50], [drop-zone|h-50] or [drop-zone|w-50h-200]
 const dropZoneRegex = /\[drop-zone(?<params>\|(?<width>w-\d+?)?(?<height>h-\d+?)?)?]/g;
-export function useClozeDropRegionsInHtml(html: string, dropRegionContext?: ClozeQuestionDropRegionContext): string {
+export function useClozeDropRegionsInHtml(html: string): string {
+    const dropRegionContext = useContext(ClozeDropRegionContext);
     if (dropRegionContext && dropRegionContext.questionPartId) {
         let index = 0;
         html = html.replace(dropZoneRegex, (matchingString, params, widthMatch, heightMatch, offset) => {

--- a/src/app/components/content/IsaacClozeQuestion.tsx
+++ b/src/app/components/content/IsaacClozeQuestion.tsx
@@ -73,10 +73,10 @@ function InlineDropRegion({id, item, contentHolder, readonly, updateAttempt, sho
     return null;
 }
 
+export type ClozeQuestionDropRegionContext = {register: (id: string, index: number) => void, questionPartId: string};
 // Matches: [drop-zone], [drop-zone|w-50], [drop-zone|h-50] or [drop-zone|w-50h-200]
 const dropZoneRegex = /\[drop-zone(?<params>\|(?<width>w-\d+?)?(?<height>h-\d+?)?)?]/g;
-export function useClozeDropRegionsInHtml(html: string): string {
-    const dropRegionContext = useContext(ClozeDropRegionContext);
+export function useClozeDropRegionsInHtml(html: string, dropRegionContext?: ClozeQuestionDropRegionContext): string {
     if (dropRegionContext && dropRegionContext.questionPartId) {
         let index = 0;
         html = html.replace(dropZoneRegex, (matchingString, params, widthMatch, heightMatch, offset) => {
@@ -86,14 +86,6 @@ export function useClozeDropRegionsInHtml(html: string): string {
             const minHeight = heightMatch ? heightMatch.slice("h-".length) + "px" : "auto";
             return `<div id="${dropId}" class="d-inline-block" style="min-width: ${minWidth}; min-height: ${minHeight}"></div>`;
         });
-        // Make sure all tables inside the cloze question exposition are ignored when being parsed as expandable
-        const htmlDom = document.createElement("html");
-        htmlDom.innerHTML = html;
-        const tableElements = htmlDom.getElementsByTagName("table");
-        for (let i = 0; i < tableElements.length; i++) {
-            tableElements[i].setAttribute("data-ignore", "true");
-        }
-        html = htmlDom.innerHTML;
     }
     return html;
 }

--- a/src/app/components/elements/LaTeX.tsx
+++ b/src/app/components/elements/LaTeX.tsx
@@ -2,7 +2,7 @@ import React, {useContext} from "react";
 import {useSelector} from "react-redux";
 import {selectors} from "../../state/selectors";
 import {AppState} from "../../state/reducers";
-import {BooleanNotation, FigureNumberingContext, FigureNumbersById, PotentialUser} from "../../../IsaacAppTypes";
+import {FigureNumberingContext} from "../../../IsaacAppTypes";
 import he from "he";
 import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
 import katex, { KatexOptions } from "katex";
@@ -224,7 +224,13 @@ const ENDREF = "==ENDREF==";
 const REF_REGEXP = new RegExp(REF + "(.*?)" + ENDREF, "g");
 const SR_REF_REGEXP = new RegExp("start text, " + REF_REGEXP.source + ", end text,", "g");
 
-export function katexify(html: string, user: PotentialUser | null, booleanNotation : BooleanNotation | null,  screenReaderHoverText: boolean, figureNumbers: FigureNumbersById) {
+export function useKatex(html: string) {
+
+    const user = useSelector(selectors.user.orNull);
+    const segueEnvironment = useSelector(selectors.segue.environmentOrUnknown);
+    const booleanNotation = useSelector((state: AppState) => state?.userPreferences?.BOOLEAN_NOTATION || null);
+    const figureNumbers = useContext(FigureNumberingContext);
+
     start.lastIndex = 0;
     let match: RegExpExecArray | null;
     let output = "";
@@ -302,7 +308,8 @@ export function katexify(html: string, user: PotentialUser | null, booleanNotati
                         `<span class="katex">${katexMathML}`);
                 }
 
-                if (screenReaderHoverText) {
+                if (segueEnvironment === "DEV") {
+                    // Show screenreader text on hover so we can easily tell what's being output by katex-a11y
                     katexRenderResult = katexRenderResult.replace(
                         '<span class="katex-html"',
                         `<span class="katex-html" title="${
@@ -335,13 +342,7 @@ export function katexify(html: string, user: PotentialUser | null, booleanNotati
 }
 
 export function LaTeX({markup, className}: {markup: string, className?: string}) {
-    const user = useSelector(selectors.user.orNull);
-    const segueEnvironment = useSelector(selectors.segue.environmentOrUnknown);
-    const booleanNotation = useSelector((state: AppState) => state?.userPreferences?.BOOLEAN_NOTATION || null);
-    const figureNumbers = useContext(FigureNumberingContext);
-
     const escapedMarkup = utils.escapeHtml(markup);
-    const katexHtml = katexify(escapedMarkup, user, booleanNotation, segueEnvironment === "DEV", figureNumbers);
-
+    const katexHtml = useKatex(escapedMarkup);
     return <span dangerouslySetInnerHTML={{__html: katexHtml}} className={className} />
 }


### PR DESCRIPTION
Drop zones were not rendering because of two passes of turning HTML into React portals, one passes to add tables and one to add drop-zones.