### PR TITLE
Gameboards "View more" incorrect ordering fix (and refactor)

### DIFF
--- a/src/IsaacAppTypes.tsx
+++ b/src/IsaacAppTypes.tsx
@@ -668,7 +668,7 @@ export enum BoardOrder {
     "-completion" = "-completion"
 }
 
-export type ActualBoardLimit = number | "ALL";
+export type NumberOfBoards = number | "ALL";
 
 export type AppGameBoard = ApiTypes.GameboardDTO & {assignedGroups?: ApiTypes.UserGroupDTO[]};
 

--- a/src/app/components/handlers/IsaacSpinner.tsx
+++ b/src/app/components/handlers/IsaacSpinner.tsx
@@ -1,19 +1,23 @@
 import React from "react";
-import {isCS, isPhy} from "../../services/siteConstants";
+import {isCS, siteSpecific} from "../../services/siteConstants";
 import classNames from "classnames";
 
 export interface IsaacSpinnerProps {
     size?: "sm" | "md" | "lg"
     className?: string
     color?: "primary" | "secondary"
+    inline?: boolean
 }
 
 // TODO: investigate and improve accessibility of both CS and default spinners. (The "Loading..." is copied from Bootstrap).
-export const IsaacSpinner = ({size = "md", className, color = "primary"} : IsaacSpinnerProps) => {
-    return <div role="status" className="pb-1">
-        <img style={isPhy ? {width: "auto", height: "5.5rem"} : {}} className={classNames(`isaac-spinner-${size}`, className)} alt="" src={isCS ? "/assets/isaac-cs-typer-css.svg" : "/assets/isaac-phy-apple-grow.svg"}/>
+export const IsaacSpinner = ({size = "md", className, color = "primary", inline = false} : IsaacSpinnerProps) => {
+    const contents = <>
+        <img style={siteSpecific({width: "auto", height: "5.5rem"}, {})} className={classNames(`isaac-spinner-${size}`, className)} alt="" src={isCS ? "/assets/isaac-cs-typer-css.svg" : "/assets/isaac-phy-apple-grow.svg"}/>
         <span className="sr-only">Loading...</span>
-    </div>
+    </>;
+    return inline
+        ? <span role="status">{contents}</span>
+        : <div role="status" className="pb-1">{contents}</div>;
 };
 
 export const Loading = () => <div className="w-100 text-center pb-2">

--- a/src/app/components/pages/MyGameboards.tsx
+++ b/src/app/components/pages/MyGameboards.tsx
@@ -304,7 +304,7 @@ export const MyGameboards = () => {
                 <div className="mt-4 mb-2">
                     {boards && boards.totalResults > 0 && <h4>You have completed <strong>{completed}</strong> of <strong>{boards.totalResults}</strong> gameboard{boards.totalResults > 1 && "s"},
                         with <strong>{inProgress}</strong> on the go and <strong>{notStarted}</strong> not started</h4>}
-                    {!boards && <h4>You have <IsaacSpinner size="sm" /> saved gameboards...</h4>}
+                    {!boards && <h4>You have <IsaacSpinner size="sm" inline /> saved gameboards...</h4>}
                 </div>
                 <div>
                     {boardView !== boardViews.table && <Row>

--- a/src/app/components/pages/MyGameboards.tsx
+++ b/src/app/components/pages/MyGameboards.tsx
@@ -65,7 +65,7 @@ enum boardCompletions {
 enum BoardLimit {
     "six" = "6",
     "eighteen" = "18",
-    "sixy" = "60",
+    "sixty" = "60",
     "All" = "ALL"
 }
 enum boardViews {

--- a/src/app/components/pages/MyGameboards.tsx
+++ b/src/app/components/pages/MyGameboards.tsx
@@ -8,7 +8,6 @@ import {
     Button,
     Card,
     CardBody,
-    CardDeck,
     CardSubtitle,
     CardTitle,
     Col,

--- a/src/app/components/pages/MyGameboards.tsx
+++ b/src/app/components/pages/MyGameboards.tsx
@@ -269,17 +269,19 @@ export const MyGameboards = () => {
                         (boardView == BoardViews.card ?
                             // Card view
                             <>
-                                <CardDeck>
-                                    {boards.boards.map(board => <Board
-                                        key={board.id}
-                                        board={board}
-                                        selectedBoards={selectedBoards}
-                                        setSelectedBoards={setSelectedBoards}
-                                        boardView={boardView}
-                                        user={user}
-                                        boards={boards}
-                                    />)}
-                                </CardDeck>
+                                <Row className={"row-cols-lg-3 row-cols-md-2 row-cols-1"}>
+                                    {boards.boards.map(board => <Col>
+                                        <Board
+                                            key={board.id}
+                                            board={board}
+                                            selectedBoards={selectedBoards}
+                                            setSelectedBoards={setSelectedBoards}
+                                            boardView={boardView}
+                                            user={user}
+                                            boards={boards}
+                                        />
+                                    </Col>)}
+                                </Row>
                                 <div className="text-center mt-3 mb-5" style={{clear: "both"}}>
                                     <p>Showing <strong>{boards.boards.length}</strong> of <strong>{boards.totalResults}</strong></p>
                                     {boards.boards.length < boards.totalResults && <Button onClick={viewMore} disabled={loading}>{loading ? <IsaacSpinner /> : "View more"}</Button>}

--- a/src/app/components/pages/MyGameboards.tsx
+++ b/src/app/components/pages/MyGameboards.tsx
@@ -8,6 +8,7 @@ import {
     Button,
     Card,
     CardBody,
+    CardDeck,
     CardSubtitle,
     CardTitle,
     Col,
@@ -164,7 +165,7 @@ const Board = (props: BoardTableProps) => {
                         {`Stage${boardStages.length !== 1 ? "s" : ""}: `}<strong>{boardStages.map(s => stageLabelMap[s]).join(', ') || "N/A"}</strong>
                     </CardSubtitle>
                     <CardSubtitle>
-                        {`Difficult${boardStages.length !== 1 ? "ies" : "y"}: `}
+                        {`Difficult${boardDifficulties.length !== 1 ? "ies" : "y"}: `}
                         <strong>
                             {boardDifficulties.length > 0 ?
                                 <AggregateDifficultyIcons stacked={above["lg"](deviceSize) || below["xs"](deviceSize)} difficulties={boardDifficulties} />
@@ -292,14 +293,14 @@ export const MyGameboards = () => {
     return <Container>
         <TitleAndBreadcrumb currentPageTitle="My gameboards" help={pageHelp} />
         {boards && boards.totalResults == 0 ?
-            <React.Fragment>
+            <>
                 <h3 className="text-center mt-4">You have no gameboards to view.</h3>
                 {isPhy && <div className="text-center mt-3 mb-5">
                     <Button color="secondary" tag={Link} to="/gameboards/new">Create a gameboard</Button>
                 </div>}
-            </React.Fragment>
+            </>
             :
-            <React.Fragment>
+            <>
                 <div className="mt-4 mb-2">
                     {boards && boards.totalResults > 0 && <h4>You have completed <strong>{completed}</strong> of <strong>{boards.totalResults}</strong> gameboard{boards.totalResults > 1 && "s"},
                         with <strong>{inProgress}</strong> on the go and <strong>{notStarted}</strong> not started</h4>}
@@ -332,31 +333,29 @@ export const MyGameboards = () => {
                     </Row>}
                 </div>
                 <ShowLoading until={boards}>
-                    {boards && boards.boards && <div>
-                        {boardView == boardViews.card ?
+                    {boards && boards.boards &&
+                        (boardView == boardViews.card ?
                             // Card view
-                            <div>
-                                <div className="block-grid-xs-1 block-grid-md-2 block-grid-lg-3 my-2">
-                                    {boards.boards.map(board => <div key={board.id}>
-                                        <Board
-                                            key={board.id}
-                                            board={board}
-                                            selectedBoards={selectedBoards}
-                                            setSelectedBoards={setSelectedBoards}
-                                            boardView={boardView}
-                                            user={user}
-                                            boards={boards}
-                                        />
-                                    </div>)}
-                                </div>
-                                <div className="text-center mt-2 mb-5" style={{clear: "both"}}>
+                            <>
+                                <CardDeck>
+                                    {boards.boards.map(board => <Board
+                                        key={board.id}
+                                        board={board}
+                                        selectedBoards={selectedBoards}
+                                        setSelectedBoards={setSelectedBoards}
+                                        boardView={boardView}
+                                        user={user}
+                                        boards={boards}
+                                    />)}
+                                </CardDeck>
+                                <div className="text-center mt-3 mb-5" style={{clear: "both"}}>
                                     <p>Showing <strong>{boards.boards.length}</strong> of <strong>{boards.totalResults}</strong></p>
                                     {boards.boards.length < boards.totalResults && <Button onClick={viewMore} disabled={loading}>{loading ? <IsaacSpinner /> : "View more"}</Button>}
                                 </div>
-                            </div>
+                            </>
                             :
                             // Table view
-                            <div>
+                            <>
                                 <Row>
                                     <Col sm={6} lg={3} xl={2}>
                                         <Label className="w-100">
@@ -474,9 +473,9 @@ export const MyGameboards = () => {
                                         </div>
                                     </CardBody>
                                 </Card>
-                            </div>}
-                    </div>}
+                            </>
+                        )}
                 </ShowLoading>
-            </React.Fragment>}
+            </>}
     </Container>;
 };

--- a/src/app/components/pages/SetAssignments.tsx
+++ b/src/app/components/pages/SetAssignments.tsx
@@ -252,7 +252,7 @@ const Board = (props: BoardProps) => {
             </tr>
             :
             // Card view
-            <Card key={board.id} className="board-card">
+            <Card key={board.id} className="board-card card-neat">
                 <CardBody className="pb-4 pt-4">
                     <button className="close" onClick={confirmDeleteBoard} aria-label="Delete gameboard">×</button>
                     <button onClick={toggleAssignModal} id={hexagonId} className="board-subject-hexagon-container">
@@ -404,14 +404,15 @@ const SetAssignmentsPageComponent = (props: SetAssignmentsPageProps) => {
                         {boardView == BoardViews.card ?
                             // Card view
                             <>
-                                <CardDeck>
-                                    {boards.boards && boards.boards.map(board =>
+                                <Row className={"row-cols-lg-3 row-cols-md-2 row-cols-1"}>
+                                    {boards.boards && boards.boards.map(board => <Col>
                                         <Board {...props}
-                                               key={board.id}
-                                               board={board}
-                                               boardView={boardView}
-                                        />)}
-                                </CardDeck>
+                                           key={board.id}
+                                           board={board}
+                                           boardView={boardView}
+                                        />
+                                    </Col>)}
+                                </Row>
                                 <div className="text-center mt-3 mb-4" style={{clear: "both"}}>
                                     <p>Showing <strong>{boards.boards.length}</strong> of <strong>{boards.totalResults}</strong></p>
                                     {boards.boards.length < boards.totalResults && <Button onClick={viewMore} disabled={loading}>{loading ? <Spinner/> : "View more"}</Button>}

--- a/src/app/components/pages/SetAssignments.tsx
+++ b/src/app/components/pages/SetAssignments.tsx
@@ -4,7 +4,6 @@ import {
     Button,
     Card,
     CardBody,
-    CardDeck,
     CardFooter,
     CardSubtitle,
     CardTitle,

--- a/src/app/components/pages/SetAssignments.tsx
+++ b/src/app/components/pages/SetAssignments.tsx
@@ -1,5 +1,4 @@
 import React, {ChangeEvent, useEffect, useState} from "react";
-import * as RS from "reactstrap";
 import {
     Alert,
     Button,
@@ -439,33 +438,33 @@ const SetAssignmentsPageComponent = (props: SetAssignmentsPageProps) => {
         <h4 className="mt-4 mb-3">
             Add a gameboard from ...
         </h4>
-        <RS.Row className="mb-4">
-            <RS.Col md={6} lg={4} className="pt-1">
+        <Row className="mb-4">
+            <Col md={6} lg={4} className="pt-1">
                 {siteSpecific(
                     // Physics
-                    <RS.Button tag={Link} onClick={() => dispatch(openIsaacBooksModal)} color="secondary" block className="px-3">
+                    <Button tag={Link} onClick={() => dispatch(openIsaacBooksModal)} color="secondary" block className="px-3">
                         our books
-                    </RS.Button>,
+                    </Button>,
                     // Computer science
-                    <RS.Button tag={Link} to={"/pages/gameboards"} color="secondary" block>
+                    <Button tag={Link} to={"/pages/gameboards"} color="secondary" block>
                         Pre-made gameboards
-                    </RS.Button>
+                    </Button>
                 )}
-            </RS.Col>
-            <RS.Col md={6} lg={4} className="pt-1">
-                <RS.Button tag={Link} to={isaacAssignmentButtons.second.link} color="secondary" block>
+            </Col>
+            <Col md={6} lg={4} className="pt-1">
+                <Button tag={Link} to={isaacAssignmentButtons.second.link} color="secondary" block>
                     {isaacAssignmentButtons.second.text}
-                </RS.Button>
-            </RS.Col>
-            <RS.Col md={12} lg={4} className="pt-1">
-                <RS.Button tag={Link} to={"/gameboard_builder"} color="secondary" block>
+                </Button>
+            </Col>
+            <Col md={12} lg={4} className="pt-1">
+                <Button tag={Link} to={"/gameboard_builder"} color="secondary" block>
                     {isaacAssignmentButtons.third.text}
-                </RS.Button>
-            </RS.Col>
-        </RS.Row>
+                </Button>
+            </Col>
+        </Row>
         {groups && groups.length == 0 && <Alert color="warning">You have not created any groups to assign work to. Please <Link to="/groups">create a group here first.</Link></Alert>}
         {boards && boards.totalResults == 0 ? <h3 className="text-center mt-4 mb-5">You have no gameboards to assign; use one of the options above to find one.</h3> :
-            <React.Fragment>
+            <>
                 {boards && boards.totalResults > 0 && <h4>You have <strong>{boards.totalResults}</strong> gameboard{boards.totalResults > 1 && "s"} ready to assign...</h4>}
                 {!boards && <h4>You have <IsaacSpinner size="sm" /> gameboards ready to assign...</h4>}
                 <Row>
@@ -586,7 +585,7 @@ const SetAssignmentsPageComponent = (props: SetAssignmentsPageProps) => {
                             </Card>}
                         </div>}
                 </ShowLoading>
-            </React.Fragment>}
+            </>}
     </Container>;
 };
 

--- a/src/app/components/pages/SetAssignments.tsx
+++ b/src/app/components/pages/SetAssignments.tsx
@@ -351,7 +351,7 @@ const SetAssignmentsPageComponent = (props: SetAssignmentsPageProps) => {
 
     const user = useSelector((state: AppState) => (state && state.user) as RegisteredUserDTO || null);
 
-    useEffect(() => {loadGroups(false);}, []);
+    useEffect(() => loadGroups(false), []);
 
     const [loading, setLoading] = useState(false);
 
@@ -363,9 +363,6 @@ const SetAssignmentsPageComponent = (props: SetAssignmentsPageProps) => {
     const [boardTitleFilter, setBoardTitleFilter] = useState<string>("");
 
     let [actualBoardLimit, setActualBoardLimit] = useState<ActualBoardLimit>(toActual(boardLimit));
-
-    const dispatch = useDispatch();
-
 
     const isaacAssignmentButtons = {
         second: {
@@ -442,7 +439,7 @@ const SetAssignmentsPageComponent = (props: SetAssignmentsPageProps) => {
             <Col md={6} lg={4} className="pt-1">
                 {siteSpecific(
                     // Physics
-                    <Button tag={Link} onClick={() => dispatch(openIsaacBooksModal)} color="secondary" block className="px-3">
+                    <Button tag={Link} onClick={openIsaacBooksModal} color="secondary" block className="px-3">
                         our books
                     </Button>,
                     // Computer science

--- a/src/app/components/pages/SetAssignments.tsx
+++ b/src/app/components/pages/SetAssignments.tsx
@@ -324,7 +324,7 @@ enum boardSubjects {
 enum BoardLimit {
     "six" = "6",
     "eighteen" = "18",
-    "sixy" = "60",
+    "sixty" = "60",
     "All" = "ALL"
 }
 function toActual(limit: BoardLimit) {

--- a/src/app/components/pages/SetAssignments.tsx
+++ b/src/app/components/pages/SetAssignments.tsx
@@ -463,7 +463,7 @@ const SetAssignmentsPageComponent = (props: SetAssignmentsPageProps) => {
         {boards && boards.totalResults == 0 ? <h3 className="text-center mt-4 mb-5">You have no gameboards to assign; use one of the options above to find one.</h3> :
             <>
                 {boards && boards.totalResults > 0 && <h4>You have <strong>{boards.totalResults}</strong> gameboard{boards.totalResults > 1 && "s"} ready to assign...</h4>}
-                {!boards && <h4>You have <IsaacSpinner size="sm" /> gameboards ready to assign...</h4>}
+                {!boards && <h4>You have <IsaacSpinner size="sm" inline /> gameboards ready to assign...</h4>}
                 <Row>
                     <Col sm={6} lg={3} xl={2}>
                         <Label className="w-100">

--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -14,7 +14,7 @@ import {
 } from "../../IsaacApiTypes";
 import * as AppTypes from "../../IsaacAppTypes";
 import {
-    ActualBoardLimit,
+    NumberOfBoards,
     AdditionalInformation,
     ATTENDANCE,
     BoardOrder,
@@ -427,7 +427,7 @@ export const api = {
         }
     },
     boards: {
-        get: (startIndex: number, limit: ActualBoardLimit, sort: BoardOrder): AxiosPromise<ApiTypes.GameboardListDTO> => {
+        get: (startIndex: number, limit: NumberOfBoards, sort: BoardOrder): AxiosPromise<ApiTypes.GameboardListDTO> => {
             return endpoint.get(`/gameboards/user_gameboards`, {params: {"start_index": startIndex, limit, sort}});
         },
         delete: (board: ApiTypes.GameboardDTO) => {

--- a/src/app/services/gameboards.tsx
+++ b/src/app/services/gameboards.tsx
@@ -183,7 +183,7 @@ export const BOARD_ORDER_NAMES: {[key in BoardOrder]: string} = {
     "-completion": "Completion Descending"
 };
 
-const parseBoardLimitAsNumber = (limit: BoardLimit) =>
+const parseBoardLimitAsNumber: (limit: BoardLimit) => NumberOfBoards = (limit: BoardLimit) =>
     limit === BoardLimit.All
         ? BoardLimit.All
         : parseInt(limit, 10);

--- a/src/app/services/gameboards.tsx
+++ b/src/app/services/gameboards.tsx
@@ -1,14 +1,17 @@
 import {GameboardDTO, RegisteredUserDTO} from "../../IsaacApiTypes";
 import {NOT_FOUND} from "./constants";
-import React from "react";
+import React, {useCallback, useEffect, useState} from "react";
 import countBy from "lodash/countBy"
 import intersection from "lodash/intersection"
 import {isCS, isPhy} from "./siteConstants";
 import {CurrentGameboardState} from "../state/reducers/gameboardsState";
 import {determineAudienceViews} from "./userContext";
-import {ViewingContext} from "../../IsaacAppTypes";
+import {NumberOfBoards, BoardOrder, ViewingContext} from "../../IsaacAppTypes";
+import {useDispatch, useSelector} from "react-redux";
+import {selectors} from "../state/selectors";
+import {loadBoards} from "../state/actions";
 
-enum boardCompletions {
+export enum BoardCompletions {
     "any" = "Any",
     "notStarted" = "Not Started",
     "inProgress" = "In Progress",
@@ -25,14 +28,14 @@ export function formatBoardOwner(user: RegisteredUserDTO, board: GameboardDTO) {
     return "Someone else";
 }
 
-export function boardCompletionSelection(board: GameboardDTO, boardCompletion: boardCompletions) {
-    if (boardCompletion == boardCompletions.notStarted && (board.percentageCompleted == 0 || !board.percentageCompleted)) {
+export function boardCompletionSelection(board: GameboardDTO, boardCompletion: BoardCompletions) {
+    if (boardCompletion == BoardCompletions.notStarted && (board.percentageCompleted == 0 || !board.percentageCompleted)) {
         return true;
-    } else if (boardCompletion == boardCompletions.completed && board.percentageCompleted && board.percentageCompleted == 100) {
+    } else if (boardCompletion == BoardCompletions.completed && board.percentageCompleted && board.percentageCompleted == 100) {
         return true;
-    } else if (boardCompletion == boardCompletions.inProgress && board.percentageCompleted && board.percentageCompleted != 100 && board.percentageCompleted != 0) {
+    } else if (boardCompletion == BoardCompletions.inProgress && board.percentageCompleted && board.percentageCompleted != 100 && board.percentageCompleted != 0) {
         return true;
-    } else return boardCompletion == boardCompletions.any;
+    } else return boardCompletion == BoardCompletions.any;
 }
 
 const createGameabordLink = (gameboardId: string) => `/gameboards#${gameboardId}`;
@@ -141,4 +144,119 @@ export function allPropertiesFromAGameboard<T extends keyof ViewingContext>(
             return aggregator;
         }, new Set<NonNullable<ViewingContext[T]>>()))
         .sort(orderedPropertyValues ? comparatorFromOrderedValues(orderedPropertyValues) : () => 0);
+}
+
+export enum BoardViews {
+    "table" = "Table View",
+    "card" = "Card View"
+}
+
+export enum BoardCreators {
+    "all" = "All",
+    "isaac" = "Isaac",
+    "me" = "Me",
+    "someoneElse" = "Someone else"
+}
+
+export enum BoardSubjects {
+    "all" = "All",
+    "physics" = "Physics",
+    "maths" = "Maths",
+    "chemistry" = "Chemistry"
+}
+
+export enum BoardLimit {
+    "six" = "6",
+    "eighteen" = "18",
+    "sixty" = "60",
+    "All" = "ALL"
+}
+
+export const BOARD_ORDER_NAMES: {[key in BoardOrder]: string} = {
+    "created": "Date Created Ascending",
+    "-created": "Date Created Descending",
+    "visited": "Date Visited Ascending",
+    "-visited": "Date Visited Descending",
+    "title": "Title Ascending",
+    "-title": "Title Descending",
+    "completion": "Completion Ascending",
+    "-completion": "Completion Descending"
+};
+
+const parseBoardLimitAsNumber = (limit: BoardLimit) =>
+    limit === BoardLimit.All
+        ? BoardLimit.All
+        : parseInt(limit, 10);
+
+export const useGameboards = (initialView: BoardViews, initialLimit: BoardLimit) => {
+    const dispatch = useDispatch();
+
+    const boards = useSelector(selectors.boards.boards);
+
+    const [boardOrder, setBoardOrder] = useState<BoardOrder>(BoardOrder.visited);
+    const [boardView, setBoardView] = useState<BoardViews>(initialView);
+    const [boardLimit, setBoardLimit] = useState<BoardLimit>(initialLimit);
+    const [boardTitleFilter, setBoardTitleFilter] = useState<string>("");
+
+    const [loading, setLoading] = useState(false);
+
+    const [numberOfBoards, setNumberOfBoards] = useState<NumberOfBoards>(parseBoardLimitAsNumber(boardLimit));
+
+    // Fetch gameboards from server, no aggregation since we want a fresh list
+    const loadInitial = useCallback((limit: NumberOfBoards) => {
+        dispatch(loadBoards(0, limit, boardOrder));
+        setLoading(true);
+    }, [loadBoards, setLoading, boardOrder]);
+
+    // Refetches the boards when the limit changes - should fetch as many boards
+    // as the new value of boardLimit
+    useEffect(() => loadInitial(parseBoardLimitAsNumber(boardLimit)), [boardLimit]);
+
+    // Refetches the boards when the order changes - should fetch the same
+    // number as is currently on screen
+    useEffect(() => loadInitial(numberOfBoards), [boardOrder]);
+
+    // Change board limit when view changes between table and cards
+    useEffect(() => {
+        if (boardView == BoardViews.table) {
+            setBoardLimit(BoardLimit.All)
+        } else if (boardView == BoardViews.card) {
+            setBoardLimit(BoardLimit.six)
+        }
+    }, [boardView]);
+
+    // Fetch boardLimit *more* boards from the server, unless we have all boards already
+    const viewMore = useCallback(() => {
+        const increment = parseBoardLimitAsNumber(boardLimit);
+        if (increment != "ALL" && numberOfBoards != "ALL") {
+            dispatch(loadBoards(numberOfBoards, increment, boardOrder));
+            setLoading(true);
+        }
+    }, [dispatch, setLoading, numberOfBoards, boardLimit, boardOrder]);
+
+    // When we get a new set of boards, record the new number
+    // Ask for some more boards if we have zero
+    useEffect(() => {
+        if (boards) {
+            const wasLoading = loading;
+            setLoading(false);
+            if (boards.boards) {
+                setNumberOfBoards(boards.boards.length);
+                if (!wasLoading && boards.boards.length == 0) {
+                    // Through deletion or something we have ended up with no boards, so fetch more.
+                    loadInitial(parseBoardLimitAsNumber(boardLimit));
+                }
+                return;
+            }
+        }
+        setNumberOfBoards(0);
+    }, [boards]);
+
+    return {
+        boards, loading, viewMore,
+        boardOrder, setBoardOrder,
+        boardView, setBoardView,
+        boardLimit, setBoardLimit,
+        boardTitleFilter, setBoardTitleFilter
+    }
 }

--- a/src/app/state/actions.tsx
+++ b/src/app/state/actions.tsx
@@ -20,7 +20,7 @@ import {
 import {
     Action,
     ActiveModal,
-    ActualBoardLimit,
+    NumberOfBoards,
     AdditionalInformation,
     AppGameBoard,
     AppGroup,
@@ -1543,7 +1543,7 @@ export const getGroupProgress = (group: UserGroupDTO) => async (dispatch: Dispat
 };
 
 // Gameboards
-export const loadBoards = (startIndex: number, limit: ActualBoardLimit, sort: BoardOrder) => async (dispatch: Dispatch<Action>) => {
+export const loadBoards = (startIndex: number, limit: NumberOfBoards, sort: BoardOrder) => async (dispatch: Dispatch<Action>) => {
     const accumulate = startIndex != 0;
     dispatch({type: ACTION_TYPE.BOARDS_REQUEST, accumulate});
     try {

--- a/src/app/state/reducers/gameboardsState.ts
+++ b/src/app/state/reducers/gameboardsState.ts
@@ -52,7 +52,7 @@ function mergeBoards(boards: Boards, additional: GameboardListDTO) {
     return {
         ...boards,
         totalResults: additional.totalResults || boards.totalResults,
-        boards: unionWith(additional.results, boards.boards, function(a, b) {return a.id == b.id})
+        boards: unionWith(boards.boards, additional.results, function(a, b) {return a.id == b.id})
     };
 }
 

--- a/src/app/state/selectors.tsx
+++ b/src/app/state/selectors.tsx
@@ -1,7 +1,7 @@
 import {AppState} from "./reducers";
 import {sortBy} from "lodash";
 import {NOT_FOUND} from "../services/constants";
-import {AppGroup, AppQuizAssignment, NOT_FOUND_TYPE, UserProgress} from "../../IsaacAppTypes";
+import {AppGroup, AppQuizAssignment, Boards, NOT_FOUND_TYPE, UserProgress} from "../../IsaacAppTypes";
 import {KEY, load} from "../services/localStorage";
 import {GroupProgressState, ProgressState} from "./reducers/assignmentsState";
 import {isDefined} from "../services/miscUtils";
@@ -89,7 +89,7 @@ export const selectors = {
                         assignedGroups: state.boards && state.boards.boardAssignees && mapGroups(state.boards.boardAssignees[board.id as string]) || undefined
                     }
                 ))
-            };
+            } as Boards;
         }
     },
 

--- a/src/scss/common/boards.scss
+++ b/src/scss/common/boards.scss
@@ -22,6 +22,15 @@ tr.board-card {
   height: 100px;
 }
 .board-card {
+  min-width: 30%;
+  @media (max-width: map-get($breakpoints, sm)) {
+    min-width: 50%;
+  }
+  margin-top: 25px;
+  .card-footer {
+    background: white;
+    border-top: unset;
+  }
   .card-body > .close {
     position: absolute;
     right: 10px;

--- a/src/scss/common/boards.scss
+++ b/src/scss/common/boards.scss
@@ -21,6 +21,9 @@
 tr.board-card {
   height: 100px;
 }
+.col > .board-card {
+  height: calc(100% - 25px);
+}
 .board-card {
   min-width: 30%;
   @media (max-width: map-get($breakpoints, sm)) {

--- a/src/test/state/reducers.test.tsx
+++ b/src/test/state/reducers.test.tsx
@@ -423,7 +423,7 @@ describe("boards reducer", () => {
         previousStates.map((previousState) => {
             const actualNextState = boards(previousState, action);
             const priorBoards = previousState && previousState.boards && previousState.boards.boards || [];
-            expect(selector.boards(actualNextState)).toEqual({totalResults: 40, boards: union(newBoards, priorBoards)});
+            expect(selector.boards(actualNextState)).toEqual({totalResults: 40, boards: union(priorBoards, newBoards)});
         });
     });
 


### PR DESCRIPTION
The primary goal of this was to make sure the "View more" button added new boards to the end of the list. That is solved by [this commit](https://github.com/isaacphysics/isaac-react-app/commit/4f4203499c8c8e82ac0a105f63000bfaf0dd475e).

I also made a couple of larger changes since the code for these components really needed a makeover:

---

A visual adjustment to `SetAssignments` and `MyGameboards` (see first commit), which makes the card view for both pages look much neater. James and Meurig approved of this change when demoing it to them.

---

The 6th commit pulls out the gameboard fetching logic for `MyGameboards` and `SetAssignments` into a hook defined in `gameboards.tsx`, and refactors the code in a few other ways:
 - Gets rid of `actualBoardLimit` (this name confused me for about an hour) and replaces it with `numberOfBoards`
 - Consistent variable name style for enums (CamelCase)
 -  Adds a bunch of comments