### PR TITLE
Allow the top-right search bar to work on the /search page

### DIFF
--- a/src/app/components/elements/MainSearch.tsx
+++ b/src/app/components/elements/MainSearch.tsx
@@ -1,4 +1,4 @@
-import React, {ChangeEvent, FormEvent, useRef, useState} from "react";
+import React, {ChangeEvent, FormEvent, useEffect, useRef, useState} from "react";
 import {SearchButton} from "./SearchButton";
 import {pushSearchToHistory} from "../../services/search";
 import {History} from "history";
@@ -7,6 +7,7 @@ import {Collapse, Form, FormGroup, Input, Label, Nav, Navbar, NavbarToggler, Nav
 import {SEARCH_CHAR_LENGTH_LIMIT} from "../../services/constants";
 import {isPhy} from "../../services/siteConstants";
 import classNames from "classnames";
+import {useLocation} from "react-router-dom";
 
 interface MainSearchProps {
     history: History;
@@ -17,7 +18,6 @@ const MainSearchComponent = ({history}: MainSearchProps) => {
     const [showSearchBox, setShowSearchBox] = useState(false);
 
     const searchInputRef = useRef<HTMLInputElement>(null);
-
     function doSearch(e: FormEvent<HTMLFormElement>) {
         e.preventDefault();
         if (searchText == "") {
@@ -26,6 +26,10 @@ const MainSearchComponent = ({history}: MainSearchProps) => {
             pushSearchToHistory(history, searchText, []);
         }
     }
+
+    // Clear this search field on location (i.e. search query) change - user should use the main search bar
+    const location = useLocation();
+    useEffect(() => { if (location.pathname === "/search") { setSearchText(""); }}, [location]);
 
     function setSearchTextAsValue(e: ChangeEvent<HTMLInputElement>) {
         setSearchText(e.target.value);

--- a/src/app/components/pages/Search.tsx
+++ b/src/app/components/pages/Search.tsx
@@ -121,7 +121,7 @@ export const Search = withRouter((props: RouteComponentProps) => {
                                     <Select
                                         inputId="document-filter" isMulti
                                         placeholder="No page type filter"
-                                        defaultValue={filtersState}
+                                        value={filtersState}
                                         options={
                                             [DOCUMENT_TYPE.CONCEPT, DOCUMENT_TYPE.QUESTION, DOCUMENT_TYPE.EVENT,
                                                 DOCUMENT_TYPE.TOPIC_SUMMARY, DOCUMENT_TYPE.GENERIC]

--- a/src/app/components/pages/Search.tsx
+++ b/src/app/components/pages/Search.tsx
@@ -3,13 +3,12 @@ import {RouteComponentProps, withRouter} from "react-router-dom";
 import {useDispatch, useSelector} from "react-redux";
 import * as RS from "reactstrap";
 import {Col, Container, Form, Input, Row} from "reactstrap";
-import queryString from "query-string";
 import {fetchSearch} from "../../state/actions";
 import {ShowLoading} from "../handlers/ShowLoading";
 import {AppState} from "../../state/reducers";
 import {LinkToContentSummaryList} from "../elements/list-groups/ContentSummaryListGroupItem";
 import {DOCUMENT_TYPE, documentDescription, SEARCH_CHAR_LENGTH_LIMIT} from "../../services/constants";
-import {pushSearchToHistory, searchResultIsPublic} from "../../services/search";
+import {parseLocationSearch, pushSearchToHistory, searchResultIsPublic} from "../../services/search";
 import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
 import {shortcuts} from "../../services/searchResults";
 import {ShortcutResponse} from "../../../IsaacAppTypes";
@@ -33,18 +32,6 @@ function deitemise(item: Item<DOCUMENT_TYPE>) {
     return item.value;
 }
 
-function parseLocationSearch(search: string): [Nullable<string>, DOCUMENT_TYPE[]] {
-    const searchParsed = queryString.parse(search);
-
-    const parsedQuery = searchParsed.query || "";
-    const query = parsedQuery instanceof Array ? parsedQuery[0] : parsedQuery;
-
-    const parsedFilters = searchParsed.types || "";
-    const possibleFilters = (Array.isArray(parsedFilters) ? parsedFilters[0] || "" : parsedFilters || "").split(",");
-    const filters = possibleFilters.filter(pf => Object.values(DOCUMENT_TYPE).includes(pf as DOCUMENT_TYPE)) as DOCUMENT_TYPE[]
-
-    return [query, filters];
-}
 
 const selectStyle: StylesConfig<Item<DOCUMENT_TYPE>, true, GroupBase<Item<DOCUMENT_TYPE>>> = {
     multiValue: (styles: CSSObjectWithLabel) => ({...styles, backgroundColor: siteSpecific("rgba(254, 161, 0, 0.9)", "rgba(255, 181, 63, 0.9)")}),

--- a/src/app/components/pages/Search.tsx
+++ b/src/app/components/pages/Search.tsx
@@ -51,6 +51,8 @@ const selectStyle: StylesConfig<Item<DOCUMENT_TYPE>, true, GroupBase<Item<DOCUME
     multiValueLabel: (styles: CSSObjectWithLabel) => ({...styles, color: "black"}),
 };
 
+// Interacting with the page's filters change the query parameters.
+// Whenever the query parameters change we send a search request to the API.
 export const Search = withRouter((props: RouteComponentProps) => {
     const {location, history} = props;
     const dispatch = useDispatch();
@@ -66,8 +68,10 @@ export const Search = withRouter((props: RouteComponentProps) => {
     }
     const [filtersState, setFiltersState] = useState<Item<DOCUMENT_TYPE>[]>(initialFilters.map(itemise));
 
-    useEffect(function triggerSearchOnUrlChange() {
-        dispatch(fetchSearch(queryState ?? "", filtersState.length ? filtersState.map(deitemise).join(",") : undefined));
+    useEffect(function triggerSearchAndUpdateLocalStateOnUrlChange() {
+        dispatch(fetchSearch(urlQuery ?? "", initialFilters.length ? initialFilters.join(",") : undefined));
+        setQueryState(urlQuery);
+        setFiltersState(initialFilters.map(itemise));
     }, [dispatch, location.search]);
 
     function updateSearchUrl(e?: FormEvent<HTMLFormElement>) {

--- a/src/app/services/search.ts
+++ b/src/app/services/search.ts
@@ -47,3 +47,16 @@ export const searchResultIsPublic = function(content: ContentSummaryDTO, user?: 
         return !content.supersededBy && !content.tags?.includes("nofilter");
     }
 };
+
+export function parseLocationSearch(search: string): [Nullable<string>, DOCUMENT_TYPE[]] {
+    const searchParsed = queryString.parse(search);
+
+    const parsedQuery = searchParsed.query || "";
+    const query = parsedQuery instanceof Array ? parsedQuery[0] : parsedQuery;
+
+    const parsedFilters = searchParsed.types || "";
+    const possibleFilters = (Array.isArray(parsedFilters) ? parsedFilters[0] || "" : parsedFilters || "").split(",");
+    const filters = possibleFilters.filter(pf => Object.values(DOCUMENT_TYPE).includes(pf as DOCUMENT_TYPE)) as DOCUMENT_TYPE[]
+
+    return [query, filters];
+}


### PR DESCRIPTION
This PR fixes the search bar in the top-right on the /search page.
This is achieved by making the query in the URL query params the definitive source for queries sent to the server. Interacting with filters and input fields changes the URL; then the URL fields are used for sending to the server.