### PR TITLE
Prevent unnecessary user updates

### DIFF
--- a/src/app/components/navigation/IsaacApp.tsx
+++ b/src/app/components/navigation/IsaacApp.tsx
@@ -106,23 +106,25 @@ export const IsaacApp = () => {
         dispatch(fetchGlossaryTerms());
     }, [dispatch]);
 
+    const loggedInUserId = isLoggedIn(user) ? user.id : undefined;
     useEffect(() => {
-        if (isLoggedIn(user)) {
+        if (loggedInUserId) {
             dispatch(requestNotifications());
-            checkForWebSocket(user);
+            checkForWebSocket(loggedInUserId);
         }
         return () => {
             closeWebSocket();
         };
-    }, [dispatch, user]);
+    }, [dispatch, loggedInUserId]);
 
+    const showNotifications = isLoggedIn(user) && showNotification(user);
     useEffect(() => {
         const dateNow = new Date();
-        if (isLoggedIn(user) && showNotification(user) && notifications && notifications.length > 0) {
+        if (showNotifications && notifications && notifications.length > 0) {
             dispatch(openActiveModal(notificationModal(notifications[0])));
             persistence.save(KEY.LAST_NOTIFICATION_TIME, dateNow.toString())
         }
-    }, [dispatch, user, notifications]);
+    }, [dispatch, showNotifications, notifications]);
 
     // Render
     return <Router history={history}>

--- a/src/app/components/navigation/NavigationBar.tsx
+++ b/src/app/components/navigation/NavigationBar.tsx
@@ -24,6 +24,7 @@ import {partitionCompleteAndIncompleteQuizzes} from "../../services/quiz";
 import {isFound} from "../../services/miscUtils";
 import {RenderNothing} from "../elements/RenderNothing";
 import classNames from "classnames";
