### PR TITLE
Add a 'q' query string parameter to pre-populate the search field in /set_tests

### DIFF
--- a/src/app/components/pages/quizzes/SetQuizzes.tsx
+++ b/src/app/components/pages/quizzes/SetQuizzes.tsx
@@ -23,6 +23,7 @@ import {below, useDeviceSize} from "../../../services/device";
 import {isDefined} from "../../../services/miscUtils";
 import {IsaacSpinner} from "../../handlers/IsaacSpinner";
 import {isEventLeaderOrStaff} from "../../../services/user";
+import queryString from "query-string";
 
 interface SetQuizzesPageProps extends RouteComponentProps {
     user: RegisteredUserDTO;
@@ -84,8 +85,10 @@ const SetQuizzesPageComponent = ({user, location}: SetQuizzesPageProps) => {
 
     const dispatch = useDispatch();
 
+    const { q }: { q?: string } = queryString.parse(location.search)
+
     const startIndex = 0;
-    const [titleFilter, setTitleFilter] = useState<string|undefined>();
+    const [titleFilter, setTitleFilter] = useState<string|undefined>(q?.replace(/[^a-zA-Z0-9 ]+/g, ''));
 
     // Set active tab using hash anchor
     useEffect(() => {


### PR DESCRIPTION
I'm not dead set on `q`, I can offer `topic` or `search` as alternatives, but I'm open to others.