### PR TITLE
Remove question type duplication in `quiz.ts`

### DIFF
--- a/src/app/services/quiz.ts
+++ b/src/app/services/quiz.ts
@@ -1,20 +1,12 @@
 import {useEffect, useMemo} from "react";
 import {useDispatch, useSelector} from "react-redux";
-
 import {isDefined} from "./miscUtils";
 import {ContentDTO, IsaacQuizSectionDTO, QuestionDTO, QuizAssignmentDTO, QuizAttemptDTO} from "../../IsaacApiTypes";
 import {selectors} from "../state/selectors";
 import {deregisterQuestion, registerQuestion} from "../state/actions";
 import {API_PATH} from "./constants";
 import {partition} from "lodash";
-
-
-// FIXME - this wasn't supposed to be hardcoded here, but circular dependency issues mean we cannot import ./questions!
-function isQuestion(doc: ContentDTO) {
-    return ["isaacMultiChoiceQuestion", "isaacItemQuestion", "isaacParsonsQuestion", "isaacNumericQuestion",
-        "isaacSymbolicQuestion", "isaacSymbolicChemistryQuestion", "isaacStringMatchQuestion", "isaacFreeTextQuestion",
-        "isaacSymbolicLogicQuestion", "isaacGraphSketcherQuestion", "isaacClozeQuestion", "isaacReorderQuestion"].indexOf(doc.type as string) >= 0;
-}
+import {isQuestion} from "./questions";
 
 export function extractQuestions(doc: ContentDTO | undefined): QuestionDTO[] {
     const qs: QuestionDTO[] = [];


### PR DESCRIPTION
The circular dependency no longer seems to be an issue (maybe since some files are lazy loaded)