### PR TITLE
Show exposition text in Graph Sketcher, remove duplicate hints

### DIFF
--- a/src/app/components/content/IsaacGraphSketcherQuestion.tsx
+++ b/src/app/components/content/IsaacGraphSketcherQuestion.tsx
@@ -1,6 +1,5 @@
 import React, {useState, useEffect, useRef} from "react";
 import {GraphChoiceDTO, IsaacGraphSketcherQuestionDTO} from "../../../IsaacApiTypes";
-import {IsaacTabbedHints} from "./IsaacHints";
 import GraphSketcherModal from "../elements/modals/GraphSketcherModal";
 import {GraphSketcher, makeGraphSketcher, LineType, GraphSketcherState} from "isaac-graph-sketcher/dist/src/GraphSketcher";
 import {useCurrentQuestionAttempt} from "../../services/questions";

--- a/src/app/components/content/IsaacGraphSketcherQuestion.tsx
+++ b/src/app/components/content/IsaacGraphSketcherQuestion.tsx
@@ -5,6 +5,7 @@ import GraphSketcherModal from "../elements/modals/GraphSketcherModal";
 import {GraphSketcher, makeGraphSketcher, LineType, GraphSketcherState} from "isaac-graph-sketcher/dist/src/GraphSketcher";
 import {useCurrentQuestionAttempt} from "../../services/questions";
 import {IsaacQuestionProps} from "../../../IsaacAppTypes";
+import {IsaacContentValueOrChildren} from "./IsaacContentValueOrChildren";
 
 const IsaacGraphSketcherQuestion = ({doc, questionId, readonly}: IsaacQuestionProps<IsaacGraphSketcherQuestionDTO>) => {
 
@@ -68,7 +69,12 @@ const IsaacGraphSketcherQuestion = ({doc, questionId, readonly}: IsaacQuestionPr
     }, [currentAttempt]);
 
     return <div className="graph-sketcher-question">
-        <div className="sketch-preview" onClick={openModal} onKeyUp={openModal} role={readonly ? undefined : "button"}
+        <div className="question-content">
+            <IsaacContentValueOrChildren value={doc.value} encoding={doc.encoding}>
+                {doc.children}
+            </IsaacContentValueOrChildren>
+        </div>
+        <div className="sketch-preview text-center" onClick={openModal} onKeyUp={openModal} role={readonly ? undefined : "button"}
              tabIndex={readonly ? undefined : 0}>
             <div ref={previewRef} className={`${questionId}-graph-sketcher-preview`} />
         </div>
@@ -76,8 +82,8 @@ const IsaacGraphSketcherQuestion = ({doc, questionId, readonly}: IsaacQuestionPr
             close={closeModal}
             onGraphSketcherStateChange={onGraphSketcherStateChange}
             initialState={initialState}
+            question={doc}
         />}
-        <IsaacTabbedHints questionPartId={questionId} hints={doc.hints} />
     </div>
 };
 export default IsaacGraphSketcherQuestion;

--- a/src/app/components/elements/modals/GraphSketcherModal.tsx
+++ b/src/app/components/elements/modals/GraphSketcherModal.tsx
@@ -2,11 +2,16 @@ import React, { useState, useEffect, ChangeEvent, useCallback } from "react";
 import { GraphSketcher, LineType, makeGraphSketcher, GraphSketcherState } from "isaac-graph-sketcher/dist/src/GraphSketcher";
 import { isDefined } from '../../../services/miscUtils';
 import debounce from "lodash/debounce";
+import {IsaacContentValueOrChildren} from "../../content/IsaacContentValueOrChildren";
+import {IsaacQuestionProps} from "../../../../IsaacAppTypes";
+import {IsaacGraphSketcherQuestionDTO} from "../../../../IsaacApiTypes";
+import {Markup} from "../markup";
 
 interface GraphSketcherModalProps {
     close: () => void;
     initialState?: GraphSketcherState;
     onGraphSketcherStateChange: (state: GraphSketcherState) => void;
+    question?: IsaacGraphSketcherQuestionDTO;
 }
 
 const GraphSketcherModal = (props: GraphSketcherModalProps) => {
@@ -102,6 +107,10 @@ const GraphSketcherModal = (props: GraphSketcherModalProps) => {
                 <option value="Orange">Orange</option>
                 <option value="Green">Green</option>
             </select>
+            {props.question?.value &&
+                <Markup trusted-markup-encoding={props.question.encoding}>
+                    {props.question.value}
+                </Markup>}
         </div>
     </div>
 }

--- a/src/app/components/elements/modals/GraphSketcherModal.tsx
+++ b/src/app/components/elements/modals/GraphSketcherModal.tsx
@@ -2,8 +2,6 @@ import React, { useState, useEffect, ChangeEvent, useCallback } from "react";
 import { GraphSketcher, LineType, makeGraphSketcher, GraphSketcherState } from "isaac-graph-sketcher/dist/src/GraphSketcher";
 import { isDefined } from '../../../services/miscUtils';
 import debounce from "lodash/debounce";
-import {IsaacContentValueOrChildren} from "../../content/IsaacContentValueOrChildren";
-import {IsaacQuestionProps} from "../../../../IsaacAppTypes";
 import {IsaacGraphSketcherQuestionDTO} from "../../../../IsaacApiTypes";
 import {Markup} from "../markup";
 


### PR DESCRIPTION
Adds exposition text above the question and within the graph editor, and removes the duplicate row of hints.