### PR TITLE
Hack to get keyboard interaction working on cloze questions

### DIFF
--- a/src/app/components/content/IsaacClozeQuestion.tsx
+++ b/src/app/components/content/IsaacClozeQuestion.tsx
@@ -26,7 +26,7 @@ const IsaacClozeQuestion = ({doc, questionId, readonly}: IsaacQuestionProps<Isaa
     const cssFriendlyQuestionPartId = questionId?.replace(/\|/g, '-') ?? ""; // Maybe we should clean up IDs more?
     const withReplacement = doc.withReplacement ?? false;
 
-    const itemsSectionId = "Non-selected-items"; // `${cssFriendlyQuestionPartId}-items-section`;
+    const itemsSectionId = "Non-selected-items";
 
     const [nonSelectedItems, setNonSelectedItems] = useState<ClozeItemDTO[]>(doc.items ? [...doc.items].map(x => ({...x, replacementId: x.id})) : []);
 

--- a/src/app/components/content/IsaacClozeQuestion.tsx
+++ b/src/app/components/content/IsaacClozeQuestion.tsx
@@ -10,11 +10,14 @@ import {
     DragUpdate,
     Droppable,
     DropResult,
-    ResponderProvided
+    ResponderProvided, useKeyboardSensor,
+    useMouseSensor,
+    useTouchSensor
 } from "react-beautiful-dnd";
 import {ClozeDropRegionContext, ClozeItemDTO, IsaacQuestionProps} from "../../../IsaacAppTypes";
 import {v4 as uuid_v4} from "uuid";
 import {Item} from "../elements/markup/portals/InlineDropZones";
+import {buildUseKeyboardSensor} from "../../services/clozeQuestionKeyboardSensor";
 
 const IsaacClozeQuestion = ({doc, questionId, readonly}: IsaacQuestionProps<IsaacClozeQuestionDTO>) => {
 
@@ -166,9 +169,9 @@ const IsaacClozeQuestion = ({doc, questionId, readonly}: IsaacQuestionProps<Isaa
         updateAttempt({...dropResult, destination: {droppableId: itemsSection, index: nonSelectedItems.length}},{announce: (_) => {return;}});
     }, [itemsSection, nonSelectedItems]);
 
-    return <div className="question-content cloze-question">
+    return <div className="question-content cloze-question" id={cssFriendlyQuestionPartId}>
         <ClozeDropRegionContext.Provider value={{questionPartId: cssFriendlyQuestionPartId, register: registerInlineDropRegion, updateAttemptCallback, readonly: readonly ?? false, inlineDropValueMap, borderMap}}>
-            <DragDropContext onDragStart={fixInlineZoneOnStartDrag} onDragEnd={updateAttempt} onDragUpdate={fixInlineZones}>
+            <DragDropContext onDragStart={fixInlineZoneOnStartDrag} onDragEnd={updateAttempt} onDragUpdate={fixInlineZones} enableDefaultSensors={false} sensors={[useMouseSensor, useTouchSensor, buildUseKeyboardSensor(itemsSection, cssFriendlyQuestionPartId, registeredDropRegionIDs)]}>
                 <IsaacContentValueOrChildren value={doc.value} encoding={doc.encoding}>
                     {doc.children}
                 </IsaacContentValueOrChildren>

--- a/src/app/components/content/IsaacClozeQuestion.tsx
+++ b/src/app/components/content/IsaacClozeQuestion.tsx
@@ -26,7 +26,7 @@ const IsaacClozeQuestion = ({doc, questionId, readonly}: IsaacQuestionProps<Isaa
     const cssFriendlyQuestionPartId = questionId?.replace(/\|/g, '-') ?? ""; // Maybe we should clean up IDs more?
     const withReplacement = doc.withReplacement ?? false;
 
-    const itemsSection = `${cssFriendlyQuestionPartId}-items-section`;
+    const itemsSectionId = "Non-selected-items"; // `${cssFriendlyQuestionPartId}-items-section`;
 
     const [nonSelectedItems, setNonSelectedItems] = useState<ClozeItemDTO[]>(doc.items ? [...doc.items].map(x => ({...x, replacementId: x.id})) : []);
 
@@ -96,10 +96,10 @@ const IsaacClozeQuestion = ({doc, questionId, readonly}: IsaacQuestionProps<Isaa
         let update = false;
 
         // Check source of drag:
-        if (source.droppableId === itemsSection) {
+        if (source.droppableId === itemsSectionId) {
             // Drag was from items section
             item = nonSelectedItems[source.index];
-            if (!withReplacement || destination.droppableId === itemsSection) {
+            if (!withReplacement || destination.droppableId === itemsSectionId) {
                 nsis.splice(source.index, 1);
                 replaceSource = (itemToReplace) => itemToReplace && nsis.splice(source.index, 0, itemToReplace);
             }
@@ -123,9 +123,9 @@ const IsaacClozeQuestion = ({doc, questionId, readonly}: IsaacQuestionProps<Isaa
         }
 
         // Check destination of drag:
-        if (destination.droppableId === itemsSection) {
+        if (destination.droppableId === itemsSectionId) {
             // Drop is into items section
-            if (!withReplacement || source.droppableId === itemsSection) {
+            if (!withReplacement || source.droppableId === itemsSectionId) {
                 nsis.splice(destination.index, 0, item);
             } else {
                 nsis.splice(nsis.findIndex((x) => x.id === item.id), 1);
@@ -166,12 +166,12 @@ const IsaacClozeQuestion = ({doc, questionId, readonly}: IsaacQuestionProps<Isaa
     }, [inlineDropValues, nonSelectedItems, registeredDropRegionIDs, dispatchSetCurrentAttempt]);
 
     const updateAttemptCallback = useCallback((dropResult) => {
-        updateAttempt({...dropResult, destination: {droppableId: itemsSection, index: nonSelectedItems.length}},{announce: (_) => {return;}});
-    }, [itemsSection, nonSelectedItems]);
+        updateAttempt({...dropResult, destination: {droppableId: itemsSectionId, index: nonSelectedItems.length}},{announce: (_) => {return;}});
+    }, [itemsSectionId, nonSelectedItems]);
 
     return <div className="question-content cloze-question" id={cssFriendlyQuestionPartId}>
         <ClozeDropRegionContext.Provider value={{questionPartId: cssFriendlyQuestionPartId, register: registerInlineDropRegion, updateAttemptCallback, readonly: readonly ?? false, inlineDropValueMap, borderMap}}>
-            <DragDropContext onDragStart={fixInlineZoneOnStartDrag} onDragEnd={updateAttempt} onDragUpdate={fixInlineZones} enableDefaultSensors={false} sensors={[useMouseSensor, useTouchSensor, buildUseKeyboardSensor(itemsSection, cssFriendlyQuestionPartId, registeredDropRegionIDs)]}>
+            <DragDropContext onDragStart={fixInlineZoneOnStartDrag} onDragEnd={updateAttempt} onDragUpdate={fixInlineZones} enableDefaultSensors={false} sensors={[useMouseSensor, useTouchSensor, buildUseKeyboardSensor(itemsSectionId, cssFriendlyQuestionPartId, registeredDropRegionIDs)]}>
                 <IsaacContentValueOrChildren value={doc.value} encoding={doc.encoding}>
                     {doc.children}
                 </IsaacContentValueOrChildren>
@@ -179,14 +179,14 @@ const IsaacClozeQuestion = ({doc, questionId, readonly}: IsaacQuestionProps<Isaa
                 {/* Items section */}
                 <Label htmlFor="non-selected-items" className="mt-3">Items: </Label>
                 <div className={"cloze-drop-zone"}>
-                    <Droppable droppableId={itemsSection} direction="horizontal" isDropDisabled={readonly}>
+                    <Droppable droppableId={itemsSectionId} direction="horizontal" isDropDisabled={readonly}>
                         {(provided, snapshot) => <div
-                            ref={provided.innerRef} {...provided.droppableProps} id="non-selected-items"
+                            ref={provided.innerRef} {...provided.droppableProps} id="non-selected-items" aria-label={"Non-selected items"}
                             className={`d-flex overflow-auto rounded p-2 mb-3 bg-grey ${snapshot.isDraggingOver ? "border border-dark" : ""}`}
                         >
                             {nonSelectedItems.map((item, i) => <Draggable key={item.replacementId} isDragDisabled={readonly} draggableId={item.replacementId || `${i}`} index={i}>
                                 {(provided) =>
-                                    <div className={"cloze-draggable"} ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps}>
+                                    <div className={"cloze-draggable"} ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps} role={"option"}>
                                         <Item item={item} />
                                     </div>
                                 }

--- a/src/app/components/content/IsaacClozeQuestion.tsx
+++ b/src/app/components/content/IsaacClozeQuestion.tsx
@@ -10,7 +10,7 @@ import {
     DragUpdate,
     Droppable,
     DropResult,
-    ResponderProvided, useKeyboardSensor,
+    ResponderProvided,
     useMouseSensor,
     useTouchSensor
 } from "react-beautiful-dnd";

--- a/src/app/components/elements/markup/portals/InlineDropZones.tsx
+++ b/src/app/components/elements/markup/portals/InlineDropZones.tsx
@@ -53,7 +53,7 @@ function InlineDropRegion({id, index, rootElement}: {id: string; index: number; 
                         {!item && "\u00A0"}
                     </div>}
                 </Droppable>
-                {item && <button aria-label={"Clear drop zone"} className={"cloze-inline-clear no-print"} onClick={clearInlineDropZone}>
+                {item && <button aria-label={`Clear drop zone ${index + 1}`} className={"cloze-inline-clear no-print"} onClick={clearInlineDropZone} tabIndex={0}>
                     <svg height="20" width="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false"
                          className="cloze-clear-cross">
                         <path d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"/>

--- a/src/app/components/elements/markup/portals/InlineDropZones.tsx
+++ b/src/app/components/elements/markup/portals/InlineDropZones.tsx
@@ -17,34 +17,38 @@ export function Item({item}: {item: ItemDTO}) {
 // Inline droppables rendered for each registered drop region
 function InlineDropRegion({id, index, rootElement}: {id: string; index: number; rootElement?: HTMLElement}) {
     const dropRegionContext = useContext(ClozeDropRegionContext);
+    const droppableId = `Drop-zone-${index + 1}`;
 
     useEffect(() => {
         // Register with the current cloze question on first render
-        dropRegionContext?.register(id, index);
+        dropRegionContext?.register(droppableId, index);
     }, []);
 
     const clearInlineDropZone = useCallback(() => {
         if (!dropRegionContext) return;
-        dropRegionContext.updateAttemptCallback({source: {droppableId: id, index: 0}, draggableId: (dropRegionContext.inlineDropValueMap[id]?.replacementId as string)} as DropResult);
+        dropRegionContext.updateAttemptCallback({source: {droppableId: droppableId, index: 0}, draggableId: (dropRegionContext.inlineDropValueMap[droppableId]?.replacementId as string)} as DropResult);
     }, [dropRegionContext]);
 
-    const item = dropRegionContext ? dropRegionContext.inlineDropValueMap[id] : undefined;
+    const item = dropRegionContext ? dropRegionContext.inlineDropValueMap[droppableId] : undefined;
 
     const droppableTarget = rootElement?.querySelector(`#${id}`);
 
     if (dropRegionContext && droppableTarget) {
         return ReactDOM.createPortal(
-            <div style={{minHeight: "inherit", position: "relative", margin: "2px"}} className={"cloze-drop-zone"}>
-                <Droppable droppableId={id} isDropDisabled={dropRegionContext.readonly} direction="vertical" >
+            <div style={{minHeight: "inherit", position: "relative", margin: "2px"}} className={"cloze-drop-zone"}  >
+                <Droppable droppableId={droppableId} isDropDisabled={dropRegionContext.readonly} direction="vertical">
                     {(provided, snapshot) => <div
                         ref={provided.innerRef} {...provided.droppableProps}
-                        className={`d-flex justify-content-center align-items-center bg-grey rounded w-100 overflow-hidden ${dropRegionContext.borderMap[id] && "border border-dark"}`}
-                        style={{minHeight: "inherit"}}
+                        className={`d-flex justify-content-center align-items-center bg-grey rounded w-100 overflow-hidden ${dropRegionContext.borderMap[droppableId] && "border border-dark"}`}
+                        style={{minHeight: "inherit"}} tabIndex={0}
                     >
-                        {item && <Draggable key={item.replacementId} draggableId={item?.replacementId as string} index={0} isDragDisabled={true}>
+                        {item &&
+                        <Draggable key={item.replacementId} draggableId={item?.replacementId as string} index={0}
+                                   isDragDisabled={true}>
                             {(provided, snapshot) =>
                                 <div
-                                    className={"cloze-draggable mr-4"} ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps}
+                                    className={"cloze-draggable mr-4"}
+                                    ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps}
                                 >
                                     <Item item={item}/>
                                 </div>

--- a/src/app/components/elements/markup/portals/Tables.tsx
+++ b/src/app/components/elements/markup/portals/Tables.tsx
@@ -56,7 +56,7 @@ export const useExpandContent = (expandable: boolean, el?: HTMLElement, unexpand
 
     const expandButton = (show && <div className={"expand-button position-relative"}>
         <button type={"button"} aria-label={"Expand content"} onClick={toggleExpanded}>
-            <div><span><img aria-hidden src={"/assets/expand-arrow.svg"} alt={"Expand icon"}/> {expanded ? "Close" : "Expand"}</span></div>
+            <div><span><img aria-hidden src={"/assets/expand-arrow.svg"}/> {expanded ? "Close" : "Expand"}</span></div>
         </button>
     </div>) || null;
 

--- a/src/app/components/elements/markup/portals/Tables.tsx
+++ b/src/app/components/elements/markup/portals/Tables.tsx
@@ -55,8 +55,8 @@ export const useExpandContent = (expandable: boolean, el?: HTMLElement, unexpand
     const show = SITE_SUBJECT === SITE.CS && expandable && !isMobile() && above["md"](deviceSize) && !expandableParent;
 
     const expandButton = (show && <div className={"expand-button position-relative"}>
-        <button type={"button"} onClick={toggleExpanded}>
-            <div><span><img aria-hidden alt={"Button to expand content"} src={"/assets/expand-arrow.svg"}/> {expanded ? "Close" : "Expand"}</span></div>
+        <button type={"button"} aria-label={"Button to expand content"} onClick={toggleExpanded}>
+            <div><span><img aria-hidden src={"/assets/expand-arrow.svg"} alt={"Expand icon"}/> {expanded ? "Close" : "Expand"}</span></div>
         </button>
     </div>) || null;
 

--- a/src/app/components/elements/markup/portals/Tables.tsx
+++ b/src/app/components/elements/markup/portals/Tables.tsx
@@ -55,7 +55,7 @@ export const useExpandContent = (expandable: boolean, el?: HTMLElement, unexpand
     const show = SITE_SUBJECT === SITE.CS && expandable && !isMobile() && above["md"](deviceSize) && !expandableParent;
 
     const expandButton = (show && <div className={"expand-button position-relative"}>
-        <button type={"button"} aria-label={"Button to expand content"} onClick={toggleExpanded}>
+        <button type={"button"} aria-label={"Expand content"} onClick={toggleExpanded}>
             <div><span><img aria-hidden src={"/assets/expand-arrow.svg"} alt={"Expand icon"}/> {expanded ? "Close" : "Expand"}</span></div>
         </button>
     </div>) || null;

--- a/src/app/services/clozeQuestionKeyboardSensor.ts
+++ b/src/app/services/clozeQuestionKeyboardSensor.ts
@@ -1,0 +1,301 @@
+import {DraggableId, FluidDragActions, PreDragActions, SensorAPI} from "react-beautiful-dnd";
+import {useCallback, useLayoutEffect, useMemo, useRef} from "react";
+
+/**
+ * This entire file is essentially a hacked version of https://github.com/atlassian/react-beautiful-dnd/blob/master/src/view/use-sensor-marshal/sensors/use-keyboard-sensor.js
+ *
+ * The nasty hack was required to force keyboard navigation of cloze questions to work, because the standard react-beautiful-dnd
+ * keyboard sensor is made for long lists of items arranged in a grid, and doesn't consider cases like ours: singleton
+ * lists, randomly scattered across the page.
+ */
+
+function noop() {}
+
+type UnbindFn = () => void;
+
+// Copied from react-beautiful-dnd
+function getOptions(
+    shared: any,
+    fromBinding: any,
+) {
+    return {
+        ...shared,
+        ...fromBinding,
+    };
+}
+
+// Copied from react-beautiful-dnd
+function bindEvents(
+    el: Window,
+    bindings: any,
+    sharedOptions?: any,
+) {
+    const unbindings: UnbindFn[] = bindings.map(
+        (binding: any) => {
+            const options: Object = getOptions(sharedOptions, binding.options);
+
+            el.addEventListener(binding.eventName, binding.fn, options);
+
+            return function unbind() {
+                el.removeEventListener(binding.eventName, binding.fn, options);
+            };
+        },
+    );
+
+    // Return a function to unbind events
+    return function unbindAll() {
+        unbindings.forEach((unbind) => {
+            unbind();
+        });
+    };
+}
+
+let DROPPABLE_INDEX: number = -1;
+
+function getDroppablePosition(initialPos: {x: number, y: number}, indexToId: Map<number, string>): {x: number, y: number} {
+    const id = indexToId.get(DROPPABLE_INDEX);
+    const el = id ? document.getElementById(id) : null;
+    return id && el ? (() => {
+        const rect = el.getBoundingClientRect()
+        return {x: rect.left, y: rect.top}
+    })() : initialPos;
+}
+
+function nextDroppable(indexToId: Map<number, string>) {
+    if (DROPPABLE_INDEX === 0) return;
+    if (DROPPABLE_INDEX === -1) {
+        DROPPABLE_INDEX = indexToId.size - 1;
+    } else {
+        DROPPABLE_INDEX--;
+    }
+}
+
+function prevDroppable(indexToId: Map<number, string>) {
+    if (DROPPABLE_INDEX === -1) return;
+    if (DROPPABLE_INDEX === indexToId.size - 1) {
+        DROPPABLE_INDEX = -1;
+    } else {
+        DROPPABLE_INDEX++;
+    }
+}
+
+// Adapted from react-beautiful-dnd
+function getDraggingBindings(
+    itemsSectionId: string,
+    idToIndex: Map<string, number>,
+    actions: FluidDragActions,
+    stop: () => void,
+) {
+    function cancel() {
+        stop();
+        actions.cancel();
+    }
+
+    function drop() {
+        stop();
+        actions.drop();
+    }
+
+    return [
+        {
+            eventName: 'scroll',
+            fn: () => {
+                const indexToId: Map<number, string> = new Map(Array.from(idToIndex.entries()).map(([id, i]) => [i, id]));
+                const itemSectionElement = document.querySelector(`div[data-rbd-droppable-id='${itemsSectionId}']`);
+                const itemBox = itemSectionElement?.getBoundingClientRect();
+                const itemSectionPos = itemBox ? {x: itemBox.left, y: itemBox.top} : {x: 0, y: 0};
+                actions.move(getDroppablePosition(itemSectionPos, indexToId));
+            }
+        },
+        {
+            eventName: 'keydown',
+            fn: (event: KeyboardEvent) => {
+
+                const indexToId: Map<number, string> = new Map(Array.from(idToIndex.entries()).map(([id, i]) => [i, id]));
+                const itemSectionElement = document.querySelector(`div[data-rbd-droppable-id='${itemsSectionId}']`);
+                const itemBox = itemSectionElement?.getBoundingClientRect();
+                const itemSectionPos = itemBox ? {x: itemBox.left, y: itemBox.top} : {x: 0, y: 0};
+
+                if (event.key === "Escape" || event.key === "Esc") {
+                    event.preventDefault();
+                    cancel();
+                    return;
+                }
+
+                // Dropping
+                if (event.key === " ") {
+                    // need to stop parent Draggable's thinking this is a lift
+                    event.preventDefault();
+                    drop();
+                    return;
+                }
+
+                // Movement
+
+                if (event.key === "ArrowDown") {
+                    event.preventDefault();
+                    prevDroppable(indexToId);
+                    actions.move(getDroppablePosition(itemSectionPos, indexToId));
+                    return;
+                }
+
+                if (event.key === "ArrowUp") {
+                    event.preventDefault();
+                    nextDroppable(indexToId);
+                    actions.move(getDroppablePosition(itemSectionPos, indexToId));
+                    return;
+                }
+
+                if (event.key === "ArrowRight") {
+                    event.preventDefault();
+                    prevDroppable(indexToId);
+                    actions.move(getDroppablePosition(itemSectionPos, indexToId));
+                    return;
+                }
+
+                if (event.key === "ArrowLeft") {
+                    event.preventDefault();
+                    nextDroppable(indexToId);
+                    actions.move(getDroppablePosition(itemSectionPos, indexToId));
+                    return;
+                }
+            },
+        },
+        // any mouse actions kills a drag
+        {
+            eventName: 'mousedown',
+            fn: cancel,
+        },
+        {
+            eventName: 'mouseup',
+            fn: cancel,
+        },
+        {
+            eventName: 'click',
+            fn: cancel,
+        },
+        {
+            eventName: 'touchstart',
+            fn: cancel,
+        },
+        // resizing the browser kills a drag
+        {
+            eventName: 'resize',
+            fn: cancel,
+        },
+        // kill if the user is using the mouse wheel
+        // We are not supporting wheel / trackpad scrolling with keyboard dragging
+        {
+            eventName: 'wheel',
+            fn: cancel,
+            // chrome says it is a violation for this to not be passive
+            // it is fine for it to be passive as we just cancel as soon as we get
+            // any event
+            options: { passive: true },
+        },
+    ];
+}
+
+// Adapted from react-beautiful-dnd
+export const buildUseKeyboardSensor = (itemsSection: string, cssFriendlyQuestionPartId: string, idToIndex: Map<string, number>) => function useKeyboardSensor(api: SensorAPI) {
+    const unbindEventsRef = useRef<() => void>(noop);
+
+    const startCaptureBinding = useMemo(
+        () => ({
+            eventName: 'keydown',
+            fn: function onKeyDown(event: KeyboardEvent) {
+                // Event already used
+                if (event.defaultPrevented) {
+                    return;
+                }
+
+                // Need to start drag with a spacebar press
+                if (event.key !== " ") {
+                    return;
+                }
+
+                const draggableId: DraggableId | null = api.findClosestDraggableId(event);
+
+                if (!draggableId) {
+                    return;
+                }
+
+                const preDrag: PreDragActions | null = api.tryGetLock(
+                    draggableId,
+                    stop,
+                    { sourceEvent: event },
+                );
+
+                // Cannot start capturing at this time
+                if (!preDrag) {
+                    return;
+                }
+                DROPPABLE_INDEX = -1;
+
+                // we are consuming the event
+                event.preventDefault();
+                let isCapturing: boolean = true;
+
+                // Make sure we only get the draggable element from a specific cloze question
+                const draggableElement = document.querySelector(`div[id=${cssFriendlyQuestionPartId}]`)?.querySelector(`div[data-rbd-draggable-id='${draggableId}']`);
+                const box = draggableElement?.getBoundingClientRect();
+                const pos = box ? {x: box.left, y: box.top} : {x: 0, y: 0};
+
+                // There is no pending period for a keyboard drag
+                // We can lift immediately
+                const actions: FluidDragActions = preDrag.fluidLift(pos);
+
+                // unbind this listener
+                unbindEventsRef.current();
+
+                // setup our function to end everything
+                function stop() {
+                    isCapturing = false;
+                    // unbind dragging bindings
+                    unbindEventsRef.current();
+                    // start listening for capture again
+                    // eslint-disable-next-line no-use-before-define
+                    listenForCapture();
+                }
+
+                // bind dragging listeners
+                unbindEventsRef.current = bindEvents(
+                    window,
+                    getDraggingBindings(itemsSection, idToIndex, actions, stop),
+                    { capture: true, passive: false },
+                );
+            },
+        }),
+        // not including startPendingDrag as it is not defined initially
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [api],
+    );
+
+    const listenForCapture = useCallback(
+        function tryStartCapture() {
+            const options = {
+                passive: false,
+                capture: true,
+            };
+
+            unbindEventsRef.current = bindEvents(
+                window,
+                [startCaptureBinding],
+                options,
+            );
+        },
+        [startCaptureBinding],
+    );
+
+    useLayoutEffect(
+        function mount() {
+            listenForCapture();
+
+            // kill any pending window events when unmounting
+            return function unmount() {
+                unbindEventsRef.current();
+            };
+        },
+        [listenForCapture],
+    );
+}

--- a/src/app/services/clozeQuestionKeyboardSensor.ts
+++ b/src/app/services/clozeQuestionKeyboardSensor.ts
@@ -52,9 +52,9 @@ function bindEvents(
 
 let DROPPABLE_INDEX: number = -1;
 
-function getDroppablePosition(cancel: () => void, initialPos: {x: number, y: number}, indexToId: Map<number, string>): {x: number, y: number} | void {
+function getDroppablePosition(cssFriendlyQuestionPartId: string, cancel: () => void, initialPos: {x: number, y: number}, indexToId: Map<number, string>): {x: number, y: number} | void {
     const id = indexToId.get(DROPPABLE_INDEX);
-    const droppable = id ? document.getElementById(id) : null;
+    const droppable = id ? document.getElementById(cssFriendlyQuestionPartId)?.querySelector(`div[data-rbd-droppable-id='${id}']`) : null;
     if (droppable) {
         const rect = droppable.getBoundingClientRect();
         return {x: rect.left, y: rect.top};
@@ -85,7 +85,8 @@ function prevDroppable(indexToId: Map<number, string>) {
 
 // Adapted from react-beautiful-dnd
 function getDraggingBindings(
-    itemsSectionId: string,
+    itemSectionId: string,
+    cssFriendlyQuestionPartId: string,
     idToIndex: Map<string, number>,
     actions: FluidDragActions,
     stop: () => void,
@@ -105,10 +106,10 @@ function getDraggingBindings(
             eventName: 'scroll',
             fn: () => {
                 const indexToId: Map<number, string> = new Map(Array.from(idToIndex.entries()).map(([id, i]) => [i, id]));
-                const itemSectionElement = document.querySelector(`div[data-rbd-droppable-id='${itemsSectionId}']`);
+                const itemSectionElement = document.getElementById(cssFriendlyQuestionPartId)?.querySelector(`div[data-rbd-droppable-id='${itemSectionId}']`);
                 if (itemSectionElement) {
                     const itemBox = itemSectionElement?.getBoundingClientRect();
-                    const newPos = getDroppablePosition(cancel, {x: itemBox.left, y: itemBox.top}, indexToId);
+                    const newPos = getDroppablePosition(cssFriendlyQuestionPartId, cancel, {x: itemBox.left, y: itemBox.top}, indexToId);
                     if (newPos) actions.move(newPos);
                 }
             }
@@ -133,7 +134,7 @@ function getDraggingBindings(
                 // Movement
                 
                 const indexToId: Map<number, string> = new Map(Array.from(idToIndex.entries()).map(([id, i]) => [i, id]));
-                const itemSectionElement = document.querySelector(`div[data-rbd-droppable-id='${itemsSectionId}']`);
+                const itemSectionElement = document.querySelector(`div[data-rbd-droppable-id='${itemSectionId}']`);
 
                 if (itemSectionElement && ["ArrowUp", "ArrowLeft", "ArrowDown", "ArrowRight"].includes(event.key)) {
                     event.preventDefault();
@@ -148,7 +149,7 @@ function getDraggingBindings(
                             break;
                     }
                     const itemBox = itemSectionElement.getBoundingClientRect();
-                    const newPos = getDroppablePosition(cancel,{x: itemBox.left, y: itemBox.top}, indexToId);
+                    const newPos = getDroppablePosition(cssFriendlyQuestionPartId, cancel,{x: itemBox.left, y: itemBox.top}, indexToId);
                     if (newPos) actions.move(newPos);
                 } else {
                     cancel();
@@ -192,7 +193,7 @@ function getDraggingBindings(
 }
 
 // Adapted from react-beautiful-dnd
-export const buildUseKeyboardSensor = (itemsSection: string, cssFriendlyQuestionPartId: string, idToIndex: Map<string, number>) => function useKeyboardSensor(api: SensorAPI) {
+export const buildUseKeyboardSensor = (itemSectionId: string, cssFriendlyQuestionPartId: string, idToIndex: Map<string, number>) => function useKeyboardSensor(api: SensorAPI) {
     const unbindEventsRef = useRef<() => void>(noop);
 
     const startCaptureBinding = useMemo(
@@ -232,7 +233,7 @@ export const buildUseKeyboardSensor = (itemsSection: string, cssFriendlyQuestion
                 let isCapturing: boolean = true;
 
                 // Make sure we only get the draggable element from a specific cloze question
-                const draggableElement = document.querySelector(`div[id=${cssFriendlyQuestionPartId}]`)?.querySelector(`div[data-rbd-draggable-id='${draggableId}']`);
+                const draggableElement = document.getElementById(cssFriendlyQuestionPartId)?.querySelector(`div[data-rbd-draggable-id='${draggableId}']`);
                 if (!draggableElement) {
                     stop();
                     return;
@@ -259,7 +260,7 @@ export const buildUseKeyboardSensor = (itemsSection: string, cssFriendlyQuestion
                 // bind dragging listeners
                 unbindEventsRef.current = bindEvents(
                     window,
-                    getDraggingBindings(itemsSection, idToIndex, actions, stop),
+                    getDraggingBindings(itemSectionId, cssFriendlyQuestionPartId, idToIndex, actions, stop),
                     { capture: true, passive: false },
                 );
             },

--- a/src/app/services/clozeQuestionKeyboardSensor.ts
+++ b/src/app/services/clozeQuestionKeyboardSensor.ts
@@ -2,7 +2,7 @@ import {DraggableId, FluidDragActions, PreDragActions, SensorAPI} from "react-be
 import {useCallback, useLayoutEffect, useMemo, useRef} from "react";
 
 /**
- * This entire file is essentially a hacked version of https://github.com/atlassian/react-beautiful-dnd/blob/master/src/view/use-sensor-marshal/sensors/use-keyboard-sensor.js
+ * This entire file is essentially a hacked version of https://github.com/atlassian/react-beautiful-dnd/blob/24a8e6021600920c0b2a28f89d5ffb17538fe96c/src/view/use-sensor-marshal/sensors/use-keyboard-sensor.js
  *
  * The nasty hack was required to force keyboard navigation of cloze questions to work, because the standard react-beautiful-dnd
  * keyboard sensor is made for long lists of items arranged in a grid, and doesn't consider cases like ours: singleton

--- a/src/app/services/katex-a11y.js
+++ b/src/app/services/katex-a11y.js
@@ -569,9 +569,14 @@ const handleObject = (tree, a11yStrings, atomType) => {
                     modifier = "";
             }
             buildRegion(a11yStrings, function(regionStrings) {
-                regionStrings.push(`start ${modifier} text`.replace(/\s+/, " "));
-                buildA11yStrings(tree.body, regionStrings, atomType);
-                regionStrings.push(`end ${modifier} text`.replace(/\s+/, " "));
+                const dropZoneRegex = /\[drop-zone(?<params>\|(?<width>w-\d+?)?(?<height>h-\d+?)?)?]/g;
+                if (tree.body.map(a => a.hasOwnProperty("text") ? a.text : "").join("").search(dropZoneRegex) !== -1) {
+                    regionStrings.push("clickable drop zone in la-tech");
+                } else {
+                    regionStrings.push(`start ${modifier} text`.replace(/\s+/, " "));
+                    buildA11yStrings(tree.body, regionStrings, atomType);
+                    regionStrings.push(`end ${modifier} text`.replace(/\s+/, " "));
+                }
             });
             break;
         }

--- a/src/app/services/katex-a11y.js
+++ b/src/app/services/katex-a11y.js
@@ -571,7 +571,7 @@ const handleObject = (tree, a11yStrings, atomType) => {
             buildRegion(a11yStrings, function(regionStrings) {
                 const dropZoneRegex = /\[drop-zone(?<params>\|(?<width>w-\d+?)?(?<height>h-\d+?)?)?]/g;
                 if (tree.body.map(a => a.hasOwnProperty("text") ? a.text : "").join("").search(dropZoneRegex) !== -1) {
-                    regionStrings.push("clickable drop zone in la-tech");
+                    regionStrings.push("clickable drop zone");
                 } else {
                     regionStrings.push(`start ${modifier} text`.replace(/\s+/, " "));
                     buildA11yStrings(tree.body, regionStrings, atomType);

--- a/src/scss/common/questions.scss
+++ b/src/scss/common/questions.scss
@@ -349,4 +349,9 @@ button {
       fill: red;
     }
   }
+  .cloze-inline-clear:focus {
+    .cloze-clear-cross {
+      fill: red;
+    }
+  }
 }

--- a/src/scss/common/scroll.scss
+++ b/src/scss/common/scroll.scss
@@ -122,3 +122,9 @@
     }
   }
 }
+
+.expand-button > button:focus-visible {
+  div {
+    outline: 0.1rem solid #000 !important;
+  }
+}


### PR DESCRIPTION
This takes `useKeyboardSensor` from `react-beautiful-dnd`, and adds some extra (nasty) stuff so that it behaves as expected with cloze questions. Since you can only interact with one cloze question at a time, this should work fine in theory, and is certainly better than the non-functioning keyboard interaction we had already. It is now actually possible to answer a cloze question only using the keyboard.

If the question re-renders underneath a drag, the drag will cancel if it can't find any elements - this shouldn't really happen much, if at all.

I also changed around some ids so that `react-beautiful-dnd` gives nice screenreader messages. There is a small chance that multiple cloze questions on a single page could break because of this, but looking at the docs it seems like `react-beautiful-dnd` separates different drag-and-drop contexts and the items inside them without us having to worry. 