+import {isLoggedIn} from "../../services/user";
 
 
 const MenuOpenContext = React.createContext<{menuOpen: boolean; setMenuOpen: React.Dispatch<React.SetStateAction<boolean>>}>({
@@ -72,12 +73,13 @@ export function useAssignmentsCount() {
     const dispatch = useAppDispatch();
     const user = useAppSelector(selectors.user.orNull);
 
+    const loggedInUserId = isLoggedIn(user) ? user.id : undefined;
     useEffect(() => {
-        if (user?.loggedIn) {
+        if (loggedInUserId) {
             dispatch(loadMyAssignments());
             dispatch(loadQuizAssignedToMe());
         }
-    }, [dispatch, user]);
+    }, [dispatch, loggedInUserId]);
 
     return useAppSelector((state: AppState) => {
         const response = {assignmentsCount: 0, quizzesCount: 0};

--- a/src/app/services/notificationChecker.ts
+++ b/src/app/services/notificationChecker.ts
@@ -3,12 +3,13 @@ import * as persistence from "./localStorage";
 import {KEY} from "./localStorage";
 
 
-export function showNotification(user: RegisteredUserDTO | null) {
+export function showNotification(user: RegisteredUserDTO | null): boolean {
     const dateNow = new Date();
     const notificationTime = persistence.load(KEY.LAST_NOTIFICATION_TIME);
     if (user && user.registrationDate && (dateNow.getTime() - new Date(user.registrationDate).getTime()) > 14*24*60*60*1000) {
         if (dateNow.getTime() - (new Date(notificationTime || "0").getTime()) > 24*60*60*1000) {
             return true
         }
-    } else return false
+    }
+    return false
 }

--- a/src/app/services/websockets.ts
+++ b/src/app/services/websockets.ts
@@ -1,6 +1,5 @@
 import {api} from "./api";
 import {UserSnapshot} from "../../IsaacAppTypes";
-import {UserSummaryDTO} from "../../IsaacApiTypes";
 import {getSnapshot, partiallyUpdateUserSnapshot} from "../state/actions";
 import {store} from "../state/store";
 
@@ -9,13 +8,13 @@ let webSocketCheckTimeout: number | null = null;
 let webSocketErrorCount = 0;
 let lastKnownServerTime: number | null = null;
 
-const openNotificationSocket = function(user: UserSummaryDTO | null): void {
+const openNotificationSocket = function(userId: number | undefined): void {
 
     if (notificationWebSocket !== null) {
         return;
     }
 
-    if (!user) {
+    if (userId === undefined) {
         return;
     }
 
@@ -110,7 +109,7 @@ const openNotificationSocket = function(user: UserSummaryDTO | null): void {
     }
 }
 
-export const checkForWebSocket = function(user: UserSummaryDTO | null , userSnapshot?: UserSnapshot): void {
+export const checkForWebSocket = function(userId?: number, userSnapshot?: UserSnapshot): void {
     try {
         if (notificationWebSocket !== null) {
             if (!userSnapshot) {
@@ -125,7 +124,7 @@ export const checkForWebSocket = function(user: UserSummaryDTO | null , userSnap
             }
             webSocketCheckTimeout = window.setTimeout(checkForWebSocket, 60000);
         } else {
-            openNotificationSocket(user);
+            openNotificationSocket(userId);
         }
     } catch (e) {
         console.log("Error establishing WebSocket connection!", e)

--- a/src/app/state/actions.tsx
+++ b/src/app/state/actions.tsx
@@ -228,7 +228,11 @@ export const submitTotpChallengeResponse = (mfaVerificationCode: string, remembe
         const afterAuthPath = persistence.load(KEY.AFTER_AUTH_PATH) || '/';
         const result = await api.authentication.mfaCompleteLogin(mfaVerificationCode, rememberMe);
 
-        await dispatch(requestCurrentUser() as any); // Request user preferences
+        // Request user preferences, as we do in the requestCurrentUser action:
+        await Promise.all([
+            dispatch(getUserAuthSettings() as any),
+            dispatch(getUserPreferences() as any)
+        ]);
         dispatch({type: ACTION_TYPE.USER_AUTH_MFA_CHALLENGE_SUCCESS});
         dispatch({type: ACTION_TYPE.USER_LOG_IN_RESPONSE_SUCCESS, user: result.data});
         persistence.remove(KEY.AFTER_AUTH_PATH);
@@ -239,7 +243,6 @@ export const submitTotpChallengeResponse = (mfaVerificationCode: string, remembe
         dispatch({type: ACTION_TYPE.USER_AUTH_MFA_CHALLENGE_FAILURE, errorMessage: extractMessage(e)});
         dispatch(showAxiosErrorToastIfNeeded("Error with verification code.", e));
     }
-    dispatch(requestCurrentUser() as any)
 };
 
 export const getUserPreferences = () => async (dispatch: Dispatch<Action>) => {
@@ -411,8 +414,11 @@ export const logInUser = (provider: AuthenticationProvider, credentials: Credent
             dispatch({type: ACTION_TYPE.USER_AUTH_MFA_CHALLENGE_REQUIRED});
             return;
         }
-
-        await dispatch(requestCurrentUser() as any); // Request user preferences
+        // Request user preferences, as we do in the requestCurrentUser action:
+        await Promise.all([
+            dispatch(getUserAuthSettings() as any),
+            dispatch(getUserPreferences() as any)
+        ]);
         dispatch({type: ACTION_TYPE.USER_LOG_IN_RESPONSE_SUCCESS, user: result.data});
         persistence.remove(KEY.AFTER_AUTH_PATH);
         history.push(afterAuthPath);
@@ -420,7 +426,6 @@ export const logInUser = (provider: AuthenticationProvider, credentials: Credent
     } catch (e: any) {
         dispatch({type: ACTION_TYPE.USER_LOG_IN_RESPONSE_FAILURE, errorMessage: extractMessage(e)})
     }
-    dispatch(requestCurrentUser() as any)
 };
 
 export const resetPassword = (params: {email: string}) => async (dispatch: Dispatch<Action>) => {
@@ -478,7 +483,11 @@ export const handleProviderCallback = (provider: AuthenticationProvider, paramet
     dispatch({type: ACTION_TYPE.AUTHENTICATION_HANDLE_CALLBACK});
     try {
         const providerResponse = await api.authentication.checkProviderCallback(provider, parameters);
-        await dispatch(requestCurrentUser() as any); // Request user preferences
+        // Request user preferences, as we do in the requestCurrentUser action:
+        await Promise.all([
+            dispatch(getUserAuthSettings() as any),
+            dispatch(getUserPreferences() as any)
+        ]);
         dispatch({type: ACTION_TYPE.USER_LOG_IN_RESPONSE_SUCCESS, user: providerResponse.data});
         if (providerResponse.data.firstLogin) {
             ReactGA.event({

--- a/src/app/state/reducers/userState.ts
+++ b/src/app/state/reducers/userState.ts
@@ -12,6 +12,7 @@ export const user = (user: UserState = null, action: Action): UserState => {
         case ACTION_TYPE.CURRENT_USER_RESPONSE_SUCCESS:
         case ACTION_TYPE.USER_DETAILS_UPDATE_RESPONSE_SUCCESS:
             return {loggedIn: true, ...action.user};
+        case ACTION_TYPE.USER_LOG_IN_RESPONSE_FAILURE:
         case ACTION_TYPE.CURRENT_USER_RESPONSE_FAILURE:
         case ACTION_TYPE.USER_LOG_OUT_RESPONSE_SUCCESS:
         case ACTION_TYPE.USER_LOG_OUT_EVERYWHERE_RESPONSE_SUCCESS:


### PR DESCRIPTION
On login success, the current user object is returned and so no further current_user requests are necessary. However, I think in order to avoid duplicating the logic for getting auth settings and preferences, we then dispatched a current_user request anyway.

This causes the Redux "user" object to change, even though its contents are identical, which causes many useEffects to fire unnecessarily. These unwanted firings caused many duplicate WebSocket requests, and duplicate auth/preference settings requests, which are bad for our server performance as much as the app performance.

After these changes, there's a bug with login. Previously, a login failure would have caused a pointless current_user request which would have reset the "user" state object back and removed the "requesting" property. Now we no longer make that unwanted request, we have to make sure we reset this, else without reloading you can't make another attempt to login if have an error this first time.

---

I am sure that the _best_ approach here would be a new action that does the settings/preferences requests, but we're likely to refactor all this anyhow so this was simpler and we can cope with the duplication.