### PR TITLE
Add Year 7/8 and 9 to dropdown options

### DIFF
--- a/src/IsaacApiTypes.tsx
+++ b/src/IsaacApiTypes.tsx
@@ -500,7 +500,7 @@ export interface GroupMembershipDTO {
     created?: Date;
 }
 
-export type Stage = "year_7" | "year_8" | "year_9" | "gcse" | "a_level" | "further_a" | "university" | "all";
+export type Stage = "year_7_and_8" | "year_7" | "year_8" | "year_9" | "gcse" | "a_level" | "further_a" | "university" | "all";
 
 export type ExamBoard = "aqa" | "cie" | "edexcel" | "eduqas" | "ocr" | "wjec" | "all";
 

--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -626,7 +626,7 @@ export const STAGES_PHY = new Set([STAGE.ALL, STAGE.YEAR_7_AND_8, STAGE.YEAR_9, 
 export const STAGES_CS = new Set([STAGE.ALL, STAGE.GCSE, STAGE.A_LEVEL]);
 export const stagesOrdered: Stage[] = ["year_7_and_8", "year_7", "year_8", "year_9", "gcse", "a_level", "further_a", "university", "all"];
 export const stageLabelMap: {[stage in Stage]: string} = {
-    year_7_and_8: "Year\u00A07\u00A0or\u00A08",
+    year_7_and_8: "Year\u00A07/8",
     year_7: "Year\u00A07",
     year_8: "Year\u00A08",
     year_9: "Year\u00A09",

--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -1047,7 +1047,6 @@ export enum EventTypeFilter {
 
 export enum EventStageFilter {
     "All stages" = "all",
-    "Year 9" = "year_9",
     "GCSE" = "gcse",
     "A-Level" = "a_level",
     "Further A" = "further_a",

--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -611,6 +611,7 @@ export const examBoardBooleanNotationMap: {[examBoard in ExamBoard]: BOOLEAN_NOT
 
 // STAGES
 export enum STAGE {
+    YEAR_7_AND_8 = "year_7_and_8",
     YEAR_7 = "year_7",
     YEAR_8 = "year_8",
     YEAR_9 = "year_9",
@@ -621,10 +622,11 @@ export enum STAGE {
     ALL = "all",
 }
 export const STAGE_NULL_OPTIONS = new Set([STAGE.ALL]);
-export const STAGES_PHY = new Set([STAGE.ALL, STAGE.GCSE, STAGE.A_LEVEL, STAGE.FURTHER_A, STAGE.UNIVERSITY]);
+export const STAGES_PHY = new Set([STAGE.ALL, STAGE.YEAR_7_AND_8, STAGE.YEAR_9, STAGE.GCSE, STAGE.A_LEVEL, STAGE.FURTHER_A, STAGE.UNIVERSITY]);
 export const STAGES_CS = new Set([STAGE.ALL, STAGE.GCSE, STAGE.A_LEVEL]);
-export const stagesOrdered: Stage[] = ["year_7", "year_8", "year_9", "gcse", "a_level", "further_a", "university", "all"];
+export const stagesOrdered: Stage[] = ["year_7_and_8", "year_7", "year_8", "year_9", "gcse", "a_level", "further_a", "university", "all"];
 export const stageLabelMap: {[stage in Stage]: string} = {
+    year_7_and_8: "Year\u00A07\u00A0or\u00A08",
     year_7: "Year\u00A07",
     year_8: "Year\u00A08",
     year_9: "Year\u00A09",
@@ -1045,8 +1047,7 @@ export enum EventTypeFilter {
 
 export enum EventStageFilter {
     "All stages" = "all",
-    "Year 7" = "year_7",
-    "Year 8" = "year_8",
+    "Year 7 or 8" = "year_7_and_8",
     "Year 9" = "year_9",
     "GCSE" = "gcse",
     "A-Level" = "a_level",

--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -1047,7 +1047,6 @@ export enum EventTypeFilter {
 
 export enum EventStageFilter {
     "All stages" = "all",
-    "Year 7 or 8" = "year_7_and_8",
     "Year 9" = "year_9",
     "GCSE" = "gcse",
     "A-Level" = "a_level",

--- a/src/app/services/userContext.ts
+++ b/src/app/services/userContext.ts
@@ -208,6 +208,8 @@ export function getFilteredExamBoardOptions(filter?: ExamBoardFilterOptions) {
 }
 
 const _STAGE_ITEM_OPTIONS = [ /* best not to export - use getFiltered */
+    {label: "Year 7/8", value: STAGE.YEAR_7_AND_8},
+    {label: "Year 9", value: STAGE.YEAR_9},
     {label: "GCSE", value: STAGE.GCSE},
     {label: "A Level", value: STAGE.A_LEVEL},
     {label: "Further A", value: STAGE.FURTHER_A},


### PR DESCRIPTION
The backend change to support the new `year_7_and_8` tag has already been merged.
I have left in the old `year_7` and `year_8` tags and their labels for the time between the release and the content script swapping them all to use the new tag.