### PR TITLE
Move `validationPending` state up to allow post question to show safely

### DIFF
--- a/src/app/components/content/IsaacQuestion.tsx
+++ b/src/app/components/content/IsaacQuestion.tsx
@@ -42,7 +42,7 @@ export const IsaacQuestion = withRouter(({doc, location}: {doc: ApiTypes.Questio
     const invalidFormatErrorStdForm = validationResponseTags?.includes("invalid_std_form");
     const fastTrackInfo = useFastTrackInformation(doc, location, canSubmit, correct);
 
-    const {confidenceState, setConfidenceState, confidenceDisabled, recordConfidence, showQuestionFeedback} = useConfidenceQuestionsValues(
+    const {confidenceState, setConfidenceState, validationPending, setValidationPending, confidenceDisabled, recordConfidence, showQuestionFeedback} = useConfidenceQuestionsValues(
         currentGameboard?.tags?.includes("CONFIDENCE_RESEARCH_BOARD"),
         "question",
         undefined,
@@ -128,6 +128,7 @@ export const IsaacQuestion = withRouter(({doc, location}: {doc: ApiTypes.Questio
                 {/* Action Buttons */}
                 {recordConfidence ?
                     <ConfidenceQuestions state={confidenceState} setState={setConfidenceState}
+                                         validationPending={validationPending} setValidationPending={setValidationPending}
                                          disableInitialState={confidenceDisabled}
                                          identifier={doc.id} type={"question"}
                                          validationResponse={validationResponse} />

--- a/src/app/components/content/IsaacQuickQuestion.tsx
+++ b/src/app/components/content/IsaacQuickQuestion.tsx
@@ -19,7 +19,7 @@ export const IsaacQuickQuestion = ({doc}: {doc: IsaacQuickQuestionDTO}) => {
     const secondaryAction = determineFastTrackSecondaryAction(fastTrackInfo);
 
     // Confidence questions
-    const {confidenceState, setConfidenceState, recordConfidence, confidenceDisabled} = useConfidenceQuestionsValues(
+    const {confidenceState, setConfidenceState, validationPending, setValidationPending, recordConfidence, confidenceDisabled} = useConfidenceQuestionsValues(
         doc.showConfidence,
         "quick_question",
         (newCS) => {
@@ -71,6 +71,7 @@ export const IsaacQuickQuestion = ({doc}: {doc: IsaacQuickQuestionDTO}) => {
         };
         return <>
             <ConfidenceQuestions state={confidenceState} setState={setConfidenceState}
+                                 validationPending={validationPending} setValidationPending={setValidationPending}
                                  disableInitialState={confidenceDisabled}
                                  identifier={doc.id} type={"quick_question"} />
             {isVisible && <Row className="mt-3">

--- a/src/app/components/elements/inputs/ConfidenceQuestions.tsx
+++ b/src/app/components/elements/inputs/ConfidenceQuestions.tsx
@@ -95,7 +95,8 @@ const confidenceInformationModal = () => openActiveModal({
 type ValidationPendingState =
   | {
     pending: true,
-    confidence: string
+    confidence: string,
+    updateState: boolean
 } | {
     pending: false
 }
@@ -107,7 +108,7 @@ export const ConfidenceQuestions = ({state, setState, validationPending, setVali
         const stateAndType: `${ActiveConfidenceState} & ${ConfidenceType}` = `${state} & ${type}`;
         switch (stateAndType) {
             case "initial & question":
-                setValidationPending({pending: true, confidence});
+                setValidationPending({pending: true, updateState: true, confidence});
                 break;
             case "initial & quick_question":
                 dispatch(logAction({
@@ -140,7 +141,7 @@ export const ConfidenceQuestions = ({state, setState, validationPending, setVali
                 answerCorrect: validationResponse.correct,
                 confidence: validationPending.confidence
             }));
-            setState("followUp");
+            if (validationPending.updateState) setState("followUp");
         }
         setValidationPending({pending: false});
     }, [validationResponse]);
@@ -195,7 +196,7 @@ export const useConfidenceQuestionsValues = (show: boolean | undefined, type: Co
     useEffect(() => {
         if (type === "question") {
             setConfidenceState("initial");
-            setValidationPending({pending: false});
+            setValidationPending(vp => vp.pending ? {...vp, updateState: false} : vp);
         }
     }, [currentAttempt]);
 


### PR DESCRIPTION
The issue was that the question flow could be corrupted by the user answering twice in quick succession (within the window of the server returning a response to an attempt), so if a validation was pending, the we needed to be able to cancel the pending state change to the confidence buttons if another answer was submitted. 
Beforehand I tried to do this with a crude work-around that ended up not working.
Doing this properly just involved allowing the `useConfidenceQuestionsValues` hook to manage the `validationPending` state, meaning it could reset it if the current attempt changes.

This PR also fixed the confidence questions not working on item questions.