### PR TITLE
Allow portal components dynamically created from content (glossary terms, tables) to be nested

### DIFF
--- a/src/IsaacAppTypes.tsx
+++ b/src/IsaacAppTypes.tsx
@@ -31,6 +31,7 @@ import {
     TAG_ID,
     TAG_LEVEL
 } from "./app/services/constants";
+import {DropResult} from "react-beautiful-dnd";
 
 export type Action =
     | {type: ACTION_TYPE.TEST_ACTION}
@@ -711,8 +712,9 @@ export const AccordionSectionContext = React.createContext<{id: string | undefin
     {id: undefined, clientId: "unknown", open: /* null is a meaningful default state for IsaacVideo */ null}
 );
 export const QuestionContext = React.createContext<string | undefined>(undefined);
-export const ClozeDropRegionContext = React.createContext<{register: (id: string, index: number) => void, questionPartId: string} | undefined>(undefined);
+export const ClozeDropRegionContext = React.createContext<{register: (id: string, index: number) => void, questionPartId: string, updateAttemptCallback: (dropResult: DropResult) => void, readonly: boolean, inlineDropValueMap: {[p: string]: ClozeItemDTO}, borderMap: {[p: string]: boolean}} | undefined>(undefined);
 export const QuizAttemptContext = React.createContext<{quizAttempt: QuizAttemptDTO | null; questionNumbers: {[questionId: string]: number}}>({quizAttempt: null, questionNumbers: {}});
