### PR TITLE
Allow editor preview to render glossary terms

### DIFF
--- a/config/webpack.config.cs.renderer.js
+++ b/config/webpack.config.cs.renderer.js
@@ -4,6 +4,7 @@ const BASE_DIRECTORY = path.resolve(__dirname, "..");
 const resolve = (p) => path.resolve(BASE_DIRECTORY, p);
 const configCS = require('./webpack.config.cs');
 const {merge} = require('webpack-merge');
+const webpack = require('webpack');
 
 module.exports = env => {
 
@@ -15,6 +16,12 @@ module.exports = env => {
         output: {
             path: resolve(`build-cs-renderer`),
         },
+
+        plugins: [
+            new webpack.DefinePlugin({
+                EDITOR_PREVIEW: 'true',
+            }),
+        ]
     };
 
     const nearly = merge(configCS(env), configCSrenderer);

--- a/config/webpack.config.phy.renderer.js
+++ b/config/webpack.config.phy.renderer.js
@@ -4,6 +4,7 @@ const BASE_DIRECTORY = path.resolve(__dirname, "..");
 const resolve = (p) => path.resolve(BASE_DIRECTORY, p);
 const configPHY = require('./webpack.config.physics');
 const {merge} = require('webpack-merge');
+const webpack = require('webpack');
 
 module.exports = env => {
 
@@ -15,6 +16,12 @@ module.exports = env => {
         output: {
             path: resolve(`build-phy-renderer`),
         },
+
+        plugins: [
+            new webpack.DefinePlugin({
+                EDITOR_PREVIEW: 'true',
+            }),
+        ]
     };
 
     const nearly = merge(configPHY(env), configPHYrenderer);

--- a/src/app/components/elements/EditorRenderer.tsx
+++ b/src/app/components/elements/EditorRenderer.tsx
@@ -4,9 +4,10 @@ import {siteSpecific} from "../../services/siteConstants";
 import {FigureNumberingContext} from "../../../IsaacAppTypes";
 import {WithFigureNumbering} from "./WithFigureNumbering";
 import {IsaacContent} from "../content/IsaacContent";
-import {Provider} from "react-redux";
+import {Provider, useDispatch} from "react-redux";
 import {store} from "../../state/store";
 import {StaticRouter} from "react-router";
+import {fetchGlossaryTerms} from "../../state/actions";
 
 function getType(doc: any) {
     if (!doc) {
@@ -25,6 +26,12 @@ function getType(doc: any) {
 function EditorListener() {
     // Wait for messages and then put doc from message into IsaacContent
     const [doc, setDoc] = useState();
+    const dispatch = useDispatch();
+
+    // Fetch glossary terms so they can be rendered
+    useEffect(() => {
+        dispatch(fetchGlossaryTerms());
+    }, [dispatch]);
 
     const listener = useCallback((message) => {
         const {doc} = message.data;

--- a/src/app/components/elements/inputs/ConfidenceQuestions.tsx
+++ b/src/app/components/elements/inputs/ConfidenceQuestions.tsx
@@ -169,7 +169,7 @@ export const ConfidenceQuestions = ({state, setState, disableInitialState, ident
             </Col>
         </Row>
         <Row className={"justify-content-center"}>
-            {confidenceStateVariables.options.map(option => <Col lg={4} md={6} sm={12} className={classNames("mb-2")}>
+            {confidenceStateVariables.options.map(option => <Col key={option.label} lg={4} md={6} sm={12} className={classNames("mb-2")}>
                 <Button color={option.color} disabled={disabled} block
                         className={classNames({"active": state === "followUp"})} type="submit"
                         onClick={() => toggle(option.label, state)}>

--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -6,6 +6,11 @@ import {BooleanNotation, NOT_FOUND_TYPE} from "../../IsaacAppTypes";
 import {BookingStatus, Difficulty, ExamBoard, Stage} from "../../IsaacApiTypes";
 import {siteSpecific} from "./siteConstants";
 
+export const STAGING_URL = siteSpecific(
+    "https://staging.isaacphysics.org",
+    "https://staging.isaaccomputerscience.org"
+);
+
 // eslint-disable-next-line no-undef
 export const API_VERSION: string = REACT_APP_API_VERSION || "any";
 
@@ -16,6 +21,8 @@ export const API_VERSION: string = REACT_APP_API_VERSION || "any";
 let apiPath = `${document.location.origin}/api/${API_VERSION}/api`;
 if (document.location.hostname === "localhost") {
     apiPath = "http://localhost:8080/isaac-api/api";
+} else if (EDITOR_PREVIEW) {
+    apiPath = `${STAGING_URL}/api/any/api`;
 } else if (document.location.hostname.endsWith(".eu.ngrok.io")) {
     apiPath = "https://isaacscience.eu.ngrok.io/isaac-api/api";
 }

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -71,6 +71,7 @@ declare var MathJax: any;
 declare var ISAAC_SITE: string;
 declare var REACT_APP_API_VERSION: string;
 declare const ENV_QUIZ_FEATURE_FLAG: boolean;
+declare var EDITOR_PREVIEW: boolean;
 
 declare module "inequality-grammar" {
   export const parseMathsExpression: (exp: string) => (any[]) | ParsingError;


### PR DESCRIPTION
Just amounts to allowing it to query an API. I chose staging to be consistent with the editor but maybe live would be preferable? - I'm not sure