### PR TITLE
Remove hardcoded special cases for regression test page

### DIFF
--- a/src/app/components/navigation/IsaacApp.tsx
+++ b/src/app/components/navigation/IsaacApp.tsx
@@ -144,9 +144,6 @@ export const IsaacApp = () => {
                     {/* Site specific pages */}
                     {SiteSpecific.Routes}
 
-                    {/* Special case */}
-                    <TrackedRoute exact path="/questions/:questionId(_regression_test_)" component={segueEnvironment !== "PROD" || isTest ? Question : NotFound} />
-
                     {/* Application pages */}
                     <TrackedRoute exact path="/" component={SiteSpecific.Homepage} />
                     <Redirect exact from="/home" to="/" /> {/* historic route which might get reintroduced with the introduction of dashboards */}

--- a/src/app/components/navigation/IsaacApp.tsx
+++ b/src/app/components/navigation/IsaacApp.tsx
@@ -49,7 +49,6 @@ import {SetAssignments} from "../pages/SetAssignments";
 import {RedirectToGameboard} from './RedirectToGameboard';
 import {Support} from "../pages/Support";
 import {AddGameboard} from "../handlers/AddGameboard";
-import {isTest} from "../../services/constants";
 import {AdminEmails} from "../pages/AdminEmails";
 import {Events} from "../pages/Events";
 import {RedirectToEvent} from "./RedirectToEvent";

--- a/src/app/services/search.ts
+++ b/src/app/services/search.ts
@@ -44,8 +44,6 @@ export const searchResultIsPublic = function(content: ContentSummaryDTO, user?: 
     } else if (isStaff(user)) {
         return true;
     } else {
-        return content.id != "_regression_test_" &&
-            !content.supersededBy &&
-            !content.tags?.includes("nofilter");
+        return !content.supersededBy && !content.tags?.includes("nofilter");
     }
 };


### PR DESCRIPTION
This is no longer required, as arbitrary pages may be tagged with 'regression_test' for the same behaviour.