### PR TITLE
Rename waiting list to request a place for waiting list only events

### DIFF
--- a/src/app/components/elements/modals/UserBookingModal.tsx
+++ b/src/app/components/elements/modals/UserBookingModal.tsx
@@ -8,6 +8,7 @@ import {atLeastOne, zeroOrLess} from "../../../services/validation";
 import {EventBookingForm} from "../EventBookingForm";
 import {useDispatch} from "react-redux";
 import {FAILURE_TOAST} from "../../navigation/Toasts";
+import {formatBookingModalConfirmMessage} from "../../../services/events";
 
 export function userBookingModal(selectedUser: UserSummaryForAdminUsersDTO, selectedEvent: AugmentedEvent, eventBookingIds: number[]) {
     return {
@@ -71,7 +72,7 @@ export function userBookingModal(selectedUser: UserSummaryForAdminUsersDTO, sele
                     />}
 
                     {(userCanBeBookedOnEvent || userCanBeAddedToWaitingList) && <RS.Input className="btn btn-block btn-secondary border-0 mt-3"
-                        type="submit" value={userCanBeBookedOnEvent ? "Book on event" : "Add to waiting list"}
+                        type="submit" value={formatBookingModalConfirmMessage(selectedEvent, userCanBeBookedOnEvent)}
                     />}
                 </span>
             </RS.Form>

--- a/src/app/components/elements/panels/AddUsersToBooking.tsx
+++ b/src/app/components/elements/panels/AddUsersToBooking.tsx
@@ -9,6 +9,7 @@ import {DateString} from "../DateString";
 import {NOT_FOUND} from "../../../services/constants";
 import {userBookingModal} from "../modals/UserBookingModal";
 import {selectors} from "../../../state/selectors";
+import {formatManageBookingActionButtonMessage} from "../../../services/events";
 
 export const AddUsersToBooking = () => {
     const dispatch = useDispatch();
@@ -92,14 +93,9 @@ export const AddUsersToBooking = () => {
                 <tbody>
                     {selectedEvent && selectedEvent !== NOT_FOUND && userResults.map(result => <tr key={result.id}>
                         <td className="align-middle">
-                            {!userBookings.includes(result.id as number) && selectedEvent.eventStatus != 'WAITING_LIST_ONLY' && atLeastOne(selectedEvent.placesAvailable) &&
+                            {!userBookings.includes(result.id as number) &&
                             <RS.Button color="primary" outline className="btn-sm" onClick={() => dispatch(openActiveModal(userBookingModal(result, selectedEvent, userBookings)))}>
-                                Book
-                            </RS.Button>
-                            }
-                            {!userBookings.includes(result.id as number) && (selectedEvent.eventStatus == 'WAITING_LIST_ONLY' || zeroOrLess(selectedEvent.placesAvailable)) &&
-                            <RS.Button color="primary" outline className="btn-sm" onClick={() => dispatch(openActiveModal(userBookingModal(result, selectedEvent, userBookings)))}>
-                                Add to WL
+                                {formatManageBookingActionButtonMessage(selectedEvent)}
                             </RS.Button>
                             }
                             {userBookings.includes(result.id as number) && <div className="text-center">Booking exists</div>}

--- a/src/app/components/pages/EventDetails.tsx
+++ b/src/app/components/pages/EventDetails.tsx
@@ -27,7 +27,12 @@ import {isLoggedIn, isStaff, isTeacher} from "../../services/user";
 import {selectors} from "../../state/selectors";
 import {reservationsModal} from "../elements/modals/ReservationsModal";
 import {IsaacContent} from "../content/IsaacContent";
-import {formatEventDetailsDate,
+import {
+    formatAvailabilityMessage,
+    formatMakeBookingButtonMessage,
+    formatCancelBookingButtonMessage,
+    formatWaitingListBookingStatusMessage,
+    formatEventDetailsDate,
     studentOnlyEventMessage,
     userCanBeAddedToEventWaitingList,
     userCanMakeEventBooking,
@@ -105,7 +110,7 @@ const EventDetails = ({match: {params: {eventId}}, location: {pathname}}: EventD
                 } else if (canMakeABooking) {
                     dispatch(bookMyselfOnEvent(event.id as string, additionalInformation));
                 } else if (canBeAddedToWaitingList) {
-                    dispatch(addMyselfToWaitingList(event.id as string, additionalInformation));
+                    dispatch(addMyselfToWaitingList(event.id as string, additionalInformation, event.isWaitingListOnly));
                 }
             }
         }
@@ -206,8 +211,8 @@ const EventDetails = ({match: {params: {eventId}}, location: {pathname}}: EventD
                                                     <u>Complete your registration below</u>.
                                                 </RS.Button>
                                             </span></span>}
-                                            {canBeAddedToWaitingList && <span> - Waiting list booking is available!</span>}
-                                            {event.userBookingStatus === "WAITING_LIST" && <span> - You are on the waiting list for this event.</span>}
+                                            {canBeAddedToWaitingList && <span> - {formatAvailabilityMessage(event)}</span>}
+                                            {event.userBookingStatus === "WAITING_LIST" && <span> - {formatWaitingListBookingStatusMessage(event)}</span>}
                                             {event.isStudentOnly && !studentOnlyRestrictionSatisfied &&
                                                 <div className="text-muted font-weight-normal">
                                                     {studentOnlyEventMessage(eventId)}
@@ -273,7 +278,7 @@ const EventDetails = ({match: {params: {eventId}}, location: {pathname}}: EventD
                                     <RS.Button onClick={loginAndReturn}>
                                         {atLeastOne(event.placesAvailable) && event.isWithinBookingDeadline ?
                                             "Login to book" :
-                                            "login to apply"
+                                            "Login to apply"
                                         }
                                     </RS.Button>
                                 }
@@ -282,7 +287,7 @@ const EventDetails = ({match: {params: {eventId}}, location: {pathname}}: EventD
                                 {isLoggedIn(user) && !event.hasExpired && <React.Fragment>
                                     {(canMakeABooking || canBeAddedToWaitingList) && !bookingFormOpen && !['CONFIRMED'].includes(event.userBookingStatus || '') &&
                                         <RS.Button onClick={() => {setBookingFormOpen(true)}}>
-                                            {event.userBookingStatus === 'RESERVED' ? 'Confirm your reservation' : 'Book a place'}
+                                            {formatMakeBookingButtonMessage(event)}
                                         </RS.Button>
                                     }
                                     {canReserveSpaces &&
@@ -292,11 +297,7 @@ const EventDetails = ({match: {params: {eventId}}, location: {pathname}}: EventD
                                     }
                                     {(event.userBookingStatus === "CONFIRMED" || event.userBookingStatus === "WAITING_LIST" || event.userBookingStatus === "RESERVED") &&
                                         <RS.Button color="primary" outline onClick={() => {dispatch(cancelMyBooking(eventId))}}>
-                                            {{
-                                                CONFIRMED: "Cancel your booking",
-                                                WAITING_LIST: "Leave waiting list",
-                                                RESERVED: "Cancel your reservation"
-                                            }[event.userBookingStatus]}
+                                            {formatCancelBookingButtonMessage(event)}
                                         </RS.Button>
                                     }
                                 </React.Fragment>}

--- a/src/app/components/pages/EventDetails.tsx
+++ b/src/app/components/pages/EventDetails.tsx
@@ -37,7 +37,8 @@ import {
     userCanBeAddedToEventWaitingList,
     userCanMakeEventBooking,
     userCanReserveEventSpaces,
-    userSatisfiesStudentOnlyRestrictionForEvent
+    userSatisfiesStudentOnlyRestrictionForEvent,
+    formatBookingModalConfirmMessage
 } from "../../services/events";
 import {EditContentButton} from "../elements/EditContentButton";
 import { isDefined } from "../../services/miscUtils";
@@ -92,10 +93,6 @@ const EventDetails = ({match: {params: {eventId}}, location: {pathname}}: EventD
         const canMakeABooking = userCanMakeEventBooking(user, event)
         const canBeAddedToWaitingList = userCanBeAddedToEventWaitingList(user, event)
         const canReserveSpaces = userCanReserveEventSpaces(user, event)
-
-        const submissionTitle = canMakeABooking ?
-            "Book now" :
-            event.isWithinBookingDeadline ? "Apply" : "Apply - deadline past";
 
         const isVirtual = event.tags?.includes("virtual");
 
@@ -263,7 +260,7 @@ const EventDetails = ({match: {params: {eventId}}, location: {pathname}}: EventD
                                                 </p>
 
                                                 <div className="text-center mt-4 mb-2">
-                                                    <RS.Input type="submit" value={submissionTitle} className="btn btn-xl btn-secondary border-0" />
+                                                    <RS.Input type="submit" value={formatBookingModalConfirmMessage(event, canMakeABooking)} className="btn btn-xl btn-secondary border-0" />
                                                 </div>
                                             </div>
                                         </RS.Form>

--- a/src/app/services/events.tsx
+++ b/src/app/services/events.tsx
@@ -134,6 +134,28 @@ export const formatCancelBookingButtonMessage = (event: AugmentedEvent) => {
     }
 }
 
+export const formatManageBookingActionButtonMessage = (event: AugmentedEvent) => {
+    if (event.userBookingStatus === "RESERVED") {
+        return "Confirm reservation"
+    }
+    if (event.isWaitingListOnly) {
+        return "Make booking request"
+    }
+    if (zeroOrLess(event.placesAvailable)) {
+        return "Add to waiting list"
+    }
+    return "Book a place"
+}
+
+export const formatBookingModalConfirmMessage = (event: AugmentedEvent, userCanMakeEventBooking?: boolean) => {
+    if (userCanMakeEventBooking) {
+        return "Book now"
+    }
+    else {
+        return event.isWithinBookingDeadline ? "Apply" : "Apply - deadline past"
+    }
+}
+
 export const stageExistsForSite = (stage: string) => {
     const stagesForSite = siteSpecific(STAGES_PHY, STAGES_CS);
     return stagesForSite.has(stage as STAGE);

--- a/src/app/services/events.tsx
+++ b/src/app/services/events.tsx
@@ -123,16 +123,15 @@ export const formatMakeBookingButtonMessage = (event: AugmentedEvent) => {
 }
 
 export const formatCancelBookingButtonMessage = (event: AugmentedEvent) => {
-    if (event.userBookingStatus == "RESERVED"){
+    if (event.userBookingStatus == "CONFIRMED") {
+        return "Cancel your booking"
+    }
+    else if (event.userBookingStatus == "RESERVED") {
         return "Cancel your reservation"
     }
-    else if (event.isWaitingListOnly) {
-        return "Cancel place request"
+    else if (event.userBookingStatus == "WAITING_LIST") {
+        return event.isWaitingListOnly ? "Cancel place request" : "Leave waiting list"
     }
-    else if (event.userBookingStatus == "WAITING_LIST"){
-        return "Leave waiting list"
-    }
-    return "Cancel your booking"
 }
 
 export const stageExistsForSite = (stage: string) => {

--- a/src/app/services/events.tsx
+++ b/src/app/services/events.tsx
@@ -7,7 +7,7 @@ import {Link} from "react-router-dom";
 import {STAGE, STAGES_CS, STAGES_PHY} from "./constants";
 import {siteSpecific} from "./siteConstants";
 import {isStudent, isTeacher} from "./user";
-import {atLeastOne} from "./validation";
+import {atLeastOne, zeroOrLess} from "./validation";
 
 export const studentOnlyEventMessage = (eventId?: string) => <React.Fragment>
     {"This event is aimed at students. If you are not a student but still wish to attend, please "}
@@ -92,6 +92,48 @@ export const formatEventCardDate = (event: AugmentedEvent, podView?: boolean) =>
         </>;
     }
 };
+
+export const formatAvailabilityMessage = (event: AugmentedEvent) => {
+    if (event.isWaitingListOnly) {
+        //  in this case, the waiting list is for booking requests that must be approved
+        return "Bookings available by request!"
+    }
+    // this is an event which can be freely joined, however it happens to be full
+    return "Waiting list booking is available!"
+}
+
+export const formatWaitingListBookingStatusMessage = (event: AugmentedEvent) => {
+    if (event.isWaitingListOnly) {
+        return "You have requested a place on this event."
+    }
+    return "You are on the waiting list for this event."
+}
+
+export const formatMakeBookingButtonMessage = (event: AugmentedEvent) => {
+    if (event.userBookingStatus === "RESERVED") {
+        return "Confirm your reservation"
+    }
+    if (event.isWaitingListOnly) {
+        return "Request a place"
+    }
+    if (zeroOrLess(event.placesAvailable)) {
+        return "Join waiting list"
+    }
+    return "Book a place"
+}
+
+export const formatCancelBookingButtonMessage = (event: AugmentedEvent) => {
+    if (event.userBookingStatus == "RESERVED"){
+        return "Cancel your reservation"
+    }
+    else if (event.isWaitingListOnly) {
+        return "Cancel place request"
+    }
+    else if (event.userBookingStatus == "WAITING_LIST"){
+        return "Leave waiting list"
+    }
+    return "Cancel your booking"
+}
 
 export const stageExistsForSite = (stage: string) => {
     const stagesForSite = siteSpecific(STAGES_PHY, STAGES_CS);

--- a/src/app/services/events.tsx
+++ b/src/app/services/events.tsx
@@ -130,7 +130,7 @@ export const formatCancelBookingButtonMessage = (event: AugmentedEvent) => {
         return "Cancel your reservation"
     }
     else if (event.userBookingStatus == "WAITING_LIST") {
-        return event.isWaitingListOnly ? "Cancel place request" : "Leave waiting list"
+        return event.isWaitingListOnly ? "Cancel booking request" : "Leave waiting list"
     }
 }
 

--- a/src/app/state/actions.tsx
+++ b/src/app/state/actions.tsx
@@ -1872,15 +1872,19 @@ export const cancelReservationsOnEvent = (eventId: string, userIds: number[], gr
     }
 };
 
-export const addMyselfToWaitingList = (eventId: string, additionalInformation: AdditionalInformation) => async (dispatch: Dispatch<Action>) => {
+export const addMyselfToWaitingList = (eventId: string, additionalInformation: AdditionalInformation, waitingListOnly?: boolean) => async (dispatch: Dispatch<Action>) => {
     try {
         dispatch({type: ACTION_TYPE.EVENT_BOOKING_WAITING_LIST_REQUEST});
         await api.eventBookings.addMyselfToWaitingList(eventId, additionalInformation);
         await dispatch(getEvent(eventId) as any);
         dispatch({type: ACTION_TYPE.EVENT_BOOKING_WAITING_LIST_RESPONSE_SUCCESS});
         dispatch(showToast({
-            title: "Waiting list booking confirmed", body: "You have been successfully added to the waiting list for this event.",
-            color: "success", timeout: 5000, closable: false,
+            title: waitingListOnly ? "Booking request received" : "Waiting list booking confirmed",
+            body: waitingListOnly ? "You have requested a place on this event." :
+                "You have been successfully added to the waiting list for this event.",
+            color: "success",
+            timeout: 5000,
+            closable: false,
         }) as any);
         dispatch(getEvent(eventId) as any);
     } catch (error) {

--- a/src/app/state/actions.tsx
+++ b/src/app/state/actions.tsx
@@ -1894,7 +1894,7 @@ export const addMyselfToWaitingList = (eventId: string, additionalInformation: A
 };
 
 export const cancelMyBooking = (eventId: string) => async (dispatch: Dispatch<Action>) => {
-    const cancel = window.confirm('Are you sure you want to cancel your booking on this event. You may not be able to re-book, especially if there is a waiting list.');
+    const cancel = window.confirm('Are you sure you want to cancel your booking on this event? You may not be able to re-book, especially if there is a waiting list.');
     if (cancel) {
         try {
             dispatch({type: ACTION_TYPE.EVENT_BOOKING_SELF_CANCELLATION_REQUEST});

--- a/src/app/state/actions.tsx
+++ b/src/app/state/actions.tsx
@@ -1920,13 +1920,13 @@ export const bookUserOnEvent = (eventBookingId: string, userId: number, addition
         dispatch(getEventBookings(eventBookingId) as any);
         dispatch(closeActiveModal() as any);
         dispatch(showToast({
-            title: "Booking successful", body: `A booking has been created.`,
+            title: "Action successful", body: "The action on behalf of the user was successful.",
             color: "success", timeout: 5000, closable: false,
         }) as any);
         dispatch({type: ACTION_TYPE.EVENT_BOOKING_USER_RESPONSE_SUCCESS});
     } catch (error) {
         dispatch({type: ACTION_TYPE.EVENT_BOOKING_USER_RESPONSE_FAILURE});
-        dispatch(showErrorToastIfNeeded("Event booking failed", error) as any);
+        dispatch(showErrorToastIfNeeded("The action on behalf of the user was unsuccessful", error) as any);
     }
 };
 


### PR DESCRIPTION
This PR removes references to the waiting list for WAITING_LIST_ONLY events, so it should be clearer to guests that they are actually requesting one of the available places (this is how WAITING_LIST_ONLY is used in practice).