### PR TITLE
Don't render `ScrollShadows` on Safari <= 13

### DIFF
--- a/src/app/components/content/IsaacCodeSnippet.tsx
+++ b/src/app/components/content/IsaacCodeSnippet.tsx
@@ -29,7 +29,8 @@ export const IsaacCodeSnippet = ({doc}: IsaacCodeProps) => {
     return <div ref={expandRef} className={classNames("position-relative code-snippet", outerClasses)}>
         {expandButton}
         <div className={innerClasses}>
-            {SITE_SUBJECT === SITE.CS && <ScrollShadows scrollRef={scrollPromptRef} />}
+            {/* ScrollShadows uses ResizeObserver, which doesn't exist on Safari <= 13 */}
+            {SITE_SUBJECT === SITE.CS && window.ResizeObserver && <ScrollShadows scrollRef={scrollPromptRef} />}
             <Row>
                 <Col>
                 <pre ref={scrollPromptRef} className="line-numbers">

--- a/src/app/components/elements/ScrollShadows.tsx
+++ b/src/app/components/elements/ScrollShadows.tsx
@@ -2,6 +2,10 @@ import React, {Dispatch, RefObject, SetStateAction, useEffect, useState} from "r
 import {isDefined} from "../../services/miscUtils";
 import classNames from "classnames";
 
+// This allows you to listen for changes in an attribute of some HTMLElement when one of a specified list of events occur.
+// It is essentially a setState where the state is also updated by an attribute you are "listening" to.
+// For example, `useEventPropertyState(ref, 0, "scrollLeft", ["scroll"]);` will update the state with `ref.current["scrollLeft"]`
+// whenever a `scroll` event is caught by a listener attached to `ref.current`.
 function useEventPropertyState<T>(ref: RefObject<HTMLElement>, initialState: T, property: string, eventTypes: (keyof HTMLElementEventMap)[], deps: React.DependencyList = []): [T, Dispatch<SetStateAction<T>>] {
     const [state, setState] = useState<T>(initialState);
 
@@ -32,9 +36,9 @@ function useEventPropertyState<T>(ref: RefObject<HTMLElement>, initialState: T, 
 }
 
 export const ScrollShadows = <T extends HTMLElement>({scrollRef} : {scrollRef : RefObject<T>}) => {
-    const [ clientWidth , setClientWidth ] = useState<number>(0);
-    const [ scrollWidth , setScrollWidth ] = useState<number>(0);
-    const [ scrollLeft , setScrollLeft ] = useEventPropertyState(scrollRef, 0, "scrollLeft", ["scroll"]);
+    const [clientWidth, setClientWidth] = useState<number>(0);
+    const [scrollWidth, setScrollWidth] = useState<number>(0);
+    const [scrollLeft, setScrollLeft] = useEventPropertyState(scrollRef, 0, "scrollLeft", ["scroll"]);
 
     useEffect(() => {
         const element = scrollRef?.current;
@@ -52,10 +56,10 @@ export const ScrollShadows = <T extends HTMLElement>({scrollRef} : {scrollRef : 
     }, [scrollRef]);
 
     const leftOpacity = scrollLeft > 1
-        ? (scrollLeft < 60 ? scrollLeft/60 : 1)
+        ? (scrollLeft < 60 ? scrollLeft / 60 : 1)
         : 0;
     const rightOpacity = (scrollWidth - clientWidth) - scrollLeft > 2
-        ? ((scrollWidth - clientWidth) - scrollLeft < 60 ? ((scrollWidth - clientWidth) - scrollLeft)/60 : 1)
+        ? ((scrollWidth - clientWidth) - scrollLeft < 60 ? ((scrollWidth - clientWidth) - scrollLeft) / 60 : 1)
         : 0;
 
     return (scrollWidth - clientWidth) > 5 ? <>

--- a/src/app/components/elements/TrustedHtml.tsx
+++ b/src/app/components/elements/TrustedHtml.tsx
@@ -102,7 +102,8 @@ const Table = ({id, html, classes, rootElement}: TableData & {rootElement: HTMLE
     if (html && parentElement) {
         return ReactDOM.createPortal(
             <div className={classNames(outerClasses, "position-relative isaac-table")} ref={expandRef}>
-                {SITE_SUBJECT === SITE.CS && <ScrollShadows scrollRef={scrollRef} />}
+                {/* ScrollShadows uses ResizeObserver, which doesn't exist on Safari <= 13 */}
+                {SITE_SUBJECT === SITE.CS && window.ResizeObserver && <ScrollShadows scrollRef={scrollRef} />}
                 {expandButton}
                 <div ref={scrollRef} className={innerClasses}>
                     <table className={classNames(classes, "table table-bordered w-100 text-center bg-white m-0")} dangerouslySetInnerHTML={{__html: html}}/>


### PR DESCRIPTION
More specifically, anything that doesn't support `window.ResizeObserver`