### PR TITLE
Patch rtk query bugs

### DIFF
--- a/src/app/components/elements/modals/GameboardCreatedModal.tsx
+++ b/src/app/components/elements/modals/GameboardCreatedModal.tsx
@@ -21,21 +21,22 @@ const GameboardSuccessfullyCreated = () =>
         </Label>
     </Row>;
 
-const GameboardCreatedModalButtons = ({gameboardId}: {gameboardId: string | undefined}) => {
+const GameboardCreatedModalButtons = ({gameboardId, resetBuilder}: {gameboardId: string | undefined, resetBuilder: () => void}) => {
     const dispatch = useAppDispatch();
+    const closeModal = () => dispatch(closeActiveModal());
     return <Row>
         <Col className="mb-1">
             <Button
                 tag={Link} to={`/add_gameboard/${gameboardId}`} color="secondary" block
-                disabled={!gameboardId} onClick={() => dispatch(closeActiveModal())}
+                disabled={!gameboardId} onClick={closeModal}
             >
                 Set as assignment
             </Button>
         </Col>
         <Col className="mb-1">
             <Button
-                tag={Link} to={`/gameboard_builder`} color="primary" outline
-                onClick={() => dispatch(closeActiveModal())}
+                color="primary" outline
+                onClick={() => {resetBuilder(); closeModal();}}
             >
                 Create another board
             </Button>
@@ -43,7 +44,7 @@ const GameboardCreatedModalButtons = ({gameboardId}: {gameboardId: string | unde
         <Col className="mb-1">
             <Button
                 tag={Link} to={`/set_assignments`} color="primary" outline
-                onClick={() => dispatch(closeActiveModal())}
+                onClick={closeModal}
             >
                 View all of your boards
             </Button>
@@ -51,13 +52,13 @@ const GameboardCreatedModalButtons = ({gameboardId}: {gameboardId: string | unde
     </Row>
 }
 
-export const GameboardCreatedModal = ({gameboardId, error}: {gameboardId: string | undefined, error: FetchBaseQueryError | SerializedError | undefined}) => {
+export const GameboardCreatedModal = ({gameboardId, error, resetBuilder}: {gameboardId: string | undefined, error: FetchBaseQueryError | SerializedError | undefined, resetBuilder: () => void}) => {
     const errorMessage = getRTKQueryErrorMessage(error).message;
     return <div>
         {gameboardId
             ? <GameboardSuccessfullyCreated/>
             : <GameboardNotFound errorMessage={errorMessage}/>
         }
-        <GameboardCreatedModalButtons gameboardId={gameboardId} />
+        <GameboardCreatedModalButtons resetBuilder={resetBuilder} gameboardId={gameboardId} />
     </div>;
 };

--- a/src/app/components/handlers/ShowLoadingQuery.tsx
+++ b/src/app/components/handlers/ShowLoadingQuery.tsx
@@ -1,0 +1,32 @@
+import React, {ReactElement} from "react";
+import {FetchBaseQueryError} from "@reduxjs/toolkit/dist/query/fetchBaseQuery";
+import {SerializedError} from "@reduxjs/toolkit";
+import {IsaacSpinner} from "./IsaacSpinner";
+import {isDefined} from "../../services";
+
+const loadingPlaceholder = <div className="w-100 text-center pb-2">
+    <h2 aria-hidden="true" className="pt-5">Loading...</h2>
+    <IsaacSpinner />
+</div>;
+
+interface ShowLoadingQueryProps<T> {
+    thenRender: (t: NonNullable<T>) => ReactElement;
+    placeholder?: ReactElement;
+    ifError: (error?: FetchBaseQueryError | SerializedError) => ReactElement;
+    query: {
+        data?: T;
+        isLoading: boolean;
+        isError: boolean;
+        error?: FetchBaseQueryError | SerializedError;
+    };
+}
+export function ShowLoadingQuery<T>({query, thenRender, placeholder, ifError}: ShowLoadingQueryProps<T>) {
+    const {data, isLoading, isError, error} = query;
+    if (isError) {
+        return ifError(error);
+    }
+    if (isLoading) {
+        return placeholder ?? loadingPlaceholder;
+    }
+    return isDefined(data) ? thenRender(data) : ifError();
+}

--- a/src/app/components/navigation/NavigationBar.tsx
+++ b/src/app/components/navigation/NavigationBar.tsx
@@ -55,7 +55,7 @@ export function MenuBadge({count, message, ...rest}: {count: number, message: st
     if (count == 0) {
         return RenderNothing;
     }
-    return <div {...rest}>
+    return <div className={"d-inline"} {...rest}>
         <span className="badge badge-pill bg-grey ml-2">{count}</span>
         <span className="sr-only"> {message}</span>
     </div>;

--- a/src/app/components/pages/Gameboard.tsx
+++ b/src/app/components/pages/Gameboard.tsx
@@ -140,7 +140,7 @@ export const GameboardViewer = ({gameboard, className}: {gameboard: GameboardDTO
 export const Gameboard = withRouter(({ location }) => {
     const dispatch = useAppDispatch();
     const gameboardId = location.hash ? location.hash.slice(1) : null;
-    const gameboardQuery = isaacApi.endpoints.getGameboardById.useQuery(gameboardId ?? skipToken);
+    const gameboardQuery = isaacApi.endpoints.getGameboardById.useQuery(gameboardId || skipToken);
     const {data: gameboard} = gameboardQuery;
     const user = useAppSelector(selectors.user.orNull);
 

--- a/src/app/components/pages/Gameboard.tsx
+++ b/src/app/components/pages/Gameboard.tsx
@@ -1,5 +1,12 @@
-import React, {useEffect} from "react";
-import {isaacApi, logAction, selectors, useAppDispatch, useAppSelector} from "../../state";
+import React, {useEffect, useState} from "react";
+import {
+    extractDataFromQueryResponse,
+    isaacApi,
+    logAction,
+    selectors,
+    useAppDispatch,
+    useAppSelector
+} from "../../state";
 import {Link, withRouter} from "react-router-dom"
 import * as RS from "reactstrap"
 import {Container} from "reactstrap"
@@ -15,7 +22,7 @@ import {
     isDefined,
     isFound,
     isPhy,
-    isTeacher,
+    isTeacher, NO_CONTENT,
     NOT_FOUND,
     showWildcard,
     siteSpecific,
@@ -29,6 +36,8 @@ import {StageAndDifficultySummaryIcons} from "../elements/StageAndDifficultySumm
 import {Markup} from "../elements/markup";
 import classNames from "classnames";
 import {skipToken} from "@reduxjs/toolkit/query";
+import {NOT_FOUND_TYPE} from "../../../IsaacAppTypes";
+import {ShowLoadingQuery} from "../handlers/ShowLoadingQuery";
 
 function extractFilterQueryString(gameboard: GameboardDTO): string {
     const csvQuery: {[key: string]: string} = {}
@@ -131,7 +140,8 @@ export const GameboardViewer = ({gameboard, className}: {gameboard: GameboardDTO
 export const Gameboard = withRouter(({ location }) => {
     const dispatch = useAppDispatch();
     const gameboardId = location.hash ? location.hash.slice(1) : null;
-    const { data: gameboard } = isaacApi.endpoints.getGameboardById.useQuery(gameboardId ?? skipToken);
+    const gameboardQuery = isaacApi.endpoints.getGameboardById.useQuery(gameboardId ?? skipToken);
+    const {data: gameboard} = gameboardQuery;
     const user = useAppSelector(selectors.user.orNull);
 
     // Show filter
@@ -149,31 +159,7 @@ export const Gameboard = withRouter(({ location }) => {
         }
     }, [dispatch, gameboard]);
 
-    const userButtons = user && isTeacher(user) ?
-        <RS.Row className="col-8 offset-2">
-            <RS.Col className="mt-4">
-                <RS.Button tag={Link} to={`/add_gameboard/${gameboardId}`} color="primary" outline className="btn-block">
-                    {siteSpecific("Set as Assignment", "Set as assignment")}
-                </RS.Button>
-            </RS.Col>
-            <RS.Col className="mt-4">
-                <RS.Button tag={Link} to={{pathname: "/gameboard_builder", search: `?base=${gameboardId}`}} color="primary" block outline>
-                    {siteSpecific("Duplicate and Edit", "Duplicate and edit")}
-                </RS.Button>
-            </RS.Col>
-        </RS.Row>
-        :
-        <React.Fragment>
-            {gameboard && gameboard !== NOT_FOUND && !gameboard.savedToCurrentUser && <RS.Row>
-                <RS.Col className="mt-4" sm={{size: 8, offset: 2}} md={{size: 4, offset: 4}}>
-                    <RS.Button tag={Link} to={`/add_gameboard/${gameboardId}`} color="primary" outline className="btn-block">
-                        {siteSpecific("Save to My Gameboards", "Save to My gameboards")}
-                    </RS.Button>
-                </RS.Col>
-            </RS.Row>}
-        </React.Fragment>
-
-    const notFoundComponent = <Container>
+    const notFoundComponent = () => <Container>
         <TitleAndBreadcrumb breadcrumbTitleOverride="Gameboard" currentPageTitle="Gameboard not found" />
         <h3 className="my-4">
             <small>
@@ -189,20 +175,36 @@ export const Gameboard = withRouter(({ location }) => {
 
     return gameboardId ?
         <RS.Container className="mb-5">
-            <ShowLoading
-                until={gameboard}
-                thenRender={gameboard => {
-                    if (showFilter) {
-                        return <Redirect to={`/gameboards/new?${extractFilterQueryString(gameboard)}#${gameboardId}`} />
+            <ShowLoadingQuery query={gameboardQuery} thenRender={(gameboard) => {
+                if (showFilter) {
+                    return <Redirect to={`/gameboards/new?${extractFilterQueryString(gameboard)}#${gameboardId}`} />
+                }
+                return <>
+                    <TitleAndBreadcrumb currentPageTitle={gameboard && gameboard.title || "Filter Generated Gameboard"}/>
+                    <GameboardViewer gameboard={gameboard} className="mt-4 mt-lg-5" />
+                    {user && isTeacher(user)
+                        ? <RS.Row className="col-8 offset-2">
+                            <RS.Col className="mt-4">
+                                <RS.Button tag={Link} to={`/add_gameboard/${gameboardId}`} color="primary" outline className="btn-block">
+                                    {siteSpecific("Set as Assignment", "Set as assignment")}
+                                </RS.Button>
+                            </RS.Col>
+                            <RS.Col className="mt-4">
+                                <RS.Button tag={Link} to={{pathname: "/gameboard_builder", search: `?base=${gameboardId}`}} color="primary" block outline>
+                                    {siteSpecific("Duplicate and Edit", "Duplicate and edit")}
+                                </RS.Button>
+                            </RS.Col>
+                        </RS.Row>
+                        : gameboard && gameboard !== NOT_FOUND && !gameboard.savedToCurrentUser && <RS.Row>
+                            <RS.Col className="mt-4" sm={{size: 8, offset: 2}} md={{size: 4, offset: 4}}>
+                                <RS.Button tag={Link} to={`/add_gameboard/${gameboardId}`} color="primary" outline className="btn-block">
+                                    {siteSpecific("Save to My Gameboards", "Save to My gameboards")}
+                                </RS.Button>
+                            </RS.Col>
+                        </RS.Row>
                     }
-                    return <React.Fragment>
-                        <TitleAndBreadcrumb currentPageTitle={gameboard && gameboard.title || "Filter Generated Gameboard"}/>
-                        <GameboardViewer gameboard={gameboard} className="mt-4 mt-lg-5" />
-                        {userButtons}
-                    </React.Fragment>
-                }}
-                ifNotFound={notFoundComponent}
-            />
+                </>
+            }} ifError={notFoundComponent} />
         </RS.Container>
         :
         <Redirect to={siteSpecific("/gameboards/new", "/gameboards#example-gameboard")} />

--- a/src/app/services/miscUtils.ts
+++ b/src/app/services/miscUtils.ts
@@ -4,7 +4,7 @@ import {NOT_FOUND} from "./";
 
 // undefined|null checker and type guard all-in-wonder.
 // Why is this not in Typescript?
-export function isDefined<T>(value: T | undefined | null): value is T {
+export function isDefined<T>(value: T | undefined | null): value is NonNullable<T> {
     return <T>value !== undefined && <T>value !== null;
 }
 

--- a/src/app/services/navigation.ts
+++ b/src/app/services/navigation.ts
@@ -70,6 +70,7 @@ export const useNavigation = (doc: ContentDTO | NOT_FOUND_TYPE | null): PageNavi
             nextItem: !previousQuestion ? determineNextGameboardItem(currentGameboard, currentDocId) : undefined,
             previousItem: previousQuestion ? {title: "Return to Previous Question", to: `/questions/${previousQuestion}`} : undefined,
             search: queryString.stringify(previousQuestion ? {board, modifiedQuestionHistory} : {board}),
+            currentGameboard
         };
     }
 

--- a/src/app/services/navigation.ts
+++ b/src/app/services/navigation.ts
@@ -37,11 +37,11 @@ export interface PageNavigation {
 const defaultPageNavigation = (currentGameboard?: GameboardDTO) => ({breadcrumbHistory: [], currentGameboard});
 
 export const useNavigation = (doc: ContentDTO | NOT_FOUND_TYPE | null): PageNavigation => {
-    const search = useLocation().search;
+    const {search} = useLocation();
     const {board: gameboardId, topic, questionHistory} = useQueryParams(true);
     const currentDocId = doc && doc !== NOT_FOUND ? doc.id as string : "";
     const dispatch = useAppDispatch();
-    const {data: currentGameboard} = isaacApi.endpoints.getGameboardById.useQuery(gameboardId ?? skipToken);
+    const {data: currentGameboard} = isaacApi.endpoints.getGameboardById.useQuery(gameboardId || skipToken);
 
     useEffect(() => {
         if (topic) dispatch(fetchTopicSummary(topic as TAG_ID));

--- a/src/app/state/slices/api/gameboards.ts
+++ b/src/app/state/slices/api/gameboards.ts
@@ -110,6 +110,7 @@ export const assignGameboard = createAsyncThunk(
                 undefined,
                 (assignmentsByMe) => assignmentsByMe.concat(newAssignments)
             ));
+            appDispatch(isaacApi.util.invalidateTags(successfulIds.map(groupId => ({type: "GroupAssignments", id: groupId}))));
             return newAssignments;
         } else {
             appDispatch(showRTKQueryErrorToastIfNeeded(

--- a/src/app/state/slices/api/index.ts
+++ b/src/app/state/slices/api/index.ts
@@ -18,8 +18,7 @@ import {
     IsaacPodDTO,
     IsaacWildcard,
     QuizAssignmentDTO,
-    TOTPSharedSecretDTO,
-    UserGameboardProgressSummaryDTO
+    TOTPSharedSecretDTO
 } from "../../../../IsaacApiTypes";
 import {
     anonymisationFunctions,


### PR DESCRIPTION
This fixes the bugs found so far in regression testing the RTK query assignment and gameboard refactor, those being:
 - Assignment progress cache isn't updated when new assignment is made
 - Fast track navigation being "totally broken"
 - Gameboard builder selecting random questions and breaking weirdly when "Create another gameboard" is clicked after creating one first
 - "My assignments" and "My tests" counter overflowing to the next line
 - Gameboard filter loading forever on filter combo without questions, instead of showing "No questions found..."
 - Non-existent gameboard loading forever instead of displaying "Not found"

A couple of the fixes are a bit hacky, the patch to `isaacBaseQuery` in particular needing a revisit to fix the types - ideally, it should be clear from the RTK Query hook types that data might come back as `NOT_FOUND`