### PR TITLE
Make use of isPhy, isCS, and siteSpecific everywhere

### DIFF
--- a/src/app/components/content/IsaacAccordion.tsx
+++ b/src/app/components/content/IsaacAccordion.tsx
@@ -11,16 +11,16 @@ import {
 } from "../../services/userContext";
 import {useSelector} from "react-redux";
 import {selectors} from "../../state/selectors";
-import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
+import {isCS, isPhy, siteSpecific} from "../../services/siteConstants";
 import {AppState} from "../../state/reducers";
 import {DOCUMENT_TYPE} from "../../services/constants";
 import {isFound} from "../../services/miscUtils";
 import { useLocation } from "react-router-dom";
 
-const defaultConceptDisplay = {
-    [SITE.PHY]: {audience: ["closed"], nonAudience: ["de-emphasised", "closed"]},
-    [SITE.CS]: {audience: ["closed"], nonAudience: ["de-emphasised", "closed"]}
-}[SITE_SUBJECT];
+const defaultConceptDisplay = siteSpecific(
+    {audience: ["closed"], nonAudience: ["de-emphasised", "closed"]},
+    {audience: ["closed"], nonAudience: ["de-emphasised", "closed"]}
+);
 const defaultQuestionDisplay = {audience: [], nonAudience: []};
 
 interface SectionWithDisplaySettings extends ContentDTO {
@@ -48,7 +48,7 @@ export const IsaacAccordion = ({doc}: {doc: ContentDTO}) => {
 
             // For CS we want relevant sections to appear first
             .sort((a, b) => {
-                if (SITE_SUBJECT !== SITE.CS) {return 0;}
+                if (!isCS) {return 0;}
                 return makeIntendedAudienceComparator(user, userContext)(a, b);
             })
 
@@ -67,7 +67,7 @@ export const IsaacAccordion = ({doc}: {doc: ContentDTO}) => {
             // If cs have "show other content" set to false hide non-audience content
             .map(section => {
                 if (
-                    SITE_SUBJECT === SITE.CS && userContext.showOtherContent === false &&
+                    isCS && userContext.showOtherContent === false &&
                     !isIntendedAudience(section.audience, userContext, user)
                 ) {
                     section.hidden = true;

--- a/src/app/components/content/IsaacCodeSnippet.tsx
+++ b/src/app/components/content/IsaacCodeSnippet.tsx
@@ -4,7 +4,7 @@ import {Col, Row} from "reactstrap";
 import hljs from 'highlight.js/lib/core';
 import {addLineNumbers} from "../../services/highlightJs";
 import {ScrollShadows} from "../elements/ScrollShadows";
-import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
+import {isCS} from "../../services/siteConstants";
 import classNames from "classnames";
 import {useExpandContent} from "../elements/markup/portals/Tables";
 import {useStatefulElementRef} from "../elements/markup/portals/utils";
@@ -31,7 +31,7 @@ const IsaacCodeSnippet = ({doc}: IsaacCodeProps) => {
         {expandButton}
         <div className={innerClasses}>
             {/* ScrollShadows uses ResizeObserver, which doesn't exist on Safari <= 13 */}
-            {SITE_SUBJECT === SITE.CS && window.ResizeObserver && <ScrollShadows element={scrollPromptRef} />}
+            {isCS && window.ResizeObserver && <ScrollShadows element={scrollPromptRef} />}
             <Row>
                 <Col>
                 <pre ref={updateScrollPromptRef} className="line-numbers">

--- a/src/app/components/content/IsaacGlossaryTerm.tsx
+++ b/src/app/components/content/IsaacGlossaryTerm.tsx
@@ -4,7 +4,7 @@ import {GlossaryTermDTO} from "../../../IsaacApiTypes";
 import {IsaacContent} from "./IsaacContent";
 import tags from "../../services/tags";
 import { isDefined } from '../../services/miscUtils';
-import { SITE, SITE_SUBJECT } from '../../services/siteConstants';
+import {isCS} from '../../services/siteConstants';
 import { TAG_ID } from '../../services/constants';
 import { Tag } from '../../../IsaacAppTypes';
 import {formatGlossaryTermId} from "../pages/Glossary";
@@ -17,7 +17,7 @@ interface IsaacGlossaryTermProps {
 
 const IsaacGlossaryTermComponent = ({doc, inPortal, linkToGlossary}: IsaacGlossaryTermProps, ref: Ref<any>) => {
     let _tags: Tag[] = [];
-    if (SITE_SUBJECT === SITE.CS && doc.tags) {
+    if (isCS && doc.tags) {
         _tags = doc.tags.map(id => tags.getById(id as TAG_ID)).filter(tag => isDefined(tag));
     }
 

--- a/src/app/components/content/IsaacQuestion.tsx
+++ b/src/app/components/content/IsaacQuestion.tsx
@@ -14,7 +14,7 @@ import {
     determineFastTrackSecondaryAction,
     useFastTrackInformation
 } from "../../services/fastTrack";
-import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
+import {isCS, isPhy} from "../../services/siteConstants";
 import {IsaacLinkHints, IsaacTabbedHints} from "./IsaacHints";
 import {isLoggedIn} from "../../services/user";
 import {fastTrackProgressEnabledBoards} from "../../services/constants";
@@ -32,7 +32,7 @@ export const IsaacQuestion = withRouter(({doc, location}: {doc: ApiTypes.Questio
     const correct = validationResponse?.correct || false;
     const locked = questionPart?.locked;
     const canSubmit = questionPart?.canSubmit && !locked || false;
-    const sigFigsError = (validationResponse?.explanation?.tags || []).includes("sig_figs") && SITE_SUBJECT === SITE.PHY;
+    const sigFigsError = isPhy && (validationResponse?.explanation?.tags || []).includes("sig_figs");
     const tooManySigFigsError = sigFigsError && (validationResponse?.explanation?.tags || []).includes("sig_figs_too_many");
     const tooFewSigFigsError = sigFigsError && (validationResponse?.explanation?.tags || []).includes("sig_figs_too_few");
     const fastTrackInfo = useFastTrackInformation(doc, location, canSubmit, correct);
@@ -83,7 +83,7 @@ export const IsaacQuestion = withRouter(({doc, location}: {doc: ApiTypes.Questio
             </Suspense>
 
             {/* CS Hints */}
-            {SITE_SUBJECT === SITE.CS && <React.Fragment>
+            {isCS && <React.Fragment>
                 <IsaacLinkHints questionPartId={doc.id as string} hints={doc.hints} />
             </React.Fragment>}
 
@@ -121,7 +121,7 @@ export const IsaacQuestion = withRouter(({doc, location}: {doc: ApiTypes.Questio
             }
 
             {/* CS Hint Reminder */}
-            {SITE_SUBJECT === SITE.CS && (!validationResponse || !correct || canSubmit) && <RS.Row>
+            {isCS && (!validationResponse || !correct || canSubmit) && <RS.Row>
                 <RS.Col xl={{size: 10, offset: 1}} >
                     {doc.hints && <p className="no-print text-center pt-2 mb-0">
                         <small>{"Don't forget to use the hints above if you need help."}</small>
@@ -130,7 +130,7 @@ export const IsaacQuestion = withRouter(({doc, location}: {doc: ApiTypes.Questio
             </RS.Row>}
 
             {/* Physics Hints */}
-            {SITE_SUBJECT === SITE.PHY && <div className={correct ? "mt-5" : ""}>
+            {isPhy && <div className={correct ? "mt-5" : ""}>
                 <IsaacTabbedHints questionPartId={doc.id as string} hints={doc.hints}/>
             </div>}
         </div>

--- a/src/app/components/content/IsaacQuickQuestion.tsx
+++ b/src/app/components/content/IsaacQuickQuestion.tsx
@@ -9,7 +9,7 @@ import {determineFastTrackSecondaryAction, useFastTrackInformation} from "../../
 import {RouteComponentProps, withRouter} from "react-router";
 import {v4 as uuid_v4} from "uuid";
 import {ConfidenceQuestions} from "../elements/inputs/QuestionConfidence";
-import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
+import {isCS} from "../../services/siteConstants";
 import classNames from "classnames";
 
 export const IsaacQuickQuestion = withRouter(({doc, location}: {doc: ApiTypes.IsaacQuickQuestionDTO} & RouteComponentProps) => {
@@ -62,7 +62,7 @@ export const IsaacQuickQuestion = withRouter(({doc, location}: {doc: ApiTypes.Is
     return <form onSubmit={e => e.preventDefault()}>
         <div className="question-component p-md-5">
             <div className={!fastTrackInfo.isFastTrackPage ? "quick-question" : ""}>
-                {SITE_SUBJECT === SITE.CS &&
+                {isCS &&
                     <div className="quick-question-title">
                         <h3>Try it yourself!</h3>
                     </div>
@@ -90,7 +90,7 @@ export const IsaacQuickQuestion = withRouter(({doc, location}: {doc: ApiTypes.Is
                 }
                 {isVisible && showConfidence && !fastTrackInfo.isFastTrackPage  && <Row className="mt-3">
                     <Col sm="12" md={!fastTrackInfo.isFastTrackPage ? {size: 10, offset: 1} : {}}>
-                        <Button color="secondary" block className={"active " + classNames({"hide-answer": SITE_SUBJECT === SITE.CS})} onClick={hideAnswer}>
+                        <Button color="secondary" block className={"active " + classNames({"hide-answer": isCS})} onClick={hideAnswer}>
                             Hide answer
                         </Button>
                     </Col>
@@ -98,7 +98,7 @@ export const IsaacQuickQuestion = withRouter(({doc, location}: {doc: ApiTypes.Is
                 }
                 {isVisible && <Row>
                     <Col sm="12" md={!fastTrackInfo.isFastTrackPage ? {size: 10, offset: 1} : {}}>
-                        <Alert color={SITE_SUBJECT === SITE.CS ? "hide" : "secondary"}>
+                        <Alert color={isCS ? "hide" : "secondary"}>
                             <IsaacContentValueOrChildren {...answer} />
                         </Alert>
                     </Col>

--- a/src/app/components/content/QuizQuestion.tsx
+++ b/src/app/components/content/QuizQuestion.tsx
@@ -4,7 +4,7 @@ import classnames from "classnames";
 import {QUESTION_TYPES} from "../../services/questions";
 import {submitQuizQuestionIfDirty} from "../../state/actions/quizzes";
 import {isDefined} from "../../services/miscUtils";
-import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
+import {isPhy, isCS} from "../../services/siteConstants";
 import {IsaacLinkHints, IsaacTabbedHints} from "./IsaacHints";
 import {IsaacContent} from "./IsaacContent";
 import * as ApiTypes from "../../../IsaacApiTypes";
@@ -37,7 +37,7 @@ export const QuizQuestion = ({doc}: { doc: ApiTypes.QuestionDTO }) => {
         <div className={
             classnames("question-component p-md-5", {"parsons-layout": ["isaacParsonsQuestion", "isaacReorderQuestion"].includes(doc.type as string)})
         }>
-            {SITE_SUBJECT === SITE.CS && doc.id && <h3 className={"mb-3"}>Question {questionNumbers[doc.id]}</h3>}
+            {isCS && doc.id && <h3 className={"mb-3"}>Question {questionNumbers[doc.id]}</h3>}
 
             {/* TODO cloze drag and drop zones don't render if previewing a quiz */}
             <Suspense fallback={<Loading/>}>
@@ -45,7 +45,7 @@ export const QuizQuestion = ({doc}: { doc: ApiTypes.QuestionDTO }) => {
             </Suspense>
 
             {/* CS Hints */}
-            {SITE_SUBJECT === SITE.CS && <React.Fragment>
+            {isCS && <React.Fragment>
                 <IsaacLinkHints questionPartId={doc.id as string} hints={doc.hints} />
             </React.Fragment>}
 
@@ -60,7 +60,7 @@ export const QuizQuestion = ({doc}: { doc: ApiTypes.QuestionDTO }) => {
             </div>}
 
             {/* Physics Hints */}
-            {SITE_SUBJECT === SITE.PHY && <div className={correct ? "mt-5" : ""}>
+            {isPhy && <div className={correct ? "mt-5" : ""}>
                 <IsaacTabbedHints questionPartId={doc.id as string} hints={doc.hints}/>
             </div>}
         </div>

--- a/src/app/components/elements/Accordion.tsx
+++ b/src/app/components/elements/Accordion.tsx
@@ -8,7 +8,7 @@ import {AppState} from "../../state/reducers";
 import {scrollVerticallyIntoView} from "../../services/scrollManager";
 import {AccordionSectionContext} from "../../../IsaacAppTypes";
 import {selectors} from "../../state/selectors";
-import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
+import {isCS, isPhy} from "../../services/siteConstants";
 import {pauseAllVideos} from "../content/IsaacVideo";
 import {v4 as uuid_v4} from "uuid";
 import {audienceStyle, notRelevantMessage, useUserContext} from "../../services/userContext";
@@ -35,7 +35,7 @@ export const Accordion = withRouter(({id, trustedTitle, index, children, startOp
 
     // Toggle
     const isFirst = index === 0;
-    const openFirst = SITE_SUBJECT === SITE.CS || Boolean(page && page !== NOT_FOUND && page.type === DOCUMENT_TYPE.QUESTION);
+    const openFirst = isCS || Boolean(page && page !== NOT_FOUND && page.type === DOCUMENT_TYPE.QUESTION);
     const [open, setOpen] = useState(startOpen === undefined ? (openFirst && isFirst) : startOpen);
 
     // If start open changes we need to update whether or not the accordion section should be open
@@ -142,7 +142,7 @@ export const Accordion = withRouter(({id, trustedTitle, index, children, startOp
                 aria-expanded={open ? "true" : "false"}
             >
                 {isConceptPage && audienceString && <span className={"stage-label badge-secondary d-flex align-items-center " +
-                    "justify-content-center " + classNames({[audienceStyle(audienceString)]: SITE_SUBJECT === SITE.CS})}>
+                    "justify-content-center " + classNames({[audienceStyle(audienceString)]: isCS})}>
                     {audienceString}
                 </span>}
                 <div className="accordion-title pl-3">
@@ -154,7 +154,7 @@ export const Accordion = withRouter(({id, trustedTitle, index, children, startOp
                                 {trustedTitle}
                             </Markup>
                         </div>}
-                        {SITE_SUBJECT === SITE.CS  && deEmphasised && <div className="ml-auto mr-3 d-flex align-items-center">
+                        {isCS  && deEmphasised && <div className="ml-auto mr-3 d-flex align-items-center">
                             <span id={`audience-help-${componentId}`} className="icon-help mx-1" />
                             <RS.UncontrolledTooltip placement="bottom" target={`audience-help-${componentId}`}>
                                 {`This content has ${notRelevantMessage(userContext)}.`}
@@ -164,7 +164,7 @@ export const Accordion = withRouter(({id, trustedTitle, index, children, startOp
                     </RS.Row>
                 </div>
 
-                {accordionIcon && SITE_SUBJECT === SITE.PHY && <span className={"accordion-icon align-self-center accordion-icon-" + accordionIcon}>
+                {accordionIcon && isPhy && <span className={"accordion-icon align-self-center accordion-icon-" + accordionIcon}>
                     <span className="sr-only">{accordionIcon == "tick" ? "All questions in this part are answered correctly" : "All questions in this part are answered incorrectly"}</span>
                 </span>}
             </RS.Button>

--- a/src/app/components/elements/ConceptGameboardButton.tsx
+++ b/src/app/components/elements/ConceptGameboardButton.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
 import {Link} from "react-router-dom";
 import classNames from "classnames";
+import {siteSpecific} from "../../services/siteConstants";
 
 export interface ConceptGameboardButtonProps {
     className?: string;
@@ -11,10 +11,10 @@ export interface ConceptGameboardButtonProps {
 export const ConceptGameboardButton = ({conceptId, className} : ConceptGameboardButtonProps) => {
 
     // Currently PHY doesn't use this
-    const gameboardGenerateHref = {
-        [SITE.PHY]: `/gameboard_builder?concepts=${conceptId}`,
-        [SITE.CS]: `/gameboard_builder?concepts=${conceptId}`
-    }[SITE_SUBJECT]
+    const gameboardGenerateHref = siteSpecific(
+        `/gameboard_builder?concepts=${conceptId}`,
+        `/gameboard_builder?concepts=${conceptId}`
+    );
 
     return <Link className={classNames(className, "btn btn-sm btn-primary")} to={gameboardGenerateHref} >
         Generate a gameboard

--- a/src/app/components/elements/EditorRenderer.tsx
+++ b/src/app/components/elements/EditorRenderer.tsx
@@ -1,6 +1,6 @@
 import React, {useCallback, useEffect, useState} from "react";
 import {Col, Row} from "reactstrap";
-import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
+import {siteSpecific} from "../../services/siteConstants";
 import {FigureNumberingContext} from "../../../IsaacAppTypes";
 import {WithFigureNumbering} from "./WithFigureNumbering";
 import {IsaacContent} from "../content/IsaacContent";
@@ -46,7 +46,7 @@ function EditorListener() {
     const colClasses = type === "question" ? "question-panel" : "";
 
     return doc ? <Row className={`${type}-content-container`}>
-            <Col md={{[SITE.CS]: {size: 8, offset: 2}, [SITE.PHY]: {size: 12}}[SITE_SUBJECT]} className={`py-4 ${colClasses}`}>
+            <Col md={siteSpecific({size: 12}, {size: 8, offset: 2})} className={`py-4 ${colClasses}`}>
                 <FigureNumberingContext.Provider value={{}}>
                     <WithFigureNumbering doc={doc}>
                         <IsaacContent doc={doc}/>

--- a/src/app/components/elements/EventBookingForm.tsx
+++ b/src/app/components/elements/EventBookingForm.tsx
@@ -7,7 +7,7 @@ import {requestEmailVerification} from "../../state/actions";
 import {UserSummaryWithEmailAddressDTO} from "../../../IsaacApiTypes";
 import {selectors} from "../../state/selectors";
 import {studentOnlyEventMessage} from "../../services/events";
-import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
+import {isCS} from "../../services/siteConstants";
 import {examBoardLabelMap, stageLabelMap} from "../../services/constants";
 
 interface EventBookingFormProps {
@@ -60,7 +60,7 @@ export const EventBookingForm = ({event, targetUser, additionalInformation, upda
                                 }
                             </RS.FormFeedback>
                         </RS.Col>
-                        {SITE_SUBJECT === SITE.CS && <RS.Col md={6} className="d-none d-md-block" />}
+                        {isCS && <RS.Col md={6} className="d-none d-md-block" />}
                         <RS.Col md={6}>
                             <RS.Label htmlFor="account-stages" className="form-required">
                                 Stage
@@ -69,7 +69,7 @@ export const EventBookingForm = ({event, targetUser, additionalInformation, upda
                                 Array.from(new Set(targetUser.registeredContexts?.map(rc => stageLabelMap[rc.stage!]))).join(", ") || ""
                             } />
                         </RS.Col>
-                        {SITE_SUBJECT == SITE.CS && <RS.Col md={6}>
+                        {isCS && <RS.Col md={6}>
                             <RS.Label htmlFor="account-examboard" className="form-required">
                                 Exam board
                             </RS.Label>

--- a/src/app/components/elements/GameboardBuilderRow.tsx
+++ b/src/app/components/elements/GameboardBuilderRow.tsx
@@ -8,7 +8,7 @@ import {useDispatch} from "react-redux";
 import {DraggableProvided} from "react-beautiful-dnd";
 import tags from "../../services/tags";
 import {Question} from "../pages/Question";
-import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
+import {isCS, siteSpecific} from "../../services/siteConstants";
 import {ContentSummary} from "../../../IsaacAppTypes";
 import {generateQuestionTitle} from "../../services/questions";
 import {
@@ -17,7 +17,6 @@ import {
     filterAudienceViewsByProperties
 } from "../../services/userContext";
 import {DifficultyIcons} from "./svg/DifficultyIcons";
-import {siteSpecific} from "../../services/miscUtils";
 
 interface GameboardBuilderRowInterface {
     provided?: DraggableProvided;
@@ -106,7 +105,7 @@ const GameboardBuilderRow = (
                 {difficulty && <DifficultyIcons difficulty={difficulty} />}
             </div>)}
         </td>
-        {SITE_SUBJECT === SITE.CS && <td className="w-5">
+        {isCS && <td className="w-5">
             {filteredAudienceViews.map(v => v.examBoard).map(examBoard => <div key={examBoard}>
                 {examBoard && <span>{tagIcon(examBoardLabelMap[examBoard])}</span>}
             </div>)}

--- a/src/app/components/elements/MainSearch.tsx
+++ b/src/app/components/elements/MainSearch.tsx
@@ -5,7 +5,7 @@ import {History} from "history";
 import {withRouter} from "react-router";
 import {Collapse, Form, FormGroup, Input, Label, Nav, Navbar, NavbarToggler, NavItem} from "reactstrap";
 import {SEARCH_CHAR_LENGTH_LIMIT} from "../../services/constants";
-import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
+import {isPhy} from "../../services/siteConstants";
 
 interface MainSearchProps {
     history: History;
@@ -36,7 +36,7 @@ const MainSearchComponent = ({history}: MainSearchProps) => {
             onClick={() => setShowSearchBox(!showSearchBox)}
         />
         <Collapse navbar isOpen={showSearchBox}>
-            <Nav className={`ml-auto ${SITE_SUBJECT === SITE.PHY ? "mb-3 mb-md-0" : ""}`} navbar id="search-menu">
+            <Nav className={`ml-auto ${isPhy ? "mb-3 mb-md-0" : ""}`} navbar id="search-menu">
                 <NavItem>
                     <Form inline onSubmit={doSearch}>
                         <FormGroup className='search--main-group'>

--- a/src/app/components/elements/PageTitle.tsx
+++ b/src/app/components/elements/PageTitle.tsx
@@ -1,6 +1,6 @@
 import React, {ReactElement, useEffect, useRef} from "react";
 import {Button, UncontrolledTooltip} from "reactstrap";
-import {SITE, SITE_SUBJECT, SITE_SUBJECT_TITLE} from "../../services/siteConstants";
+import {isPhy, SITE_SUBJECT_TITLE} from "../../services/siteConstants";
 import {closeActiveModal, openActiveModal, setMainContentId} from "../../state/actions";
 import {useDispatch, useSelector} from "react-redux";
 import {AppState} from "../../state/reducers";
@@ -46,7 +46,7 @@ export const PageTitle = ({currentPageTitle, subTitle, disallowLaTeX, help, clas
     const openModal = useSelector((state: AppState) => Boolean(state?.activeModals?.length));
     const headerRef = useRef<HTMLHeadingElement>(null);
 
-    const showModal = modalId && SITE_SUBJECT === SITE.PHY;
+    const showModal = modalId && isPhy;
 
     useEffect(() => {dispatch(setMainContentId("main-heading"));}, []);
     useEffect(() => {

--- a/src/app/components/elements/RelatedContent.tsx
+++ b/src/app/components/elements/RelatedContent.tsx
@@ -4,7 +4,7 @@ import {ContentDTO, ContentSummaryDTO} from "../../../IsaacApiTypes";
 import {Link} from "react-router-dom";
 import {difficultyShortLabelMap, DOCUMENT_TYPE, documentTypePathPrefix, stageLabelMap} from "../../services/constants";
 import {useDispatch, useSelector} from "react-redux";
-import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
+import {isCS, isPhy, siteSpecific} from "../../services/siteConstants";
 import {sortByNumberStringValue, sortByStringValue} from "../../services/sorting";
 import {logAction} from "../../state/actions";
 import {
@@ -144,8 +144,8 @@ export function RelatedContent({content, parentPage, conceptId = ""}: RelatedCon
     const dispatch = useDispatch();
     const user = useSelector(selectors.user.orNull);
     const userContext = useUserContext();
-    const audienceFilteredContent = content.filter(c => SITE_SUBJECT === SITE.PHY || isIntendedAudience(c.audience, userContext, user));
-    const showConceptGameboardButton = isTeacher(useSelector(selectors.user.orNull)) && SITE_SUBJECT === SITE.CS;
+    const audienceFilteredContent = content.filter(c => isPhy || isIntendedAudience(c.audience, userContext, user));
+    const showConceptGameboardButton = isCS && isTeacher(useSelector(selectors.user.orNull));
 
     // level, difficulty, title; all ascending (reverse the calls for required ordering)
     const sortedContent = audienceFilteredContent
@@ -181,8 +181,10 @@ export function RelatedContent({content, parentPage, conceptId = ""}: RelatedCon
         </ListGroupItem>
     };
 
-    return {
-        [SITE.PHY]: renderConceptsAndQuestions(concepts, questions, makeListGroupItem, conceptId, showConceptGameboardButton),
-        [SITE.CS]: renderQuestions(questions, makeListGroupItem, conceptId, showConceptGameboardButton)
-    }[SITE_SUBJECT];
+    return siteSpecific(
+        // Physics
+        renderConceptsAndQuestions(concepts, questions, makeListGroupItem, conceptId, showConceptGameboardButton),
+        // Computer Science
+        renderQuestions(questions, makeListGroupItem, conceptId, showConceptGameboardButton)
+    );
 }

--- a/src/app/components/elements/ShareLink.tsx
+++ b/src/app/components/elements/ShareLink.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useRef, useState} from "react";
-import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
+import {isCS, siteSpecific} from "../../services/siteConstants";
 import {useSelector} from "react-redux";
 import {isMobile} from "../../services/device";
 import {selectors} from "../../state/selectors";
@@ -13,7 +13,7 @@ export const ShareLink = ({linkUrl, reducedWidthLink, gameboardId, clickAwayClos
     const shareLink = useRef<HTMLInputElement>(null);
     const csUrlOrigin = segueEnvironment !== "DEV" ? "https://isaaccs.org" : window.location.origin;
     let shortenedLinkUrl = linkUrl;
-    if (SITE_SUBJECT == SITE.CS && segueEnvironment !== "DEV") {
+    if (isCS && segueEnvironment !== "DEV") {
         shortenedLinkUrl = shortenedLinkUrl.replace('/questions/', '/q/');
         shortenedLinkUrl = shortenedLinkUrl.replace('/concepts/', '/c/');
         shortenedLinkUrl = shortenedLinkUrl.replace('/pages/', '/p/');
@@ -21,7 +21,7 @@ export const ShareLink = ({linkUrl, reducedWidthLink, gameboardId, clickAwayClos
         shortenedLinkUrl = shortenedLinkUrl.replace('/assignments/', '/a/');
     }
 
-    const shareUrl = {[SITE.PHY]: window.location.origin, [SITE.CS]: csUrlOrigin}[SITE_SUBJECT] + shortenedLinkUrl;
+    const shareUrl = siteSpecific(window.location.origin, csUrlOrigin) + shortenedLinkUrl;
 
     function toggleShareLink() {
         setShowShareLink(!showShareLink);
@@ -51,7 +51,7 @@ export const ShareLink = ({linkUrl, reducedWidthLink, gameboardId, clickAwayClos
             {showDuplicateAndEdit && <React.Fragment>
                 <hr className="text-center mt-4" />
                 <a href={`/gameboard_builder?base=${gameboardId}`} className="px-1">
-                    {{[SITE.PHY]: "Duplicate and Edit", [SITE.CS]: "Duplicate and edit"}[SITE_SUBJECT]}
+                    {siteSpecific("Duplicate and Edit", "Duplicate and edit")}
                 </a>
             </React.Fragment>}
         </div>

--- a/src/app/components/elements/cards/EventCard.tsx
+++ b/src/app/components/elements/cards/EventCard.tsx
@@ -5,7 +5,7 @@ import {Link} from "react-router-dom";
 import {AugmentedEvent} from "../../../../IsaacAppTypes";
 import {DateString} from "../DateString";
 import {formatEventCardDate} from "../../../services/events";
-import {SITE, SITE_SUBJECT} from "../../../services/siteConstants";
+import {isPhy} from "../../../services/siteConstants";
 
 export const EventCard = ({event, pod = false}: {event: AugmentedEvent; pod?: boolean}) => {
     const {id, title, subtitle, eventThumbnail, location, hasExpired, date, numberOfPlaces, eventStatus} = event;
@@ -17,7 +17,7 @@ export const EventCard = ({event, pod = false}: {event: AugmentedEvent; pod?: bo
     return <RS.Card className={classnames({'card-neat': true, 'disabled text-muted': hasExpired, 'm-4': pod, 'mb-4': !pod})}>
         {eventThumbnail && <div className={'event-card-image text-center'}>
             {
-                SITE_SUBJECT === SITE.PHY && (hasExpired ? <div className={"event-card-image-banner disabled"}>This event has expired</div> :
+                isPhy && (hasExpired ? <div className={"event-card-image-banner disabled"}>This event has expired</div> :
                     ((isVirtualEvent || isTeacherEvent || isStudentEvent) &&
                         <div className={"event-card-image-banner"}>
                             {isTeacherEvent && "Teacher "}
@@ -54,7 +54,7 @@ export const EventCard = ({event, pod = false}: {event: AugmentedEvent; pod?: bo
                     View details
                     <span className='sr-only'> of the event: {title} {" - "} <DateString>{date}</DateString></span>
                 </Link>
-                {SITE_SUBJECT === SITE.PHY && <div className="event-card-icons">
+                {isPhy && <div className="event-card-icons">
                     {isTeacherEvent && <img src="/assets/phy/key_stage_sprite.svg#teacher-hat" alt="Teacher event" title="Teacher event"/>}
                     {isStudentEvent && <img src="/assets/phy/teacher_features_sprite.svg#groups" alt="Student event" title="Student event"/>}
                     {isVirtualEvent && <img src="/assets/phy/computer.svg" alt="Virtual event" title="Virtual event"/>}

--- a/src/app/components/elements/inputs/QuestionConfidence.tsx
+++ b/src/app/components/elements/inputs/QuestionConfidence.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import {closeActiveModal, openActiveModal} from "../../../state/actions";
 import {useDispatch} from "react-redux";
 import classNames from "classnames";
-import {SITE, SITE_SUBJECT} from "../../../services/siteConstants";
+import {isCS} from "../../../services/siteConstants";
 
 
 interface QuestionConfidenceProps {
@@ -14,7 +14,6 @@ interface QuestionConfidenceProps {
 
 export const ConfidenceQuestions = ({hideOptions, isVisible, toggle}: QuestionConfidenceProps) => {
     const dispatch = useDispatch();
-    const isCs = SITE_SUBJECT === SITE.CS;
 
     function quickQuestionInformationModal() {
         dispatch(openActiveModal({
@@ -32,7 +31,7 @@ export const ConfidenceQuestions = ({hideOptions, isVisible, toggle}: QuestionCo
         }))
     }
 
-    return <div className={"quick-question-options " + classNames({"quick-question-secondary": isCs && isVisible})} hidden={hideOptions}>
+    return <div className={"quick-question-options " + classNames({"quick-question-secondary": isCS && isVisible})} hidden={hideOptions}>
         <Col>
             {!isVisible && <Row>
                 <Col md="9">
@@ -49,17 +48,17 @@ export const ConfidenceQuestions = ({hideOptions, isVisible, toggle}: QuestionCo
             </Row>
             <Row>
                 <Col className="mx-auto mb-2">
-                    <Button color={isCs && isVisible ? "negative-answer" : "negative"} block className={isVisible ? "active" : ""} onClick={() => toggle(isVisible ? "No" : "Low")}>
+                    <Button color={isCS && isVisible ? "negative-answer" : "negative"} block className={isVisible ? "active" : ""} onClick={() => toggle(isVisible ? "No" : "Low")}>
                         {isVisible ? "No" : "Low"}
                     </Button>
                 </Col>
                 <Col className="mx-auto mb-2">
-                    <Button color={isCs && isVisible ? "neutral-answer" : "neutral"} block className={isVisible ? "active" : ""} onClick={() => toggle(isVisible ? "Partly" : "Medium")}>
+                    <Button color={isCS && isVisible ? "neutral-answer" : "neutral"} block className={isVisible ? "active" : ""} onClick={() => toggle(isVisible ? "Partly" : "Medium")}>
                         {isVisible ? "Partly" : "Medium"}
                     </Button>
                 </Col>
                 <Col className="mx-auto mb-2">
-                    <Button color={isCs && isVisible ?"positive-answer" : "positive"} block className={isVisible ? "active" : ""} onClick={() => toggle(isVisible ? "Yes" : "High")}>
+                    <Button color={isCS && isVisible ? "positive-answer" : "positive"} block className={isVisible ? "active" : ""} onClick={() => toggle(isVisible ? "Yes" : "High")}>
                         {isVisible ? "Yes" : "High"}
                     </Button>
                 </Col>

--- a/src/app/components/elements/inputs/UserContextAccountInput.tsx
+++ b/src/app/components/elements/inputs/UserContextAccountInput.tsx
@@ -5,7 +5,7 @@ import * as RS from "reactstrap";
 import {CustomInput, Input} from "reactstrap";
 import {BOOLEAN_NOTATION, EMPTY_BOOLEAN_NOTATION_RECORD, EXAM_BOARD, STAGE} from "../../../services/constants";
 import {getFilteredExamBoardOptions, getFilteredStageOptions} from "../../../services/userContext";
-import {SITE, SITE_SUBJECT, TEACHER_REQUEST_ROUTE} from "../../../services/siteConstants";
+import {isPhy, siteSpecific, isCS, TEACHER_REQUEST_ROUTE} from "../../../services/siteConstants";
 import {ExamBoard, UserContext} from "../../../../IsaacApiTypes";
 import {v4 as uuid_v4} from "uuid";
 import {isDefined} from "../../../services/miscUtils";
@@ -45,7 +45,7 @@ function UserContextRow({
             onChange={e => {
                 const stage = e.target.value as STAGE;
                 let examBoard;
-                if (SITE_SUBJECT === SITE.CS) {
+                if (isCS) {
                     // Set exam board to something sensible
                     const onlyOneAtThisStage = existingUserContexts.filter(uc => uc.stage === e.target.value).length === 1;
                     examBoard = getFilteredExamBoardOptions(
@@ -69,7 +69,7 @@ function UserContextRow({
         </Input>
 
         {/* Exam Board Selector */}
-        {SITE_SUBJECT === SITE.CS && <Input
+        {isCS && <Input
             className="form-control w-auto d-inline-block pl-1 pr-0 ml-sm-2 mt-1 mt-sm-0" type="select"
             aria-label="Exam Board"
             value={userContext.examBoard || ""}
@@ -112,27 +112,31 @@ export function UserContextAccountInput({
 
     return <div>
         <RS.Label htmlFor="user-context-selector" className="form-required">
-            {SITE.CS === SITE_SUBJECT && <span>Show me content for:</span>}
-            {SITE.PHY === SITE_SUBJECT && <span>{teacher ? "I am teaching..." : "I am interested in..."}</span>}
+            {siteSpecific(
+                <span>{teacher ? "I am teaching..." : "I am interested in..."}</span>,
+                <span>Show me content for:</span>
+            )}
         </RS.Label>
-        {SITE.PHY === SITE_SUBJECT && <React.Fragment>
-            <span id={`show-me-content-${componentId}`} className="icon-help" />
-            <RS.UncontrolledTooltip placement="bottom" target={`show-me-content-${componentId}`}>
-                Choose a stage here to pre-select the material that is most relevant to your interests.<br />
-                You will be able to change this preference on relevant pages.<br />
-                If you prefer to see all content by default, select "All stages".
-            </RS.UncontrolledTooltip>
-        </React.Fragment>}
-        {SITE.CS === SITE_SUBJECT && <React.Fragment>
-            <span id={`show-me-content-${componentId}`} className="icon-help" />
-            <RS.UncontrolledTooltip placement="bottom" target={`show-me-content-${componentId}`}>
-                {teacher ?
-                    <>Add a stage and examination board for each qualification you are teaching.<br />On content pages, this will allow you to quickly switch between your personalised views of the content, depending on which class you are currently teaching.</> :
-                    <>Select a stage and examination board here to filter the content so that you will only see material that is relevant for the qualification you have chosen.</>
-                }
-            </RS.UncontrolledTooltip>
-        </React.Fragment>}
-        <div id="user-context-selector" className={SITE_SUBJECT === SITE.PHY ? "d-flex flex-wrap" : ""}>
+        {siteSpecific(
+            <React.Fragment>
+                <span id={`show-me-content-${componentId}`} className="icon-help" />
+                <RS.UncontrolledTooltip placement="bottom" target={`show-me-content-${componentId}`}>
+                    Choose a stage here to pre-select the material that is most relevant to your interests.<br />
+                    You will be able to change this preference on relevant pages.<br />
+                    If you prefer to see all content by default, select "All stages".
+                </RS.UncontrolledTooltip>
+            </React.Fragment>,
+            <React.Fragment>
+                <span id={`show-me-content-${componentId}`} className="icon-help" />
+                <RS.UncontrolledTooltip placement="bottom" target={`show-me-content-${componentId}`}>
+                    {teacher ?
+                        <>Add a stage and examination board for each qualification you are teaching.<br />On content pages, this will allow you to quickly switch between your personalised views of the content, depending on which class you are currently teaching.</> :
+                        <>Select a stage and examination board here to filter the content so that you will only see material that is relevant for the qualification you have chosen.</>
+                    }
+                </RS.UncontrolledTooltip>
+            </React.Fragment>
+        )}
+        <div id="user-context-selector" className={isPhy ? "d-flex flex-wrap" : ""}>
             {userContexts.map((userContext, index) => {
                 const showPlusOption = teacher &&
                     index === userContexts.length - 1 &&
@@ -161,10 +165,10 @@ export function UserContextAccountInput({
                         >
                             +
                         </button>
-                        {SITE_SUBJECT === SITE.CS && <span className="ml-1">add stage</span>}
+                        {isCS && <span className="ml-1">add stage</span>}
                     </RS.Label>}
 
-                    {SITE_SUBJECT === SITE.CS && index === userContexts.length - 1 && (userContexts.findIndex(p => p.stage === STAGE.ALL && p.examBoard === EXAM_BOARD.ALL) === -1) && <RS.Label className="mt-2">
+                    {isCS && index === userContexts.length - 1 && (userContexts.findIndex(p => p.stage === STAGE.ALL && p.examBoard === EXAM_BOARD.ALL) === -1) && <RS.Label className="mt-2">
                         <CustomInput
                             type="checkbox" id={`hide-content-check-${componentId}`} className="d-inline-block"
                             checked={isDefined(displaySettings.HIDE_NON_AUDIENCE_CONTENT) ? !displaySettings.HIDE_NON_AUDIENCE_CONTENT : true}
@@ -181,7 +185,7 @@ export function UserContextAccountInput({
 
                     {!teacher && <><br/>
                         <small>
-                            If you are a teacher, <Link to={TEACHER_REQUEST_ROUTE} target="_blank">upgrade your account</Link> to choose more than one {SITE_SUBJECT === SITE.CS && "exam board and "}stage.
+                            If you are a teacher, <Link to={TEACHER_REQUEST_ROUTE} target="_blank">upgrade your account</Link> to choose more than one {isCS && "exam board and "}stage.
                         </small>
                     </>}
                 </RS.FormGroup>

--- a/src/app/components/elements/inputs/UserContextPicker.tsx
+++ b/src/app/components/elements/inputs/UserContextPicker.tsx
@@ -9,7 +9,7 @@ import {
     setTransientShowOtherContentPreference,
     setTransientStagePreference
 } from "../../../state/actions";
-import {SITE, SITE_SUBJECT} from "../../../services/siteConstants";
+import {isCS} from "../../../services/siteConstants";
 import {selectors} from "../../../state/selectors";
 import {history} from "../../../services/history";
 import queryString from "query-string";
@@ -27,12 +27,12 @@ export const UserContextPicker = ({className, hideLabels = true}: {className?: s
 
     const unusual = {
         stage: !filteredStages.map(s => s.value).includes(userContext.stage),
-        examBoard: SITE_SUBJECT === SITE.CS && !filteredExamBoardOptions.map(s => s.value).includes(userContext.examBoard),
+        examBoard: isCS && !filteredExamBoardOptions.map(s => s.value).includes(userContext.examBoard),
     };
     const showUnusualContextMessage = unusual.stage || unusual.examBoard;
-    const showHideOtherContentSelector = SITE_SUBJECT === SITE.CS && segueEnvironment === "DEV";
+    const showHideOtherContentSelector = isCS && segueEnvironment === "DEV";
     const showStageSelector = getFilteredStageOptions({byUser: user}).length > 1 || showUnusualContextMessage;
-    const showExamBoardSelector = SITE_SUBJECT === SITE.CS && (getFilteredExamBoardOptions({byUser: user}).length > 1 || showUnusualContextMessage);
+    const showExamBoardSelector = isCS && (getFilteredExamBoardOptions({byUser: user}).length > 1 || showUnusualContextMessage);
 
 
     return <div className="d-flex">
@@ -56,7 +56,7 @@ export const UserContextPicker = ({className, hideLabels = true}: {className?: s
                 onChange={e => {
                     const newParams: {[key: string]: unknown} = {...qParams, stage: e.target.value};
                     const stage = e.target.value as STAGE;
-                    if (SITE_SUBJECT === SITE.CS) {
+                    if (isCS) {
                         // Drive exam board selection so that it is a valid option - by default use All.
                         let examBoard = EXAM_BOARD.ALL;
                         const possibleExamBoards =
@@ -112,7 +112,7 @@ export const UserContextPicker = ({className, hideLabels = true}: {className?: s
         {showUnusualContextMessage && <div className="mt-2 ml-1">
             <span id={`unusual-viewing-context-explanation`} className="icon-help mx-1" />
             <RS.UncontrolledTooltip placement="bottom" target={`unusual-viewing-context-explanation`}>
-                You are seeing {stageLabelMap[userContext.stage]} {SITE_SUBJECT === SITE.CS ? examBoardLabelMap[userContext.examBoard] : ""}{" "}
+                You are seeing {stageLabelMap[userContext.stage]} {isCS ? examBoardLabelMap[userContext.examBoard] : ""}{" "}
                 content, which is different to your account settings. <br />
                 {unusual.stage && unusual.examBoard && <>
                     {userContext.explanation.stage === userContext.explanation.examBoard ?

--- a/src/app/components/elements/list-groups/ContentSummaryListGroupItem.tsx
+++ b/src/app/components/elements/list-groups/ContentSummaryListGroupItem.tsx
@@ -10,7 +10,7 @@ import * as RS from "reactstrap";
 import {Link} from "react-router-dom";
 import React, {useRef} from "react";
 import tags from "../../../services/tags";
-import {SITE, SITE_SUBJECT} from "../../../services/siteConstants";
+import {isCS, isPhy, siteSpecific} from "../../../services/siteConstants";
 import {
     AUDIENCE_DISPLAY_FIELDS,
     determineAudienceViews,
@@ -40,23 +40,23 @@ export const ContentSummaryListGroupItem = ({item, search, displayTopicTitle}: {
 
     let title = item.title;
     let titleClasses = "content-summary-link-title flex-grow-1 ";
-    let titleTextClass = SITE_SUBJECT == SITE.PHY ? "text-secondary" : undefined;
+    let titleTextClass = isPhy ? "text-secondary" : undefined;
     const itemSubject = tags.getSpecifiedTag(TAG_LEVEL.subject, item.tags as TAG_ID[]);
     if (itemSubject) {
         titleClasses += itemSubject.id;
     }
     const iconClasses = `search-item-icon ${itemSubject?.id}-fill`;
     const hierarchyTags = tags.getByIdsAsHierarchy((item.tags || []) as TAG_ID[])
-        .filter((t, i) => SITE_SUBJECT !== SITE.CS || i !== 0); // CS always has Computer Science at the top level
+        .filter((t, i) => !isCS || i !== 0); // CS always has Computer Science at the top level
 
-    const questionIcon = {
-        [SITE.CS]: item.correct ?
-            <img src="/assets/tick-rp.svg" alt=""/> :
-            <img src="/assets/question.svg" alt="Question page"/>,
-        [SITE.PHY]: item.correct ?
+    const questionIcon = siteSpecific(
+        item.correct ?
             <svg className={iconClasses}><use href={`/assets/tick-rp-hex.svg#icon`} xlinkHref={`/assets/tick-rp-hex.svg#icon`}/></svg> :
-            <svg className={iconClasses}><use href={`/assets/question-hex.svg#icon`} xlinkHref={`/assets/question-hex.svg#icon`}/></svg>
-    }[SITE_SUBJECT];
+            <svg className={iconClasses}><use href={`/assets/question-hex.svg#icon`} xlinkHref={`/assets/question-hex.svg#icon`}/></svg>,
+        item.correct ?
+            <img src="/assets/tick-rp.svg" alt=""/> :
+            <img src="/assets/question.svg" alt="Question page"/>
+    );
 
     let typeLabel;
 
@@ -73,7 +73,7 @@ export const ContentSummaryListGroupItem = ({item, search, displayTopicTitle}: {
             icon = questionIcon;
             iconLabel = item.correct ? "Completed question icon" : "Question icon";
             audienceViews = filterAudienceViewsByProperties(determineAudienceViews(item.audience), AUDIENCE_DISPLAY_FIELDS);
-            if (SITE_SUBJECT === SITE.CS) {
+            if (isCS) {
                 typeLabel = "Question";
             }
             break;
@@ -81,7 +81,7 @@ export const ContentSummaryListGroupItem = ({item, search, displayTopicTitle}: {
             linkDestination = `/${documentTypePathPrefix[DOCUMENT_TYPE.CONCEPT]}/${item.id}`;
             icon = <img src="/assets/concept.svg" alt="Concept page"/>;
             iconLabel = "Concept page icon";
-            if (SITE_SUBJECT === SITE.CS) {
+            if (isCS) {
                 typeLabel = "Concept";
             }
             break;

--- a/src/app/components/elements/list-groups/ListGroupFooter.tsx
+++ b/src/app/components/elements/list-groups/ListGroupFooter.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import {Link} from "react-router-dom";
 import {ListGroup, ListGroupItem} from "reactstrap";
-import {SITE, SITE_SUBJECT} from "../../../services/siteConstants";
-
+import {siteSpecific} from "../../../services/siteConstants";
 
 interface FooterLinkProps {
     linkTo: string;
@@ -18,22 +17,8 @@ const FooterLink = ({linkTo, children}: FooterLinkProps ) => {
 };
 
 let key = 0;
-const footerLinks = {
-    [SITE.CS]: {
-        left: [
-            <FooterLink key={key++} linkTo="/about">About us</FooterLink>,
-            <FooterLink key={key++} linkTo="/contact">Contact us</FooterLink>,
-            <FooterLink key={key++} linkTo="/accessibility">
-                Accessibility <span className="d-none d-md-inline">statement</span>
-            </FooterLink>,
-        ],
-        right: [
-            <FooterLink key={key++} linkTo="/privacy">Privacy policy</FooterLink>,
-            <FooterLink key={key++} linkTo="/terms">Terms of use</FooterLink>,
-            <FooterLink key={key++} linkTo="/cookies">Cookie policy</FooterLink>,
-        ]
-    },
-    [SITE.PHY]: {
+const footerLinks = siteSpecific(
+    {
         left: [
             <FooterLink key={key++} linkTo="/about">About Us</FooterLink>,
             <FooterLink key={key++} linkTo="/contact">Contact Us</FooterLink>,
@@ -50,18 +35,32 @@ const footerLinks = {
             <FooterLink key={key++} linkTo="/extraordinary_problems">Extraordinary Problems</FooterLink>,
             <FooterLink key={key++} linkTo="/chemistry">Isaac Chemistry</FooterLink>,
         ]
+    },
+    {
+        left: [
+            <FooterLink key={key++} linkTo="/about">About us</FooterLink>,
+            <FooterLink key={key++} linkTo="/contact">Contact us</FooterLink>,
+            <FooterLink key={key++} linkTo="/accessibility">
+                Accessibility <span className="d-none d-md-inline">statement</span>
+            </FooterLink>,
+        ],
+        right: [
+            <FooterLink key={key++} linkTo="/privacy">Privacy policy</FooterLink>,
+            <FooterLink key={key++} linkTo="/terms">Terms of use</FooterLink>,
+            <FooterLink key={key++} linkTo="/cookies">Cookie policy</FooterLink>,
+        ]
     }
-};
+);
 
 export const ListGroupFooter = () => (
     <div className="footer-links">
         <h2 className="h5">Links</h2>
         <div className="d-flex flex-row pt-lg-3">
             <ListGroup className="w-50 mb-3 link-list">
-                {footerLinks[SITE_SUBJECT].left}
+                {footerLinks.left}
             </ListGroup>
             <ListGroup className="w-50 mb-3 link-list">
-                {footerLinks[SITE_SUBJECT].right}
+                {footerLinks.right}
             </ListGroup>
         </div>
     </div>

--- a/src/app/components/elements/list-groups/ListGroupFooterBottom.tsx
+++ b/src/app/components/elements/list-groups/ListGroupFooterBottom.tsx
@@ -1,44 +1,44 @@
 import React from "react";
 import {ListGroup, ListGroupItem} from "reactstrap";
-import {SITE, SITE_SUBJECT} from "../../../services/siteConstants";
 import {ExternalLink} from "../ExternalLink";
+import {siteSpecific} from "../../../services/siteConstants";
 
-export const ListGroupFooterBottom = () => (
-    SITE_SUBJECT === SITE.CS ?
-        <div className='footer-links footer-bottom'>
-            <ListGroup className='d-flex flex-wrap flex-row'>
-                <ListGroupItem className='footer-bottom-info border-0 px-0 py-0 bg-transparent'>
-                    <p className='pt-2 mb-lg-0'>
-                        All teaching materials on this site are available under the&nbsp;
-                        <ExternalLink href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" className="d-inline text-dark font-weight-bold">
-                            Open Government Licence v3.0
-                        </ExternalLink>, except where otherwise stated.
-                    </p>
-                </ListGroupItem>
+export const ListGroupFooterBottom = () => siteSpecific(
+    // Physics
+    <div className="w-100">
+        <div className='text-center'>
+            All materials on this site are licensed under the {" "}
+            <ExternalLink href="https://creativecommons.org/licenses/by/4.0/">
+                <strong>Creative&nbsp;Commons&nbsp;license</strong>
+            </ExternalLink>, unless stated otherwise.
+        </div>
+    </div>,
+    // Computer Science
+    <div className='footer-links footer-bottom'>
+        <ListGroup className='d-flex flex-wrap flex-row'>
+            <ListGroupItem className='footer-bottom-info border-0 px-0 py-0 bg-transparent'>
+                <p className='pt-2 mb-lg-0'>
+                    All teaching materials on this site are available under the&nbsp;
+                    <ExternalLink href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" className="d-inline text-dark font-weight-bold">
+                        Open Government Licence v3.0
+                    </ExternalLink>, except where otherwise stated.
+                </p>
+            </ListGroupItem>
 
-                <ListGroupItem className='footer-bottom-logos border-0 px-0 py-0 pb-4 pb-md-1 bg-transparent d-flex justify-content-between d-print-none'>
-                    <ExternalLink href="https://teachcomputing.org/">
-                        <img src="/assets/logos/ncce.png" alt='National Centre for Computing Education website' className='logo-mr' height="57px" />
-                    </ExternalLink>
-                    <ExternalLink href="https://teachcomputing.org">
-                        <img src="/assets/logos/teach-computing.svg" alt='Teach Computing website' className="logo-mr" height="57px" />
-                    </ExternalLink>
-                    <ExternalLink href="https://www.raspberrypi.org/">
-                        <img src="/assets/logos/raspberry-pi.png" alt='Raspberry Pi website' className='logo-mr' height="57px" />
-                    </ExternalLink>
-                    <ExternalLink href="https://isaacphysics.org/">
-                        <img src="/assets/logos/isaacphysics.png" alt='Issac Physics website' className='logo-mr' height="57px" />
-                    </ExternalLink>
-                </ListGroupItem>
-            </ListGroup>
-        </div>
-        :
-        <div className="w-100">
-            <div className='text-center'>
-                All materials on this site are licensed under the {" "}
-                <ExternalLink href="https://creativecommons.org/licenses/by/4.0/">
-                    <strong>Creative&nbsp;Commons&nbsp;license</strong>
-                </ExternalLink>, unless stated otherwise.
-            </div>
-        </div>
+            <ListGroupItem className='footer-bottom-logos border-0 px-0 py-0 pb-4 pb-md-1 bg-transparent d-flex justify-content-between d-print-none'>
+                <ExternalLink href="https://teachcomputing.org/">
+                    <img src="/assets/logos/ncce.png" alt='National Centre for Computing Education website' className='logo-mr' height="57px" />
+                </ExternalLink>
+                <ExternalLink href="https://teachcomputing.org">
+                    <img src="/assets/logos/teach-computing.svg" alt='Teach Computing website' className="logo-mr" height="57px" />
+                </ExternalLink>
+                <ExternalLink href="https://www.raspberrypi.org/">
+                    <img src="/assets/logos/raspberry-pi.png" alt='Raspberry Pi website' className='logo-mr' height="57px" />
+                </ExternalLink>
+                <ExternalLink href="https://isaacphysics.org/">
+                    <img src="/assets/logos/isaacphysics.png" alt='Issac Physics website' className='logo-mr' height="57px" />
+                </ExternalLink>
+            </ListGroupItem>
+        </ListGroup>
+    </div>
 );

--- a/src/app/components/elements/list-groups/ListGroupSocial.tsx
+++ b/src/app/components/elements/list-groups/ListGroupSocial.tsx
@@ -1,35 +1,18 @@
 import React from "react";
 import {ListGroup, ListGroupItem} from "reactstrap";
-import {SITE, SITE_SUBJECT} from "../../../services/siteConstants";
+import {SITE_SUBJECT_TITLE} from "../../../services/siteConstants";
 import {ExternalLink} from "../ExternalLink";
+import {SOCIAL_LINKS} from "../../../services/constants";
 
-interface Links {
-    name: string;
-    href: string;
-}
-
-const links: {[site in SITE]: Links[]} = {
-    cs: [
-        {name: "Facebook", href: "https://www.facebook.com/IsaacComputerScience/"},
-        {name: "Twitter", href: "https://twitter.com/isaaccompsci"},
-        {name: "Instagram", href: "https://www.instagram.com/isaaccompsci/"},
-        {name: "YouTube", href: "https://www.youtube.com/channel/UC-qoIYj8kgR8RZtQphrRBYQ/"}
-    ],
-    physics: [
-        {name: "Facebook", href: "https://www.facebook.com/isaacphysicsUK"},
-        {name: "Twitter", href: "https://twitter.com/isaacphysics"},
-        {name: "YouTube", href: "https://www.youtube.com/user/isaacphysics/"}
-    ]
-};
 export const ListGroupSocial = () => {
     return (
         <div className='footer-links footer-links-social'>
             <h2 className="h5">Get social</h2>
             <ListGroup className='mt-3 pb-5 py-lg-3 link-list d-md-flex flex-row'>
-                {links[SITE_SUBJECT].map(({name, href}) =>
+                {Object.entries(SOCIAL_LINKS).map(([_, {name, href}]) =>
                     <ListGroupItem key={name} className='border-0 px-0 py-0 pb-1 bg-transparent'>
                         <ExternalLink href={href}>
-                            <img src={`/assets/${name.toLowerCase()}_icon.svg`} alt={`Isaac ${SITE_SUBJECT} on ${name}`} className='logo-mr'/>
+                            <img src={`/assets/${name.toLowerCase()}_icon.svg`} alt={`Isaac ${SITE_SUBJECT_TITLE} on ${name}`} className='logo-mr'/>
                         </ExternalLink>
                     </ListGroupItem>
                 )}

--- a/src/app/components/elements/list-groups/TopicSummaryLinks.tsx
+++ b/src/app/components/elements/list-groups/TopicSummaryLinks.tsx
@@ -13,7 +13,7 @@ import {Link} from "react-router-dom";
 import {useSelector} from "react-redux";
 import {selectors} from "../../../state/selectors";
 import {DOCUMENT_TYPE, documentTypePathPrefix} from "../../../services/constants";
-import {SITE, SITE_SUBJECT} from "../../../services/siteConstants";
+import {isCS} from "../../../services/siteConstants";
 import classNames from "classnames";
 import {Markup} from "../markup";
 
@@ -25,7 +25,7 @@ export function TopicSummaryLinks({items, search}: {items: ContentSummaryDTO[]; 
         {items
             // For CS we want relevant sections to appear first
             .sort((itemA, itemB) => {
-                if (SITE_SUBJECT !== SITE.CS) {return 0;}
+                if (!isCS) {return 0;}
                 return makeIntendedAudienceComparator(user, userContext)(itemA, itemB);
             })
 
@@ -45,7 +45,7 @@ export function TopicSummaryLinks({items, search}: {items: ContentSummaryDTO[]; 
                     tag={Link} to={{pathname: `/${documentTypePathPrefix[DOCUMENT_TYPE.CONCEPT]}/${item.id}`, search}}
                     block color="link" className={"d-flex align-items-stretch " + classNames({"de-emphasised": item.deEmphasised})}
                 >
-                    <div className={"stage-label badge-primary d-flex align-items-center justify-content-center " + classNames({[audienceStyle(stringifyAudience(item.audience, userContext))]: SITE_SUBJECT === SITE.CS})}>
+                    <div className={"stage-label badge-primary d-flex align-items-center justify-content-center " + classNames({[audienceStyle(stringifyAudience(item.audience, userContext))]: isCS})}>
                         {stringifyAudience(item.audience, userContext)}
                     </div>
                     <div className="title pl-3 d-flex">

--- a/src/app/components/elements/markup/latexRendering.ts
+++ b/src/app/components/elements/markup/latexRendering.ts
@@ -4,7 +4,7 @@ import {selectors} from "../../../state/selectors";
 import {AppState} from "../../../state/reducers";
 import {BooleanNotation, FigureNumberingContext, FigureNumbersById, PotentialUser} from "../../../../IsaacAppTypes";
 import he from "he";
-import {SITE, SITE_SUBJECT} from "../../../services/siteConstants";
+import {isCS} from "../../../services/siteConstants";
 import katex, { KatexOptions } from "katex";
 import 'katex/dist/contrib/mhchem.mjs';
 import renderA11yString from "../../../services/katex-a11y";
@@ -258,7 +258,7 @@ export function katexify(html: string, user: PotentialUser | null, booleanNotati
                 const latexUnEntitied = he.decode(latex);
                 const latexMunged = munge(latexUnEntitied);
                 let macrosToUse;
-                if (SITE_SUBJECT == SITE.CS) {
+                if (isCS) {
                     if (user?.loggedIn && booleanNotation) {
                         macrosToUse = booleanNotation?.ENG ? KatexMacrosWithEngineeringBool : KatexMacrosWithMathsBool;
                     } else {

--- a/src/app/components/elements/markup/markdownRendering.ts
+++ b/src/app/components/elements/markup/markdownRendering.ts
@@ -1,7 +1,7 @@
 import {MARKDOWN_RENDERER} from "../../../services/constants";
 // @ts-ignore
 import {Remarkable, utils} from "remarkable";
-import {SITE, SITE_SUBJECT} from "../../../services/siteConstants";
+import {isPhy} from "../../../services/siteConstants";
 
 MARKDOWN_RENDERER.renderer.rules.link_open = function(tokens: Remarkable.LinkOpenToken[], idx: number/* options, env */) {
     const href = utils.escapeHtml(tokens[idx].href || "");
@@ -54,7 +54,7 @@ export const regexProcessMarkdown = (markdown: string) => {
     const regexRules = {
         "[$1]($2)": /\\link{([^}]*)}{([^}]*)}/g,
     };
-    if (SITE_SUBJECT === SITE.PHY) {
+    if (isPhy) {
         Object.assign(regexRules, {
             "[**Glossary**](/glossary)": /\*\*Glossary\*\*/g,
             "[**Concepts**](/concepts)": /\*\*Concepts\*\*/g,

--- a/src/app/components/elements/markup/portals/Tables.tsx
+++ b/src/app/components/elements/markup/portals/Tables.tsx
@@ -1,7 +1,7 @@
 import React, {MouseEventHandler, useContext, useState} from "react";
 import classNames from "classnames";
 import ReactDOM from "react-dom";
-import {SITE, SITE_SUBJECT} from "../../../../services/siteConstants";
+import {isCS} from "../../../../services/siteConstants";
 import {ScrollShadows} from "../../ScrollShadows";
 import {above, isMobile, useDeviceSize} from "../../../../services/device";
 import {ExpandableParentContext} from "../../../../../IsaacAppTypes";
@@ -23,7 +23,7 @@ const Table = ({id, html, classes, rootElement}: TableData & {rootElement: HTMLE
             <div className={classNames(outerClasses, "isaac-table")} ref={updateExpandRef}>
                 <div className={"position-relative"}>
                     {/* ScrollShadows uses ResizeObserver, which doesn't exist on Safari <= 13 */}
-                    {SITE_SUBJECT === SITE.CS && window.ResizeObserver && <ScrollShadows element={scrollRef} />}
+                    {isCS && window.ResizeObserver && <ScrollShadows element={scrollRef} />}
                     {expandButton}
                     <div ref={updateScrollRef} className={classNames(innerClasses, "overflow-auto")} dangerouslySetInnerHTML={{__html: modifiedHtml}} />
                     {renderPortalElements(scrollRef)}
@@ -52,7 +52,7 @@ export const useExpandContent = (expandable: boolean, el?: HTMLElement, unexpand
     const expandableParent = useContext(ExpandableParentContext);
     const deviceSize = useDeviceSize();
 
-    const show = SITE_SUBJECT === SITE.CS && expandable && !isMobile() && above["md"](deviceSize) && !expandableParent;
+    const show = isCS && expandable && !isMobile() && above["md"](deviceSize) && !expandableParent;
 
     const expandButton = (show && <div className={"expand-button position-relative"}>
         <button type={"button"} onClick={toggleExpanded}>

--- a/src/app/components/elements/modals/LoginOrSignUpModal.tsx
+++ b/src/app/components/elements/modals/LoginOrSignUpModal.tsx
@@ -8,9 +8,8 @@ import {store} from "../../../state/store";
 import {GoogleSignInButton, PasswordResetButton, TFAInput, EmailPasswordInputs, useLoginLogic} from "../../pages/LogIn";
 import * as persistence from "../../../services/localStorage";
 import {KEY} from "../../../services/localStorage";
-import {siteSpecific} from "../../../services/miscUtils";
 import classNames from "classnames";
-import {SITE, SITE_SUBJECT} from "../../../services/siteConstants";
+import {isCS, siteSpecific} from "../../../services/siteConstants";
 
 const LoginOrSignUpBody = () => {
 
@@ -36,7 +35,7 @@ const LoginOrSignUpBody = () => {
     }
 
     return <Row id={"login-page"}>
-        <Col lg={6} className={classNames("content-body", {"pattern-06-inverted": SITE_SUBJECT === SITE.CS})}>
+        <Col lg={6} className={classNames("content-body", {"pattern-06-inverted": isCS})}>
             {siteSpecific(
                 <img src={"/assets/phy/logo.svg"} alt={"Isaac Physics Logo"} />,
                 <img src={"/assets/logo.svg"} className={"mt-5 ml-3"} style={{width: "90%"}} alt={"Isaac Computer Science Logo"} />

--- a/src/app/components/elements/modals/QuestionSearchModal.tsx
+++ b/src/app/components/elements/modals/QuestionSearchModal.tsx
@@ -16,12 +16,11 @@ import {DIFFICULTY_ICON_ITEM_OPTIONS, EXAM_BOARD_NULL_OPTIONS, SortOrder, STAGE}
 import {getFilteredExamBoardOptions, getFilteredStageOptions, useUserContext} from "../../../services/userContext";
 import {searchResultIsPublic} from "../../../services/search";
 import {isStaff} from "../../../services/user";
-import {SITE, SITE_SUBJECT} from "../../../services/siteConstants";
+import {isCS, isPhy, siteSpecific} from "../../../services/siteConstants";
 import {ContentSummary} from "../../../../IsaacAppTypes";
 import {AudienceContext, Difficulty, ExamBoard} from "../../../../IsaacApiTypes";
 import {Item, selectOnChange} from "../../../services/select";
 import {GroupBase} from "react-select/dist/declarations/src/types";
-import {siteSpecific} from "../../../services/miscUtils";
 import {Loading} from "../../handlers/IsaacSpinner";
 
 // Immediately load GameboardBuilderRow, but allow splitting
@@ -105,7 +104,7 @@ export const QuestionSearchModal = ({originalSelectedQuestions, setOriginalSelec
         setSortState(newSortState);
     };
 
-    const tagOptions: { options: Item<string>[]; label: string }[] = SITE_SUBJECT === SITE.PHY ? tags.allTags.map(groupTagSelectionsByParent) : tags.allSubcategoryTags.map(groupTagSelectionsByParent);
+    const tagOptions: { options: Item<string>[]; label: string }[] = isPhy ? tags.allTags.map(groupTagSelectionsByParent) : tags.allSubcategoryTags.map(groupTagSelectionsByParent);
     const groupBaseTagOptions: GroupBase<Item<string>>[] = tagOptions;
 
     useEffect(() => {
@@ -115,16 +114,16 @@ export const QuestionSearchModal = ({originalSelectedQuestions, setOriginalSelec
     const addSelectionsRow = <div className="d-lg-flex align-items-baseline">
         <div className="flex-grow-1 mb-1">
             <strong className={selectedQuestions.size > 10 ? "text-danger" : ""}>
-                {{
-                    [SITE.PHY]: `${selectedQuestions.size} Question${selectedQuestions.size !== 1 ? "s" : ""} Selected`,
-                    [SITE.CS]: `${selectedQuestions.size} question${selectedQuestions.size !== 1 ? "s" : ""} selected`
-                }[SITE_SUBJECT]}
+                {siteSpecific(
+                    `${selectedQuestions.size} Question${selectedQuestions.size !== 1 ? "s" : ""} Selected`,
+                    `${selectedQuestions.size} question${selectedQuestions.size !== 1 ? "s" : ""} selected`
+                )}
             </strong>
         </div>
         <div>
             <RS.Input
                 type="button"
-                value={{[SITE.PHY]: "Add Selections to Gameboard", [SITE.CS]: "Add selections to gameboard"}[SITE_SUBJECT]}
+                value={siteSpecific("Add Selections to Gameboard", "Add selections to gameboard")}
                 disabled={isEqual(new Set(originalSelectedQuestions.keys()), new Set(selectedQuestions.keys()))}
                 className={"btn btn-block btn-secondary border-0"}
                 onClick={() => {
@@ -138,7 +137,7 @@ export const QuestionSearchModal = ({originalSelectedQuestions, setOriginalSelec
 
     return <div className="mb-4">
         <RS.Row>
-            {SITE_SUBJECT === SITE.PHY && <RS.Col lg={3} className="text-wrap my-2">
+            {isPhy && <RS.Col lg={3} className="text-wrap my-2">
                 <RS.Label htmlFor="question-search-book">Book</RS.Label>
                 <Select
                     inputId="question-search-book" isClearable placeholder="None" {...selectStyle}
@@ -156,7 +155,7 @@ export const QuestionSearchModal = ({originalSelectedQuestions, setOriginalSelec
                     ]}
                 />
             </RS.Col>}
-            <RS.Col lg={SITE_SUBJECT === SITE.CS ? 12 : 9} className={`text-wrap mt-2 ${isBookSearch ? "d-none" : ""}`}>
+            <RS.Col lg={siteSpecific(9, 12)} className={`text-wrap mt-2 ${isBookSearch ? "d-none" : ""}`}>
                 <RS.Label htmlFor="question-search-topic">Topic</RS.Label>
                 <Select
                     inputId="question-search-topic" isMulti placeholder="Any" {...selectStyle}
@@ -181,7 +180,7 @@ export const QuestionSearchModal = ({originalSelectedQuestions, setOriginalSelec
                     options={DIFFICULTY_ICON_ITEM_OPTIONS} onChange={selectOnChange(setSearchDifficulties, true)}
                 />
             </RS.Col>
-            {SITE_SUBJECT === SITE.CS && <RS.Col lg={6} className={`text-wrap my-2`}>
+            {isCS && <RS.Col lg={6} className={`text-wrap my-2`}>
                 <RS.Label htmlFor="question-search-exam-board">Exam Board</RS.Label>
                 <Select
                     inputId="question-search-exam-board" isClearable isMulti placeholder="Any" {...selectStyle}
@@ -192,7 +191,7 @@ export const QuestionSearchModal = ({originalSelectedQuestions, setOriginalSelec
             </RS.Col>}
         </RS.Row>
         <RS.Row>
-            {SITE_SUBJECT === SITE.PHY && isStaff(user) && <RS.Col className="text-wrap mb-2">
+            {isPhy && isStaff(user) && <RS.Col className="text-wrap mb-2">
                 <RS.Form>
                     <RS.Label check><input type="checkbox" checked={searchFastTrack} onChange={e => setSearchFastTrack(e.target.checked)} />{' '}Show FastTrack questions</RS.Label>
                 </RS.Form>
@@ -203,7 +202,7 @@ export const QuestionSearchModal = ({originalSelectedQuestions, setOriginalSelec
                 <RS.Label htmlFor="question-search-title">Search</RS.Label>
                 <RS.Input id="question-search-title"
                     type="text"
-                    placeholder={{[SITE.CS]: "e.g. Creating an AST", [SITE.PHY]: "e.g. Man vs. Horse"}[SITE_SUBJECT]}
+                    placeholder={siteSpecific("e.g. Man vs. Horse", "e.g. Creating an AST")}
                     onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                         setSearchQuestionName(e.target.value);
                     }}
@@ -226,7 +225,7 @@ export const QuestionSearchModal = ({originalSelectedQuestions, setOriginalSelec
                         <th className="w-25">Topic</th>
                         <th className="w-15">Stage</th>
                         <th className={siteSpecific("w-15","w-10")}>Difficulty</th>
-                        {SITE_SUBJECT === SITE.CS && <th className="w-5">Exam boards</th>}
+                        {isCS && <th className="w-5">Exam boards</th>}
                     </tr>
                 </thead>
                 <tbody>

--- a/src/app/components/elements/modals/RequiredAccountInformationModal.tsx
+++ b/src/app/components/elements/modals/RequiredAccountInformationModal.tsx
@@ -16,10 +16,10 @@ import {isMobile} from "../../../services/device";
 import {isLoggedIn, isStudent} from "../../../services/user";
 import {SchoolInput} from "../inputs/SchoolInput";
 import {GenderInput} from "../inputs/GenderInput";
-import {SITE, SITE_SUBJECT, SITE_SUBJECT_TITLE, TEACHER_REQUEST_ROUTE} from "../../../services/siteConstants";
+import {isPhy, isCS, SITE_SUBJECT_TITLE, TEACHER_REQUEST_ROUTE} from "../../../services/siteConstants";
 import {selectors} from "../../../state/selectors";
 import {UserContextAccountInput} from "../inputs/UserContextAccountInput";
-import { isDefined } from "../../../services/miscUtils";
+import {isDefined} from "../../../services/miscUtils";
 import {Link} from "react-router-dom";
 
 const RequiredAccountInfoBody = () => {
@@ -60,8 +60,8 @@ const RequiredAccountInfoBody = () => {
     }
 
     const allUserFieldsAreValid =
-        (SITE_SUBJECT === SITE.PHY && validateUserContexts(initialUserContexts)) ||
-        (SITE_SUBJECT === SITE.CS && validateUserSchool(initialUserValue) && validateUserGender(initialUserValue) && validateUserContexts(initialUserContexts));
+        (isPhy && validateUserContexts(initialUserContexts)) ||
+        (isCS && validateUserSchool(initialUserValue) && validateUserGender(initialUserValue) && validateUserContexts(initialUserContexts));
 
     return <RS.Form onSubmit={formSubmission}>
         {!allUserFieldsAreValid && <RS.CardBody className="py-0">
@@ -79,8 +79,8 @@ const RequiredAccountInfoBody = () => {
             </div>}
 
             <RS.Row className="d-flex flex-wrap my-2">
-                {((SITE_SUBJECT === SITE.CS && !validateUserGender(initialUserValue)) || !validateUserContexts(initialUserContexts)) && <RS.Col lg={6}>
-                    {SITE_SUBJECT === SITE.CS && !validateUserGender(initialUserValue) && <div className="mb-3">
+                {((isCS && !validateUserGender(initialUserValue)) || !validateUserContexts(initialUserContexts)) && <RS.Col lg={6}>
+                    {isCS && !validateUserGender(initialUserValue) && <div className="mb-3">
                         <GenderInput
                             userToUpdate={userToUpdate} setUserToUpdate={setUserToUpdate}
                             submissionAttempted={submissionAttempted} idPrefix="modal"
@@ -95,7 +95,7 @@ const RequiredAccountInfoBody = () => {
                         />
                     </div>}
                 </RS.Col>}
-                {SITE_SUBJECT === SITE.CS && !validateUserSchool(initialUserValue) && <RS.Col>
+                {isCS && !validateUserSchool(initialUserValue) && <RS.Col>
                     <SchoolInput
                         userToUpdate={userToUpdate} setUserToUpdate={setUserToUpdate}
                         submissionAttempted={submissionAttempted} idPrefix="modal"

--- a/src/app/components/elements/panels/EventOverviews.tsx
+++ b/src/app/components/elements/panels/EventOverviews.tsx
@@ -11,7 +11,7 @@ import {atLeastOne, zeroOrLess} from "../../../services/validation";
 import {sortOnPredicateAndReverse} from "../../../services/sorting";
 import {PotentialUser} from "../../../../IsaacAppTypes";
 import {isEventLeader} from "../../../services/user";
-import {SITE, SITE_SUBJECT} from "../../../services/siteConstants";
+import {isCS} from "../../../services/siteConstants";
 
 export enum EventOverviewFilter {
     "All events" = "ALL",
@@ -37,7 +37,7 @@ export const EventOverviews = ({setSelectedEventId, user}: {user: PotentialUser;
             As an event leader, you are only able to see the details of events which you manage.
         </div>}
         <div className="clearfix">
-            {SITE_SUBJECT === SITE.CS && <div className="mb-3 float-left">
+            {isCS && <div className="mb-3 float-left">
                 <RS.Button color="primary" size="sm" tag={Link} to="/events_toolkit">Events toolkit</RS.Button>
             </div>}
             <div className="float-right mb-4">

--- a/src/app/components/elements/panels/ManageExistingBookings.tsx
+++ b/src/app/components/elements/panels/ManageExistingBookings.tsx
@@ -19,7 +19,7 @@ import {BookingStatus, EventBookingDTO, UserSummaryWithEmailAddressDTO} from "..
 import {DateString} from "../DateString";
 import {sortOnPredicateAndReverse} from "../../../services/sorting";
 import {API_PATH, bookingStatusMap, examBoardLabelMap, stageLabelMap} from "../../../services/constants";
-import {SITE, SITE_SUBJECT} from "../../../services/siteConstants";
+import {isCS} from "../../../services/siteConstants";
 import {selectors} from "../../../state/selectors";
 
 export const ManageExistingBookings = ({user, eventBookingId}: {user: PotentialUser; eventBookingId: string}) => {
@@ -111,7 +111,7 @@ export const ManageExistingBookings = ({user, eventBookingId}: {user: PotentialU
                             <th className="align-middle">
                                 Stage
                             </th>
-                            {SITE_SUBJECT == SITE.CS && <th className="align-middle">
+                            {isCS && <th className="align-middle">
                                 Exam board
                             </th>}
                             <th className="align-middle">
@@ -178,7 +178,7 @@ export const ManageExistingBookings = ({user, eventBookingId}: {user: PotentialU
                                     <td className="align-middle">
                                         {Array.from(new Set(booking.userBooked?.registeredContexts?.map(rc => stageLabelMap[rc.stage!]))).join(", ")}
                                     </td>
-                                    {SITE_SUBJECT == SITE.CS && <td className="align-middle">
+                                    {isCS && <td className="align-middle">
                                         {Array.from(new Set(booking.userBooked?.registeredContexts?.map(rc => examBoardLabelMap[rc.examBoard!]))).join(", ")}
                                     </td>}
                                     <td className="align-middle text-center">{booking.reservedById || "-"}</td>

--- a/src/app/components/elements/panels/UserDetails.tsx
+++ b/src/app/components/elements/panels/UserDetails.tsx
@@ -10,7 +10,7 @@ import {SchoolInput} from "../inputs/SchoolInput";
 import {DobInput} from "../inputs/DobInput";
 import {GenderInput} from "../inputs/GenderInput";
 import {UserAuthenticationSettingsDTO, UserContext} from "../../../../IsaacApiTypes";
-import {SITE, SITE_SUBJECT, TEACHER_REQUEST_ROUTE} from "../../../services/siteConstants";
+import {isCS, TEACHER_REQUEST_ROUTE} from "../../../services/siteConstants";
 import {Link} from "react-router-dom";
 import {UserContextAccountInput} from "../inputs/UserContextAccountInput";
 import {BooleanNotationInput} from "../inputs/BooleanNotationInput";
@@ -115,7 +115,7 @@ export const UserDetails = (props: UserDetailsProps) => {
             <Col md={6}>
                 <FormGroup>
                     <GenderInput userToUpdate={userToUpdate} setUserToUpdate={setUserToUpdate} submissionAttempted={submissionAttempted}
-                                 required={SITE_SUBJECT === SITE.CS}/>
+                                 required={isCS}/>
                 </FormGroup>
             </Col>
         </Row>
@@ -123,7 +123,7 @@ export const UserDetails = (props: UserDetailsProps) => {
             <Col md={6}>
                 <FormGroup>
                     <SchoolInput userToUpdate={userToUpdate} setUserToUpdate={setUserToUpdate} submissionAttempted={submissionAttempted}
-                                 required={SITE_SUBJECT === SITE.CS}/>
+                                 required={isCS}/>
                 </FormGroup>
             </Col>
             <Col md={6}>
@@ -134,7 +134,7 @@ export const UserDetails = (props: UserDetailsProps) => {
                 />
             </Col>
         </Row>
-        {SITE_SUBJECT === SITE.CS && <Row>
+        {isCS && <Row>
             <Col md={6}>
                 <FormGroup>
                     <Label className="d-inline-block pr-2" htmlFor="programming-language-select">

--- a/src/app/components/elements/panels/UserEmailPreferences.tsx
+++ b/src/app/components/elements/panels/UserEmailPreferences.tsx
@@ -5,7 +5,7 @@ import {TrueFalseRadioInput} from "../inputs/TrueFalseRadioInput";
 import {useSelector} from "react-redux";
 import {AppState} from "../../../state/reducers";
 import {validateEmailPreferences} from "../../../services/validation";
-import {SITE_SUBJECT_TITLE, SITE_SUBJECT, SITE} from "../../../services/siteConstants";
+import {siteSpecific, SITE_SUBJECT_TITLE} from "../../../services/siteConstants";
 
 interface UserEmailPreferencesProps {
     emailPreferences: UserEmailPreferences;
@@ -17,18 +17,18 @@ export const UserEmailPreference = ({emailPreferences, setEmailPreferences, subm
     const error = useSelector((state: AppState) => state && state.error);
     const defaultEmailPreferences = {ASSIGNMENTS: true};
     const isaacEmailPreferences = {
-        assignments: {
-            [SITE.CS]: "If you're a student, set this to 'Yes' to receive assignment notifications from your teacher.",
-            [SITE.PHY]: "Get notified when your teacher gives your group a new assignment."
-        },
-        news: {
-            [SITE.CS]: "Be the first to know about new topics, new platform features, and our fantastic competition giveaways.",
-            [SITE.PHY]: "New content and website feature updates, as well as interesting news about Isaac."
-        },
-        events: {
-            [SITE.CS]: "Get valuable updates on our free student workshops/teacher CPD events happening near you.",
-            [SITE.PHY]: "Information about new virtual or real world physics events."
-        }
+        assignments: siteSpecific(
+            "Get notified when your teacher gives your group a new assignment.",
+            "If you're a student, set this to 'Yes' to receive assignment notifications from your teacher."
+        ),
+        news: siteSpecific(
+            "New content and website feature updates, as well as interesting news about Isaac.",
+            "Be the first to know about new topics, new platform features, and our fantastic competition giveaways."
+        ),
+        events: siteSpecific(
+            "Information about new virtual or real world physics events.",
+            "Get valuable updates on our free student workshops/teacher CPD events happening near you."
+        )
     };
 
     // initially set email preferences to default value
@@ -60,7 +60,7 @@ export const UserEmailPreference = ({emailPreferences, setEmailPreferences, subm
                     <tr>
                         <td className="form-required">Assignments</td>
                         <td className="d-none d-sm-table-cell">
-                            {isaacEmailPreferences.assignments[SITE_SUBJECT]}
+                            {isaacEmailPreferences.assignments}
                         </td>
                         <td className="text-center">
                             <TrueFalseRadioInput
@@ -73,7 +73,7 @@ export const UserEmailPreference = ({emailPreferences, setEmailPreferences, subm
                     <tr>
                         <td className="form-required">News</td>
                         <td className="d-none d-sm-table-cell">
-                            {isaacEmailPreferences.news[SITE_SUBJECT]}
+                            {isaacEmailPreferences.news}
                         </td>
                         <td className="text-center">
                             <TrueFalseRadioInput
@@ -86,7 +86,7 @@ export const UserEmailPreference = ({emailPreferences, setEmailPreferences, subm
                     <tr>
                         <td className="form-required">Events</td>
                         <td className="d-none d-sm-table-cell">
-                            {isaacEmailPreferences.events[SITE_SUBJECT]}
+                            {isaacEmailPreferences.events}
                         </td>
                         <td className="text-center">
                             <TrueFalseRadioInput

--- a/src/app/components/elements/quiz/QuizAttemptComponent.tsx
+++ b/src/app/components/elements/quiz/QuizAttemptComponent.tsx
@@ -19,7 +19,7 @@ import {Col, Row} from "reactstrap";
 import {TitleAndBreadcrumb} from "../TitleAndBreadcrumb";
 import {showQuizSettingModal} from "../../../state/actions/quizzes";
 import {useDispatch} from "react-redux";
-import {SITE, SITE_SUBJECT} from "../../../services/siteConstants";
+import {siteSpecific} from "../../../services/siteConstants";
 import {below, useDeviceSize} from "../../../services/device";
 import {IsaacContentValueOrChildren} from "../../content/IsaacContentValueOrChildren";
 import {closeActiveModal, openActiveModal} from "../../../state/actions";
@@ -152,7 +152,7 @@ function QuizSection({attempt, page}: { attempt: QuizAttemptDTO, page: number })
 
     return section ?
         <Row className="question-content-container">
-            <Col md={{[SITE.CS]: {size: 8, offset: 2}, [SITE.PHY]: {size: 12}}[SITE_SUBJECT]} className="py-4 question-panel">
+            <Col md={siteSpecific({size: 12}, {size: 8, offset: 2})} className="py-4 question-panel">
                 <UserContextPicker className="no-print text-right"/>
                 <Row>
                     {rubric && renderRubric && <Col className="text-right">

--- a/src/app/components/elements/quiz/QuizProgressCommon.tsx
+++ b/src/app/components/elements/quiz/QuizProgressCommon.tsx
@@ -4,23 +4,23 @@ import { Button } from "reactstrap";
 import { IsaacQuizSectionDTO, Mark, QuizAssignmentDTO, QuizUserFeedbackDTO } from "../../../../IsaacApiTypes";
 import { PageSettings } from "../../../../IsaacAppTypes";
 import { isQuestion } from "../../../services/questions";
-import { SITE, SITE_SUBJECT } from "../../../services/siteConstants";
 import { closeActiveModal, openActiveModal } from "../../../state/actions";
 import { returnQuizToStudent } from "../../../state/actions/quizzes";
 import { IsaacSpinner } from "../../handlers/IsaacSpinner";
+import {siteSpecific} from "../../../services/siteConstants";
 
-export const ICON = {
-    [SITE.CS]: {
-        correct: <img src="/assets/tick-rp.svg" alt="Correct" style={{width: 30}} />,
-        incorrect: <img src="/assets/cross-rp.svg" alt="Incorrect" style={{width: 30}} />,
-        notAttempted: <img src="/assets/dash.svg" alt="Not attempted" style={{width: 30}} />,
-    },
-    [SITE.PHY]: {
+export const ICON = siteSpecific(
+    {
         correct: <svg style={{width: 30, height: 30}}><use href={`/assets/tick-rp-hex.svg#icon`} xlinkHref={`/assets/tick-rp-hex.svg#icon`}/></svg>,
         incorrect: <svg style={{width: 30, height: 30}}><use href={`/assets/cross-rp-hex.svg#icon`} xlinkHref={`/assets/cross-rp-hex.svg#icon`}/></svg>,
         notAttempted: <svg  style={{width: 30, height: 30}}><use href={`/assets/dash-hex.svg#icon`} xlinkHref={`/assets/dash-hex.svg#icon`}/></svg>,
+    },
+    {
+        correct: <img src="/assets/tick-rp.svg" alt="Correct" style={{width: 30}} />,
+        incorrect: <img src="/assets/cross-rp.svg" alt="Incorrect" style={{width: 30}} />,
+        notAttempted: <img src="/assets/dash.svg" alt="Not attempted" style={{width: 30}} />,
     }
-}[SITE_SUBJECT];
+);
 
 interface ResultsTableProps {
     assignment: QuizAssignmentDTO;

--- a/src/app/components/elements/views/QuestionProgressCharts.tsx
+++ b/src/app/components/elements/views/QuestionProgressCharts.tsx
@@ -5,7 +5,7 @@ import {bb, Chart} from "billboard.js";
 import tags from "../../../services/tags";
 import Select, { SingleValue } from "react-select";
 import {difficultiesOrdered, difficultyLabelMap, doughnutColours, specificDoughnutColours, STAGE, stageLabelMap, TAG_ID} from "../../../services/constants";
-import {SITE, SITE_SUBJECT} from "../../../services/siteConstants";
+import {isCS, isPhy, siteSpecific} from "../../../services/siteConstants";
 import {getFilteredStageOptions} from "../../../services/userContext";
 import {Difficulty} from "../../../../IsaacApiTypes";
 import {comparatorFromOrderedValues} from "../../../services/gameboards";
@@ -60,7 +60,7 @@ export const QuestionProgressCharts = (props: QuestionProgressChartsProps) => {
 
     useEffect(() => {
         const charts: Chart[] = [];
-        if (SITE_SUBJECT === SITE.PHY && !isAllZero(categoryColumns)) {
+        if (isPhy && !isAllZero(categoryColumns)) {
             charts.push(bb.generate({
                 data: {
                     columns: categoryColumns,
@@ -91,7 +91,7 @@ export const QuestionProgressCharts = (props: QuestionProgressChartsProps) => {
             ...OPTIONS
         }));
 
-        if (SITE_SUBJECT === SITE.PHY) {
+        if (isPhy) {
             charts.push(bb.generate({
                 data: {
                     columns: difficultyColumns,
@@ -125,10 +125,10 @@ export const QuestionProgressCharts = (props: QuestionProgressChartsProps) => {
         }
     }, [questionsByTag, questionsByLevel, categoryColumns, topicColumns, difficultyColumns]);
 
-    const noCharts = {[SITE.CS]: 2, [SITE.PHY]: 3}[SITE_SUBJECT];
+    const noCharts = siteSpecific(3, 2);
 
     return <RS.Row>
-        {SITE_SUBJECT === SITE.PHY && <RS.Col xl={12/noCharts} md={12/noCharts} className="mt-4 d-flex flex-column">
+        {isPhy && <RS.Col xl={12/noCharts} md={12/noCharts} className="mt-4 d-flex flex-column">
             <div className="height-40px text-flex-align mb-2">
                 Questions by {topTagLevel}
             </div>
@@ -138,7 +138,7 @@ export const QuestionProgressCharts = (props: QuestionProgressChartsProps) => {
                 </div>
             </div>
         </RS.Col>}
-        {SITE_SUBJECT === SITE.CS && <RS.Col md={3}/>}
+        {isCS && <RS.Col md={3}/>}
         <RS.Col xl={12/noCharts} md={4} className="mt-4 d-flex flex-column">
             <div className="height-40px text-flex-align mb-2">
                 <Select
@@ -158,8 +158,8 @@ export const QuestionProgressCharts = (props: QuestionProgressChartsProps) => {
                 </div>
             </div>
         </RS.Col>
-        {SITE_SUBJECT === SITE.CS && <RS.Col md={3}/>}
-        {SITE_SUBJECT === SITE.PHY && <RS.Col xl={12/noCharts} md={12/noCharts} className="mt-4 d-flex flex-column">
+        {isCS && <RS.Col md={3}/>}
+        {isPhy && <RS.Col xl={12/noCharts} md={12/noCharts} className="mt-4 d-flex flex-column">
             <div className="height-40px text-flex-align mb-2">
                 <Select
                     inputId={`${subId}-stage-select`}

--- a/src/app/components/handlers/IsaacSpinner.tsx
+++ b/src/app/components/handlers/IsaacSpinner.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
+import {isCS, isPhy} from "../../services/siteConstants";
 import classNames from "classnames";
 
 export interface IsaacSpinnerProps {
@@ -11,7 +11,7 @@ export interface IsaacSpinnerProps {
 // TODO: investigate and improve accessibility of both CS and default spinners. (The "Loading..." is copied from Bootstrap).
 export const IsaacSpinner = ({size = "md", className, color = "primary"} : IsaacSpinnerProps) => {
     return <div role="status" className="pb-1">
-        <img style={SITE_SUBJECT === SITE.PHY ? {width: "auto", height: "5.5rem"} : {}} className={classNames(`isaac-spinner-${size}`, className)} alt="" src={SITE_SUBJECT === SITE.CS ? "/assets/isaac-cs-typer-css.svg" : "/assets/isaac-phy-apple-grow.svg"}/>
+        <img style={isPhy ? {width: "auto", height: "5.5rem"} : {}} className={classNames(`isaac-spinner-${size}`, className)} alt="" src={isCS ? "/assets/isaac-cs-typer-css.svg" : "/assets/isaac-phy-apple-grow.svg"}/>
         <span className="sr-only">Loading...</span>
     </div>
 };

--- a/src/app/components/navigation/DowntimeWarningBanner.tsx
+++ b/src/app/components/navigation/DowntimeWarningBanner.tsx
@@ -2,7 +2,8 @@ import React, {useState} from 'react';
 import * as RS from 'reactstrap';
 import {Alert} from 'reactstrap';
 import Cookies from 'js-cookie';
-import {SITE, SITE_SUBJECT, SITE_SUBJECT_TITLE} from "../../services/siteConstants";
+import {SITE_SUBJECT_TITLE} from "../../services/siteConstants";
+import {SOCIAL_LINKS} from "../../services/constants";
 
 const DOWNTIME_COOKIE = "downtimeBannerDismissed";
 
@@ -11,11 +12,6 @@ export const DowntimeWarningBanner = () => {
         const currentCookieValue = Cookies.get(DOWNTIME_COOKIE);
         return currentCookieValue != "1";
     });
-
-    const twitterLink = {
-        [SITE.CS]: "https://twitter.com/isaaccompsci",
-        [SITE.PHY]: "https://twitter.com/isaacphysics"
-    }[SITE_SUBJECT];
 
     function clickDismiss() {
         setCookie(false);
@@ -32,7 +28,7 @@ export const DowntimeWarningBanner = () => {
                         <span>Please note Isaac {SITE_SUBJECT_TITLE} will be unavailable for an hour at 5pm BST on Friday 23<sup>rd</sup> July
                             for essential maintenance. You will need to log in again once the maintenance is complete.
                             <br />
-                            <a href={twitterLink} target="_blank" rel="noopener noreferrer">Check our Twitter feed</a> for any updates on the day.
+                            <a href={SOCIAL_LINKS.twitter.href} target="_blank" rel="noopener noreferrer">Check our Twitter feed</a> for any updates on the day.
                         </span>
                     </RS.Col>
                     <RS.Col xs={12} md={3} className="text-center">

--- a/src/app/components/navigation/Footer.tsx
+++ b/src/app/components/navigation/Footer.tsx
@@ -4,7 +4,7 @@ import {ListGroupFooter} from "../elements/list-groups/ListGroupFooter";
 import {ListGroupSocial} from "../elements/list-groups/ListGroupSocial";
 import {ListGroupFooterBottom} from "../elements/list-groups/ListGroupFooterBottom";
 import {Link} from "react-router-dom";
-import {SITE_SUBJECT, SITE} from "../../services/siteConstants";
+import {siteSpecific} from "../../services/siteConstants";
 
 const ExternalLink = ({href, children}: {href: string; children: any}) => (
     // eslint-disable-next-line react/jsx-no-target-blank
@@ -18,7 +18,32 @@ export const Footer = () => (
         <div className="footerTop d-print-none">
             <Container>
                 <Row className="px-3 px-sm-0 pb-3 pb-md-4">
-                    {SITE_SUBJECT === SITE.CS ?
+                    {siteSpecific(
+                        // Physics
+                        <Col md="4" lg="3" className="logo-col">
+                            <div className="d-flex flex-row">
+                                <Link to="/">
+                                    <img
+                                        src="/assets/phy/logo-small.svg"
+                                        className="footerLogo"
+                                        alt="Isaac Physics homepage"
+                                    />
+                                </Link>
+                            </div>
+                            <div className="footer-links logo-text pt-3">
+                                A&nbsp;<ExternalLink href="https://www.gov.uk/government/organisations/department-for-education">
+                                <strong>Department for Education</strong>
+                            </ExternalLink> project at the {' '}
+                                <ExternalLink href="https://www.cam.ac.uk">
+                                    <strong>University&nbsp;of&nbsp;Cambridge</strong>
+                                </ExternalLink>,
+                                <br />supported by {' '}
+                                <ExternalLink href="https://www.ogdentrust.com/">
+                                    <strong>The&nbsp;Ogden&nbsp;Trust</strong>
+                                </ExternalLink>.
+                            </div>
+                        </Col>,
+                        // Computer science
                         <Col md='4' lg='3' className="pt-5 logo-col">
                             <div className="d-flex flex-row">
                                 <Link to="/">
@@ -38,31 +63,7 @@ export const Footer = () => (
                                 </p>
                             </div>
                         </Col>
-                        :
-                        <Col md="4" lg="3" className="logo-col">
-                            <div className="d-flex flex-row">
-                                <Link to="/">
-                                    <img
-                                        src="/assets/phy/logo-small.svg"
-                                        className="footerLogo"
-                                        alt="Isaac Physics homepage"
-                                    />
-                                </Link>
-                            </div>
-                            <div className="footer-links logo-text pt-3">
-                                A&nbsp;<ExternalLink href="https://www.gov.uk/government/organisations/department-for-education">
-                                    <strong>Department for Education</strong>
-                                </ExternalLink> project at the {' '}
-                                <ExternalLink href="https://www.cam.ac.uk">
-                                    <strong>University&nbsp;of&nbsp;Cambridge</strong>
-                                </ExternalLink>,
-                                <br />supported by {' '}
-                                <ExternalLink href="https://www.ogdentrust.com/">
-                                    <strong>The&nbsp;Ogden&nbsp;Trust</strong>
-                                </ExternalLink>.
-                            </div>
-                        </Col>
-                    }
+                    )}
                     <Col
                         md={{size: 7, offset: 1}}
                         lg={{size: 5, offset: 1}}

--- a/src/app/components/navigation/IsaacApp.tsx
+++ b/src/app/components/navigation/IsaacApp.tsx
@@ -55,7 +55,7 @@ import {EventManager} from "../pages/EventManager";
 import {MyGameboards} from "../pages/MyGameboards";
 import {FreeTextBuilder} from "../pages/FreeTextBuilder";
 import {MarkdownBuilder} from "../pages/MarkdownBuilder";
-import SiteSpecific from "../site/siteSpecific";
+import SiteSpecific from "../site/siteSpecificComponents";
 import StaticPageRoute from "./StaticPageRoute";
 import {Redirect} from "react-router";
 import {UnsupportedBrowserBanner} from "./UnsupportedBrowserWarningBanner";

--- a/src/app/components/navigation/NavigationBar.tsx
+++ b/src/app/components/navigation/NavigationBar.tsx
@@ -18,7 +18,7 @@ import {
 import {loadMyAssignments} from "../../state/actions";
 import {filterAssignmentsByStatus} from "../../services/assignments";
 import {selectors} from "../../state/selectors";
-import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
+import {isCS} from "../../services/siteConstants";
 import {loadQuizAssignedToMe} from "../../state/actions/quizzes";
 import {partitionCompleteAndIncompleteQuizzes} from "../../services/quiz";
 import {isFound} from "../../services/miscUtils";
@@ -101,7 +101,7 @@ export const NavigationBar = ({children}: {children: React.ReactNode}) => {
                 Menu
             </NavbarToggler>
 
-            <Collapse isOpen={menuOpen} navbar className={`px-0 mx-0 mx-xl-5 ${SITE_SUBJECT === SITE.CS ? "px-xl-5" : ""}`}>
+            <Collapse isOpen={menuOpen} navbar className={`px-0 mx-0 mx-xl-5 ${isCS ? "px-xl-5" : ""}`}>
                 <Nav navbar className="justify-content-between" id="main-menu">
                     {children}
                 </Nav>

--- a/src/app/components/navigation/TrackedRoute.tsx
+++ b/src/app/components/navigation/TrackedRoute.tsx
@@ -10,7 +10,7 @@ import {Unauthorised} from "../pages/Unauthorised";
 import {isTeacher} from "../../services/user";
 import {selectors} from "../../state/selectors";
 import {GOOGLE_ANALYTICS_ACCOUNT_ID} from "../../services/constants";
-import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
+import {isPhy} from "../../services/siteConstants";
 
 ReactGA.initialize(GOOGLE_ANALYTICS_ACCOUNT_ID);
 ReactGA.set({ anonymizeIp: true });
@@ -53,7 +53,7 @@ export const TrackedRoute = function({component, trackingOptions, componentProps
                             persistence.save(KEY.AFTER_AUTH_PATH, props.location.pathname + props.location.search) && <Redirect to="/login"/>
                             :
                             user && !isTeacher(user) && rest.ifUser && rest.ifUser.name === isTeacher.name ? // TODO we should try to find a more robust way than this
-                                SITE_SUBJECT === SITE.PHY ? <Redirect to="/pages/contact_us_teacher"/> : <Redirect to="/pages/teacher_accounts"/>
+                                isPhy ? <Redirect to="/pages/contact_us_teacher"/> : <Redirect to="/pages/teacher_accounts"/>
                                 :
                                 user && user.loggedIn && !ifUser(user) ?
                                     <Unauthorised/>

--- a/src/app/components/navigation/WarningBanner.tsx
+++ b/src/app/components/navigation/WarningBanner.tsx
@@ -2,7 +2,6 @@ import React, {useState} from 'react';
 import * as RS from 'reactstrap';
 import {Alert} from 'reactstrap';
 import Cookies from 'js-cookie';
-import {SITE, SITE_SUBJECT, SITE_SUBJECT_TITLE} from "../../services/siteConstants";
 
 const WARNING_COOKIE = "warningBannerDismissed";
 
@@ -11,11 +10,6 @@ export const WarningBanner = () => {
         const currentCookieValue = Cookies.get(WARNING_COOKIE);
         return currentCookieValue !== "1";
     });
-
-    const twitterLink = {
-        [SITE.CS]: "https://twitter.com/isaaccompsci",
-        [SITE.PHY]: "https://twitter.com/isaacphysics"
-    }[SITE_SUBJECT];
 
     function clickDismiss() {
         setCookie(false);

--- a/src/app/components/pages/AllTopics.tsx
+++ b/src/app/components/pages/AllTopics.tsx
@@ -13,7 +13,7 @@ import * as persistence from "../../services/localStorage";
 import {useQueryParams} from "../../services/reactRouterExtension";
 import {useUserContext} from "../../services/userContext";
 import {RenderNothing} from "../elements/RenderNothing";
-import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
+import {isCS} from "../../services/siteConstants";
 import {MetaDescription} from "../elements/MetaDescription";
 
 export function AllTopicsWithoutAStage() {
@@ -131,7 +131,7 @@ export const AllTopics = ({stage}: {stage: STAGE.A_LEVEL | STAGE.GCSE}) => {
     return <div className="pattern-02">
         <Container>
             <TitleAndBreadcrumb currentPageTitle={stage === STAGE.A_LEVEL ? "A level topics" : "GCSE topics"}/>
-            {SITE_SUBJECT === SITE.CS && <MetaDescription description={metaDescriptionMap[stage]} />}
+            {isCS && <MetaDescription description={metaDescriptionMap[stage]} />}
 
             <Tabs className="pt-3" tabContentClass="pt-3" activeTabOverride={activeTab} refreshHash={stage} onActiveTabChange={setActiveTab}>
                 {

--- a/src/app/components/pages/AssignmentProgress.tsx
+++ b/src/app/components/pages/AssignmentProgress.tsx
@@ -36,7 +36,7 @@ import {Link} from "react-router-dom";
 import {API_PATH, MARKBOOK_TYPE_TAB} from "../../services/constants";
 import {downloadLinkModal} from "../elements/modals/AssignmentProgressModalCreators";
 import {formatDate} from "../elements/DateString";
-import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
+import {siteSpecific} from "../../services/siteConstants";
 import {getAssignmentCSVDownloadLink, hasGameboard} from "../../services/assignments";
 import {getQuizAssignmentCSVDownloadLink} from "../../services/quiz";
 import {usePageSettings} from "../../services/progress";
@@ -416,7 +416,7 @@ const AssignmentDetails = (props: AssignmentDetailsProps) => {
     const dispatch = useDispatch();
     const [isExpanded, setIsExpanded] = useState(false);
 
-    const assignmentPath = SITE_SUBJECT == SITE.PHY ? "assignment_progress" : "my_markbook";
+    const assignmentPath = siteSpecific("assignment_progress", "my_markbook");
 
     function openAssignmentDownloadLink(event: React.MouseEvent<HTMLButtonElement & HTMLAnchorElement>) {
         event.stopPropagation();
@@ -690,7 +690,7 @@ export function AssignmentProgress(props: AssignmentProgressPageProps) {
     return <>
         <Container>
             <TitleAndBreadcrumb
-                currentPageTitle={{[SITE.PHY]: "Assignment Progress", [SITE.CS]: "My markbook"}[SITE_SUBJECT]}
+                currentPageTitle={siteSpecific("Assignment Progress", "My markbook")}
                 subTitle="Track your group performance by question"
                 help={pageHelp}
                 modalId="assignment_progress_help"

--- a/src/app/components/pages/Concept.tsx
+++ b/src/app/components/pages/Concept.tsx
@@ -19,7 +19,7 @@ import {EditContentButton} from "../elements/EditContentButton";
 import {ShareLink} from "../elements/ShareLink";
 import {PrintButton} from "../elements/PrintButton";
 import {Markup} from "../elements/markup";
-import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
+import {isCS, isPhy, siteSpecific} from "../../services/siteConstants";
 import {IntendedAudienceWarningBanner} from "../navigation/IntendedAudienceWarningBanner";
 import {SupersededDeprecatedWarningBanner} from "../navigation/SupersededDeprecatedWarningBanner";
 import {CanonicalHrefElement} from "../navigation/CanonicalHrefElement";
@@ -63,7 +63,7 @@ export const Concept = withRouter(({match: {params}, location: {search}, concept
                 </div>
 
                 <Row className="concept-content-container">
-                    <Col md={{[SITE.CS]: {size: 8, offset: 2}, [SITE.PHY]: {size: 12}}[SITE_SUBJECT]} className="py-4">
+                    <Col md={siteSpecific({size: 12}, {size: 8, offset: 2})} className="py-4">
 
                         <SupersededDeprecatedWarningBanner doc={doc} />
 
@@ -79,11 +79,11 @@ export const Concept = withRouter(({match: {params}, location: {search}, concept
                             </Markup>
                         </p>}
 
-                        {SITE_SUBJECT === SITE.CS && doc.relatedContent && <RelatedContent conceptId={conceptId} content={doc.relatedContent} parentPage={doc} />}
+                        {isCS && doc.relatedContent && <RelatedContent conceptId={conceptId} content={doc.relatedContent} parentPage={doc} />}
 
                         <NavigationLinks navigation={navigation} />
 
-                        {SITE_SUBJECT === SITE.PHY && doc.relatedContent && <RelatedContent conceptId={conceptId} content={doc.relatedContent} parentPage={doc} />}
+                        {isPhy && doc.relatedContent && <RelatedContent conceptId={conceptId} content={doc.relatedContent} parentPage={doc} />}
                     </Col>
                 </Row>
             </Container>

--- a/src/app/components/pages/Contact.tsx
+++ b/src/app/components/pages/Contact.tsx
@@ -20,10 +20,11 @@ import {PotentialUser} from "../../../IsaacAppTypes";
 import {validateEmail} from "../../services/validation";
 import queryString from "query-string";
 import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
-import {SITE, SITE_SUBJECT, SITE_SUBJECT_TITLE, WEBMASTER_EMAIL} from "../../services/siteConstants";
+import {isCS, isPhy, SITE_SUBJECT_TITLE, WEBMASTER_EMAIL} from "../../services/siteConstants";
 import {PageFragment} from "../elements/PageFragment";
 import {selectors} from "../../state/selectors";
 import {MetaDescription} from "../elements/MetaDescription";
+import {SOCIAL_LINKS} from "../../services/constants";
 
 const determineUrlQueryPresets = (user?: PotentialUser | null) => {
     const urlQuery = queryString.parse(location.search);
@@ -41,19 +42,6 @@ const determineUrlQueryPresets = (user?: PotentialUser | null) => {
         urlQuery.message as string || presetMessage
     ];
 };
-
-const siteSpecific = {
-    [SITE.PHY]: {social: {
-        twitter: "https://twitter.com/isaacphysics",
-        facebook: "https://www.facebook.com/isaacphysicsUK",
-        youtube: "https://www.youtube.com/user/isaacphysics/",
-    }},
-    [SITE.CS]: {social: {
-        twitter: "https://twitter.com/IsaacCompSci",
-        facebook: "https://www.facebook.com/IsaacComputerScience/",
-        youtube: "https://www.youtube.com/channel/UC-qoIYj8kgR8RZtQphrRBYQ",
-    }}
-}[SITE_SUBJECT];
 
 export const Contact = () => {
     const dispatch = useDispatch();
@@ -91,11 +79,11 @@ export const Contact = () => {
 
     return <Container id="contact-page" className="pb-5">
         <TitleAndBreadcrumb currentPageTitle="Contact us" />
-        {SITE_SUBJECT === SITE.CS && <MetaDescription description={metaDescriptionCS}/>}
+        {isCS && <MetaDescription description={metaDescriptionCS}/>}
         <div className="pt-4">
             <Row>
                 <Col size={12} md={{size: 3, order: 1}} xs={{order: 2}} className="mt-4 mt-md-0">
-                    {SITE_SUBJECT === SITE.PHY && <div>
+                    {isPhy && <div>
                         <h3>Frequently Asked Question?</h3>
                         <p> You might like to check our FAQs pages to see if they can help you: <a href="/support/student">student FAQs</a> | <a href="/support/teacher">teacher FAQs</a></p>
                     </div>
@@ -104,17 +92,14 @@ export const Contact = () => {
                     <p>If you&apos;d like to find out more about our upcoming events, visit our <a href="/events">Events Page</a></p>
                     <h3>Problems with the site?</h3>
                     <p>We always want to improve so please report any issues to <a className="small" href={`mailto:${WEBMASTER_EMAIL}`}>{WEBMASTER_EMAIL}</a></p>
-                    {SITE_SUBJECT === SITE.PHY && <div>
+                    {isPhy && <div>
                         <h3>Call us</h3>
                         <p>Give us a call on <a href="tel:+441223337066">01223 337066</a></p>
                     </div>
                     }
                     <h3>Follow us</h3>
                     <p>Follow us on:</p>
-                    <a href={siteSpecific.social.youtube}>YouTube</a><br/>
-                    <a href={siteSpecific.social.twitter}>Twitter</a><br/>
-                    <a href={siteSpecific.social.facebook}>Facebook</a><br/>
-                    {(SITE_SUBJECT === SITE.CS) && <a href="https://www.instagram.com/isaaccompsci/">Instagram</a>}
+                    {Object.entries(SOCIAL_LINKS).map(([_, {name, href}], i) => <>{i > 0 && <br/>}<a href={href}>{name}</a></>)}
                 </Col>
                 <Col size={12} md={{size: 9, order: 2}} xs={{order: 1}}>
                     <Card>

--- a/src/app/components/pages/ContentEmails.tsx
+++ b/src/app/components/pages/ContentEmails.tsx
@@ -6,7 +6,7 @@ import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
 import classnames from "classnames";
 import {debounce} from 'lodash';
 import {convert} from 'html-to-text';
-import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
+import {isPhy} from "../../services/siteConstants";
 import {EmailTemplateDTO} from "../../../IsaacApiTypes";
 
 interface ContentEmailsProps {
@@ -47,7 +47,7 @@ const ContentEmails = (props: ContentEmailsProps) => {
         })
     }, [emailSubject, plaintextTemplate, htmlTemplate, overrideEnvelopeFrom]);
 
-    const mailgunAddress = SITE_SUBJECT === SITE.PHY ? "no-reply@mail.isaacphysics.org" : "no-reply@mail.isaaccomputerscience.org";
+    const mailgunAddress = isPhy ? "no-reply@mail.isaacphysics.org" : "no-reply@mail.isaaccomputerscience.org";
 
     return <RS.Container id="admin-emails-page">
         <TitleAndBreadcrumb currentPageTitle="Content email sending" />

--- a/src/app/components/pages/Equality.tsx
+++ b/src/app/components/pages/Equality.tsx
@@ -6,7 +6,7 @@ import {ifKeyIsEnter} from "../../services/navigation";
 import katex from "katex";
 import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
 import {RouteComponentProps} from "react-router";
-import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
+import {siteSpecific} from "../../services/siteConstants";
 import { Inequality, makeInequality } from 'inequality';
 import { sanitiseInequalityState } from '../../services/questions';
 import { parseMathsExpression, parseBooleanExpression, ParsingError } from 'inequality-grammar';
@@ -28,7 +28,7 @@ const Equality = withRouter(({location}: RouteComponentProps<{}, {}, {board?: st
     const [errors, setErrors] = useState<string[]>();
     const user = useSelector(selectors.user.orNull);
     // Does this really need to be a state variable if it is immutable?
-    const [editorMode, setEditorMode] = useState(queryParams.mode || { [SITE.PHY]: 'maths', [SITE.CS]: 'logic' }[SITE_SUBJECT]);
+    const [editorMode, setEditorMode] = useState(queryParams.mode || siteSpecific('maths', 'logic'));
 
     /*** Text based input stuff */
     const hiddenEditorRef = useRef<HTMLDivElement | null>(null);

--- a/src/app/components/pages/Events.tsx
+++ b/src/app/components/pages/Events.tsx
@@ -14,7 +14,7 @@ import {selectors} from "../../state/selectors";
 import {isTeacher} from "../../services/user";
 import {RenderNothing} from "../elements/RenderNothing";
 import {CoronavirusWarningBanner} from "../navigation/CoronavirusWarningBanner";
-import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
+import {isCS} from "../../services/siteConstants";
 import {MetaDescription} from "../elements/MetaDescription";
 import {stageExistsForSite} from "../../services/events";
 
@@ -62,7 +62,7 @@ export const Events = withRouter(({history, location}: RouteComponentProps) => {
     return <div>
         <RS.Container>
             <TitleAndBreadcrumb currentPageTitle={"Events"} help={pageHelp} />
-            {SITE_SUBJECT === SITE.CS && <>
+            {isCS && <>
                 <CoronavirusWarningBanner />
                 <MetaDescription description={metaDescriptionCS} />
             </>}

--- a/src/app/components/pages/GameboardBuilder.tsx
+++ b/src/app/components/pages/GameboardBuilder.tsx
@@ -29,7 +29,7 @@ import Select from "react-select";
 import {withRouter} from "react-router-dom";
 import queryString from "query-string";
 import {ShowLoading} from "../handlers/ShowLoading";
-import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
+import {isCS, siteSpecific} from "../../services/siteConstants";
 import {selectors} from "../../state/selectors";
 import intersection from "lodash/intersection";
 import {ContentSummary} from "../../../IsaacAppTypes";
@@ -37,7 +37,6 @@ import {IsaacSpinner} from "../handlers/IsaacSpinner";
 import {useUserContext} from "../../services/userContext";
 import {EXAM_BOARD, STAGE} from "../../services/constants";
 import {selectOnChange} from "../../services/select";
-import {siteSpecific} from "../../services/miscUtils";
 import {isFound} from "../../services/miscUtils";
 const GameboardBuilderRow = lazy(() => import("../elements/GameboardBuilderRow"));
 
@@ -128,7 +127,7 @@ const GameboardBuilder = withRouter((props: {location: {search?: string}}) => {
                         <RS.Label htmlFor="gameboard-builder-name">Gameboard title:</RS.Label>
                         <RS.Input id="gameboard-builder-name"
                             type="text"
-                            placeholder={{[SITE.CS]: "e.g. Year 12 Network components", [SITE.PHY]: "e.g. Year 12 Dynamics"}[SITE_SUBJECT]}
+                            placeholder={siteSpecific("e.g. Year 12 Dynamics", "e.g. Year 12 Network components")}
                             defaultValue={gameboardTitle}
                             onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                                 setGameboardTitle(e.target.value);
@@ -186,7 +185,7 @@ const GameboardBuilder = withRouter((props: {location: {search?: string}}) => {
                                     <th className="w-25">Topic</th>
                                     <th className="w-15">Stage</th>
                                     <th className={siteSpecific("w-15","w-10")}>Difficulty</th>
-                                    {SITE_SUBJECT === SITE.CS && <th className="w-5">Exam boards</th>}
+                                    {isCS && <th className="w-5">Exam boards</th>}
                                 </tr>
                             </thead>
                             <Droppable droppableId="droppable">
@@ -233,7 +232,7 @@ const GameboardBuilder = withRouter((props: {location: {search?: string}}) => {
                                                                     }))
                                                                 }}
                                                             >
-                                                                {{[SITE.CS]: "Add questions", [SITE.PHY]: "Add Questions"}[SITE_SUBJECT]}
+                                                                {siteSpecific("Add Questions", "Add questions")}
                                                             </RS.Button>
                                                         </ShowLoading>
                                                     </div>
@@ -259,7 +258,7 @@ const GameboardBuilder = withRouter((props: {location: {search?: string}}) => {
 
                             let subjects = [];
 
-                            if (SITE_SUBJECT == SITE.CS) {
+                            if (isCS) {
                                 subjects.push("computer_science");
                             } else {
                                 const definedSubjects = ["physics", "maths", "chemistry"];
@@ -297,7 +296,7 @@ const GameboardBuilder = withRouter((props: {location: {search?: string}}) => {
                             dispatch(logAction({type: "SAVE_GAMEBOARD", events: eventLog}));
                         }}
                     >
-                        {{[SITE.CS]: "Save gameboard", [SITE.PHY]: "Save Gameboard"}[SITE_SUBJECT]}
+                        {siteSpecific("Save Gameboard", "Save gameboard")}
                     </RS.Button>
                 </div>
 

--- a/src/app/components/pages/GameboardFilter.tsx
+++ b/src/app/components/pages/GameboardFilter.tsx
@@ -25,7 +25,7 @@ import {useDeviceSize} from "../../services/device";
 import Select, {GroupBase} from "react-select";
 import {getFilteredExamBoardOptions, getFilteredStageOptions, useUserContext} from "../../services/userContext";
 import {DifficultyFilter} from "../elements/svg/DifficultyFilter";
-import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
+import {isCS, isPhy, siteSpecific} from "../../services/siteConstants";
 import {groupTagSelectionsByParent} from "../../services/gameboardBuilder";
 import {AppState} from "../../state/reducers";
 import {ContentSummaryDTO} from "../../../IsaacApiTypes";
@@ -33,7 +33,7 @@ import {debounce} from "lodash";
 import {History} from "history";
 import {Dispatch} from "redux";
 import {IsaacSpinner} from "../handlers/IsaacSpinner";
-import {isCS, isDefined, isPhy, siteSpecific} from "../../services/miscUtils";
+import {isDefined} from "../../services/miscUtils";
 import {CanonicalHrefElement} from "../navigation/CanonicalHrefElement";
 import {MetaDescription} from "../elements/MetaDescription";
 
@@ -362,7 +362,7 @@ export const GameboardFilter = withRouter(({location}: RouteComponentProps) => {
 
     const choices = [tags.allSubjectTags.map(itemiseTag)];
     let i;
-    if (SITE_SUBJECT === SITE.PHY) {
+    if (isPhy) {
         for (i = 0; i < selections.length && i < 2; i++) {
             const selection = selections[i];
             if (selection.length !== 1) break;
@@ -416,7 +416,7 @@ export const GameboardFilter = withRouter(({location}: RouteComponentProps) => {
     // Title changing states and logic
     const [customBoardTitle, setCustomBoardTitle] = useState<string>();
     const [pendingCustomBoardTitle, setPendingCustomBoardTitle] = useState<string>();
-    const defaultBoardTitle = SITE_SUBJECT === SITE.PHY ? generatePhyBoardName(selections) : generateCSBoardName(selections);
+    const defaultBoardTitle = isPhy ? generatePhyBoardName(selections) : generateCSBoardName(selections);
     const [isEditingTitle, setIsEditingTitle] = useState<boolean>(false);
 
     function loadNewGameboard(stages: Item<string>[], difficulties: Item<string>[], concepts: Item<string>[],
@@ -427,8 +427,8 @@ export const GameboardFilter = withRouter(({location}: RouteComponentProps) => {
         if (stages.length) params.stages = toCSV(stages);
         if (difficulties.length) params.difficulties = toCSV(difficulties);
         if (concepts.length) params.concepts = toCSV(concepts);
-        if (SITE_SUBJECT === SITE.CS && examBoards.length) params.examBoards = toCSV(examBoards);
-        if (SITE_SUBJECT === SITE.PHY) {params.questionCategories = "quick_quiz,learn_and_practice";}
+        if (isCS && examBoards.length) params.examBoards = toCSV(examBoards);
+        if (isPhy) {params.questionCategories = "quick_quiz,learn_and_practice";}
         params.title = boardTitle;
 
         // Populate query parameters with the selected subjects, fields, and topics
@@ -502,7 +502,7 @@ export const GameboardFilter = withRouter(({location}: RouteComponentProps) => {
 
         <RS.Card id="filter-panel" className="mt-4 px-2 py-3 p-sm-4 pb-5">
             {/* Filter Summary */}
-            {SITE_SUBJECT === SITE.PHY && <RS.Row>
+            {isPhy && <RS.Row>
                 <RS.Col sm={8} lg={9}>
                     <button className="bg-transparent w-100 p-0" onClick={() => setFilterExpanded(!filterExpanded)}>
                         <RS.Row>
@@ -528,7 +528,7 @@ export const GameboardFilter = withRouter(({location}: RouteComponentProps) => {
                 </RS.Col>
             </RS.Row>}
 
-            {SITE_SUBJECT === SITE.CS && (filterExpanded
+            {isCS && (filterExpanded
                 ?
                 <RS.Row className={"mb-3"}>
                     <RS.Col>

--- a/src/app/components/pages/Generic.tsx
+++ b/src/app/components/pages/Generic.tsx
@@ -15,7 +15,7 @@ import {EditContentButton} from "../elements/EditContentButton";
 import {ShareLink} from "../elements/ShareLink";
 import {PrintButton} from "../elements/PrintButton";
 import {WithFigureNumbering} from "../elements/WithFigureNumbering";
-import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
+import {siteSpecific} from "../../services/siteConstants";
 import {MetaDescription} from "../elements/MetaDescription";
 
 interface GenericPageComponentProps {
@@ -47,7 +47,7 @@ export const Generic = withRouter(({pageIdOverride, match: {params}}: GenericPag
                 </div>
 
                 <Row className="generic-content-container">
-                    <Col md={{[SITE.CS]: {size: 8, offset: 2}, [SITE.PHY]: {size: 12}}[SITE_SUBJECT]} className="py-4">
+                    <Col md={siteSpecific({size: 12}, {size: 8, offset: 2})} className="py-4">
                         <WithFigureNumbering doc={doc}>
                             <IsaacContent doc={doc} />
                         </WithFigureNumbering>

--- a/src/app/components/pages/Glossary.tsx
+++ b/src/app/components/pages/Glossary.tsx
@@ -17,7 +17,7 @@ import Select from "react-select";
 import {useUserContext} from "../../services/userContext";
 import {useUrlHashValue} from "../../services/reactRouterExtension";
 import {Item} from "../../services/select";
-import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
+import {isCS} from "../../services/siteConstants";
 import {MetaDescription} from "../elements/MetaDescription";
 
 /*
@@ -195,7 +195,7 @@ export const Glossary = () => {
     const thenRender = <div className="glossary-page">
         <Container>
             <TitleAndBreadcrumb currentPageTitle="Glossary" />
-            {SITE_SUBJECT === SITE.CS && <MetaDescription description={metaDescriptionCS} />}
+            {isCS && <MetaDescription description={metaDescriptionCS} />}
 
             <div className="no-print d-flex align-items-center">
                 <div className="question-actions question-actions-leftmost mt-3">

--- a/src/app/components/pages/GroupProgress.tsx
+++ b/src/app/components/pages/GroupProgress.tsx
@@ -27,7 +27,7 @@ import {
 import {Link} from "react-router-dom";
 import {API_PATH} from "../../services/constants";
 import {downloadLinkModal} from "../elements/modals/AssignmentProgressModalCreators";
-import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
+import {siteSpecific} from "../../services/siteConstants";
 import {isDefined} from '../../services/miscUtils';
 import {formatDate} from "../elements/DateString";
 import {IsaacSpinner} from "../handlers/IsaacSpinner";
@@ -458,7 +458,7 @@ export function GroupProgress(props: GroupProgressPageProps): JSX.Element {
     return <React.Fragment>
         <Container>
             <TitleAndBreadcrumb
-                currentPageTitle={{[SITE.PHY]: "Group Progress", [SITE.CS]: "My markbook"}[SITE_SUBJECT]}
+                currentPageTitle={siteSpecific("Group Progress", "My markbook")}
                 subTitle="Track your group performance by assignment"
                 help={pageHelp}
             />

--- a/src/app/components/pages/Groups.tsx
+++ b/src/app/components/pages/Groups.tsx
@@ -46,8 +46,8 @@ import {selectors} from "../../state/selectors";
 import {RegisteredUserDTO, UserGroupDTO} from "../../../IsaacApiTypes";
 import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
 import {ifKeyIsEnter} from "../../services/navigation";
-import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
 import {isStaff} from "../../services/user";
+import {isCS, siteSpecific} from "../../services/siteConstants";
 
 const stateFromProps = (state: AppState) => (state && {
     groups: selectors.groups.groups(state),
@@ -233,8 +233,8 @@ const GroupEditor = ({group, selectGroup, updateGroup, createNewGroup, groupName
                     <span className="d-none d-lg-inline-block">&nbsp;or&nbsp;</span>
                     <span className="d-inline-block d-md-none">&nbsp;</span>
                     <Button
-                        size="sm" className={SITE_SUBJECT === SITE.CS ? "text-white" : "" + " d-none d-sm-inline"}
-                        color={{[SITE.PHY]: "primary", [SITE.CS]: "secondary"}[SITE_SUBJECT]}
+                        size="sm" className={isCS ? "text-white" : "" + " d-none d-sm-inline"}
+                        color={siteSpecific("primary", "secondary")}
                         onClick={() => showGroupInvitationModal(false)}
                     >
                         Invite users
@@ -242,8 +242,8 @@ const GroupEditor = ({group, selectGroup, updateGroup, createNewGroup, groupName
                     {isStaff(user) && usersInGroup.length > 0 &&
                         <span className="d-none d-lg-inline-block">&nbsp;or&nbsp;
                             <Button
-                                size="sm" className={SITE_SUBJECT === SITE.CS ? "text-white" : ""}
-                                color={{[SITE.PHY]: "primary", [SITE.CS]: "secondary"}[SITE_SUBJECT]}
+                                size="sm" className={isCS ? "text-white" : ""}
+                                color={siteSpecific("primary", "secondary")}
                                 onClick={() => showGroupEmailModal(usersInGroup)}
                             >
                                 Email users
@@ -259,7 +259,7 @@ const GroupEditor = ({group, selectGroup, updateGroup, createNewGroup, groupName
                     />
                     {(isUserGroupOwner || group === null) && <InputGroupAddon addonType="append">
                         <Button
-                            color={{[SITE.PHY]: "secondary", [SITE.CS]: "primary"}[SITE_SUBJECT]}
+                            color={siteSpecific("secondary", "primary")}
                             className="p-0 border-dark" disabled={newGroupName == "" || initialGroupName == newGroupName}
                             onClick={saveUpdatedGroup}
                         >

--- a/src/app/components/pages/LogIn.tsx
+++ b/src/app/components/pages/LogIn.tsx
@@ -6,7 +6,7 @@ import {AppState} from "../../state/reducers";
 import {history} from "../../services/history";
 import {Redirect} from "react-router";
 import {selectors} from "../../state/selectors";
-import {SITE, SITE_SUBJECT, SITE_SUBJECT_TITLE} from "../../services/siteConstants";
+import {isCS, SITE_SUBJECT_TITLE} from "../../services/siteConstants";
 import {MetaDescription} from "../elements/MetaDescription";
 
 /* Interconnected state and functions providing a "logging in" API - intended to be used within a component that displays
@@ -210,7 +210,7 @@ export const LogIn = () => {
     const metaDescriptionCS = "Log in to your account. Access free GCSE and A level Computer Science resources. Use our materials to learn and revise for your exams.";
 
     return <Container id="login-page" className="my-4">
-        {SITE_SUBJECT === SITE.CS && <MetaDescription description={metaDescriptionCS} />}
+        {isCS && <MetaDescription description={metaDescriptionCS} />}
         <Row>
             <Col md={{offset: 1, size: 10}} lg={{offset: 2, size: 8}} xl={{offset: 3, size: 6}}>
                 <Card>

--- a/src/app/components/pages/MyAccount.tsx
+++ b/src/app/components/pages/MyAccount.tsx
@@ -45,7 +45,7 @@ import {TeacherConnections} from "../elements/panels/TeacherConnections";
 import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
 import {ifKeyIsEnter} from "../../services/navigation";
 import {ShowLoading} from "../handlers/ShowLoading";
-import {SITE, SITE_SUBJECT, SITE_SUBJECT_TITLE} from "../../services/siteConstants";
+import {isCS, SITE_SUBJECT_TITLE} from "../../services/siteConstants";
 import {isStaff} from "../../services/user";
 import {ErrorState} from "../../state/reducers/internalAppState";
 import {AdminUserGetState} from "../../state/reducers/adminState";
@@ -152,8 +152,8 @@ const AccountPageComponent = ({user, updateCurrentUser, getChosenUserAuthSetting
 
     useEffect(() => {
         const currentEmailPreferences = (userPreferences?.EMAIL_PREFERENCE) ? userPreferences.EMAIL_PREFERENCE : {};
-        const currentProgrammingLanguage = SITE_SUBJECT === SITE.CS ? (userPreferences?.PROGRAMMING_LANGUAGE ? userPreferences.PROGRAMMING_LANGUAGE: {}) : undefined;
-        const currentBooleanNotation = SITE_SUBJECT === SITE.CS ? (userPreferences?.BOOLEAN_NOTATION ? userPreferences.BOOLEAN_NOTATION: {}) : undefined;
+        const currentProgrammingLanguage = isCS ? (userPreferences?.PROGRAMMING_LANGUAGE ? userPreferences.PROGRAMMING_LANGUAGE: {}) : undefined;
+        const currentBooleanNotation = isCS ? (userPreferences?.BOOLEAN_NOTATION ? userPreferences.BOOLEAN_NOTATION: {}) : undefined;
         const currentDisplaySettings = (userPreferences?.DISPLAY_SETTING) ? userPreferences.DISPLAY_SETTING: {};
         const currentUserPreferences: UserPreferencesDTO = {
             EMAIL_PREFERENCE: currentEmailPreferences,

--- a/src/app/components/pages/MyGameboards.tsx
+++ b/src/app/components/pages/MyGameboards.tsx
@@ -40,7 +40,7 @@ import {above, below, isMobile, useDeviceSize} from "../../services/device";
 import {formatDate} from "../elements/DateString";
 import {ShareLink} from "../elements/ShareLink";
 import {Link} from "react-router-dom";
-import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
+import {isPhy} from "../../services/siteConstants";
 import {IsaacSpinner} from "../handlers/IsaacSpinner";
 import {AggregateDifficultyIcons} from "../elements/svg/DifficultyIcons";
 
@@ -294,7 +294,7 @@ export const MyGameboards = () => {
         {boards && boards.totalResults == 0 ?
             <React.Fragment>
                 <h3 className="text-center mt-4">You have no gameboards to view.</h3>
-                {SITE_SUBJECT === SITE.PHY && <div className="text-center mt-3 mb-5">
+                {isPhy && <div className="text-center mt-3 mb-5">
                     <Button color="secondary" tag={Link} to="/gameboards/new">Create a gameboard</Button>
                 </div>}
             </React.Fragment>

--- a/src/app/components/pages/MyProgress.tsx
+++ b/src/app/components/pages/MyProgress.tsx
@@ -22,11 +22,11 @@ import {ActivityGraph} from "../elements/views/ActivityGraph";
 import {ProgressBar} from "../elements/views/ProgressBar";
 import {safePercentage} from "../../services/validation";
 import {TeacherAchievement} from "../elements/TeacherAchievement";
-import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
+import {isPhy, siteSpecific} from "../../services/siteConstants";
 import {LinkToContentSummaryList} from "../elements/list-groups/ContentSummaryListGroupItem";
 
-const siteSpecific = {
-    [SITE.PHY]: {
+const siteSpecificStats = siteSpecific(
+    {
         questionTypeStatsList: [
             "isaacMultiChoiceQuestion", "isaacNumericQuestion", "isaacSymbolicQuestion", "isaacSymbolicChemistryQuestion",
             "isaacClozeQuestion", "isaacReorderQuestion"
@@ -43,7 +43,7 @@ const siteSpecific = {
         typeColWidth: "col-lg-6",
         tagColWidth: "col-lg-12"
     },
-    [SITE.CS]: {
+    {
         questionTypeStatsList: [
             "isaacMultiChoiceQuestion", "isaacItemQuestion", "isaacParsonsQuestion", "isaacNumericQuestion",
             "isaacStringMatchQuestion", "isaacFreeTextQuestion", "isaacSymbolicLogicQuestion", "isaacClozeQuestion"
@@ -52,7 +52,7 @@ const siteSpecific = {
         typeColWidth: "col-lg-4",
         tagColWidth: "col-lg-12"
     }
-}[SITE_SUBJECT];
+);
 
 interface MyProgressProps extends RouteComponentProps<{userIdOfInterest: string}> {
     user: PotentialUser;
@@ -101,7 +101,7 @@ const MyProgress = withRouter((props: MyProgressProps) => {
                             <Col>
                                 <AggregateQuestionStats userProgress={progress} />
                             </Col>
-                            {SITE_SUBJECT === SITE.PHY && <Col className="align-self-center" xs={12} md={3}>
+                            {isPhy && <Col className="align-self-center" xs={12} md={3}>
                                 <StreakPanel userProgress={progress} />
                             </Col>}
                         </Row>
@@ -142,11 +142,11 @@ const MyProgress = withRouter((props: MyProgressProps) => {
                         <div className="mt-4">
                             <h4>Question parts correct by Type</h4>
                             <Row>
-                                {siteSpecific.questionTypeStatsList.map((qType: string) => {
+                                {siteSpecificStats.questionTypeStatsList.map((qType: string) => {
                                     const correct = progress?.correctByType?.[qType] || null;
                                     const attempts = progress?.attemptsByType?.[qType] || null;
                                     const percentage = safePercentage(correct, attempts);
-                                    return <Col key={qType} className={`${siteSpecific.typeColWidth} mt-2 type-progress-bar`}>
+                                    return <Col key={qType} className={`${siteSpecificStats.typeColWidth} mt-2 type-progress-bar`}>
                                         <div className={"px-2"}>
                                             {HUMAN_QUESTION_TYPES[qType]} questions correct
                                         </div>
@@ -160,16 +160,16 @@ const MyProgress = withRouter((props: MyProgressProps) => {
                             </Row>
                         </div>
 
-                        {SITE_SUBJECT === SITE.PHY && <div className="mt-4">
+                        {isPhy && <div className="mt-4">
                             <h4>Isaac Books</h4>
                             Questions completed correctly, against questions attempted for each of our <a href={"/pages/order_books"}>mastery books</a>.
                             <Row>
-                                {Object.entries(siteSpecific.questionCountByTag).map(([qType, total]) => {
+                                {Object.entries(siteSpecificStats.questionCountByTag).map(([qType, total]) => {
                                     const correct = Math.min(progress?.correctByTag?.[qType] || 0, total);
                                     const attempted = Math.min(progress?.attemptsByTag?.[qType] || 0, total);
                                     const correctPercentage = safePercentage(correct, total) || 0;
                                     const attemptedPercentage = safePercentage(attempted, total) || 0;
-                                    return total > 0 && <Col key={qType} className={`${siteSpecific.tagColWidth} mt-2 type-progress-bar`}>
+                                    return total > 0 && <Col key={qType} className={`${siteSpecificStats.tagColWidth} mt-2 type-progress-bar`}>
                                         <div className={"px-2"}>
                                             {HUMAN_QUESTION_TAGS.get(qType)} questions
                                         </div>
@@ -200,7 +200,7 @@ const MyProgress = withRouter((props: MyProgressProps) => {
                             </Col>}
                         </Row>
                     </div>,
-                    ...(viewingOwnData && isTeacher(user) && SITE_SUBJECT == SITE.PHY && {"Teacher Activity": <div>
+                    ...(isPhy && viewingOwnData && isTeacher(user) && {"Teacher Activity": <div>
                         <TeacherAchievement
                             verb="created"
                             count={achievements && achievements.TEACHER_GROUPS_CREATED}

--- a/src/app/components/pages/Question.tsx
+++ b/src/app/components/pages/Question.tsx
@@ -21,7 +21,7 @@ import {selectors} from "../../state/selectors";
 import {DocumentSubject} from "../../../IsaacAppTypes";
 import {Markup} from "../elements/markup";
 import {FastTrackProgress} from "../elements/FastTrackProgress";
-import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
+import {isPhy, siteSpecific} from "../../services/siteConstants";
 import tags from "../../services/tags";
 import queryString from "query-string";
 import {IntendedAudienceWarningBanner} from "../navigation/IntendedAudienceWarningBanner";
@@ -38,7 +38,7 @@ interface QuestionPageProps extends RouteComponentProps<{questionId: string}> {
 
 
 function getTags(docTags?: string[]) {
-    if (SITE_SUBJECT !== SITE.PHY) {
+    if (!isPhy) {
         return [];
     }
     if (!docTags) return [];
@@ -87,7 +87,7 @@ export const Question = withRouter(({questionIdOverride, match, location}: Quest
                     </div>
                 </div>
                 <Row className="question-content-container">
-                    <Col md={{[SITE.CS]: {size: 8, offset: 2}, [SITE.PHY]: {size: 12}}[SITE_SUBJECT]} className="py-4 question-panel">
+                    <Col md={siteSpecific({size: 12}, {size: 8, offset: 2})} className="py-4 question-panel">
 
                         <SupersededDeprecatedWarningBanner doc={doc} />
 

--- a/src/app/components/pages/Registration.tsx
+++ b/src/app/components/pages/Registration.tsx
@@ -31,7 +31,7 @@ import {DateInput} from "../elements/inputs/DateInput";
 import {loadZxcvbnIfNotPresent, passwordDebounce} from "../../services/passwordStrength"
 import {FIRST_LOGIN_STATE} from "../../services/firstLogin";
 import {Redirect, RouteComponentProps, withRouter} from "react-router";
-import {SITE, SITE_SUBJECT, SITE_SUBJECT_TITLE} from "../../services/siteConstants";
+import {isCS, SITE_SUBJECT_TITLE} from "../../services/siteConstants";
 import {selectors} from "../../state/selectors";
 import {MetaDescription} from "../elements/MetaDescription";
 
@@ -104,7 +104,7 @@ export const Registration = withRouter(({location}:  RouteComponentProps<{}, {},
     return <Container id="registration-page" className="mb-5">
 
         <TitleAndBreadcrumb currentPageTitle="Registration" className="mb-4" />
-        {SITE_SUBJECT === SITE.CS && <MetaDescription description={metaDescriptionCS} />}
+        {isCS && <MetaDescription description={metaDescriptionCS} />}
 
         <Card>
             <CardBody>

--- a/src/app/components/pages/Search.tsx
+++ b/src/app/components/pages/Search.tsx
@@ -15,7 +15,7 @@ import {shortcuts} from "../../services/searchResults";
 import {ShortcutResponse} from "../../../IsaacAppTypes";
 import {isIntendedAudience, useUserContext} from "../../services/userContext";
 import {UserContextPicker} from "../elements/inputs/UserContextPicker";
-import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
+import {isCS, isPhy, siteSpecific} from "../../services/siteConstants";
 import {selectors} from "../../state/selectors";
 import Select, {CSSObjectWithLabel, GroupBase, StylesConfig} from "react-select";
 import {IsaacSpinner} from "../handlers/IsaacSpinner";
@@ -47,7 +47,7 @@ function parseLocationSearch(search: string): [Nullable<string>, DOCUMENT_TYPE[]
 }
 
 const selectStyle: StylesConfig<Item<DOCUMENT_TYPE>, true, GroupBase<Item<DOCUMENT_TYPE>>> = {
-    multiValue: (styles: CSSObjectWithLabel) => ({...styles, backgroundColor: {[SITE.PHY]: "rgba(254, 161, 0, 0.9)", [SITE.CS]: "rgba(255, 181, 63, 0.9)"}[SITE_SUBJECT]}),
+    multiValue: (styles: CSSObjectWithLabel) => ({...styles, backgroundColor: siteSpecific("rgba(254, 161, 0, 0.9)", "rgba(255, 181, 63, 0.9)")}),
     multiValueLabel: (styles: CSSObjectWithLabel) => ({...styles, color: "black"}),
 };
 
@@ -61,7 +61,7 @@ export const Search = withRouter((props: RouteComponentProps) => {
     const [queryState, setQueryState] = useState(urlQuery);
 
     let initialFilters = urlFilters;
-    if (SITE_SUBJECT === SITE.CS && urlFilters.length === 0) {
+    if (isCS && urlFilters.length === 0) {
         initialFilters = [DOCUMENT_TYPE.CONCEPT, DOCUMENT_TYPE.EVENT, DOCUMENT_TYPE.TOPIC_SUMMARY, DOCUMENT_TYPE.GENERIC];
     }
     const [filtersState, setFiltersState] = useState<Item<DOCUMENT_TYPE>[]>(initialFilters.map(itemise));
@@ -89,7 +89,7 @@ export const Search = withRouter((props: RouteComponentProps) => {
     // Process results and add shortcut responses
     const filteredSearchResults = searchResults?.results && searchResults.results
         .filter(result => searchResultIsPublic(result, user))
-        .filter(result => SITE_SUBJECT === SITE.PHY || isIntendedAudience(result.audience, userContext, user));
+        .filter(result => isPhy || isIntendedAudience(result.audience, userContext, user));
     const shortcutResponses = (queryState ? shortcuts(queryState) : []) as ShortcutResponse[];
     const shortcutAndFilteredSearchResults = (shortcutResponses || []).concat(filteredSearchResults || []);
 
@@ -125,7 +125,7 @@ export const Search = withRouter((props: RouteComponentProps) => {
                             <RS.Col md={7} sm={12}>
                                 <RS.Form inline className="search-filters">
                                     <RS.Label htmlFor="document-filter" className="d-none d-lg-inline-block mr-1">
-                                        {`Filter${{[SITE.CS]: "s", [SITE.PHY]: ""}[SITE_SUBJECT]}:`}
+                                        {`Filter${siteSpecific("","s")}:`}
                                     </RS.Label>
                                     <Select
                                         inputId="document-filter" isMulti
@@ -134,7 +134,7 @@ export const Search = withRouter((props: RouteComponentProps) => {
                                         options={
                                             [DOCUMENT_TYPE.CONCEPT, DOCUMENT_TYPE.QUESTION, DOCUMENT_TYPE.EVENT,
                                                 DOCUMENT_TYPE.TOPIC_SUMMARY, DOCUMENT_TYPE.GENERIC]
-                                                .filter(v => SITE_SUBJECT === SITE.CS || v !== DOCUMENT_TYPE.TOPIC_SUMMARY)
+                                                .filter(v => isCS || v !== DOCUMENT_TYPE.TOPIC_SUMMARY)
                                                 .map(itemise)
                                         }
                                         className="basic-multi-select w-100 w-md-75 w-lg-50 mb-2 mb-md-0"
@@ -142,7 +142,7 @@ export const Search = withRouter((props: RouteComponentProps) => {
                                         onChange={selectOnChange(setFiltersState, false)}
                                         styles={selectStyle}
                                     />
-                                    {SITE_SUBJECT === SITE.CS && <RS.Label className="mt-2 mb-2 mb-md-0">
+                                    {isCS && <RS.Label className="mt-2 mb-2 mb-md-0">
                                         <UserContextPicker className="text-right" />
                                     </RS.Label>}
                                 </RS.Form>

--- a/src/app/components/pages/SetAssignments.tsx
+++ b/src/app/components/pages/SetAssignments.tsx
@@ -48,7 +48,7 @@ import {
 import {connect, useDispatch, useSelector} from "react-redux";
 import {formatDate} from "../elements/DateString";
 import {ShareLink} from "../elements/ShareLink";
-import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
+import {isPhy, siteSpecific} from "../../services/siteConstants";
 import {isAdminOrEventManager, isStaff} from "../../services/user";
 import {isDefined} from "../../services/miscUtils";
 import {
@@ -141,7 +141,7 @@ const AssignGroup = ({groups, board, assignBoard}: BoardProps) => {
         </Label>}
         <Button
             className="mt-2 mb-2"
-            block color={{[SITE.CS]: "primary", [SITE.PHY]: "secondary"}[SITE_SUBJECT]}
+            block color={siteSpecific("secondary", "primary")}
             onClick={assign}
             disabled={selectedGroups.length === 0 || (isDefined(assignmentNotes) && assignmentNotes.length > 500)}
         >Assign to group{selectedGroups.length > 1 ? "s" : ""}</Button>
@@ -381,20 +381,11 @@ const SetAssignmentsPageComponent = (props: SetAssignmentsPageProps) => {
 
     const isaacAssignmentButtons = {
         second: {
-            link: {
-                [SITE.CS]: "/topics",
-                [SITE.PHY]: "/pages/pre_made_gameboards"
-            },
-            text: {
-                [SITE.CS]: "Topics list",
-                [SITE.PHY]: "our Boards for Lessons"
-            }
+            link: siteSpecific("/pages/pre_made_gameboards", "/topics"),
+            text: siteSpecific("our Boards for Lessons", "Topics list")
         },
         third: {
-            text: {
-                [SITE.CS]: "Create gameboard",
-                [SITE.PHY]: "create a gameboard"
-            }
+            text: siteSpecific("create a gameboard", "Create gameboard")
         }
     };
 
@@ -461,7 +452,7 @@ const SetAssignmentsPageComponent = (props: SetAssignmentsPageProps) => {
         </h4>
         <RS.Row className="mb-4">
             <RS.Col md={6} lg={4} className="pt-1">
-                {SITE_SUBJECT === SITE.PHY ?
+                {isPhy ?
                     <RS.Button tag={Link} onClick={() => dispatch(openIsaacBooksModal)} color="secondary" block className="px-3">
                         our GCSE &amp; A Level books
                     </RS.Button> :
@@ -471,13 +462,13 @@ const SetAssignmentsPageComponent = (props: SetAssignmentsPageProps) => {
                 }
             </RS.Col>
             <RS.Col md={6} lg={4} className="pt-1">
-                <RS.Button tag={Link} to={isaacAssignmentButtons.second.link[SITE_SUBJECT]} color="secondary" block>
-                    {isaacAssignmentButtons.second.text[SITE_SUBJECT]}
+                <RS.Button tag={Link} to={isaacAssignmentButtons.second.link} color="secondary" block>
+                    {isaacAssignmentButtons.second.text}
                 </RS.Button>
             </RS.Col>
             <RS.Col md={12} lg={4} className="pt-1">
                 <RS.Button tag={Link} to={"/gameboard_builder"} color="secondary" block>
-                    {isaacAssignmentButtons.third.text[SITE_SUBJECT]}
+                    {isaacAssignmentButtons.third.text}
                 </RS.Button>
             </RS.Col>
         </RS.Row>
@@ -542,14 +533,14 @@ const SetAssignmentsPageComponent = (props: SetAssignmentsPageProps) => {
                                                     Filter boards <Input type="text" onChange={(e) => setBoardTitleFilter(e.target.value)} placeholder="Filter boards by name"/>
                                                 </Label>
                                             </Col>
-                                            {SITE_SUBJECT == SITE.PHY && <Col sm={6} lg={2}>
+                                            {isPhy && <Col sm={6} lg={2}>
                                                 <Label className="w-100">
                                                     Subject <Input type="select" value={boardSubject} onChange={e => setBoardSubject(e.target.value as boardSubjects)}>
                                                     {Object.values(boardSubjects).map(subject => <option key={subject} value={subject}>{subject}</option>)}
                                                 </Input>
                                                 </Label>
                                             </Col>}
-                                            <Col lg={SITE_SUBJECT == SITE.PHY ? 2 : {size: 2, offset: 6}}>
+                                            <Col lg={isPhy ? 2 : {size: 2, offset: 6}}>
                                                 <Label className="w-100">
                                                     Creator <Input type="select" value={boardCreator} onChange={e => setBoardCreator(e.target.value as boardCreators)}>
                                                     {Object.values(boardCreators).map(creator => <option key={creator} value={creator}>{creator}</option>)}

--- a/src/app/components/pages/Support.tsx
+++ b/src/app/components/pages/Support.tsx
@@ -8,7 +8,7 @@ import {history} from "../../services/history";
 import {fromPairs} from "lodash";
 import {PageFragment} from "../elements/PageFragment";
 import {NotFound} from "./NotFound";
-import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
+import {isCS, siteSpecific} from "../../services/siteConstants";
 import {isDefined} from "../../services/miscUtils";
 import {MetaDescription} from "../elements/MetaDescription";
 
@@ -30,8 +30,8 @@ interface SupportCategories {
     };
 }
 
-const support: {student: SupportCategories; teacher: SupportCategories} = {
-    [SITE.CS]: {
+const support: {student: SupportCategories; teacher: SupportCategories} = siteSpecific(
+    {
         student: {
             title: "Student support",
             categories:{
@@ -50,7 +50,7 @@ const support: {student: SupportCategories; teacher: SupportCategories} = {
             }
         }
     },
-    [SITE.PHY]: {
+    {
         student: {
             title: "Student FAQ",
             categories:{
@@ -74,8 +74,8 @@ const support: {student: SupportCategories; teacher: SupportCategories} = {
                 legal: { category: "legal", title: "Legal", icon: "faq"}
             }
         }
-    },
-}[SITE_SUBJECT];
+    }
+);
 
 function supportPath(type?: string, category?: string) {
     return `/support/${type || "student"}/${category || "general"}`;
@@ -121,7 +121,7 @@ export const SupportPageComponent = ({match: {params: {type, category}}}: RouteC
         <Row>
             <Col>
                 <TitleAndBreadcrumb currentPageTitle={section.title} />
-                {SITE_SUBJECT === SITE.CS && isDefined(type) && <MetaDescription description={metaDescriptionMap[type]} />}
+                {isCS && isDefined(type) && <MetaDescription description={metaDescriptionMap[type]} />}
             </Col>
         </Row>
         <Row>

--- a/src/app/components/pages/TeacherRequest.tsx
+++ b/src/app/components/pages/TeacherRequest.tsx
@@ -22,7 +22,7 @@ import {api} from "../../services/api";
 import {Link} from "react-router-dom";
 import {schoolNameWithPostcode, isTeacher} from "../../services/user";
 import {IsaacContent} from "../content/IsaacContent";
-import {SITE, SITE_SUBJECT, SITE_SUBJECT_TITLE, WEBMASTER_EMAIL} from "../../services/siteConstants";
+import {isPhy, SITE_SUBJECT_TITLE, WEBMASTER_EMAIL} from "../../services/siteConstants";
 import {selectors} from "../../state/selectors";
 
 const warningFragmentId = "teacher_registration_warning_message";
@@ -136,7 +136,7 @@ export const TeacherRequest = () => {
                                         {"name of your school should be shown in the 'School' field. If any of the "}
                                         {"information is incorrect or missing, you can amend it on your "}
                                         <Link to="/account">My account</Link>{" page."}
-                                        {SITE_SUBJECT === SITE.PHY && noSchool}
+                                        {isPhy && noSchool}
                                     </p>
                                     <Row>
                                         <Col size={12} md={6}>

--- a/src/app/components/pages/quizzes/MyQuizzes.tsx
+++ b/src/app/components/pages/quizzes/MyQuizzes.tsx
@@ -13,9 +13,9 @@ import {AppQuizAssignment} from "../../../../IsaacAppTypes";
 import {extractTeacherName} from "../../../services/user";
 import {isFound} from "../../../services/miscUtils";
 import {Spacer} from "../../elements/Spacer";
-import {SITE, SITE_SUBJECT} from "../../../services/siteConstants";
 import {Tabs} from "../../elements/Tabs";
 import {isAttempt, partitionCompleteAndIncompleteQuizzes} from "../../../services/quiz";
+import {siteSpecific} from "../../../services/siteConstants";
 
 interface MyQuizzesPageProps extends RouteComponentProps {
     user: RegisteredUserDTO;
@@ -58,27 +58,27 @@ function QuizItem({item}: QuizAssignmentProps) {
                 <div className="text-center mt-4">
                     {assignment ? <>
                         {status === Status.Unstarted && <RS.Button tag={Link} to={`/test/assignment/${assignment.id}`}>
-                            {{[SITE.CS]: "Start test", [SITE.PHY]: "Start Test"}[SITE_SUBJECT]}
+                            {siteSpecific("Start Test", "Start test")}
                         </RS.Button>}
                         {status === Status.Started && <RS.Button tag={Link} to={`/test/assignment/${assignment.id}`}>
-                            {{[SITE.CS]: "Continue test", [SITE.PHY]: "Continue Test"}[SITE_SUBJECT]}
+                            {siteSpecific("Continue Test", "Continue test")}
                         </RS.Button>}
                         {status === Status.Complete && (
                             assignment.quizFeedbackMode !== "NONE" ?
                                 <RS.Button tag={Link} to={`/test/attempt/${assignment.attempt?.id}/feedback`}>
-                                    {{[SITE.CS]: "View feedback", [SITE.PHY]: "View Feedback"}[SITE_SUBJECT]}
+                                    {siteSpecific("View Feedback", "View feedback")}
                                 </RS.Button>
                                 :
                                 <strong>No feedback available</strong>
                         )}
                     </> : attempt && <>
                         {status === Status.Started && <RS.Button tag={Link} to={`/test/attempt/${attempt.quizId}`}>
-                            {{[SITE.CS]: "Continue test", [SITE.PHY]: "Continue Test"}[SITE_SUBJECT]}
+                            {siteSpecific("Continue Test", "Continue test")}
                         </RS.Button>}
                         {status === Status.Complete && (
                             attempt.feedbackMode !== "NONE" ?
                                 <RS.Button tag={Link} to={`/test/attempt/${attempt.id}/feedback`}>
-                                    {{[SITE.CS]: "View feedback", [SITE.PHY]: "View Feedback"}[SITE_SUBJECT]}
+                                    {siteSpecific("View Feedback", "View feedback")}
                                 </RS.Button>
                                 :
                                 <strong>No feedback available</strong>
@@ -143,11 +143,11 @@ const MyQuizzesPageComponent = ({user}: MyQuizzesPageProps) => {
     };
 
     return <RS.Container>
-        <TitleAndBreadcrumb currentPageTitle={{[SITE.CS]: "My tests", [SITE.PHY]: "My Tests"}[SITE_SUBJECT]} help={pageHelp} />
+        <TitleAndBreadcrumb currentPageTitle={siteSpecific("My Tests", "My tests")} help={pageHelp} />
 
         <Tabs className="mb-5 mt-4" tabContentClass="mt-4">
             {{
-                [{[SITE.CS]: "In progress tests", [SITE.PHY]: "In Progress Tests"}[SITE_SUBJECT]]:
+                [siteSpecific("In Progress Tests", "In progress tests")]:
                     <ShowLoading
                         until={quizAssignments}
                         ifNotFound={<RS.Alert color="warning">Your test assignments failed to load, please try refreshing the page.</RS.Alert>}
@@ -155,7 +155,7 @@ const MyQuizzesPageComponent = ({user}: MyQuizzesPageProps) => {
                         <QuizGrid quizzes={incompleteQuizzes} empty="You don't have any incomplete or assigned tests."/>
                     </ShowLoading>,
 
-                [{[SITE.CS]: "Completed tests", [SITE.PHY]: "Completed Tests"}[SITE_SUBJECT]]:
+                [siteSpecific("Completed Tests", "Completed tests")]:
                     <ShowLoading
                         until={quizAssignments}
                         ifNotFound={<RS.Alert color="warning">Your test assignments failed to load, please try refreshing the page.</RS.Alert>}
@@ -163,7 +163,7 @@ const MyQuizzesPageComponent = ({user}: MyQuizzesPageProps) => {
                         <QuizGrid quizzes={completedQuizzes} empty="You haven't completed any tests."/>
                     </ShowLoading>,
 
-                [{[SITE.CS]: "Practice tests", [SITE.PHY]: "Practice Tests"}[SITE_SUBJECT]]:
+                [siteSpecific("Practice Tests", "Practice tests")]:
                     <ShowLoading until={quizzes}>
                         {quizzes && <>
                             {quizzes.length === 0 && <p><em>There are no tests currently available.</em></p>}
@@ -174,7 +174,7 @@ const MyQuizzesPageComponent = ({user}: MyQuizzesPageProps) => {
                                         {quiz.summary && <div className="small text-muted d-none d-md-block">{quiz.summary}</div>}
                                         <Spacer />
                                         <RS.Button tag={Link} to={{pathname: `/test/attempt/${quiz.id}`}}>
-                                            {{[SITE.CS]: "Take test", [SITE.PHY]: "Take Test"}[SITE_SUBJECT]}
+                                            {siteSpecific("Take Test", "Take test")}
                                         </RS.Button>
                                     </div>
                                 </RS.ListGroupItem>)}

--- a/src/app/components/pages/quizzes/SetQuizzes.tsx
+++ b/src/app/components/pages/quizzes/SetQuizzes.tsx
@@ -17,7 +17,7 @@ import {formatDate} from "../../elements/DateString";
 import {AppQuizAssignment} from "../../../../IsaacAppTypes";
 import {loadGroups} from "../../../state/actions";
 import {MANAGE_QUIZ_TAB, NOT_FOUND} from "../../../services/constants";
-import {SITE, SITE_SUBJECT} from "../../../services/siteConstants";
+import {siteSpecific} from "../../../services/siteConstants";
 import {Tabs} from "../../elements/Tabs";
 import {below, useDeviceSize} from "../../../services/device";
 import {isDefined} from "../../../services/miscUtils";
@@ -62,10 +62,10 @@ function QuizAssignment({user, assignment}: QuizAssignmentProps) {
 
                 <div className="mt-4 text-right">
                     <RS.Button color="tertiary" size="sm" outline onClick={cancel} disabled={isCancelling} className="mr-1">
-                        {isCancelling ? <><IsaacSpinner size="sm" /> Cancelling...</> : {[SITE.CS]: "Cancel test", [SITE.PHY]: "Cancel Test"}[SITE_SUBJECT]}
+                        {isCancelling ? <><IsaacSpinner size="sm" /> Cancelling...</> : siteSpecific("Cancel Test", "Cancel test")}
                     </RS.Button>
                     <RS.Button tag={Link} to={`/quiz/assignment/${assignment.id}/feedback`} disabled={isCancelling} color={isCancelling ? "tertiary" : undefined} size="sm" className="ml-1">
-                        {{[SITE.CS]: "View results", [SITE.PHY]: "View Results"}[SITE_SUBJECT]}
+                        {siteSpecific("View Results", "View results")}
                     </RS.Button>
                 </div>
             </RS.CardBody>
@@ -79,7 +79,7 @@ const SetQuizzesPageComponent = ({user, location}: SetQuizzesPageProps) => {
     const quizzes = useSelector(selectors.quizzes.available);
     const [filteredQuizzes, setFilteredQuizzes] = useState<Array<QuizSummaryDTO> | undefined>();
     const [activeTab, setActiveTab] = useState(MANAGE_QUIZ_TAB.set);
-    const [pageTitle, setPageTitle] = useState({[SITE.CS]: "Manage tests", [SITE.PHY]: (activeTab !== MANAGE_QUIZ_TAB.manage ? "Set" : "Manage") + " Tests"}[SITE_SUBJECT]);
+    const [pageTitle, setPageTitle] = useState(siteSpecific((activeTab !== MANAGE_QUIZ_TAB.manage ? "Set" : "Manage") + " Tests", "Manage tests"));
     const quizAssignments = useSelector(selectors.quizzes.assignments);
 
     const dispatch = useDispatch();
@@ -94,7 +94,7 @@ const SetQuizzesPageComponent = ({user, location}: SetQuizzesPageProps) => {
             (hashAnchor && MANAGE_QUIZ_TAB[hashAnchor as any]) ||
             MANAGE_QUIZ_TAB.set;
         setActiveTab(tab);
-        setPageTitle({[SITE.CS]: "Manage tests", [SITE.PHY]: (tab !== MANAGE_QUIZ_TAB.manage ? "Set" : "Manage") + " Tests"}[SITE_SUBJECT])
+        setPageTitle(siteSpecific((tab !== MANAGE_QUIZ_TAB.manage ? "Set" : "Manage") + " Tests", "Manage tests"));
     }, [hashAnchor]);
 
     useEffect(() => {
@@ -120,7 +120,7 @@ const SetQuizzesPageComponent = ({user, location}: SetQuizzesPageProps) => {
     }, [titleFilter, quizzes]);
 
     function activeTabChanged(tabIndex: number) {
-        setPageTitle({[SITE.CS]: "Manage tests", [SITE.PHY]: (tabIndex !== MANAGE_QUIZ_TAB.manage ? "Set" : "Manage") + " Tests"}[SITE_SUBJECT])
+        setPageTitle(siteSpecific((tabIndex !== MANAGE_QUIZ_TAB.manage ? "Set" : "Manage") + " Tests", "Manage tests"))
     }
 
     const pageHelp = <span>
@@ -140,7 +140,7 @@ const SetQuizzesPageComponent = ({user, location}: SetQuizzesPageProps) => {
         <TitleAndBreadcrumb currentPageTitle={pageTitle} help={pageHelp} />
         <Tabs className="my-4 mb-5" tabContentClass="mt-4" activeTabOverride={activeTab} onActiveTabChange={activeTabChanged}>
             {{
-                [{[SITE.CS]: "Available tests", [SITE.PHY]: "Set Tests"}[SITE_SUBJECT]]:
+                [siteSpecific("Set Tests", "Available tests")]:
                 <ShowLoading until={filteredQuizzes}>
                     {filteredQuizzes && <>
                         <p>The following tests are available to set to your groups.</p>
@@ -158,7 +158,7 @@ const SetQuizzesPageComponent = ({user, location}: SetQuizzesPageProps) => {
                                     {quiz.summary && <div className="small text-muted d-none d-md-block">{quiz.summary}</div>}
                                     <Spacer />
                                     <RS.Button className={below["md"](deviceSize) ? "btn-sm" : ""} onClick={() => dispatch(showQuizSettingModal(quiz))}>
-                                        {{[SITE.CS]: "Set test", [SITE.PHY]: "Set Test"}[SITE_SUBJECT]}
+                                        {siteSpecific("Set Test", "Set test")}
                                     </RS.Button>
                                 </div>
                                 <div className="d-none d-md-flex align-items-center">
@@ -171,7 +171,7 @@ const SetQuizzesPageComponent = ({user, location}: SetQuizzesPageProps) => {
                     </>}
                 </ShowLoading>,
 
-                [{[SITE.CS]: "Previously set tests", [SITE.PHY]: "Manage Tests"}[SITE_SUBJECT]]:
+                [siteSpecific("Manage Tests", "Previously set tests")]:
                 <ShowLoading until={quizAssignments} ifNotFound={<RS.Alert color="warning">Tests you have assigned have failed to load, please try refreshing the page.</RS.Alert>}>
                     {quizAssignments && quizAssignments !== NOT_FOUND && <>
                         {quizAssignments.length === 0 && <p>You have not set any tests to your groups yet.</p>}

--- a/src/app/components/site/siteSpecificComponents.ts
+++ b/src/app/components/site/siteSpecificComponents.ts
@@ -1,4 +1,4 @@
-import {SITE, SITE_SUBJECT} from "../../services/siteConstants";
+import {siteSpecific} from "../../services/siteConstants";
 import {HomepageCS} from "./cs/HomepageCS";
 import {HeaderCS} from "./cs/HeaderCS";
 import {RoutesCS} from "./cs/RoutesCS";
@@ -6,15 +6,15 @@ import {HomepagePhy} from "./phy/HomepagePhy";
 import {HeaderPhy} from "./phy/HeaderPhy";
 import {RoutesPhy} from "./phy/RoutesPhy";
 
-export default {
-    [SITE.PHY]: {
+export default siteSpecific(
+    {
         Homepage: HomepagePhy,
         Header: HeaderPhy,
         Routes: RoutesPhy,
     },
-    [SITE.CS]: {
+    {
         Homepage: HomepageCS,
         Header: HeaderCS,
         Routes: RoutesCS,
     }
-}[SITE_SUBJECT];
+);

--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -30,7 +30,7 @@ import {
 import {handleApiGoneAway, handleServerError} from "../state/actions";
 import {EventOverviewFilter} from "../components/elements/panels/EventOverviews";
 import {securePadCredentials, securePadPasswordReset} from "./credentialPadding";
-import {SITE, SITE_SUBJECT} from "./siteConstants";
+import {isPhy} from "./siteConstants";
 
 export const endpoint = axios.create({
     baseURL: API_PATH,
@@ -330,7 +330,7 @@ export const api = {
         },
         generateTemporary: (params: {[key: string]: string}): AxiosPromise<ApiTypes.GameboardDTO> => {
             // TODO FILTER: Temporarily force physics to search for problem solving questions
-            if (SITE_SUBJECT === SITE.PHY) {
+            if (isPhy) {
                 if (!Object.keys(params).includes("questionCategories")) {
                     params.questionCategories = QUESTION_CATEGORY.PROBLEM_SOLVING;
                 }

--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -4,7 +4,7 @@ import {Remarkable} from "remarkable";
 import {linkify} from "remarkable/linkify";
 import {BooleanNotation, NOT_FOUND_TYPE} from "../../IsaacAppTypes";
 import {BookingStatus, Difficulty, ExamBoard, Stage} from "../../IsaacApiTypes";
-import {SITE, SITE_SUBJECT} from "./siteConstants";
+import {siteSpecific} from "./siteConstants";
 
 // eslint-disable-next-line no-undef
 export const API_VERSION: string = REACT_APP_API_VERSION || "any";
@@ -23,18 +23,32 @@ export const isTest = document.location.hostname.startsWith("test.");
 
 export const API_PATH: string = apiPath;
 
-const EDITOR_BASE_URL = {
-    [SITE.PHY]: "https://editor.isaacphysics.org",
-    [SITE.CS]: "https://editor.isaaccomputerscience.org",
-}[SITE_SUBJECT];
+const EDITOR_BASE_URL = siteSpecific(
+    "https://editor.isaacphysics.org",
+    "https://editor.isaaccomputerscience.org",
+);
 
 export const EDITOR_URL = EDITOR_BASE_URL + "/#!/edit/master/";
 export const EDITOR_COMPARE_URL = EDITOR_BASE_URL + "/#!/compare";
 
-export const GOOGLE_ANALYTICS_ACCOUNT_ID = {
-    [SITE.PHY]: "UA-122616705-1",
-    [SITE.CS]: "UA-137475074-1",
-}[SITE_SUBJECT];
+export const GOOGLE_ANALYTICS_ACCOUNT_ID = siteSpecific(
+    "UA-122616705-1",
+    "UA-137475074-1"
+);
+
+export const SOCIAL_LINKS = siteSpecific(
+    {
+        youtube: {name: "YouTube", href: "https://www.youtube.com/user/isaacphysics"},
+        twitter: {name: "Twitter", href: "https://twitter.com/isaacphysics"},
+        facebook: {name: "Facebook", href: "https://www.facebook.com/isaacphysicsUK"},
+    },
+    {
+        youtube: {name: "YouTube", href: "https://www.youtube.com/channel/UC-qoIYj8kgR8RZtQphrRBYQ"},
+        twitter: {name: "Twitter", href: "https://twitter.com/isaaccompsci"},
+        facebook: {name: "Facebook", href: "https://www.facebook.com/IsaacComputerScience"},
+        instagram: {name: "Instagram", href: "https://www.instagram.com/isaaccompsci"}
+    }
+);
 
 export const CODE_EDITOR_BASE_URL = document.location.hostname === "localhost" ? "http://localhost:3000" : "https://editor.isaaccode.org";
 
@@ -981,9 +995,10 @@ export const HOME_CRUMB = {title: "Home", to: "/"};
 export const ALL_TOPICS_CRUMB = {title: "All topics", to: "/topics"};
 export const ADMIN_CRUMB = {title: "Admin", to: "/admin"};
 export const EVENTS_CRUMB = {title: "Events", to: "/events"};
-export const ASSIGNMENT_PROGRESS_CRUMB = SITE_SUBJECT === SITE.PHY ?
-    {title: "Assignment Progress", to: "/assignment_progress"} :
-    {title: "My markbook", to: "/my_markbook"};
+export const ASSIGNMENT_PROGRESS_CRUMB = siteSpecific(
+    {title: "Assignment Progress", to: "/assignment_progress"},
+    {title: "My markbook", to: "/my_markbook"}
+);
 
 export enum UserRole {
     ADMIN = "ADMIN",
@@ -1095,8 +1110,8 @@ _REVERSE_GREEK_LETTERS_MAP["ε"] = "epsilon"; // Take this one in preference!
 export const REVERSE_GREEK_LETTERS_MAP = _REVERSE_GREEK_LETTERS_MAP;
 
 
-export const specificDoughnutColours: { [key: string]: string } = {
-    [SITE.PHY]: {
+export const specificDoughnutColours: { [key: string]: string } = siteSpecific(
+    {
         "Physics": "#944cbe",
         "Maths": "#007fa9",
         "Chemistry": "#e22e25",
@@ -1107,11 +1122,11 @@ export const specificDoughnutColours: { [key: string]: string } = {
         [difficultyLabelMap.challenge_2]: "#955a0f",
         [difficultyLabelMap.challenge_3]: "#764811"
     },
-    [SITE.CS]: {}
-}[SITE_SUBJECT];
+    {}
+);
 
-export const doughnutColours = {
-    [SITE.PHY]: [
+export const doughnutColours = siteSpecific(
+    [
         "#944cbe",
         "#007fa9",
         "#e22e25",
@@ -1119,7 +1134,7 @@ export const doughnutColours = {
         "#448525",
         "#fea100"
     ],
-    [SITE.CS]: [
+    [
         "#feae42",
         "#000000",
         "#e51f6f",
@@ -1129,12 +1144,12 @@ export const doughnutColours = {
         "#aaaaaa",
         "#dbdbdb"
     ]
-}[SITE_SUBJECT];
+);
 
-export const progressColour = {
-    [SITE.PHY]: '#509E2E',
-    [SITE.CS]: '#000000'
-}[SITE_SUBJECT];
+export const progressColour = siteSpecific(
+    '#509E2E',
+    '#000000'
+);
 
 export const GRAY_120 = '#c9cad1';
 

--- a/src/app/services/events.tsx
+++ b/src/app/services/events.tsx
@@ -5,7 +5,7 @@ import {DateString, FRIENDLY_DATE, TIME_ONLY} from "../components/elements/DateS
 import React from "react";
 import {Link} from "react-router-dom";
 import {STAGE, STAGES_CS, STAGES_PHY} from "./constants";
-import {SITE, SITE_SUBJECT} from "./siteConstants";
+import {siteSpecific} from "./siteConstants";
 import {isStudent, isTeacher} from "./user";
 import {atLeastOne} from "./validation";
 
@@ -94,8 +94,8 @@ export const formatEventCardDate = (event: AugmentedEvent, podView?: boolean) =>
 };
 
 export const stageExistsForSite = (stage: string) => {
-    const stagesForSite = SITE_SUBJECT === SITE.CS ? STAGES_CS : STAGES_PHY
-    return stagesForSite.has(stage as STAGE)
+    const stagesForSite = siteSpecific(STAGES_PHY, STAGES_CS);
+    return stagesForSite.has(stage as STAGE);
 }
 
 export const userSatisfiesStudentOnlyRestrictionForEvent = (user: PotentialUser | null, event: AugmentedEvent) => {

--- a/src/app/services/gameboards.tsx
+++ b/src/app/services/gameboards.tsx
@@ -3,7 +3,7 @@ import {NOT_FOUND} from "./constants";
 import React from "react";
 import countBy from "lodash/countBy"
 import intersection from "lodash/intersection"
-import {SITE, SITE_SUBJECT} from "./siteConstants";
+import {isCS, isPhy} from "./siteConstants";
 import {CurrentGameboardState} from "../state/reducers/gameboardsState";
 import {determineAudienceViews} from "./userContext";
 import {ViewingContext} from "../../IsaacAppTypes";
@@ -89,12 +89,12 @@ export const generateGameboardSubjectHexagons = (boardSubjects: string[]) => {
 
 export const showWildcard = (board: GameboardDTO) => {
     const re = new RegExp('(phys_book_gcse_ch.*|pre_uni_maths.*)');
-    const isaacPhysicsBoard = board?.tags?.includes("ISAAC_BOARD") && SITE_SUBJECT === SITE.PHY;
+    const isaacPhysicsBoard = isPhy && board?.tags?.includes("ISAAC_BOARD");
     return board?.id && (re.test(board.id) || isaacPhysicsBoard)
 };
 
 export const determineGameboardSubjects = (board: GameboardDTO) => {
-    if (SITE_SUBJECT === SITE.CS) {
+    if (isCS) {
         return ["compsci"];
     }
     const subjects = ["physics", "maths", "chemistry"];

--- a/src/app/services/miscUtils.ts
+++ b/src/app/services/miscUtils.ts
@@ -1,5 +1,4 @@
 import React, {RefObject, useCallback, useEffect, useRef, useState} from "react";
-import {SITE, SITE_SUBJECT} from "./siteConstants";
 import {NOT_FOUND_TYPE} from "../../IsaacAppTypes";
 import {NOT_FOUND} from "./constants";
 
@@ -101,14 +100,6 @@ export function useOutsideCallback(ref: RefObject<any>, callback : () => void, d
             document.removeEventListener("mousedown", handleClickOutside);
         };
     }, [...deps, ref]);
-}
-
-export const isPhy = SITE_SUBJECT === SITE.PHY;
-
-export const isCS = SITE_SUBJECT === SITE.CS;
-
-export function siteSpecific<P, C>(phy: P, cs: C) {
-    return isPhy ? phy : cs;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/src/app/services/passwordStrength.ts
+++ b/src/app/services/passwordStrength.ts
@@ -1,5 +1,5 @@
 import {PasswordFeedback, ZxcvbnResult} from "../../IsaacAppTypes";
-import {SITE, SITE_SUBJECT} from "./siteConstants";
+import {siteSpecific} from "./siteConstants";
 import axios from "axios";
 
 export const passwordStrengthText: {[score: number]: string} = {
@@ -10,10 +10,10 @@ export const passwordStrengthText: {[score: number]: string} = {
     4: "Very Strong"
 };
 
-const zxcvbnSrc = {
-    [SITE.CS]: 'https://cdn.isaaccomputerscience.org',
-    [SITE.PHY]: 'https://cdn.isaacphysics.org'
-}[SITE_SUBJECT] + "/vendor/dropbox/zxcvbn-isaac.js";
+const zxcvbnSrc = siteSpecific(
+    'https://cdn.isaacphysics.org',
+    'https://cdn.isaaccomputerscience.org'
+) + "/vendor/dropbox/zxcvbn-isaac.js";
 
 
 export function loadZxcvbnIfNotPresent() {

--- a/src/app/services/siteConstants.ts
+++ b/src/app/services/siteConstants.ts
@@ -2,18 +2,19 @@ export enum SITE {PHY = "physics", CS = "cs"}
 // eslint-disable-next-line no-undef
 export const SITE_SUBJECT = ISAAC_SITE as SITE;
 
-export const SITE_SUBJECT_TITLE = {
-    [SITE.PHY]: "Physics",
-    [SITE.CS]: "Computer Science"
-}[SITE_SUBJECT];
+// Boolean representing if the current site is Isaac Physics
+export const isPhy = SITE_SUBJECT === SITE.PHY;
 
-export const WEBMASTER_EMAIL = {
-    [SITE.PHY]: "webmaster@isaacphysics.org",
-    [SITE.CS]: "webmaster@isaaccomputerscience.org"
-}[SITE_SUBJECT];
+// Boolean representing if the current site is Isaac CS
+export const isCS = SITE_SUBJECT === SITE.CS;
 
-export const TEACHER_REQUEST_ROUTE = {
-    [SITE.PHY]: "/pages/contact_us_teacher",
-    [SITE.CS]: "/pages/teacher_accounts"
-}[SITE_SUBJECT];
+// Picks between two arguments based on whether the site is Physics or CS
+export function siteSpecific<P, C>(phy: P, cs: C) {
+    return isPhy ? phy : cs;
+}
 
+export const SITE_SUBJECT_TITLE = siteSpecific("Physics", "Computer Science");
+
+export const WEBMASTER_EMAIL = siteSpecific("webmaster@isaacphysics.org", "webmaster@isaaccomputerscience.org");
+
+export const TEACHER_REQUEST_ROUTE = siteSpecific("/pages/contact_us_teacher", "/pages/teacher_accounts");

--- a/src/app/services/tags.ts
+++ b/src/app/services/tags.ts
@@ -1,6 +1,6 @@
-import {SITE, SITE_SUBJECT} from "./siteConstants";
+import {siteSpecific} from "./siteConstants";
 import {PhysicsTagService} from "./tagsPhy";
 import {CsTagService} from "./tagsCS";
 
-const subjectSpecificTagService = {[SITE.PHY]: PhysicsTagService, [SITE.CS]: CsTagService}[SITE_SUBJECT];
+const subjectSpecificTagService = siteSpecific(PhysicsTagService, CsTagService);
 export default new subjectSpecificTagService();

--- a/src/app/services/topics.ts
+++ b/src/app/services/topics.ts
@@ -4,7 +4,7 @@ import {LinkInfo} from "./navigation";
 import {isIntendedAudience, UseUserContextReturnType} from "./userContext";
 import {NOT_FOUND_TYPE, PotentialUser} from "../../IsaacAppTypes";
 import {CurrentTopicState} from "../state/reducers/topicState";
-import {SITE, SITE_SUBJECT} from "./siteConstants";
+import {isPhy} from "./siteConstants";
 
 const filterForConcepts = (contents: ContentSummaryDTO[]) => {
     return contents.filter(content => content.type === DOCUMENT_TYPE.CONCEPT);
@@ -16,7 +16,7 @@ const filterForQuestions = (contents: ContentSummaryDTO[]) => {
 
 export const filterAndSeparateRelatedContent = (contents: ContentSummaryDTO[], userContext: UseUserContextReturnType, user: PotentialUser | null) => {
     const examBoardFilteredContent = contents.filter(c =>
-        SITE_SUBJECT === SITE.PHY ||
+        isPhy ||
         userContext.showOtherContent ||
         isIntendedAudience(c.audience, userContext, user)
     );

--- a/src/app/services/validation.ts
+++ b/src/app/services/validation.ts
@@ -7,7 +7,7 @@ import {
 } from "../../IsaacAppTypes";
 import {UserContext, UserSummaryWithEmailAddressDTO} from "../../IsaacApiTypes";
 import {FAILURE_TOAST} from "../components/navigation/Toasts";
-import {SITE, SITE_SUBJECT} from "./siteConstants";
+import {isCS} from "./siteConstants";
 import {EXAM_BOARD, STAGE} from "./constants";
 import {isStudent} from "./user";
 
@@ -59,7 +59,7 @@ export function validateUserContexts(userContexts?: UserContext[]): boolean {
     if (userContexts.length === 0) {return false;}
     return userContexts.every(uc =>
         Object.values(STAGE).includes(uc.stage as STAGE) && //valid stage
-        (SITE_SUBJECT !== SITE.CS || Object.values(EXAM_BOARD).includes(uc.examBoard as EXAM_BOARD)) // valid exam board for cs
+        (!isCS || Object.values(EXAM_BOARD).includes(uc.examBoard as EXAM_BOARD)) // valid exam board for cs
     );
 }
 
@@ -89,7 +89,7 @@ export const withinLast2Hours = withinLastNMinutes.bind(null, 120);
 
 export function allRequiredInformationIsPresent(user?: ValidationUser | null, userPreferences?: UserPreferencesDTO | null, userContexts?: UserContext[]) {
     return user && userPreferences
-        && (SITE_SUBJECT !== SITE.CS || (validateUserSchool(user) && validateUserGender(user)
+        && (!isCS || (validateUserSchool(user) && validateUserGender(user)
         && validateName(user.givenName) && validateName(user.familyName)))
         && (userPreferences.EMAIL_PREFERENCE === null || validateEmailPreferences(userPreferences.EMAIL_PREFERENCE))
         && validateUserContexts(userContexts);


### PR DESCRIPTION
The focus of this is to have a standard interface for deciding which content to show based on the current site. It's big, but the code should be nicer to read from now on.
This also stops a large amount of objects being created (not sure if this is an optimisation or not).