+export const ExpandableParentContext = React.createContext<boolean>(false);
 
 export interface AppAssignmentProgress {
     user: ApiTypes.UserSummaryDTO;

--- a/src/app/components/content/IsaacClozeQuestion.tsx
+++ b/src/app/components/content/IsaacClozeQuestion.tsx
@@ -1,11 +1,6 @@
-import React, {RefObject, useContext, useEffect, useRef, useState} from "react";
-import * as RS from "reactstrap";
+import React, {useCallback, useEffect, useMemo, useRef, useState} from "react";
 import {Label} from "reactstrap";
-import {
-    IsaacClozeQuestionDTO,
-    ItemChoiceDTO,
-    ItemDTO
-} from "../../../IsaacApiTypes";
+import {IsaacClozeQuestionDTO, ItemChoiceDTO, ItemDTO} from "../../../IsaacApiTypes";
 import {useCurrentQuestionAttempt} from "../../services/questions";
 import {IsaacContentValueOrChildren} from "./IsaacContentValueOrChildren";
 import {
@@ -17,118 +12,48 @@ import {
     DropResult,
     ResponderProvided
 } from "react-beautiful-dnd";
-import ReactDOM from 'react-dom';
 import {ClozeDropRegionContext, ClozeItemDTO, IsaacQuestionProps} from "../../../IsaacAppTypes";
 import {v4 as uuid_v4} from "uuid";
-import {Item} from "../../services/select";
-
-function Item({item}: {item: ItemDTO}) {
-    return <RS.Badge className="m-2 p-2">
-        <IsaacContentValueOrChildren value={item.value} encoding={item.encoding || "html"}>
-            {item.children}
-        </IsaacContentValueOrChildren>
-    </RS.Badge>;
-}
-
-interface InlineDropRegionProps {
-    id: string; item?: ClozeItemDTO; contentHolder: RefObject<HTMLDivElement>; readonly?: boolean; updateAttempt: (dropResult : DropResult) => void; showBorder: boolean;
-}
-function InlineDropRegion({id, item, contentHolder, readonly, updateAttempt, showBorder}: InlineDropRegionProps) {
-
-    function clearInlineDropZone() {
-        updateAttempt({source: {droppableId: id, index: 0}, draggableId: (item?.replacementId as string)} as DropResult);
-    }
-
-    const droppableTarget = contentHolder.current?.querySelector(`#${id}`);
-    if (droppableTarget) {
-        return ReactDOM.createPortal(
-            <div style={{minHeight: "inherit", position: "relative", margin: "2px"}}>
-                <Droppable droppableId={id} isDropDisabled={readonly} direction="vertical" >
-                    {(provided, snapshot) => <div
-                        ref={provided.innerRef} {...provided.droppableProps}
-                        className={`d-flex justify-content-center align-items-center bg-grey rounded w-100 overflow-hidden ${showBorder && "border border-dark"}`}
-                        style={{minHeight: "inherit"}}
-                    >
-                        {item && <Draggable key={item.replacementId} draggableId={item?.replacementId as string} index={0} isDragDisabled={true}>
-                            {(provided, snapshot) =>
-                                <div
-                                    className={"cloze-draggable mr-4"} ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps}
-                                >
-                                    <Item item={item}/>
-                                </div>
-                            }
-                        </Draggable>}
-                        {!item && "\u00A0"}
-                    </div>}
-                </Droppable>
-                {item && <button aria-label={"Clear drop zone"} className={"cloze-inline-clear"} onClick={clearInlineDropZone}>
-                    <svg height="20" width="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false"
-                         className="cloze-clear-cross">
-                        <path d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"/>
-                    </svg>
-                </button>}
-            </div>,
-            droppableTarget);
-    }
-    return null;
-}
-
-export type ClozeQuestionDropRegionContext = {register: (id: string, index: number) => void, questionPartId: string};
-// Matches: [drop-zone], [drop-zone|w-50], [drop-zone|h-50] or [drop-zone|w-50h-200]
-const dropZoneRegex = /\[drop-zone(?<params>\|(?<width>w-\d+?)?(?<height>h-\d+?)?)?]/g;
-export function useClozeDropRegionsInHtml(html: string): string {
-    const dropRegionContext = useContext(ClozeDropRegionContext);
-    if (dropRegionContext && dropRegionContext.questionPartId) {
-        let index = 0;
-        const safeQuestionId = dropRegionContext.questionPartId.replaceAll("_", "-");
-        html = html.replace(dropZoneRegex, (matchingString, params, widthMatch, heightMatch, offset) => {
-            const dropId = `drop-region-${safeQuestionId}-${offset}`;
-            dropRegionContext.register(dropId, index++); // also increments index
-            const minWidth = widthMatch ? widthMatch.slice("w-".length) + "px" : "100px";
-            const minHeight = heightMatch ? heightMatch.slice("h-".length) + "px" : "auto";
-            return `<div id="${dropId}" class="d-inline-block" style="min-width: ${minWidth}; min-height: ${minHeight}"></div>`;
-        });
-    }
-    return html;
-}
+import {Item} from "../elements/portals/InlineDropZones";
 
 export function IsaacClozeQuestion({doc, questionId, readonly}: IsaacQuestionProps<IsaacClozeQuestionDTO>) {
 
     const { currentAttempt, dispatchSetCurrentAttempt } = useCurrentQuestionAttempt<ItemChoiceDTO>(questionId);
 
     const cssFriendlyQuestionPartId = questionId?.replace(/\|/g, '-') ?? ""; // Maybe we should clean up IDs more?
-    const questionContentRef = useRef<HTMLDivElement>(null);
     const withReplacement = doc.withReplacement ?? false;
 
     const itemsSection = `${cssFriendlyQuestionPartId}-items-section`;
 
     const [nonSelectedItems, setNonSelectedItems] = useState<ClozeItemDTO[]>(doc.items ? [...doc.items].map(x => ({...x, replacementId: x.id})) : []);
 
-    const registeredDropRegionIDs = useRef<string[]>([]).current;
-    const [inlineDropValues, setInlineDropValues] = useState<(ClozeItemDTO | undefined)[]>(() => currentAttempt?.items || []);
+    const registeredDropRegionIDs = useRef<Map<string, number>>(new Map()).current;
 
     const [borderMap, setBorderMap] = useState<{[dropId: string]: boolean}>({});
 
+    const [inlineDropValues, setInlineDropValues] = useState<(ClozeItemDTO | undefined)[]>(() => currentAttempt?.items || []);
+    // Whenever the inlineDropValues change or a drop region is added, computes a map from drop region id -> drop region value
+    const inlineDropValueMap = useMemo(() => Array.from(registeredDropRegionIDs.entries()).reduce((dict, [dropId, i]) => Object.assign(dict, {[dropId]: inlineDropValues[i]}), {}), [inlineDropValues]);
+
     useEffect(() => {
         if (currentAttempt?.items) {
-            const idvs = currentAttempt.items as (ClozeItemDTO | undefined)[];
-            setInlineDropValues(registeredDropRegionIDs.map((_, i) => idvs[i] ? {...idvs[i], replacementId: `${idvs[i]?.id}-${uuid_v4()}`} : undefined));
-
+            setInlineDropValues(currentAttempt.items.map((idv: ClozeItemDTO | undefined) => idv ? ({...idv, replacementId: `${idv?.id}-${uuid_v4()}`}) : undefined));
             // If the question allows duplicates, then the items in the non-selected item section should never change
             //  (apart from on question load - this case is handled in the initial state of nonSelectedItems)
             if (!withReplacement) {
-                setNonSelectedItems(nonSelectedItems.filter(i => !currentAttempt.items?.map(si => si?.id).includes(i.id)).map(x => ({...x, replacementId: x.id})) || []);
+                setNonSelectedItems(nsis => nsis.filter(i => !currentAttempt.items?.map(si => si?.id).includes(i.id)).map(x => ({...x, replacementId: x.id})) || []);
             }
         }
         }, [currentAttempt]);
 
-    function registerInlineDropRegion(dropRegionId: string) {
-        if (!registeredDropRegionIDs.includes(dropRegionId)) {
-            registeredDropRegionIDs.push(dropRegionId);
-            setInlineDropValues(registeredDropRegionIDs.map(() => undefined));
-            setBorderMap(registeredDropRegionIDs.reduce((dict: {[dropId: string]: boolean}, id) => Object.assign(dict, {[id]: false}), {}));
+    const registerInlineDropRegion = (dropRegionId: string, index: number) => {
+        if (!registeredDropRegionIDs.has(dropRegionId)) {
+            registeredDropRegionIDs.set(dropRegionId, index);
+            const registeredDropRegionEntries = Array.from(registeredDropRegionIDs.entries());
+            setInlineDropValues(idvs => [...idvs]); // This is messy, but it makes sure that the inlineDropValueMap is recomputed
+            setBorderMap(registeredDropRegionEntries.reduce((dict, [dropId, index]) => Object.assign(dict, {[dropId]: false}), {}));
         }
-    }
+    };
 
     function fixInlineZoneOnStartDrag({source}: DragStart, provided: ResponderProvided) {
         fixInlineZones({destination: source} as DragUpdate, provided);
@@ -137,10 +62,9 @@ export function IsaacClozeQuestion({doc, questionId, readonly}: IsaacQuestionPro
     // This is run on drag update to highlight the droppable that the user is dragging over
     //  this gives more control over when a droppable is highlighted
     function fixInlineZones({destination}: DragUpdate, provided: ResponderProvided) {
-        registeredDropRegionIDs.map((dropId, i) => {
-            const destinationDropIndex = destination ? registeredDropRegionIDs.indexOf(dropId) : -1;
+        Array.from(registeredDropRegionIDs.entries()).map(([dropId, index]) => {
+            const destinationDropIndex = destination ? index : -1;
             const destinationDragIndex = destination?.index ?? -1;
-
             borderMap[dropId] = (dropId === destination?.droppableId && destinationDropIndex !== -1 && destinationDragIndex === 0);
         });
         // Tell React about the changes to borderMap
@@ -148,8 +72,7 @@ export function IsaacClozeQuestion({doc, questionId, readonly}: IsaacQuestionPro
     }
 
     // Run after a drag action ends
-    function updateAttempt({source, destination, draggableId}: DropResult, provided: ResponderProvided) {
-
+    const updateAttempt = useCallback(({source, destination, draggableId}: DropResult, provided: ResponderProvided) => {
         // Make sure borders are removed, since drag has ended
         fixInlineZones({destination: undefined} as DragUpdate, provided);
 
@@ -157,7 +80,7 @@ export function IsaacClozeQuestion({doc, questionId, readonly}: IsaacQuestionPro
 
         if (!destination) return; // Drag had no destination
 
-        const inlineDropIndex = (id : string) => registeredDropRegionIDs.indexOf(id)
+        const inlineDropIndex = (id : string) => registeredDropRegionIDs.get(id);
 
         const nsis = [...nonSelectedItems];
         const idvs = [...inlineDropValues];
@@ -180,13 +103,13 @@ export function IsaacClozeQuestion({doc, questionId, readonly}: IsaacQuestionPro
         } else {
             // Drag was from inline drop section
             // When splicing inline drop values, you always need to delete and replace
-            const sourceDropIndex = inlineDropIndex(source.droppableId);
-            if (sourceDropIndex !== -1) {
+            const sourceDropIndex = inlineDropIndex(source.droppableId) as number;
+            if (sourceDropIndex !== undefined) {
                 const maybeItem = idvs[sourceDropIndex]; // This nastiness is to appease typescript
                 if (maybeItem) {
                     item = maybeItem;
-                    idvs.splice(sourceDropIndex, 1, undefined);
-                    replaceSource = (itemToReplace) => idvs.splice(sourceDropIndex, 1, itemToReplace);
+                    idvs[sourceDropIndex] = undefined;
+                    replaceSource = (itemToReplace) => {idvs[sourceDropIndex] = itemToReplace;};
                     update = true;
                 } else {
                     return;
@@ -207,10 +130,11 @@ export function IsaacClozeQuestion({doc, questionId, readonly}: IsaacQuestionPro
             }
         } else {
             // Drop is into inline drop section
-            const destinationDropIndex = inlineDropIndex(destination.droppableId);
-            if (destinationDropIndex !== -1 && destination.index === 0) {
+            const destinationDropIndex = inlineDropIndex(destination.droppableId) as number;
+            if (destinationDropIndex !== undefined && destination.index === 0) {
                 replaceSource(idvs[destinationDropIndex]);
-                idvs.splice(destinationDropIndex, 1, withReplacement ? {...item, replacementId: item.id + uuid_v4()} : item);
+                // Important! This extends the array with `undefined`s if `destinationDropIndex` is out of bounds
+                idvs[destinationDropIndex] = withReplacement ? {...item, replacementId: item.id + uuid_v4()} : item
             } else {
                 replaceSource(item);
             }
@@ -236,10 +160,14 @@ export function IsaacClozeQuestion({doc, questionId, readonly}: IsaacQuestionPro
             };
             dispatchSetCurrentAttempt(itemChoice);
         }
-    }
+    }, [inlineDropValues, nonSelectedItems, registeredDropRegionIDs, dispatchSetCurrentAttempt]);
 
-    return <div ref={questionContentRef} className="question-content cloze-question">
-        <ClozeDropRegionContext.Provider value={{questionPartId: cssFriendlyQuestionPartId, register: registerInlineDropRegion}}>
+    const updateAttemptCallback = useCallback((dropResult) => {
+        updateAttempt({...dropResult, destination: {droppableId: itemsSection, index: nonSelectedItems.length}},{announce: (_) => {return;}});
+    }, [itemsSection, nonSelectedItems]);
+
+    return <div className="question-content cloze-question">
+        <ClozeDropRegionContext.Provider value={{questionPartId: cssFriendlyQuestionPartId, register: registerInlineDropRegion, updateAttemptCallback, readonly: readonly ?? false, inlineDropValueMap, borderMap}}>
             <DragDropContext onDragStart={fixInlineZoneOnStartDrag} onDragEnd={updateAttempt} onDragUpdate={fixInlineZones}>
                 <IsaacContentValueOrChildren value={doc.value} encoding={doc.encoding}>
                     {doc.children}
@@ -263,17 +191,6 @@ export function IsaacClozeQuestion({doc, questionId, readonly}: IsaacQuestionPro
                         {provided.placeholder}
                     </div>}
                 </Droppable>
-
-                {/* Inline droppables rendered for each registered drop region */}
-                {registeredDropRegionIDs.map((dropRegionId, index) =>
-                    <InlineDropRegion
-                        key={dropRegionId} contentHolder={questionContentRef} readonly={readonly}
-                        id={dropRegionId} item={inlineDropValues[index]} updateAttempt={(dropResult) => {
-                            updateAttempt({...dropResult, destination: {droppableId: itemsSection, index: nonSelectedItems.length}},{announce: (_) => {return;}});
-                        }}
-                        showBorder={borderMap[dropRegionId]}
-                    />
-                )}
             </DragDropContext>
         </ClozeDropRegionContext.Provider>
     </div>;

--- a/src/app/components/content/IsaacCodeSnippet.tsx
+++ b/src/app/components/content/IsaacCodeSnippet.tsx
@@ -5,8 +5,9 @@ import hljs from 'highlight.js/lib/core';
 import {addLineNumbers} from "../../services/highlightJs";
 import {ScrollShadows} from "../elements/ScrollShadows";
 import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
-import {useExpandContent} from "../elements/TrustedHtml";
 import classNames from "classnames";
+import {useExpandContent} from "../elements/portals/Tables";
+import {useStatefulElementRef} from "../elements/portals/utils";
 
 interface IsaacCodeProps {
     doc: CodeSnippetDTO;
@@ -22,18 +23,18 @@ export const IsaacCodeSnippet = ({doc}: IsaacCodeProps) => {
         }
     }, [doc]);
 
-    const scrollPromptRef = useRef<HTMLPreElement>(null);
-    const expandRef = useRef<HTMLDivElement>(null);
+    const [scrollPromptRef, updateScrollPromptRef] = useStatefulElementRef<HTMLDivElement>();
+    const [expandRef, updateExpandRef] = useStatefulElementRef<HTMLDivElement>();
     const {expandButton, innerClasses, outerClasses} = useExpandContent(doc.expandable ?? false, expandRef);
 
-    return <div ref={expandRef} className={classNames("position-relative code-snippet", outerClasses)}>
+    return <div ref={updateExpandRef} className={classNames("position-relative code-snippet", outerClasses)}>
         {expandButton}
         <div className={innerClasses}>
             {/* ScrollShadows uses ResizeObserver, which doesn't exist on Safari <= 13 */}
-            {SITE_SUBJECT === SITE.CS && window.ResizeObserver && <ScrollShadows scrollRef={scrollPromptRef} />}
+            {SITE_SUBJECT === SITE.CS && window.ResizeObserver && <ScrollShadows element={scrollPromptRef} />}
             <Row>
                 <Col>
-                <pre ref={scrollPromptRef} className="line-numbers">
+                <pre ref={updateScrollPromptRef} className="line-numbers">
                     <code ref={codeSnippetRef} className={doc.disableHighlighting ? 'plaintext' : doc.language}>
                         {doc.code}
                     </code>

--- a/src/app/components/content/IsaacGlossaryTerm.tsx
+++ b/src/app/components/content/IsaacGlossaryTerm.tsx
@@ -11,16 +11,17 @@ import {formatGlossaryTermId} from "../pages/Glossary";
 
 interface IsaacGlossaryTermProps {
     doc: GlossaryTermDTO;
+    inPortal?: boolean;
     linkToGlossary?: boolean;
 }
 
-const IsaacGlossaryTermComponent = ({doc, linkToGlossary}: IsaacGlossaryTermProps, ref: Ref<any>) => {
+const IsaacGlossaryTermComponent = ({doc, inPortal, linkToGlossary}: IsaacGlossaryTermProps, ref: Ref<any>) => {
     let _tags: Tag[] = [];
     if (SITE_SUBJECT === SITE.CS && doc.tags) {
         _tags = doc.tags.map(id => tags.getById(id as TAG_ID)).filter(tag => isDefined(tag));
     }
 
-    return <Row className="glossary_term" key={doc.id}>
+    const termContents = <>
         <Col md={3} className="glossary_term_name">
             <p ref={ref}>
                 {linkToGlossary && <a href={`#${(doc.id && formatGlossaryTermId(doc.id)) ?? ""}`}>
@@ -35,7 +36,9 @@ const IsaacGlossaryTermComponent = ({doc, linkToGlossary}: IsaacGlossaryTermProp
             {doc.explanation && <IsaacContent doc={doc.explanation} />}
             {/* {_tags && _tags.length > 0 && <p className="topics">Used in: {_tags.map(tag => tag.title).join(', ')}</p>} */}
         </Col>
-    </Row>;
+    </>
+
+    return (inPortal === true) ? termContents : <Row className="glossary_term" key={doc.id}>{termContents}</Row>;
 };
 
 export const IsaacGlossaryTerm = React.forwardRef(IsaacGlossaryTermComponent);

--- a/src/app/components/elements/ScrollShadows.tsx
+++ b/src/app/components/elements/ScrollShadows.tsx
@@ -1,4 +1,4 @@
-import React, {Dispatch, RefObject, SetStateAction, useEffect, useState} from "react";
+import React, {Dispatch, SetStateAction, useEffect, useState} from "react";
 import {isDefined} from "../../services/miscUtils";
 import classNames from "classnames";
 
@@ -46,9 +46,7 @@ export const ScrollShadows = <T extends HTMLElement>({element} : {element : T | 
             setScrollWidth(element.scrollWidth);
             setScrollLeft(element.scrollLeft);
         });
-        if (element) {
-            resizeObserver.observe(element);
-        }
+        resizeObserver.observe(element);
         return () => resizeObserver.disconnect();
     }, [element]);
 

--- a/src/app/components/elements/ScrollShadows.tsx
+++ b/src/app/components/elements/ScrollShadows.tsx
@@ -6,17 +6,15 @@ import classNames from "classnames";
 // It is essentially a setState where the state is also updated by an attribute you are "listening" to.
 // For example, `useEventPropertyState(ref, 0, "scrollLeft", ["scroll"]);` will update the state with `ref.current["scrollLeft"]`
 // whenever a `scroll` event is caught by a listener attached to `ref.current`.
-function useEventPropertyState<T>(ref: RefObject<HTMLElement>, initialState: T, property: string, eventTypes: (keyof HTMLElementEventMap)[], deps: React.DependencyList = []): [T, Dispatch<SetStateAction<T>>] {
+function useEventPropertyState<T>(element: HTMLElement | undefined, initialState: T, property: string, eventTypes: (keyof HTMLElementEventMap)[], deps: React.DependencyList = []): [T, Dispatch<SetStateAction<T>>] {
     const [state, setState] = useState<T>(initialState);
 
     useEffect(() => {
-        const element = ref?.current;
         if (!element) return;
 
         setState((element as Record<string, any>)[property] as T);
 
         const listener = () => {
-            const element = ref?.current;
             if (isDefined(element)) {
                 setState((element as Record<string, any>)[property] as T);
             }
@@ -30,19 +28,18 @@ function useEventPropertyState<T>(ref: RefObject<HTMLElement>, initialState: T, 
                 element.removeEventListener(eventType, listener);
             });
         }
-    }, [ref, ...deps]);
+    }, [element, ...deps]);
 
     return [state, setState];
 }
 
-export const ScrollShadows = <T extends HTMLElement>({scrollRef} : {scrollRef : RefObject<T>}) => {
+export const ScrollShadows = <T extends HTMLElement>({element} : {element : T | undefined}) => {
     const [clientWidth, setClientWidth] = useState<number>(0);
     const [scrollWidth, setScrollWidth] = useState<number>(0);
-    const [scrollLeft, setScrollLeft] = useEventPropertyState(scrollRef, 0, "scrollLeft", ["scroll"]);
+    const [scrollLeft, setScrollLeft] = useEventPropertyState(element, 0, "scrollLeft", ["scroll"]);
 
     useEffect(() => {
-        const element = scrollRef?.current;
-
+        if (!element) return;
         const resizeObserver = new ResizeObserver((entries) => {
             const element = entries[0].target;
             setClientWidth(element.clientWidth);
@@ -53,7 +50,7 @@ export const ScrollShadows = <T extends HTMLElement>({scrollRef} : {scrollRef : 
             resizeObserver.observe(element);
         }
         return () => resizeObserver.disconnect();
-    }, [scrollRef]);
+    }, [element]);
 
     const leftOpacity = scrollLeft > 1
         ? (scrollLeft < 60 ? scrollLeft / 60 : 1)

--- a/src/app/components/elements/Tabs.tsx
+++ b/src/app/components/elements/Tabs.tsx
@@ -1,10 +1,12 @@
-import React, {ReactNode, useEffect, useRef, useState} from "react";
+import React, {ReactNode, useEffect, useState} from "react";
 import {Nav, NavItem, NavLink, TabContent, TabPane} from "reactstrap";
 import {pauseAllVideos} from "../content/IsaacVideo";
 import {LaTeX} from "./LaTeX";
 import {isDefined} from "../../services/miscUtils";
-import {ExpandableParentContext, useExpandContent} from "./TrustedHtml";
 import classNames from "classnames";
+import {useStatefulElementRef} from "./portals/utils";
+import {useExpandContent} from "./portals/Tables";
+import {ExpandableParentContext} from "../../../IsaacAppTypes";
 
 type StringOrTabFunction = string | ((tabTitle: string, tabIndex: number) => string);
 
@@ -47,10 +49,10 @@ export const Tabs = (props: TabsProps) => {
         }
     }
 
-    const expandRef = useRef(null);
+    const [expandRef, updateExpandRef] = useStatefulElementRef<HTMLDivElement>();
     const {expandButton, innerClasses, outerClasses} = useExpandContent(expandable ?? false, expandRef);
 
-    return <div className={classNames({"mt-4": isDefined(expandButton)}, outerClasses)} ref={expandRef}>
+    return <div className={classNames({"mt-4": isDefined(expandButton)}, outerClasses)} ref={updateExpandRef}>
         {expandButton}
         <div
             className={classNames(className, innerClasses, "position-relative")}

--- a/src/app/components/elements/TrustedHtml.tsx
+++ b/src/app/components/elements/TrustedHtml.tsx
@@ -1,6 +1,5 @@
 import React, {useContext} from "react";
 import {useKatex} from "./LaTeX";
-import {GlossaryTermDTO} from "../../../IsaacApiTypes";
 import {useGlossaryTermsInHtml} from "./portals/GlossaryTerms";
 import {useAccessibleTablesInHtml} from "./portals/Tables";
 import {useStatefulElementRef} from "./portals/utils";

--- a/src/app/components/elements/TrustedHtml.tsx
+++ b/src/app/components/elements/TrustedHtml.tsx
@@ -1,135 +1,55 @@
-import React, {useCallback, useContext, useEffect, useRef, useState} from "react";
-import {ClozeDropRegionContext} from "../../../IsaacAppTypes";
+import React, {useContext} from "react";
 import {useKatex} from "./LaTeX";
-import {useClozeDropRegionsInHtml} from "../content/IsaacClozeQuestion";
-import ReactDOM from "react-dom";
-import classNames from "classnames";
-import {ScrollShadows} from "./ScrollShadows";
-import {above, isMobile, useDeviceSize} from "../../services/device";
-import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
-import {isDefined} from "../../services/miscUtils";
+import {GlossaryTermDTO} from "../../../IsaacApiTypes";
+import {useGlossaryTermsInHtml} from "./portals/GlossaryTerms";
+import {useAccessibleTablesInHtml} from "./portals/Tables";
+import {useStatefulElementRef} from "./portals/utils";
+import {useClozeDropRegionsInHtml} from "./portals/InlineDropZones";
+import {ClozeDropRegionContext} from "../../../IsaacAppTypes";
 
-interface TableData {
-    id: number;
-    html: string;
-    classes: string[];
-    expandable?: boolean;
-}
-
-const htmlDom = document.createElement("html");
-function useAccessibleTables(html: string): {htmlWithModifiedTables: string, tableData: TableData[]} {
-    // Skip turning the table into a portal component if we are in a cloze question exposition. This is because if
-    // the HTML that provides the root element for a drop-zone is put inside a Table component, then the Table might
-    // re-render and not cause the InlineDropZone related to that root element to rerender, since the InlineDropZone
-    // is a child component of IsaacClozeQuestion, and not Table.
+// TODO move this into TrustedMarkdown and require all cloze questions to be markdown (requires editor change)
+// Renders cloze question drop-zones (turning them into elements)
+const useRenderClozeDropZones = (html: string) => {
+    // If not in a cloze question, don't bother trying to find and render drop-zones
     const dropRegionContext = useContext(ClozeDropRegionContext);
-    const renderTablesInPortals = !(dropRegionContext && dropRegionContext.questionPartId);
+    if (!dropRegionContext) return html;
 
-    // This can't be quick but it is more robust than writing regular expressions...
-    htmlDom.innerHTML = html;
-
-    // Table manipulation
-    const tableElements = [...htmlDom.getElementsByTagName("table")];
-    const tableInnerHTMLs: TableData[] = [];
-    for (let i = 0; i < tableElements.length; i++) {
-        const table = tableElements[i];
-        // Insert parent div to handle table overflow
-        const parent = table.parentElement as HTMLElement;
-        const div = document.createElement("div");
-        if (!renderTablesInPortals) {
-            table.setAttribute("class", classNames("table table-bordered w-100 text-center bg-white m-0", table.className));
-            div.setAttribute("class", "overflow-auto mb-4");
-            parent.insertBefore(div, table);
-            div.appendChild(parent.removeChild(table));
-        } else {
-            div.setAttribute("id", `table-${i}`);
-            parent.insertBefore(div, table);
-            tableInnerHTMLs.push({id: i, html: table.innerHTML, classes: (table.getAttribute("class") || "").split(/\s+/)});
-            parent.removeChild(table);
-        }
-    }
-    return {htmlWithModifiedTables: htmlDom.innerHTML, tableData: tableInnerHTMLs};
+    let index = 0;
+    // Matches: [drop-zone], [drop-zone|w-50], [drop-zone|h-50] or [drop-zone|w-50h-200]
+    // Used to match and render cloze question drop zones into divs
+    const dropZoneRegex = /\[drop-zone(?<params>\|(?<width>w-\d+?)?(?<height>h-\d+?)?)?]/g;
+    const safeQuestionId = dropRegionContext.questionPartId.replaceAll("_", "-");
+    return html.replace(dropZoneRegex, (_match, params, widthMatch, heightMatch, offset) => {
+        const dropId = `drop-region-${index}-${safeQuestionId}`;
+        const minWidth = widthMatch ? widthMatch.slice("w-".length) + "px" : "100px";
+        const minHeight = heightMatch ? heightMatch.slice("h-".length) + "px" : "auto";
+        return `<div data-index="${index++}" id="${dropId}" class="d-inline-block" style="min-width: ${minWidth}; min-height: ${minHeight}"></div>`;
+    });
 }
 
-export const ExpandableParentContext = React.createContext<boolean>(false);
-
-export const useExpandContent = (expandable: boolean, ref: React.RefObject<HTMLElement>, unexpandedInnerClasses = "") => {
-    const [ expanded, setExpanded ] = useState(false);
-
-    const toggleExpanded = () => {
-        const newExpanded = !expanded;
-        if (newExpanded) {
-            ref.current?.scrollIntoView({
-                behavior: "smooth",
-                block: "nearest"
-            });
-        }
-        setExpanded(newExpanded);
-    }
-
-    const expandableParent = useContext(ExpandableParentContext);
-    const deviceSize = useDeviceSize();
-
-    const show = SITE_SUBJECT === SITE.CS && expandable && !isMobile() && above["md"](deviceSize) && !expandableParent;
-
-    const expandButton = (show && <div className={"expand-button position-relative"}>
-        <button onClick={toggleExpanded}>
-            <div><span><img aria-hidden alt={"Button to expand content"} src={"/assets/expand-arrow.svg"}/> {expanded ? "Close" : "Expand"}</span></div>
-        </button>
-    </div>) || null;
-
-    // If screen size goes below md, then the `isaac-expand-bg` class no longer applies (the screen is too thin)
-    const innerClasses = (expanded && show) ? "" : unexpandedInnerClasses;
-    const outerClasses = show ? (expanded ? "isaac-expand-bg expand-outer" : "expand-outer") : "";
-
-    return {expandButton, innerClasses, outerClasses};
-}
-
-// A portal component to manage table elements from inside the React DOM
-const Table = ({id, html, classes, rootElement}: TableData & {rootElement: HTMLElement}) => {
-    const [ parentElement, setParentElement ] = useState<Element | null>(null);
-
-    useEffect(() => {
-        if (isDefined(rootElement)) {
-            setParentElement(rootElement.querySelector(`#table-${id}`));
-        }
-    }, [rootElement]);
-
-    const scrollRef = useRef<HTMLDivElement>(null);
-    const expandRef = useRef<HTMLDivElement>(null);
-    const {expandButton, innerClasses, outerClasses} = useExpandContent(classes.includes("expandable"), expandRef, "overflow-auto mb-4");
-
-    if (html && parentElement) {
-        return ReactDOM.createPortal(
-            <div className={classNames(outerClasses, "position-relative isaac-table")} ref={expandRef}>
-                {/* ScrollShadows uses ResizeObserver, which doesn't exist on Safari <= 13 */}
-                {SITE_SUBJECT === SITE.CS && window.ResizeObserver && <ScrollShadows scrollRef={scrollRef} />}
-                {expandButton}
-                <div ref={scrollRef} className={innerClasses}>
-                    <table className={classNames(classes, "table table-bordered w-100 text-center bg-white m-0")} dangerouslySetInnerHTML={{__html: html}}/>
-                </div>
-            </div>,
-            parentElement
-        );
-    }
-    return null;
-}
-
-export const TrustedHtml = ({html, span, className}: {html: string; span?: boolean; className?: string;}) => {
-    const [ htmlRef, setHtmlRef ] = useState<HTMLDivElement>();
-    const updateHtmlRef = useCallback(ref => {
-        if (ref !== null) {
-            setHtmlRef(ref);
-        }
-    }, []);
+// This component renders the HTML given to it inside a React element.
+//
+// It also handles specific "special" elements produced by `TrustedMarkdown` (i.e. `span` elements that mark inline
+// glossary terms). The component produced by an element is rendered alongside the component that contains the
+// html of that element (i.e. in this case `tooltips` are rendered next to `ElementType`, whose `dangerouslySetInnerHTML`
+// contains the `span`s that those `UncontrolledTooltip`s refer to).
+export const TrustedHtml = ({html, span, className}: {html: string; span?: boolean; className?: string; glossaryTerms?: GlossaryTermDTO[]}) => {
+    const [htmlRef, updateHtmlRef] = useStatefulElementRef<HTMLDivElement>();
 
     const katexHtml = useKatex(html);
-    const katexHtmlWithClozeDropZones = useClozeDropRegionsInHtml(katexHtml);
-    const {htmlWithModifiedTables, tableData} = useAccessibleTables(katexHtmlWithClozeDropZones);
+
+    const htmlWithRenderedDropZones = useRenderClozeDropZones(katexHtml);
+
+    const {htmlWithModifiedTables, renderTables} = useAccessibleTablesInHtml(htmlWithRenderedDropZones);
+    const {htmlWithDropZones, renderDropZones} = useClozeDropRegionsInHtml(htmlWithModifiedTables);
+    const {htmlWithGlossaryTerms, tooltips, renderGlossaryTerms} = useGlossaryTermsInHtml(htmlWithDropZones);
 
     const ElementType = span ? "span" : "div";
     return <>
-        <ElementType ref={updateHtmlRef} className={className} dangerouslySetInnerHTML={{__html: htmlWithModifiedTables}} />
-        {htmlRef && tableData.map(({id, html, classes}) => <Table key={id} rootElement={htmlRef} id={id} html={html} classes={classes}/>)}
+        <ElementType ref={updateHtmlRef} className={className} dangerouslySetInnerHTML={{__html: htmlWithGlossaryTerms}} />
+        {renderTables(htmlRef)}
+        {renderGlossaryTerms(htmlRef)}
+        {renderDropZones(htmlRef)}
+        {tooltips}
     </>;
 };

--- a/src/app/components/elements/TrustedHtml.tsx
+++ b/src/app/components/elements/TrustedHtml.tsx
@@ -33,7 +33,7 @@ const useRenderClozeDropZones = (html: string) => {
 // glossary terms). The component produced by an element is rendered alongside the component that contains the
 // html of that element (i.e. in this case `tooltips` are rendered next to `ElementType`, whose `dangerouslySetInnerHTML`
 // contains the `span`s that those `UncontrolledTooltip`s refer to).
-export const TrustedHtml = ({html, span, className}: {html: string; span?: boolean; className?: string; glossaryTerms?: GlossaryTermDTO[]}) => {
+export const TrustedHtml = ({html, span, className}: {html: string; span?: boolean; className?: string}) => {
     const [htmlRef, updateHtmlRef] = useStatefulElementRef<HTMLDivElement>();
 
     const katexHtml = useKatex(html);

--- a/src/app/components/elements/TrustedMarkdown.tsx
+++ b/src/app/components/elements/TrustedMarkdown.tsx
@@ -1,19 +1,9 @@
-import React, {useState} from "react";
-import ReactDOMServer from "react-dom/server";
-import {Provider, useSelector, useStore} from "react-redux";
-import * as RS from "reactstrap";
-import {Router} from "react-router-dom"
-import {AppState} from "../../state/reducers";
+import React from "react";
 import {MARKDOWN_RENDERER} from "../../services/constants";
 import {TrustedHtml} from "./TrustedHtml";
-import {IsaacGlossaryTerm} from "../content/IsaacGlossaryTerm";
-import {GlossaryTermDTO} from "../../../IsaacApiTypes";
 // @ts-ignore
 import {Remarkable, utils} from "remarkable";
-import {v4 as uuid_v4} from "uuid";
-import {history} from "../../services/history";
 import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
-
 
 MARKDOWN_RENDERER.renderer.rules.link_open = function(tokens: Remarkable.LinkOpenToken[], idx: number/* options, env */) {
     const href = utils.escapeHtml(tokens[idx].href || "");
@@ -26,27 +16,10 @@ MARKDOWN_RENDERER.renderer.rules.link_open = function(tokens: Remarkable.LinkOpe
     }
 };
 
-function getTermFromCandidateTerms(candidateTerms: GlossaryTermDTO[]) {
-    if (candidateTerms.length === 0) {
-        return null;
-    } else if (candidateTerms.length === 1) {
-        return candidateTerms[0];
-    } else {
-        console.warn('More than one candidate term was found: ', candidateTerms);
-        return candidateTerms[0];
-    }
-}
-
+// The job of this component is to render standard and Isaac-specific markdown (glossary terms, cloze question
+// drop zones) into HTML, which is then passed to `TrustedHTML`. The Isaac-specific markdown must be processed first,
+// so that it doesn't get incorrectly rendered with Remarkable (the markdown renderer we use).
 export const TrustedMarkdown = ({markdown}: {markdown: string}) => {
-    const store = useStore();
-
-    const glossaryTerms = useSelector((state: AppState) => state && state.glossaryTerms);
-    const [componentUuid, setComponentUuid] = useState(uuid_v4().slice(0, 8));
-
-    // This tooltips array is necessary later on: it will contain
-    // UncontrolledTooltip elements that cannot be pre-rendered as static HTML.
-    const tooltips: JSX.Element[] = [];
-
     // Matches strings such as [glossary:glossary-demo|boolean-algebra] which MUST be at the beginning of the line.
     // This is used to render the full version of a glossary term using the IsaacGlossaryTerm component.
     const glossaryBlockRegexp = /^\[glossary:(?<id>[a-z-|]+?)\]/gm;
@@ -56,51 +29,14 @@ export const TrustedMarkdown = ({markdown}: {markdown: string}) => {
     // This is used to produce a hoverable element showing the glossary term, and its definition in a tooltip.
     const glossaryInlineRegexp = /\[glossary-inline:(?<id>[a-z-|]+?)\s*(?:"(?<text>[A-Za-z0-9 ]+)")?\]/g;
 
-    const glossaryIdsInMarkdown = Array.from(new Set([
-        ...Array.from(markdown.matchAll(glossaryBlockRegexp)).filter(m => m.groups && m.groups.id),
-        ...Array.from(markdown.matchAll(glossaryInlineRegexp)).filter(m => m.groups && m.groups.id),
-    ]));
-
-    if (glossaryTerms && glossaryTerms.length > 0 && glossaryIdsInMarkdown.length > 0) {
-        // Markdown can't cope with React components, so we pre-render our component to static HTML, which Markdown will then ignore.
-        // This requires a bunch of stuff to be passed down along with the component.
-        markdown = markdown.replace(glossaryBlockRegexp, (_match, id) => {
-            const term = getTermFromCandidateTerms(glossaryTerms.filter(term => (term.id as string) === id));
-            if (term === null) {
-                console.error('No valid term for "' + id + '" found among the filtered terms: ', glossaryTerms);
-                return "";
-            }
-
-            return ReactDOMServer.renderToStaticMarkup(
-                <Provider store={store}>
-                    <Router history={history}>
-                        <IsaacGlossaryTerm doc={term} />
-                    </Router>
-                </Provider>
-            );
-        });
-
-        // This is easier: we replace an inline glossary term with a <span> which is later targeted by ReactStrap's UncontrolledTooltip.
-        // The tooltip components can be rendered as regular react objects, so we just add them to an array,
-        // and return them inside the JSX.Element that is returned as TrustedMarkdown.
-        markdown = markdown.replace(glossaryInlineRegexp, (_match, id, text, offset) => {
-            const term = getTermFromCandidateTerms(glossaryTerms.filter(term => (term.id as string) === id));
-            if (term === null) {
-                console.error('No valid term for "' + id + '" found among the filtered terms: ', glossaryTerms);
-                return "";
-            }
-
-            const cssFriendlyTermId = (term.id as string).replace(/\|/g, '-');
-            const tooltipTargetId = `glossary-${componentUuid}-${cssFriendlyTermId}-${offset}`;
-            // This is properly horrible but it works...
-            tooltips.push(
-                <RS.UncontrolledTooltip placement="bottom" target={tooltipTargetId}>
-                    <TrustedMarkdown markdown={term.explanation && term.explanation.value || ''} />
-                </RS.UncontrolledTooltip>
-            );
-            return `<span class="inline-glossary-term" id="${tooltipTargetId}">${text || term.value}</span>`;
-        });
-    }
+    markdown = markdown.replace(glossaryBlockRegexp, (_match, id) => {
+        const cssFriendlyTermId = id.replace(/\|/g, '-');
+        return `<span data-type="full" id="glossary-term-${cssFriendlyTermId}">Loading glossary...</span>`;
+    });
+    markdown = markdown.replace(glossaryInlineRegexp, (_match, id, text, offset) => {
+        const cssFriendlyTermId = id.replace(/\|/g, '-');
+        return `<span data-type="inline" class="inline-glossary-term" ${text ? `data-text="${text}"` : ""} id="glossary-term-${cssFriendlyTermId}">Loading glossary...</span>`;
+    });
 
     // RegEx replacements to match Latex inspired Isaac Physics functionality
     const regexRules = {
@@ -120,6 +56,5 @@ export const TrustedMarkdown = ({markdown}: {markdown: string}) => {
     const html = MARKDOWN_RENDERER.render(regexProcessedMarkdown);
     return <div>
         <TrustedHtml html={html}/>
-        {tooltips}
     </div>;
 };

--- a/src/app/components/elements/TrustedMarkdown.tsx
+++ b/src/app/components/elements/TrustedMarkdown.tsx
@@ -31,7 +31,7 @@ export const TrustedMarkdown = ({markdown}: {markdown: string}) => {
 
     markdown = markdown.replace(glossaryBlockRegexp, (_match, id) => {
         const cssFriendlyTermId = id.replace(/\|/g, '-');
-        return `<span data-type="full" id="glossary-term-${cssFriendlyTermId}">Loading glossary...</span>`;
+        return `<div data-type="full" id="glossary-term-${cssFriendlyTermId}">Loading glossary...</div>`;
     });
     markdown = markdown.replace(glossaryInlineRegexp, (_match, id, text, offset) => {
         const cssFriendlyTermId = id.replace(/\|/g, '-');
@@ -54,6 +54,7 @@ export const TrustedMarkdown = ({markdown}: {markdown: string}) => {
     );
 
     const html = MARKDOWN_RENDERER.render(regexProcessedMarkdown);
+
     return <div>
         <TrustedHtml html={html}/>
     </div>;

--- a/src/app/components/elements/portals/GlossaryTerms.tsx
+++ b/src/app/components/elements/portals/GlossaryTerms.tsx
@@ -1,0 +1,85 @@
+import {GlossaryTermDTO} from "../../../../IsaacApiTypes";
+import React, {useState} from "react";
+import ReactDOM from "react-dom";
+import {IsaacGlossaryTerm} from "../../content/IsaacGlossaryTerm";
+import {useSelector} from "react-redux";
+import {AppState} from "../../../state/reducers";
+import {v4 as uuid_v4} from "uuid";
+import {UncontrolledTooltip} from "reactstrap";
+import {TrustedMarkdown} from "../TrustedMarkdown";
+
+const GlossaryTerm = ({term, id, rootElement}: {term: GlossaryTermDTO, id: string, rootElement: HTMLElement}) => {
+    const parentElement = rootElement.querySelector(`#${id}`);
+    if (parentElement) {
+        return ReactDOM.createPortal(
+            <IsaacGlossaryTerm doc={term}/>,
+            parentElement
+        );
+    }
+    return null;
+}
+
+function getTermFromCandidateTerms(candidateTerms: GlossaryTermDTO[]) {
+    if (candidateTerms.length === 0) {
+        return null;
+    } else if (candidateTerms.length === 1) {
+        return candidateTerms[0];
+    } else {
+        console.warn('More than one candidate term was found: ', candidateTerms);
+        return candidateTerms[0];
+    }
+}
+
+// The component that uses this hook should be using the pattern demonstrated in `TrustedHtml`.
+// This pattern is the following:
+// - The html produced by this hook is rendered within an element using the `dangerouslySetInnerHTML` attribute. Call this the root element.
+// - When calling `renderGlossaryTerms`, *pass the root element*
+// - Ensure that the root element is set and updated using the `useStatefulElementRef` hook. This means that when the element
+// is added to the DOM, a update occurs for all components that take this element as a prop.
+//
+// Using this pattern, you can safely nest portal components to an arbitrary depth (as far as I can tell)
+export const useGlossaryTermsInHtml = (html: string) => {
+    const glossaryTerms = useSelector((state: AppState) => state && state.glossaryTerms);
+    const [componentUuid] = useState(uuid_v4().slice(0, 8));
+
+    if (!glossaryTerms) {
+        return {htmlWithGlossaryTerms: html, tooltips: [], renderGlossaryTerms: () => []}
+    }
+
+    const tooltips: JSX.Element[] = [];
+    const fullTermContainers: {id: string; term: GlossaryTermDTO}[] = [];
+
+    const htmlDom = document.createElement("html");
+    htmlDom.innerHTML = html;
+    const spans = htmlDom.querySelectorAll("span[id^='glossary-term-']") as NodeListOf<HTMLElement>;
+    for (let i = 0; i < spans.length; i++) {
+        const termId = spans[i].id.slice(14);
+        const term = getTermFromCandidateTerms(glossaryTerms.filter(term => term.id?.replace(/\|/g, '-') === termId));
+
+        if (term) {
+            const uniqueId = `${termId}-${componentUuid}-${i}`;
+            if (spans[i].dataset.type === "full") {
+                const fullTermDiv = document.createElement('div');
+                fullTermDiv.setAttribute("id", uniqueId);
+                spans[i].parentNode?.replaceChild(fullTermDiv, spans[i]);
+                fullTermContainers.push({id: fullTermDiv.id, term: {...term}});
+            } else if (spans[i].dataset.type === "inline") { // Assume inline
+                const text = spans[i].dataset.text;
+                spans[i].innerHTML = text ?? term.value ?? "";
+                spans[i].setAttribute("id", uniqueId);
+                tooltips.push(
+                    <UncontrolledTooltip key={uniqueId} placement="bottom" target={uniqueId}>
+                        <TrustedMarkdown markdown={term.explanation?.value || ''} />
+                    </UncontrolledTooltip>
+                );
+            }
+        } else {
+            console.error('No valid term for "' + termId + '" found among the filtered terms: ', glossaryTerms);
+        }
+    }
+    return {
+        htmlWithGlossaryTerms: htmlDom.innerHTML,
+        tooltips: tooltips,
+        renderGlossaryTerms: (ref?: HTMLElement) => ref ? fullTermContainers.map(({id, term}) => <GlossaryTerm key={id} id={id} term={term} rootElement={ref}/>) : []
+    };
+}

--- a/src/app/components/elements/portals/InlineDropZones.tsx
+++ b/src/app/components/elements/portals/InlineDropZones.tsx
@@ -1,0 +1,104 @@
+import {ClozeDropRegionContext} from "../../../../IsaacAppTypes";
+import {Draggable, Droppable, DropResult} from "react-beautiful-dnd";
+import ReactDOM from "react-dom";
+import React, {useCallback, useContext, useEffect} from "react";
+import {ItemDTO} from "../../../../IsaacApiTypes";
+import {IsaacContentValueOrChildren} from "../../content/IsaacContentValueOrChildren";
+import {Badge} from "reactstrap";
+
+export function Item({item}: {item: ItemDTO}) {
+    return <Badge className="m-2 p-2">
+        <IsaacContentValueOrChildren value={item.value} encoding={item.encoding || "html"}>
+            {item.children}
+        </IsaacContentValueOrChildren>
+    </Badge>;
+}
+
+// Inline droppables rendered for each registered drop region
+export function InlineDropRegion({id, index, rootElement}: {id: string; index: number; rootElement?: HTMLElement}) {
+    const dropRegionContext = useContext(ClozeDropRegionContext);
+    if (!dropRegionContext) return null;
+    const {updateAttemptCallback, inlineDropValueMap, borderMap, readonly, register} = dropRegionContext;
+
+    useEffect(() => {
+        // Register with the current cloze question on first render
+        register(id, index);
+    }, []);
+
+    const clearInlineDropZone = useCallback(() => {
+        updateAttemptCallback({source: {droppableId: id, index: 0}, draggableId: (inlineDropValueMap[id]?.replacementId as string)} as DropResult);
+    }, [updateAttemptCallback, inlineDropValueMap]);
+
+    const item = inlineDropValueMap[id];
+
+    const droppableTarget = rootElement?.querySelector(`#${id}`);
+
+    if (droppableTarget) {
+        return ReactDOM.createPortal(
+            <div style={{minHeight: "inherit", position: "relative", margin: "2px"}}>
+                <Droppable droppableId={id} isDropDisabled={readonly} direction="vertical" >
+                    {(provided, snapshot) => <div
+                        ref={provided.innerRef} {...provided.droppableProps}
+                        className={`d-flex justify-content-center align-items-center bg-grey rounded w-100 overflow-hidden ${borderMap[id] && "border border-dark"}`}
+                        style={{minHeight: "inherit"}}
+                    >
+                        {item && <Draggable key={item.replacementId} draggableId={item?.replacementId as string} index={0} isDragDisabled={true}>
+                            {(provided, snapshot) =>
+                                <div
+                                    className={"cloze-draggable mr-4"} ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps}
+                                >
+                                    <Item item={item}/>
+                                </div>
+                            }
+                        </Draggable>}
+                        {!item && "\u00A0"}
+                    </div>}
+                </Droppable>
+                {item && <button aria-label={"Clear drop zone"} className={"cloze-inline-clear"} onClick={clearInlineDropZone}>
+                    <svg height="20" width="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false"
+                         className="cloze-clear-cross">
+                        <path d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"/>
+                    </svg>
+                </button>}
+            </div>,
+            droppableTarget);
+    }
+    return null;
+}
+
+// The component that uses this hook should be using the pattern demonstrated in `TrustedHtml`.
+// This pattern is the following:
+// - The html produced by this hook is rendered within an element using the `dangerouslySetInnerHTML` attribute. Call this the root element.
+// - When calling `renderDropZones`, *pass the root element*
+// - Ensure that the root element is set and updated using the `useStatefulElementRef` hook. This means that when the element
+// is added to the DOM, a update occurs for all components that take this element as a prop.
+//
+// Using this pattern, you can safely nest portal components to an arbitrary depth (as far as I can tell)
+export function useClozeDropRegionsInHtml(html: string): {htmlWithDropZones: string; renderDropZones: (ref?: HTMLElement) => JSX.Element[]} {
+    // If not in a cloze question, don't bother trying to find and render drop-zone divs
+    const dropRegionContext = useContext(ClozeDropRegionContext);
+    if (!dropRegionContext) return {htmlWithDropZones: html, renderDropZones: () => []};
+
+    const dropIds: { id: string; index: number }[] = [];
+    const htmlDom = document.createElement("html");
+    htmlDom.innerHTML = html;
+    // Looks for all div elements with ids starting with "drop-region-". These are the drop-zones that the component
+    // using this hook is charged with rendering.
+    const dropZones = htmlDom.querySelectorAll("div[id^='drop-region-']") as NodeListOf<HTMLElement>;
+    if (dropZones.length === 0) return {htmlWithDropZones: html, renderDropZones: () => []};
+    for (let i = 0; i < dropZones.length; i++) {
+        const index = parseInt(dropZones[i].dataset.index ?? "x");
+        if (isNaN(index)) {
+            console.error("Drop zone div element has invalid index data attribute!", dropZones[i]);
+            continue;
+        }
+        dropIds.push({id: dropZones[i].id, index});
+    }
+
+    const renderDropZones = useCallback((ref?: HTMLElement) => ref ? dropIds.map(({id, index}) => <InlineDropRegion key={id} rootElement={ref} id={id} index={index}/>) : [], []);
+
+    return {
+        htmlWithDropZones: htmlDom.innerHTML,
+        renderDropZones
+    };
+}

--- a/src/app/components/elements/portals/Tables.tsx
+++ b/src/app/components/elements/portals/Tables.tsx
@@ -87,7 +87,7 @@ interface TableData {
 //
 // Using this pattern, you can safely nest portal components to an arbitrary depth (as far as I can tell)
 export function useAccessibleTablesInHtml(html: string): {htmlWithModifiedTables: string, renderTables: (ref?: HTMLElement) => JSX.Element[]} {
-    // This can't be quick but it is more robust than writing regular expressions...
+    // This is more robust than writing regex, and is surprisingly very quick!
     const htmlDom = document.createElement("html");
     htmlDom.innerHTML = html;
     // Table manipulation

--- a/src/app/components/elements/portals/Tables.tsx
+++ b/src/app/components/elements/portals/Tables.tsx
@@ -1,0 +1,112 @@
+import React, {MouseEventHandler, useContext, useState} from "react";
+import classNames from "classnames";
+import ReactDOM from "react-dom";
+import {SITE, SITE_SUBJECT} from "../../../services/siteConstants";
+import {ScrollShadows} from "../ScrollShadows";
+import {useGlossaryTermsInHtml} from "./GlossaryTerms";
+import {above, isMobile, useDeviceSize} from "../../../services/device";
+import {ExpandableParentContext} from "../../../../IsaacAppTypes";
+import {useClozeDropRegionsInHtml} from "./InlineDropZones";
+import {useStatefulElementRef} from "./utils";
+
+// A portal component to manage table elements from inside the React DOM
+const Table = ({id, html, classes, rootElement}: TableData & {rootElement: HTMLElement}) => {
+    const parentElement = rootElement.querySelector(`#table-${id}`);
+
+    const tableHtml = `<table class="${classNames(classes, "table table-bordered w-100 text-center bg-white m-0")}">${html}</table>`;
+    const {htmlWithDropZones, renderDropZones} = useClozeDropRegionsInHtml(tableHtml);
+    const {htmlWithGlossaryTerms, tooltips, renderGlossaryTerms} = useGlossaryTermsInHtml(htmlWithDropZones);
+
+    const [scrollRef, updateScrollRef] = useStatefulElementRef<HTMLDivElement>();
+    const [expandRef, updateExpandRef] = useStatefulElementRef<HTMLElement>();
+    const {expandButton, innerClasses, outerClasses} = useExpandContent(classes.includes("expandable"), expandRef, "overflow-auto mb-4");
+
+    if (htmlWithGlossaryTerms && parentElement) {
+        return ReactDOM.createPortal(
+            <div className={classNames(outerClasses, "position-relative isaac-table")} ref={updateExpandRef}>
+                {/* ScrollShadows uses ResizeObserver, which doesn't exist on Safari <= 13 */}
+                {SITE_SUBJECT === SITE.CS && window.ResizeObserver && <ScrollShadows element={scrollRef} />}
+                {expandButton}
+                <div ref={updateScrollRef} className={innerClasses} dangerouslySetInnerHTML={{__html: htmlWithGlossaryTerms}} />
+                {renderDropZones(scrollRef)}
+                {renderGlossaryTerms(scrollRef)}
+                {tooltips}
+            </div>,
+            parentElement
+        );
+    }
+    return null;
+}
+
+export const useExpandContent = (expandable: boolean, el?: HTMLElement, unexpandedInnerClasses = "") => {
+    const [ expanded, setExpanded ] = useState(false);
+
+    const toggleExpanded: MouseEventHandler = (event) => {
+        const newExpanded = !expanded;
+        if (newExpanded) {
+            el?.scrollIntoView({
+                behavior: "smooth",
+                block: "nearest"
+            });
+        }
+        setExpanded(newExpanded);
+    }
+
+    const expandableParent = useContext(ExpandableParentContext);
+    const deviceSize = useDeviceSize();
+
+    const show = SITE_SUBJECT === SITE.CS && expandable && !isMobile() && above["md"](deviceSize) && !expandableParent;
+
+    const expandButton = (show && <div className={"expand-button position-relative"}>
+        <button type={"button"} onClick={toggleExpanded}>
+            <div><span><img aria-hidden alt={"Button to expand content"} src={"/assets/expand-arrow.svg"}/> {expanded ? "Close" : "Expand"}</span></div>
+        </button>
+    </div>) || null;
+
+    // If screen size goes below md, then the `isaac-expand-bg` class no longer applies (the screen is too thin)
+    const innerClasses = (expanded && show) ? "" : unexpandedInnerClasses;
+    const outerClasses = show ? (expanded ? "isaac-expand-bg expand-outer" : "expand-outer") : "";
+
+    return {expandButton, innerClasses, outerClasses};
+}
+
+interface TableData {
+    id: number;
+    html: string;
+    classes: string[];
+    expandable?: boolean;
+}
+
+// TODO Need to change this so that it only deals with the top layer of nested tables
+// The component that uses this hook should be using the pattern demonstrated in `TrustedHtml`.
+// This pattern is the following:
+// - The html produced by this hook is rendered within an element using the `dangerouslySetInnerHTML` attribute. Call this the root element.
+// - When calling `renderTables`, *pass the root element*
+// - Ensure that the root element is set and updated using the `useStatefulElementRef` hook. This means that when the element
+// is added to the DOM, a update occurs for all components that take this element as a prop.
+//
+// Using this pattern, you can safely nest portal components to an arbitrary depth (as far as I can tell)
+export function useAccessibleTablesInHtml(html: string): {htmlWithModifiedTables: string, renderTables: (ref?: HTMLElement) => JSX.Element[]} {
+    // This can't be quick but it is more robust than writing regular expressions...
+    const htmlDom = document.createElement("html");
+    htmlDom.innerHTML = html;
+    // Table manipulation
+    const tableElements = [...htmlDom.getElementsByTagName("table")];
+    if (tableElements.length === 0) return {htmlWithModifiedTables: html, renderTables: () => []};
+
+    const tableInnerHTMLs: TableData[] = [];
+    for (let i = 0; i < tableElements.length; i++) {
+        const table = tableElements[i];
+        // Insert parent div to handle table overflow
+        const parent = table.parentElement as HTMLElement;
+        const div = document.createElement("div");
+        div.setAttribute("id", `table-${i}`);
+        parent.insertBefore(div, table);
+        tableInnerHTMLs.push({id: i, html: table.innerHTML, classes: (table.getAttribute("class") || "").split(/\s+/)});
+        parent.removeChild(table);
+    }
+    return {
+        htmlWithModifiedTables: htmlDom.innerHTML,
+        renderTables: (ref?: HTMLElement) => ref ? tableInnerHTMLs.map(({id, html, classes}) => <Table key={id} rootElement={ref} id={id} html={html} classes={classes}/>) : []
+    };
+}

--- a/src/app/components/elements/portals/utils.ts
+++ b/src/app/components/elements/portals/utils.ts
@@ -1,0 +1,13 @@
+import {useCallback, useState} from "react";
+
+// This is a hook that abstracts the callback ref pattern, allowing for updates to a refs value (specifically one
+// referring to an element) to cause component updates
+export function useStatefulElementRef<T>(): [T | undefined, (ref: any) => void]{
+    const [ ref, setRef ] = useState<T>();
+    const updateRef = useCallback(ref => {
+        if (ref !== null) {
+            setRef(ref);
+        }
+    }, []);
+    return [ref, updateRef];
+}


### PR DESCRIPTION
**Disclaimer**: this was complicated, and the following explanation may be incoherent, so a demo of the code in person would be best for someone wanting to review it.

---

This presents and implements a pattern for portal components to be nested. This sounds nasty, but if we want things like tables, glossary terms and cloze question drop zones to be handled in React, it needs to be figured out - after abstracting some things, it's nicer than it seems at first glance!

The main idea is to use [callback refs](https://reactjs.org/docs/refs-and-the-dom.html#callback-refs) to allow portal components to be re-rendered when the ref of the element they should be rending inside updates. The other idea is to make sure that any component using `dangerouslySetInnerHTML={{__html: html}}` is in charge of rendering any portal components whose parent elements are in `html`.

This PR also separates some previously-intertwined things. `TrustedMarkdown` now **only** renders markdown into html, `TrustedHtml` only renders portal components and uses `dangerouslySetInnerHTML`, and `IsaacClozeQuestion` no longer contains portal components. 

Each portal component has its own separate file (in the `elements/portals` subdirectory), and own hook that deals solely with finding elements for those components to be rendered inside. The hook returns a callback which renders the portal components, when given an `HTMLElement` that contains the parent elements they expect to be rendered inside.

Regarding efficiency of loading HTML into a new `<html>` element and querying it for tags/ids etc. inside JavaScript, it takes on the order of a few milliseconds.

Useful pages to test that the changes have fixed what they need to, and not broken anything else:

- [Regression test page Part K](http://localhost:8003/questions/_regression_test_), a cloze question with LaTeX and tables
- [Any of the questions here](https://isaaccomputerscience.org/gameboards#791bf30f-98d2-4dc1-b30b-b5376b680b75) are good to check if you go to the question and change `https://isaaccomputerscience.org` to `http://localhost:8003`
- [Expanding tables test page](http://localhost:8003/concepts/c0107d3b-9a96-4f4f-8949-76d1cd2771f8)
- [The page that started it all](http://localhost:8003/concepts/sys_os_utility_software?examBoard=all&stage=all&topic=software) - specifically look at the second to last accordion section which contains a table with an inline glossary term inside. 
- [First hint of first question here](http://localhost:8003/questions/data_compr_04) and [here](http://localhost:8003/questions/data_compr_05), contains glossary terms (non-inline ones)
