### PR TITLE
User context (stage, exam board, school) reconfirmation modal

### DIFF
--- a/src/app/components/elements/inputs/UserContextAccountInput.tsx
+++ b/src/app/components/elements/inputs/UserContextAccountInput.tsx
@@ -117,7 +117,7 @@ export function UserContextAccountInput({
             // Physics
             <React.Fragment>
                 <span id={`show-me-content-${componentId}`} className="icon-help" />
-                <RS.UncontrolledTooltip placement="bottom" target={`show-me-content-${componentId}`}>
+                <RS.UncontrolledTooltip placement={"left-start"} target={`show-me-content-${componentId}`}>
                     {"Choose a stage here to pre-select the material that is most relevant to your interests."}<br />
                     {"You will be able to change this preference on relevant pages."}<br />
                     {'If you prefer to see all content by default, select "All stages".'}
@@ -126,7 +126,7 @@ export function UserContextAccountInput({
             // Computer science
             <React.Fragment>
                 <span id={`show-me-content-${componentId}`} className="icon-help" />
-                <RS.UncontrolledTooltip placement="bottom" target={`show-me-content-${componentId}`}>
+                <RS.UncontrolledTooltip placement={"left-start"} target={`show-me-content-${componentId}`}>
                     {teacher ?
                         <>Add a stage and examination board for each qualification you are teaching.<br />On content pages, this will allow you to quickly switch between your personalised views of the content, depending on which class you are currently teaching.</> :
                         <>Select a stage and examination board here to filter the content so that you will only see material that is relevant for the qualification you have chosen.</>

--- a/src/app/components/elements/modals/UserContextReconfirmationModal.tsx
+++ b/src/app/components/elements/modals/UserContextReconfirmationModal.tsx
@@ -1,0 +1,98 @@
+import React, {useCallback, useMemo, useState} from "react";
+import {isMobile} from "../../../services/device";
+import {Button, Col, Form, Input, Row} from "reactstrap";
+import {validateUserContexts, validateUserSchool} from "../../../services/validation";
+import {UserContextAccountInput} from "../inputs/UserContextAccountInput";
+import {SchoolInput} from "../inputs/SchoolInput";
+import {isDefined} from "../../../services/miscUtils";
+import {BooleanNotation, DisplaySettings} from "../../../../IsaacAppTypes";
+import {useDispatch, useSelector} from "react-redux";
+import {selectors} from "../../../state/selectors";
+import {AppState} from "../../../state/reducers";
+import {isLoggedIn} from "../../../services/user";
+import {closeActiveModal, updateCurrentUser} from "../../../state/actions";
+import {isCS, SITE_SUBJECT_TITLE, siteSpecific} from "../../../services/siteConstants";
+
+const UserContextReconfimationModalBody = () => {
+    const dispatch = useDispatch();
+    const user = useSelector(selectors.user.orNull);
+    const userPreferences = useSelector((state: AppState) => state?.userPreferences);
+
+    const [submissionAttempted, setSubmissionAttempted] = useState(false);
+
+    const initialUserValue = useMemo(() => ({...user, password: null}), [user]);
+    const [userToUpdate, setUserToUpdate] = useState(initialUserValue);
+
+    const initialUserContexts = useMemo(() =>
+        user?.loggedIn && isDefined(user.registeredContexts) ? [...user.registeredContexts] : []
+    , [user]);
+    const [userContexts, setUserContexts] = useState(initialUserContexts.length ? initialUserContexts : [{}]);
+
+    const [booleanNotation, setBooleanNotation] = useState<BooleanNotation | undefined>();
+    const [displaySettings, setDisplaySettings] = useState<DisplaySettings>({...userPreferences?.DISPLAY_SETTING});
+
+    const allFieldsAreValid = useMemo(() =>
+        validateUserContexts(userContexts) && validateUserSchool(userToUpdate)
+    , [userContexts, userToUpdate]);
+
+    const userPreferencesToUpdate = useMemo(() => ({
+        BOOLEAN_NOTATION: booleanNotation, DISPLAY_SETTING: displaySettings
+    }), [booleanNotation, displaySettings]);
+
+    // Form submission
+    const formSubmission = useCallback((event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        setSubmissionAttempted(true);
+        if (user && isLoggedIn(user) && allFieldsAreValid) {
+            dispatch(updateCurrentUser(userToUpdate, userPreferencesToUpdate, userContexts, null, user, false));
+            dispatch(closeActiveModal());
+        }
+    }, [userToUpdate, userContexts, userPreferencesToUpdate, user]);
+
+    return <Form onSubmit={formSubmission} className={"mb-2"}>
+        <div>
+            So that Isaac {SITE_SUBJECT_TITLE} can continue to show you relevant content, we ask that you review your
+            stage{isCS && ", exam board"} and school account details at the beginning of each academic year.
+        </div>
+        <div className="text-right text-muted required-before">
+            Required
+        </div>
+        <Row className="my-2">
+            <Col xs={12} md={siteSpecific(6, 12)} lg={6}>
+                 <UserContextAccountInput
+                    user={userToUpdate} userContexts={userContexts} setUserContexts={setUserContexts}
+                    displaySettings={displaySettings} setDisplaySettings={setDisplaySettings}
+                    setBooleanNotation={setBooleanNotation} submissionAttempted={submissionAttempted}
+                 />
+            </Col>
+            <Col xs={12} md={6}>
+                <SchoolInput
+                    userToUpdate={userToUpdate} setUserToUpdate={setUserToUpdate}
+                    submissionAttempted={submissionAttempted} idPrefix="modal"
+                    required
+                />
+            </Col>
+        </Row>
+        <div className="text-muted small pb-2">
+            Updating this information helps us continue to show you relevant content throughout your educational journey.
+            Full details on how we use your personal information can be found in our <a target="_blank" href="/privacy">Privacy Policy</a>.
+        </div>
+
+        {submissionAttempted && !allFieldsAreValid && <div>
+            <h4 role="alert" className="text-danger text-center mb-4">
+                Not all required fields have been correctly filled.
+            </h4>
+        </div>}
+
+        <div className="text-center pb-3 pt-1">
+            <Button type={"submit"} color={"secondary"} className={"border-0 my-1 w-lg-50 w-100"}>
+                Update details
+            </Button>
+        </div>
+    </Form>;
+}
+
+export const userContextReconfimationModal = {
+    title: "Please review your details",
+    body: <UserContextReconfimationModalBody />,
+}

--- a/src/app/components/elements/modals/UserContextReconfirmationModal.tsx
+++ b/src/app/components/elements/modals/UserContextReconfirmationModal.tsx
@@ -7,10 +7,9 @@ import {isDefined} from "../../../services/miscUtils";
 import {BooleanNotation, DisplaySettings} from "../../../../IsaacAppTypes";
 import {useDispatch, useSelector} from "react-redux";
 import {selectors} from "../../../state/selectors";
-import {AppState} from "../../../state/reducers";
 import {isLoggedIn, isTeacher} from "../../../services/user";
 import {closeActiveModal, logAction, updateCurrentUser} from "../../../state/actions";
-import {isCS, SITE_SUBJECT_TITLE, siteSpecific} from "../../../services/siteConstants";
+import {SITE_SUBJECT_TITLE, siteSpecific} from "../../../services/siteConstants";
 
 const buildModalText = (buildConnectionsLink: (text: string) => React.ReactNode, buildPrivacyPolicyLink: (text: string) => React.ReactNode) => ({
     teacher: {

--- a/src/app/components/elements/modals/UserContextReconfirmationModal.tsx
+++ b/src/app/components/elements/modals/UserContextReconfirmationModal.tsx
@@ -50,10 +50,13 @@ const UserContextReconfimationModalBody = () => {
     }, [userToUpdate, userContexts, userPreferencesToUpdate, user]);
 
     return <Form onSubmit={formSubmission} className={"mb-2"}>
-        <div>
+        <p>
             So that Isaac {SITE_SUBJECT_TITLE} can continue to show you relevant content, we ask that you review your
             stage{isCS && ", exam board"} and school account details at the beginning of each academic year.
-        </div>
+        </p>
+        <p>
+            You might also want to <a target={"_blank"} rel="noopener" href={"/account#teacherconnections"}>review who has access to your data <span className={"sr-only"}>(opens in new tab)</span></a> if you've changed school or teachers.
+        </p>
         <div className="text-right text-muted required-before">
             Required
         </div>

--- a/src/app/components/elements/modals/UserContextReconfirmationModal.tsx
+++ b/src/app/components/elements/modals/UserContextReconfirmationModal.tsx
@@ -1,6 +1,5 @@
 import React, {useCallback, useMemo, useState} from "react";
-import {isMobile} from "../../../services/device";
-import {Button, Col, Form, Input, Row} from "reactstrap";
+import {Button, Col, Form, Row} from "reactstrap";
 import {validateUserContexts, validateUserSchool} from "../../../services/validation";
 import {UserContextAccountInput} from "../inputs/UserContextAccountInput";
 import {SchoolInput} from "../inputs/SchoolInput";
@@ -10,7 +9,7 @@ import {useDispatch, useSelector} from "react-redux";
 import {selectors} from "../../../state/selectors";
 import {AppState} from "../../../state/reducers";
 import {isLoggedIn} from "../../../services/user";
-import {closeActiveModal, updateCurrentUser} from "../../../state/actions";
+import {closeActiveModal, logAction, updateCurrentUser} from "../../../state/actions";
 import {isCS, SITE_SUBJECT_TITLE, siteSpecific} from "../../../services/siteConstants";
 
 const UserContextReconfimationModalBody = () => {
@@ -39,6 +38,12 @@ const UserContextReconfimationModalBody = () => {
         BOOLEAN_NOTATION: booleanNotation, DISPLAY_SETTING: displaySettings
     }), [booleanNotation, displaySettings]);
 
+    const logReviewTeacherConnections = useCallback(() => {
+        dispatch(logAction({
+            type: "REVIEW_TEACHER_CONNECTIONS"
+        }));
+    }, []);
+
     // Form submission
     const formSubmission = useCallback((event: React.FormEvent<HTMLFormElement>) => {
         event.preventDefault();
@@ -55,7 +60,7 @@ const UserContextReconfimationModalBody = () => {
             stage{isCS && ", exam board"} and school account details at the beginning of each academic year.
         </p>
         <p>
-            You might also want to <a target={"_blank"} rel="noopener" href={"/account#teacherconnections"}>review who has access to your data <span className={"sr-only"}>(opens in new tab)</span></a> if you've changed school or teachers.
+            You might also want to <a target={"_blank"} onClick={logReviewTeacherConnections} rel="noopener" href={"/account#teacherconnections"}>review who has access to your data <span className={"sr-only"}>(opens in new tab)</span></a> if you've changed school or teachers.
         </p>
         <div className="text-right text-muted required-before">
             Required

--- a/src/app/services/localStorage.ts
+++ b/src/app/services/localStorage.ts
@@ -4,6 +4,7 @@ export enum KEY {
     CURRENT_USER_ID = "currentUserId",
     FIRST_LOGIN = "firstLogin",
     REQUIRED_MODAL_SHOWN_TIME = "requiredModalShownTime",
+    RECONFIRM_USER_CONTEXT_SHOWN_TIME = "reconfirmStageExamBoardShownTime",
     LOGIN_OR_SIGN_UP_MODAL_SHOWN_TIME = "loginOrSignUpModalShownTime",
     LAST_NOTIFICATION_TIME = "lastNotificationTime",
     ANONYMISE_USERS = "anonymiseUsers",

--- a/src/app/state/middleware/notificationManager.ts
+++ b/src/app/state/middleware/notificationManager.ts
@@ -1,25 +1,55 @@
 import {Dispatch, Middleware, MiddlewareAPI} from "redux";
 import {ACTION_TYPE} from "../../services/constants";
-import {Action} from "../../../IsaacAppTypes";
+import {Action, LoggedInUser} from "../../../IsaacAppTypes";
 import {logAction, openActiveModal} from "../actions";
-import {allRequiredInformationIsPresent, withinLast50Minutes, withinLast2Hours} from "../../services/validation";
+import {allRequiredInformationIsPresent, withinLast2Hours, withinLast50Minutes} from "../../services/validation";
 import {isLoggedIn} from "../../services/user";
 import * as persistence from "../../services/localStorage";
 import {KEY} from "../../services/localStorage";
 import {requiredAccountInformationModal} from "../../components/elements/modals/RequiredAccountInformationModal";
 import {loginOrSignUpModal} from "../../components/elements/modals/LoginOrSignUpModal";
+import {userContextReconfimationModal} from "../../components/elements/modals/UserContextReconfirmationModal";
+
+// Returns true if the user hasn't updated their stage, exam board and school since *last August*,
+// and it's at least the 24th of August
+const needToUpdateUserContextDetails = (user: LoggedInUser) => {
+    // First calculate when the last August before today was...
+    let date = new Date();
+    if (date.getMonth() < 8) {
+        date.setFullYear(date.getFullYear() - 1);
+    }
+    date.setMonth(8, 1);
+    date.setHours(0, 0, 0, 0);
+    // Date is now the 1st day of last August
+    if (user.registeredContextsLastConfirmed && user.registeredContextsLastConfirmed < date) {
+        date.setDate(24);
+        // Date is now the 24th of last August (the last week of August, give or take)
+        if (Date.now() > date.valueOf()) {
+            return true;
+        }
+    }
+    return false;
+}
 
 export const notificationCheckerMiddleware: Middleware = (middlewareApi: MiddlewareAPI) => (dispatch: Dispatch) => async (action: Action) => {
 
     const state = middlewareApi.getState();
     if([ACTION_TYPE.CURRENT_USER_RESPONSE_SUCCESS, ACTION_TYPE.ROUTER_PAGE_CHANGE].includes(action.type)) {
-        if (
-            state && isLoggedIn(state.user) &&
-            !allRequiredInformationIsPresent(state.user, state.userPreferences, state.user.registeredContexts) &&
-            !withinLast50Minutes(persistence.load(KEY.REQUIRED_MODAL_SHOWN_TIME))
-        ) {
-            persistence.save(KEY.REQUIRED_MODAL_SHOWN_TIME, new Date().toString());
-            await dispatch(openActiveModal(requiredAccountInformationModal) as any);
+        if (state && isLoggedIn(state.user)) {
+            // Required account info model - takes precedence over stage/exam board re-confirmation modal, only
+            // shown once every 50 minutes (using a key in clients browser storage)
+            if (!allRequiredInformationIsPresent(state.user, state.userPreferences, state.user.registeredContexts) &&
+                !withinLast50Minutes(persistence.load(KEY.REQUIRED_MODAL_SHOWN_TIME))) {
+                persistence.save(KEY.REQUIRED_MODAL_SHOWN_TIME, new Date().toString());
+                await dispatch(openActiveModal(requiredAccountInformationModal));
+            }
+            // User context re-confirmation modal - used to request a user to update their stage and/or exam board
+            // once every academic year.
+            else if (needToUpdateUserContextDetails(state.user) &&
+                     !withinLast50Minutes(persistence.load(KEY.RECONFIRM_USER_CONTEXT_SHOWN_TIME))) {
+                persistence.save(KEY.RECONFIRM_USER_CONTEXT_SHOWN_TIME, new Date().toString());
+                await dispatch(openActiveModal(userContextReconfimationModal));
+            }
         }
     }
 
@@ -28,8 +58,7 @@ export const notificationCheckerMiddleware: Middleware = (middlewareApi: Middlew
 
         if (lastQuestionId === null) {
             persistence.session.save(KEY.FIRST_ANON_QUESTION, action.questionId);
-        } else {
-            if (
+        } else if (
                 state && !isLoggedIn(state.user) &&
                 lastQuestionId !== action.questionId &&
                 !withinLast2Hours(persistence.load(KEY.LOGIN_OR_SIGN_UP_MODAL_SHOWN_TIME))
@@ -40,7 +69,6 @@ export const notificationCheckerMiddleware: Middleware = (middlewareApi: Middlew
                 persistence.session.remove(KEY.FIRST_ANON_QUESTION);
                 persistence.save(KEY.LOGIN_OR_SIGN_UP_MODAL_SHOWN_TIME, new Date().toString());
                 await dispatch(openActiveModal(loginOrSignUpModal) as any);
-            }
         }
     }
 

--- a/src/app/state/middleware/notificationManager.ts
+++ b/src/app/state/middleware/notificationManager.ts
@@ -1,42 +1,22 @@
 import {Dispatch, Middleware, MiddlewareAPI} from "redux";
 import {ACTION_TYPE} from "../../services/constants";
-import {Action, LoggedInUser} from "../../../IsaacAppTypes";
+import {Action} from "../../../IsaacAppTypes";
 import {logAction, openActiveModal} from "../actions";
-import {allRequiredInformationIsPresent, withinLast2Hours, withinLast50Minutes} from "../../services/validation";
+import {allRequiredInformationIsPresent, withinLast50Minutes, withinLast2Hours} from "../../services/validation";
 import {isLoggedIn} from "../../services/user";
 import * as persistence from "../../services/localStorage";
 import {KEY} from "../../services/localStorage";
 import {requiredAccountInformationModal} from "../../components/elements/modals/RequiredAccountInformationModal";
 import {loginOrSignUpModal} from "../../components/elements/modals/LoginOrSignUpModal";
 import {userContextReconfimationModal} from "../../components/elements/modals/UserContextReconfirmationModal";
-
-// Returns true if the user hasn't updated their stage, exam board and school since *last August*,
-// and it's at least the 24th of August
-const needToUpdateUserContextDetails = (user: LoggedInUser) => {
-    // First calculate when the last August before today was...
-    let date = new Date();
-    if (date.getMonth() < 8) {
-        date.setFullYear(date.getFullYear() - 1);
-    }
-    date.setMonth(8, 1);
-    date.setHours(0, 0, 0, 0);
-    // Date is now the 1st day of last August
-    if (user.registeredContextsLastConfirmed && user.registeredContextsLastConfirmed < date) {
-        date.setDate(24);
-        // Date is now the 24th of last August (the last week of August, give or take)
-        if (Date.now() > date.valueOf()) {
-            return true;
-        }
-    }
-    return false;
-}
+import {needToUpdateUserContextDetails} from "./utils";
 
 export const notificationCheckerMiddleware: Middleware = (middlewareApi: MiddlewareAPI) => (dispatch: Dispatch) => async (action: Action) => {
 
     const state = middlewareApi.getState();
     if([ACTION_TYPE.CURRENT_USER_RESPONSE_SUCCESS, ACTION_TYPE.ROUTER_PAGE_CHANGE].includes(action.type)) {
         if (state && isLoggedIn(state.user)) {
-            // Required account info model - takes precedence over stage/exam board re-confirmation modal, only
+            // Required account info modal - takes precedence over stage/exam board re-confirmation modal, and is only
             // shown once every 50 minutes (using a key in clients browser storage)
             if (!allRequiredInformationIsPresent(state.user, state.userPreferences, state.user.registeredContexts) &&
                 !withinLast50Minutes(persistence.load(KEY.REQUIRED_MODAL_SHOWN_TIME))) {
@@ -45,7 +25,7 @@ export const notificationCheckerMiddleware: Middleware = (middlewareApi: Middlew
             }
             // User context re-confirmation modal - used to request a user to update their stage and/or exam board
             // once every academic year.
-            else if (needToUpdateUserContextDetails(state.user) &&
+            else if (needToUpdateUserContextDetails(state.user.registeredContextsLastConfirmed) &&
                      !withinLast50Minutes(persistence.load(KEY.RECONFIRM_USER_CONTEXT_SHOWN_TIME))) {
                 persistence.save(KEY.RECONFIRM_USER_CONTEXT_SHOWN_TIME, new Date().toString());
                 await dispatch(openActiveModal(userContextReconfimationModal));

--- a/src/app/state/middleware/utils.ts
+++ b/src/app/state/middleware/utils.ts
@@ -1,23 +1,10 @@
-// Returns true if lastConfirmedDate is before *last August*, and it's at least the 24th of August. False otherwise
-export const needToUpdateUserContextDetails = (lastConfirmedDate: Date | undefined) => {
-    // First calculate when the beginning of last August before today was...
+export const needToUpdateUserContextDetails = (lastConfirmedDate: Date | undefined): boolean => {
     let date = new Date();
-    if (date.getMonth() <= 7) { // Month is 0-indexed for some stupid
+    if (date.getMonth() < 7) { // Month is 0-indexed for some stupid reason
         date.setFullYear(date.getFullYear() - 1);
     }
     date.setMonth(7, 1);
     date.setHours(0, 0, 0, 0);
-    // Date is now the 1st day of last August...
-
-    // If the user last confirmed their registered contexts before last August...
-    if (lastConfirmedDate && lastConfirmedDate < date) {
-        // Check if we're past the 24th of the August after
-        date.setDate(24);
-        date.setFullYear(date.getFullYear() + 1);
-        // Date is now the 24th of the August *after the last one* (the last week, give or take)
-        if (Date.now() > date.valueOf()) {
-            return true;
-        }
-    }
-    return false;
+    // Date is now the 1st day of most recent August
+    return !!lastConfirmedDate && lastConfirmedDate <= date;
 }

--- a/src/app/state/middleware/utils.ts
+++ b/src/app/state/middleware/utils.ts
@@ -1,0 +1,23 @@
+// Returns true if lastConfirmedDate is before *last August*, and it's at least the 24th of August. False otherwise
+export const needToUpdateUserContextDetails = (lastConfirmedDate: Date | undefined) => {
+    // First calculate when the beginning of last August before today was...
+    let date = new Date();
+    if (date.getMonth() <= 7) { // Month is 0-indexed for some stupid
+        date.setFullYear(date.getFullYear() - 1);
+    }
+    date.setMonth(7, 1);
+    date.setHours(0, 0, 0, 0);
+    // Date is now the 1st day of last August...
+
+    // If the user last confirmed their registered contexts before last August...
+    if (lastConfirmedDate && lastConfirmedDate < date) {
+        // Check if we're past the 24th of the August after
+        date.setDate(24);
+        date.setFullYear(date.getFullYear() + 1);
+        // Date is now the 24th of the August *after the last one* (the last week, give or take)
+        if (Date.now() > date.valueOf()) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/src/app/state/selectors.tsx
+++ b/src/app/state/selectors.tsx
@@ -123,7 +123,8 @@ export const selectors = {
         progress: (state: AppState) => state?.myProgress,
         snapshot: (state: AppState) => state?.myProgress?.userSnapshot,
         achievementsRecord: (state: AppState) => state?.myProgress?.userSnapshot?.achievementsRecord,
-        answeredQuestionsByDate: (state: AppState) => state?.myAnsweredQuestionsByDate
+        answeredQuestionsByDate: (state: AppState) => state?.myAnsweredQuestionsByDate,
+        preferences: (state: AppState) => state?.userPreferences
     },
 
     mainContentId: {

--- a/src/test/services/notifications.test.ts
+++ b/src/test/services/notifications.test.ts
@@ -5,23 +5,12 @@ jest.useFakeTimers();
 describe("Account detail reconfirmation modal is shown at the correct times", () => {
     it("Doesn't show the modal if the user has updated their details since last August", async () => {
         jest.useFakeTimers().setSystemTime(new Date("2000-09-01")); //
-        expect(needToUpdateUserContextDetails(new Date("2000-04-01"))).toBe(false);
+        expect(needToUpdateUserContextDetails(new Date("2000-08-02"))).toBe(false);
     })
-    it("Doesn't show the modal if the user hasn't updated their details since last August, but it isn't 24th August yet", async () => {
-        jest.useFakeTimers().setSystemTime(new Date("2000-08-01"));
-        expect(needToUpdateUserContextDetails(new Date("1999-04-01"))).toBe(false);
-    })
-    it("Shows the modal if the user hasn't updated their details since last August, and it's past the 24th August", async () => {
+    it("Shows the modal if the user hasn't updated their details since most recent August", async () => {
         jest.useFakeTimers().setSystemTime(new Date("2000-08-25"));
         expect(needToUpdateUserContextDetails(new Date("1999-04-01"))).toBe(true);
-    })
-    it("Doesn't show the modal if the date is between August 1st and 24th of the current year, and current date is 25th August", async () => {
-        jest.useFakeTimers().setSystemTime(new Date("2000-08-25"));
-        expect(needToUpdateUserContextDetails(new Date("2000-08-10"))).toBe(false);
-    })
-    it("Doesn't show the modal if the date is between August 24th and 31st of the current year, and current date is 25th August", async () => {
-        jest.useFakeTimers().setSystemTime(new Date("2000-08-25"));
-        expect(needToUpdateUserContextDetails(new Date("2000-08-28"))).toBe(false);
+        expect(needToUpdateUserContextDetails(new Date("2000-07-25"))).toBe(true);
     })
     it("Doesn't show the modal if somehow the given date is far into the future", async () => {
         jest.useFakeTimers().setSystemTime(new Date("2000-08-25"));

--- a/src/test/services/notifications.test.ts
+++ b/src/test/services/notifications.test.ts
@@ -1,0 +1,30 @@
+import {needToUpdateUserContextDetails} from "../../app/state/middleware/utils";
+
+jest.useFakeTimers();
+
+describe("Account detail reconfirmation modal is shown at the correct times", () => {
+    it("Doesn't show the modal if the user has updated their details since last August", async () => {
+        jest.useFakeTimers().setSystemTime(new Date("2000-09-01")); //
+        expect(needToUpdateUserContextDetails(new Date("2000-04-01"))).toBe(false);
+    })
+    it("Doesn't show the modal if the user hasn't updated their details since last August, but it isn't 24th August yet", async () => {
+        jest.useFakeTimers().setSystemTime(new Date("2000-08-01"));
+        expect(needToUpdateUserContextDetails(new Date("1999-04-01"))).toBe(false);
+    })
+    it("Shows the modal if the user hasn't updated their details since last August, and it's past the 24th August", async () => {
+        jest.useFakeTimers().setSystemTime(new Date("2000-08-25"));
+        expect(needToUpdateUserContextDetails(new Date("1999-04-01"))).toBe(true);
+    })
+    it("Doesn't show the modal if the date is between August 1st and 24th of the current year, and current date is 25th August", async () => {
+        jest.useFakeTimers().setSystemTime(new Date("2000-08-25"));
+        expect(needToUpdateUserContextDetails(new Date("2000-08-10"))).toBe(false);
+    })
+    it("Doesn't show the modal if the date is between August 24th and 31st of the current year, and current date is 25th August", async () => {
+        jest.useFakeTimers().setSystemTime(new Date("2000-08-25"));
+        expect(needToUpdateUserContextDetails(new Date("2000-08-28"))).toBe(false);
+    })
+    it("Doesn't show the modal if somehow the given date is far into the future", async () => {
+        jest.useFakeTimers().setSystemTime(new Date("2000-08-25"));
+        expect(needToUpdateUserContextDetails(new Date("2100-08-30"))).toBe(false);
+    })
+});


### PR DESCRIPTION
Modal will show to anyone who hasn't updated their user context details since the most recent 1st August.

**After final copyedit:**

Teacher relevant text on Phy:
![image](https://user-images.githubusercontent.com/33040507/183870612-5a9cc24d-0d76-4181-88c1-7ceb078cf144.png)

Student relevant text on CS
![image](https://user-images.githubusercontent.com/33040507/183871084-3be75359-986c-4c31-a0ac-3cb1949e6fbc.png)

