### PR TITLE
My Progress bars out of total questions in each Isaac book

### DIFF
--- a/src/IsaacAppTypes.tsx
+++ b/src/IsaacAppTypes.tsx
@@ -839,15 +839,15 @@ export enum ATTENDANCE {
 }
 
 export interface QuestionSearchQuery {
-    searchString: string;
-    tags: string;
+    searchString?: string;
+    tags?: string;
     levels?: string;
     stages?: string;
     difficulties?: string;
     examBoards?: string;
-    fasttrack: boolean;
-    startIndex: number;
-    limit: number;
+    fasttrack?: boolean;
+    startIndex?: number;
+    limit?: number;
 }
 
 export interface QuestionSearchResponse {

--- a/src/app/components/elements/modals/QuestionSearchModal.tsx
+++ b/src/app/components/elements/modals/QuestionSearchModal.tsx
@@ -64,7 +64,7 @@ export const QuestionSearchModal = ({originalSelectedQuestions, setOriginalSelec
     const [selectedQuestions, setSelectedQuestions] = useState<Map<string, ContentSummary>>(new Map(originalSelectedQuestions));
     const [questionOrder, setQuestionOrder] = useState([...originalQuestionOrder]);
 
-    const questions = useSelector((state: AppState) => state && state.gameboardEditorQuestions);
+    const questions = useSelector((state: AppState) => state && state.questionSearchResult);
     const user = useSelector((state: AppState) => state && state.user);
 
     const searchDebounce = useCallback(

--- a/src/app/components/elements/views/ProgressBar.tsx
+++ b/src/app/components/elements/views/ProgressBar.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
+import {isDefined} from "../../../services/miscUtils";
 
 interface ProgressBarProps {
     percentage: number;
-    children: string;
+    primaryTitle?: string;
+    secondaryPercentage?: number;
+    secondaryTitle?: string;
+    children: string | JSX.Element | JSX.Element[];
     type?: string;
 }
 
@@ -14,10 +18,11 @@ const BAR_COLOURS = new Map([
     ["chemistry_16", "bar-chemistry"],
 ]);
 
-export const ProgressBar = ({percentage, children, type}: ProgressBarProps) => {
+export const ProgressBar = ({percentage, primaryTitle, secondaryPercentage, secondaryTitle, children, type}: ProgressBarProps) => {
     let colour = type && BAR_COLOURS.get(type);
     return <div className="progress-bar-outer mb-2">
-        <div className={`progress-bar-inner ${colour}`} style={{width: `${percentage}%`}}>
+        {isDefined(secondaryPercentage) && <div className={`progress-bar-secondary ${colour}`} title={secondaryTitle} style={{width: `${secondaryPercentage}%`}} />}
+        <div className={`progress-bar-inner ${colour}`} style={{width: `${percentage}%`}} title={primaryTitle}>
             <span className="pl-3">
                 {children}
             </span>

--- a/src/app/state/reducers/gameboardsState.ts
+++ b/src/app/state/reducers/gameboardsState.ts
@@ -123,8 +123,8 @@ export const fasttrackConcepts = (state: FasttrackConceptsState = null, action: 
     }
 };
 
-type GameboardEditorQuestionsState = ContentSummaryDTO[] | null;
-export const gameboardEditorQuestions = (gameboardEditorQuestions: GameboardEditorQuestionsState = null, action: Action) => {
+type QuestionSearchResultState = ContentSummaryDTO[] | null;
+export const questionSearchResult = (gameboardEditorQuestions: QuestionSearchResultState = null, action: Action) => {
     switch(action.type) {
         case ACTION_TYPE.QUESTION_SEARCH_RESPONSE_SUCCESS: {
             return action.questions.map((question) => {

--- a/src/app/state/reducers/index.ts
+++ b/src/app/state/reducers/index.ts
@@ -35,7 +35,7 @@ import {
 } from "./adminState";
 import {activeAuthorisations, groupMemberships, groups, otherUserAuthorisations} from "./groupsState";
 import {currentTopic} from "./topicState";
-import {boards, currentGameboard, fasttrackConcepts, gameboardEditorQuestions, wildcards} from "./gameboardsState";
+import {boards, currentGameboard, fasttrackConcepts, questionSearchResult, wildcards} from "./gameboardsState";
 import {search} from "./searchState";
 import {assignments, assignmentsByMe, groupProgress, progress} from "./assignmentsState";
 import {
@@ -110,7 +110,7 @@ const appReducer = combineReducers({
     boards,
     currentGameboard,
     wildcards,
-    gameboardEditorQuestions,
+    questionSearchResult,
     fasttrackConcepts,
 
     // Assignments

--- a/src/scss/common/progress-bar.scss
+++ b/src/scss/common/progress-bar.scss
@@ -12,9 +12,15 @@
     white-space: nowrap;
   }
 
-  .progress-bar-inner {
+  .progress-bar-inner, .progress-bar-secondary {
+    position: absolute;
     background: $primary;
     height: 100%;
     //transition: width .2s ease-in;
+  }
+
+  .progress-bar-secondary {
+    position: absolute;
+    opacity: 0.3;
   }
 }

--- a/src/scss/phy/progress-bar.scss
+++ b/src/scss/phy/progress-bar.scss
@@ -1,7 +1,7 @@
 @import "../common/progress-bar";
 
 .progress-bar-outer {
-  .progress-bar-inner {
+  .progress-bar-inner, .progress-bar-secondary {
     background: $secondary;
   }
   .bar-alevel {


### PR DESCRIPTION
This makes each Isaac books progress bar show the percentage of correct answers out of total questions in that book. The total questions in each book is calculated by searching for, and then counting all questions that contain that books tag.

I also added a secondary bar that shows the number of questions attempted, which sits behind the "correct" bar. Each bar has a title on hover (and on screenread) that indicates its statistic: x [attempted|correct] out of y.

![image](https://user-images.githubusercontent.com/33040507/169558625-6e6ed9c0-8ee0-492b-9f72-acae925e99ed.png)
