### PR TITLE
Hotfix/renderer define plugin clash

### DIFF
--- a/config/webpack.config.common.js
+++ b/config/webpack.config.common.js
@@ -11,7 +11,10 @@ const webpack = require('webpack');
 // Read in the .env file and put into `process.env`:
 require('dotenv').config();
 
-module.exports = (isProd) => {
+module.exports = (env) => {
+
+    let isProd = env['prod'] ?? false;
+    let isRenderer = env['renderer'] ?? false;
 
     return {
         stats: {
@@ -159,7 +162,7 @@ module.exports = (isProd) => {
             new webpack.DefinePlugin({
                 REACT_APP_API_VERSION: `"${process.env.REACT_APP_API_VERSION}"`,
                 ENV_QUIZ_FEATURE_FLAG: process.env.QUIZ_FEATURE && process.env.QUIZ_FEATURE.trim() === "true",
-                EDITOR_PREVIEW: 'false',
+                EDITOR_PREVIEW: JSON.stringify(isRenderer)
             }),
         ].filter(Boolean),
     };

--- a/config/webpack.config.common.js
+++ b/config/webpack.config.common.js
@@ -14,7 +14,7 @@ require('dotenv').config();
 module.exports = (env) => {
 
     let isProd = env['prod'] ?? false;
-    let isRenderer = env['renderer'] ?? false;
+    let isRenderer = env['isRenderer'] ?? false;
 
     return {
         stats: {

--- a/config/webpack.config.cs.js
+++ b/config/webpack.config.cs.js
@@ -10,8 +10,6 @@ const webpack = require('webpack');
 
 module.exports = env => {
 
-    let isProd = env['prod'];
-
     let configCS = {
         entry: {
             'isaac-cs': [resolve('src/index-cs')],
@@ -43,5 +41,5 @@ module.exports = env => {
         ],
     };
 
-    return merge(configCommon(isProd), configCS);
+    return merge(configCommon(env), configCS);
 };

--- a/config/webpack.config.cs.renderer.js
+++ b/config/webpack.config.cs.renderer.js
@@ -4,7 +4,6 @@ const BASE_DIRECTORY = path.resolve(__dirname, "..");
 const resolve = (p) => path.resolve(BASE_DIRECTORY, p);
 const configCS = require('./webpack.config.cs');
 const {merge} = require('webpack-merge');
-const webpack = require('webpack');
 
 module.exports = env => {
 
@@ -15,16 +14,10 @@ module.exports = env => {
 
         output: {
             path: resolve(`build-cs-renderer`),
-        },
-
-        plugins: [
-            new webpack.DefinePlugin({
-                EDITOR_PREVIEW: 'true',
-            }),
-        ]
+        }
     };
 
-    const nearly = merge(configCS(env), configCSrenderer);
+    const nearly = merge(configCS({...env, isRenderer: true}), configCSrenderer);
 
     nearly.entry = configCSrenderer.entry;
 

--- a/config/webpack.config.phy.renderer.js
+++ b/config/webpack.config.phy.renderer.js
@@ -4,7 +4,6 @@ const BASE_DIRECTORY = path.resolve(__dirname, "..");
 const resolve = (p) => path.resolve(BASE_DIRECTORY, p);
 const configPHY = require('./webpack.config.physics');
 const {merge} = require('webpack-merge');
-const webpack = require('webpack');
 
 module.exports = env => {
 
@@ -15,16 +14,10 @@ module.exports = env => {
 
         output: {
             path: resolve(`build-phy-renderer`),
-        },
-
-        plugins: [
-            new webpack.DefinePlugin({
-                EDITOR_PREVIEW: 'true',
-            }),
-        ]
+        }
     };
 
-    const nearly = merge(configPHY(env), configPHYrenderer);
+    const nearly = merge(configPHY({...env, isRenderer: true}), configPHYrenderer);
 
     nearly.entry = configPHYrenderer.entry;
 

--- a/config/webpack.config.physics.js
+++ b/config/webpack.config.physics.js
@@ -10,8 +10,6 @@ const webpack = require('webpack');
 
 module.exports = env => {
 
-    let isProd = env['prod'];
-
     let configPhysics = {
         entry: {
             'isaac-phy': [resolve('src/index-phy')],
@@ -43,5 +41,5 @@ module.exports = env => {
         ],
     };
 
-    return merge(configCommon(isProd), configPhysics);
+    return merge(configCommon(env), configPhysics);
 };


### PR DESCRIPTION
This fixes an issue where Webpack complains that the plugin `EDITOR_PREVIEW` is defined twice when using the renderer. It also cuts down a bit on repeated code by moving the definition of `isProd` into the common config.