### PR TITLE
Assignment Schedule

### DIFF
--- a/src/IsaacAppTypes.tsx
+++ b/src/IsaacAppTypes.tsx
@@ -627,6 +627,13 @@ export interface AdminStatsResponse {
     viewQuestionEvents: number;
 }
 
+export interface ValidAssignmentWithListingDate extends AssignmentDTO {
+    gameboardId: string;
+    groupId: number;
+    id: number;
+    listingDate: Date;
+}
+
 export interface FigureNumbersById {[figureId: string]: number}
 export const FigureNumberingContext = React.createContext<FigureNumbersById>({});
 export const AccordionSectionContext = React.createContext<{id: string | undefined; clientId: string, open: boolean | null}>(
@@ -639,6 +646,18 @@ export const ExpandableParentContext = React.createContext<boolean>(false);
 export const ConfidenceContext = React.createContext<{recordConfidence: boolean}>({recordConfidence: false});
 export const AssignmentProgressPageSettingsContext = React.createContext<PageSettings>({colourBlind: false, formatAsPercentage: false, setColourBlind: () => {}, setFormatAsPercentage: () => {}});
 export const GameboardContext = React.createContext<GameboardDTO | undefined>(undefined);
+export const AssignmentScheduleContext = React.createContext<{
+    boardsById: {[id: string]: GameboardDTO};
+    groupsById: {[id: number]: AppGroup};
+    groupFilter: {[id: number]: boolean};
+    boardIdsByGroupId: {[id: number]: string[]};
+    groups: AppGroup[];
+    gameboards: GameboardDTO[];
+    openAssignmentModal: (assignment: ValidAssignmentWithListingDate) => void;
+    collapsed: boolean;
+    setCollapsed: (b: boolean) => void;
+    viewBy: "startDate" | "dueDate";
+}>({boardsById: {}, groupsById: {}, groupFilter: {}, boardIdsByGroupId: {}, groups: [], gameboards: [], openAssignmentModal: () => {}, collapsed: false, setCollapsed: () => {}, viewBy: "startDate"});
 
 export interface AppAssignmentProgress {
     user: ApiTypes.UserSummaryDTO;

--- a/src/IsaacAppTypes.tsx
+++ b/src/IsaacAppTypes.tsx
@@ -650,7 +650,7 @@ export const AssignmentScheduleContext = React.createContext<{
     boardsById: {[id: string]: GameboardDTO};
     groupsById: {[id: number]: AppGroup};
     groupFilter: {[id: number]: boolean};
-    boardIdsByGroupId: {[id: number]: string[]};
+    boardIdsByGroupId: {[id: number]: string[] | undefined};
     groups: AppGroup[];
     gameboards: GameboardDTO[];
     openAssignmentModal: (assignment: ValidAssignmentWithListingDate) => void;

--- a/src/app/components/elements/panels/EventAttendance.tsx
+++ b/src/app/components/elements/panels/EventAttendance.tsx
@@ -33,7 +33,7 @@ export const EventAttendance = ({user, eventId}: {user: PotentialUser; eventId: 
     let canRecordAttendance = false;
     if (selectedEvent && selectedEvent.date) {
         const morningOfEvent = new Date(selectedEvent.date);
-        morningOfEvent.setHours(0, 0);
+        morningOfEvent.setUTCHours(0, 0);
         canRecordAttendance = morningOfEvent <= new Date();
     }
 

--- a/src/app/components/handlers/ShowLoadingQuery.tsx
+++ b/src/app/components/handlers/ShowLoadingQuery.tsx
@@ -1,4 +1,4 @@
-import React, {ReactElement} from "react";
+import React from "react";
 import {FetchBaseQueryError} from "@reduxjs/toolkit/dist/query/fetchBaseQuery";
 import {SerializedError} from "@reduxjs/toolkit";
 import {IsaacSpinner} from "./IsaacSpinner";

--- a/src/app/components/handlers/ShowLoadingQuery.tsx
+++ b/src/app/components/handlers/ShowLoadingQuery.tsx
@@ -2,31 +2,79 @@ import React, {ReactElement} from "react";
 import {FetchBaseQueryError} from "@reduxjs/toolkit/dist/query/fetchBaseQuery";
 import {SerializedError} from "@reduxjs/toolkit";
 import {IsaacSpinner} from "./IsaacSpinner";
-import {isDefined} from "../../services";
+import {isDefined, isFound, SITE_SUBJECT_TITLE, WEBMASTER_EMAIL} from "../../services";
+import {getRTKQueryErrorMessage} from "../../state";
+import {Alert} from "reactstrap";
+import {NOT_FOUND_TYPE} from "../../../IsaacAppTypes";
 
 const loadingPlaceholder = <div className="w-100 text-center pb-2">
     <h2 aria-hidden="true" className="pt-5">Loading...</h2>
     <IsaacSpinner />
 </div>;
 
-interface ShowLoadingQueryProps<T> {
-    thenRender: (t: NonNullable<T>) => ReactElement;
-    placeholder?: ReactElement;
-    ifError: (error?: FetchBaseQueryError | SerializedError) => ReactElement;
-    query: {
-        data?: T;
-        isLoading: boolean;
-        isError: boolean;
-        error?: FetchBaseQueryError | SerializedError;
+export const DefaultQueryError = ({error, title}: {error?: FetchBaseQueryError | SerializedError, title: string}) => {
+    const errorDetails = getRTKQueryErrorMessage(error);
+    return <Alert color={"warning"}>
+        {title ?? "Error fetching data from server"}: {errorDetails.message}
+        {errorDetails.status ? <><br/>Status code: {errorDetails.status}</> : ""}
+        <br/>
+        You may want to refresh the page, or <a href={`mailto:${WEBMASTER_EMAIL}`}>email</a> us if
+        this continues to happen.
+        Please include in your email the name and email associated with this
+        Isaac {SITE_SUBJECT_TITLE} account, alongside the details of the error given above.
+    </Alert>;
+};
+
+interface ShowLoadingQueryInfo<T> {
+    data?: T | NOT_FOUND_TYPE;
+    isLoading: boolean;
+    isError: boolean;
+    error?: FetchBaseQueryError | SerializedError;
+}
+// The Error and loading data of the first query take precedence over the second one
+export function combineQueries<T, R, S>(firstQuery: ShowLoadingQueryInfo<T>, secondQuery: ShowLoadingQueryInfo<R>, combineResult: (firstQueryResult: NonNullable<T>, secondQueryResult: NonNullable<R>) => NonNullable<S>): ShowLoadingQueryInfo<S> {
+    return {
+        data: isFound<T>(firstQuery.data) && isFound<R>(secondQuery.data) ? combineResult(firstQuery.data, secondQuery.data) : undefined,
+        isLoading: firstQuery.isLoading || secondQuery.isLoading,
+        isError: firstQuery.isError || secondQuery.isError,
+        error: firstQuery.error ?? secondQuery.error,
     };
 }
-export function ShowLoadingQuery<T>({query, thenRender, placeholder, ifError}: ShowLoadingQueryProps<T>) {
+
+interface ShowLoadingQueryBaseProps<T> {
+    placeholder?: JSX.Element | JSX.Element[];
+    query: ShowLoadingQueryInfo<T>;
+    ifNotFound?: JSX.Element | JSX.Element[];
+}
+type ShowLoadingQueryErrorProps<T> = ShowLoadingQueryBaseProps<T> & ({
+    ifError: (error?: FetchBaseQueryError | SerializedError) => JSX.Element | JSX.Element[];
+    defaultErrorTitle?: undefined;
+} | {
+    ifError?: undefined;
+    defaultErrorTitle: string;
+});
+type ShowLoadingQueryProps<T> = ShowLoadingQueryErrorProps<T> & ({
+    thenRender: (t: NonNullable<T>) => JSX.Element | JSX.Element[];
+    children?: undefined;
+} | {
+    thenRender?: undefined;
+    children: JSX.Element | JSX.Element[];
+});
+// A flexible way of displaying whether a RTKQ query is loading or errored. You can give as props:
+//  - Either: `children` or `thenRender` (a function that takes the query data and returns a React element)
+//  - Either: `defaultErrorTitle` (the title for the default error component) or `ifError` (a function that takes the query error and produces a React element)
+//  - `placeholder` (React element to show while loading)
+//  - `query` (the object returned by a RTKQ useQuery hook)
+export function ShowLoadingQuery<T>({query, thenRender, children, placeholder, ifError, ifNotFound, defaultErrorTitle}: ShowLoadingQueryProps<T>) {
     const {data, isLoading, isError, error} = query;
+    const renderError = () => ifError ? <>{ifError(error)}</> : <DefaultQueryError error={error} title={defaultErrorTitle}/>;
     if (isError) {
-        return ifError(error);
+        return renderError();
     }
     if (isLoading) {
-        return placeholder ?? loadingPlaceholder;
+        return placeholder ? <>{placeholder}</> : loadingPlaceholder;
     }
-    return isDefined(data) ? thenRender(data) : ifError();
+    return isDefined(data)
+        ? (isFound<T>(data) ? <>{thenRender ? thenRender(data) : children}</> : (ifNotFound ? <>{ifNotFound}</> : renderError()))
+        : renderError();
 }

--- a/src/app/components/navigation/IsaacApp.tsx
+++ b/src/app/components/navigation/IsaacApp.tsx
@@ -83,6 +83,7 @@ import {QuizPreview} from "../pages/quizzes/QuizPreview";
 import {QuizDoFreeAttempt} from "../pages/quizzes/QuizDoFreeAttempt";
 import {GameboardFilter} from "../pages/GameboardFilter";
 import {Loading} from "../handlers/IsaacSpinner";
+import {AssignmentSchedule} from "../pages/AssignmentSchedule";
 
 const ContentEmails = lazy(() => import('../pages/ContentEmails'));
 const MyProgress = lazy(() => import('../pages/MyProgress'));
@@ -211,6 +212,7 @@ export const IsaacApp = () => {
                     {/* Teacher pages */}
                     <TrackedRoute exact path="/groups" ifUser={isTeacher} component={Groups} />
                     <TrackedRoute exact path="/set_assignments" ifUser={isTeacher} component={SetAssignments} />
+                    <TrackedRoute exact path="/assignment_schedule" ifUser={isTeacher} component={AssignmentSchedule} /> {/* Currently in beta, not yet advertised or listed on navigation menus */}
                     <TrackedRoute exact path="/set_tests" ifUser={isTeacher} component={SetQuizzes} />
                     <Redirect from="/set_quizzes" to="/set_tests" />
 

--- a/src/app/components/pages/AssignmentProgress.tsx
+++ b/src/app/components/pages/AssignmentProgress.tsx
@@ -47,6 +47,7 @@ import {GameboardItem, GameboardItemState, QuizAssignmentDTO, QuizUserFeedbackDT
 import {Link} from "react-router-dom";
 import {
     API_PATH,
+    ASSIGNMENT_PROGRESS_PATH,
     getAssignmentCSVDownloadLink,
     getQuizAssignmentCSVDownloadLink,
     isDefined,
@@ -351,8 +352,6 @@ const AssignmentDetails = ({assignment}: {assignment: EnhancedAssignment}) => {
     const dispatch = useAppDispatch();
     const [isExpanded, setIsExpanded] = useState(false);
 
-    const assignmentPath = siteSpecific("assignment_progress", "my_markbook");
-
     function openAssignmentDownloadLink(event: React.MouseEvent<HTMLButtonElement & HTMLAnchorElement>) {
         event.stopPropagation();
         event.preventDefault();
@@ -375,7 +374,7 @@ const AssignmentDetails = ({assignment}: {assignment: EnhancedAssignment}) => {
                 <span className="d-none d-md-inline">,</span>
                 <Button className="d-none d-md-inline" color="link" tag="a" href={getAssignmentCSVDownloadLink(assignment.id as number)} onClick={openAssignmentDownloadLink}>Download CSV</Button>
                 <span className="d-none d-md-inline">or</span>
-                <Button className="d-none d-md-inline" color="link" tag="a" href={`/${assignmentPath}/${assignment.id}`} onClick={openSingleAssignment}>View individual assignment</Button>
+                <Button className="d-none d-md-inline" color="link" tag="a" href={`/${ASSIGNMENT_PROGRESS_PATH}/${assignment.id}`} onClick={openSingleAssignment}>View individual assignment</Button>
             </div>
         </div>
         {isExpanded && <ProgressLoader assignment={assignment} />}

--- a/src/app/components/pages/AssignmentSchedule.tsx
+++ b/src/app/components/pages/AssignmentSchedule.tsx
@@ -1,0 +1,577 @@
+import {assignGameboard, isaacApi, loadGroups, selectors, useAppDispatch, useAppSelector} from "../../state";
+import {AssignmentDTO, GameboardDTO, RegisteredUserDTO, UserGroupDTO} from "../../../IsaacApiTypes";
+import {groupBy, mapValues, range, sortBy} from "lodash";
+import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
+import React, {ChangeEvent, useCallback, useContext, useEffect, useMemo, useRef, useState, Fragment} from "react";
+import {
+    Alert,
+    Button,
+    ButtonGroup,
+    Card,
+    CardBody,
+    CardFooter,
+    CardHeader,
+    Col,
+    Container,
+    Input,
+    Label,
+    Modal,
+    ModalBody,
+    ModalFooter,
+    ModalHeader,
+    Row
+} from "reactstrap";
+import {
+    ASSIGNMENT_PROGRESS_PATH,
+    BoardLimit,
+    formatBoardOwner,
+    getAssignmentStartDate,
+    isDefined,
+    isStaff,
+    Item,
+    itemise,
+    MONTH_NAMES,
+    nthHourOf,
+    selectOnChange,
+    siteSpecific,
+    TODAY
+} from "../../services";
+import {AssignmentScheduleContext, BoardOrder, ValidAssignmentWithListingDate} from "../../../IsaacAppTypes";
+import {calculateHexagonProportions, Hexagon} from "../elements/svg/Hexagon";
+import classNames from "classnames";
+import Select from "react-select";
+import {currentYear, DateInput} from "../elements/inputs/DateInput";
+import {GameboardViewerInner} from "./Gameboard";
+import {Link, useLocation} from "react-router-dom";
+import {combineQueries, ShowLoadingQuery} from "../handlers/ShowLoadingQuery";
+
+interface AssignmentListEntryProps {
+    assignment: ValidAssignmentWithListingDate;
+}
+const AssignmentListEntry = ({assignment}: AssignmentListEntryProps) => {
+    const user = useAppSelector(selectors.user.orNull) as RegisteredUserDTO;
+    const {openAssignmentModal, viewBy} = useContext(AssignmentScheduleContext);
+    const [ unassignGameboard ] = isaacApi.endpoints.unassignGameboard.useMutation();
+    const deleteAssignment = () => {
+        if (confirm(`Are you sure you want to unassign ${assignment.gameboard?.title ?? "this gameboard"} from ${assignment.groupName ? `group ${assignment.groupName}` : "this group"}?`)) {
+            unassignGameboard({boardId: assignment.gameboardId, groupId: assignment.groupId});
+        }
+    }
+    const assignmentStartDate = getAssignmentStartDate(assignment);
+    return <Card className={"my-1"}>
+        <CardHeader className={"pt-2 pb-0 d-flex text-break"}>
+            <h4><a target={"_blank"} href={assignment.gameboardId ? `/gameboards#${assignment.gameboardId}` : undefined}>{assignment.gameboard?.title ?? "No gameboard title"}</a></h4>
+            <div className={"ml-auto text-right"}>
+                <Button color="link" size="sm" onClick={() => openAssignmentModal(assignment)}>
+                    Copy
+                </Button>
+                <Button color="link" size="sm" onClick={deleteAssignment}>
+                    Delete
+                </Button>
+            </div>
+        </CardHeader>
+        <CardBody>
+            <div>Assigned to: <strong>{assignment.groupName}</strong></div>
+            {viewBy === "startDate" && assignment.dueDate && <div>Due date: <strong>{new Date(assignment.dueDate).toDateString()}</strong></div>}
+            {viewBy === "dueDate" && assignmentStartDate && <div>Start date: <strong>{new Date(assignmentStartDate).toDateString()}</strong>{assignmentStartDate > TODAY().valueOf() && <span className={"text-muted"}> (not started)</span>}</div>}
+            {assignment.gameboard && <div>By: <strong>{formatBoardOwner(user, assignment.gameboard)}</strong></div>}
+            {assignment.listingDate <= TODAY() && <div>
+                <a color="link" target={"_blank"} href={`/${ASSIGNMENT_PROGRESS_PATH}/${assignment.id}`}>
+                    View assignment progress <span className={"sr-only"}>(opens in new tab)</span>
+                </a>
+            </div>}
+        </CardBody>
+    </Card>;
+}
+
+// If the hexagon proportions change, the CSS class bg-timeline needs revisiting
+const dateHexagon = calculateHexagonProportions(20, 1);
+const DateAssignmentList = ({date, assignments}: {date: number; assignments: ValidAssignmentWithListingDate[]}) => {
+    const [open, setOpen] = useState<boolean>(false);
+    const {boardsById, collapsed, setCollapsed, viewBy} = useContext(AssignmentScheduleContext);
+    useEffect(() => {
+        if (collapsed) setOpen(false);
+    }, [collapsed]);
+    return <>
+        <div tabIndex={0} role={"button"} aria-label={(open ? "Collapse" : "Expand") + ` list for day ${date}`} onKeyPress={(e) => {
+            if (e.key === "Enter") {
+                setOpen(o => !o);
+                setCollapsed(false);
+            }
+        }} onClick={() => {
+            setOpen(o => !o);
+            setCollapsed(false);
+        }} className={"hexagon-date"}>
+            <svg height={dateHexagon.quarterHeight * 4} width={"100%"}>
+                <Hexagon className={"fill-secondary"} {...dateHexagon}/>
+                {<foreignObject height={dateHexagon.quarterHeight * 4} width={"100%"} y={11} x={dateHexagon.halfWidth * 2.5 + 12}>
+                    <p className={classNames("date-assignment-count", {"text-muted": !open})}>
+                        {assignments[0].listingDate.toDateString().split(" ")[0]} - {assignments.length} assignment{assignments.length > 1 ? "s" : ""}{viewBy === "startDate" ? " set" : " due"}
+                    </p>
+                </foreignObject>}
+                <svg x={2.5 * dateHexagon.halfWidth - (open ? 7 : 3)} y={dateHexagon.quarterHeight * 2 - (open ? 3 : 6.5)}>
+                    <polygon className={classNames("date-toggle-arrow fill-secondary", {"open": open})} points="0 1.75 1.783 0 8.75 7 1.783 14 0 12.25 5.25 7"
+                             transform={open ? "rotate(90 7 7.5)" : "rotate(0 7 7.5)"}/>
+                </svg>
+                {<foreignObject height={dateHexagon.quarterHeight * 4} width={dateHexagon.halfWidth * 2} y={2} x={0}>
+                    <div className={"position-relative w-100"}>
+                        <h3 className={"position-absolute text-white"} style={{left: "50%", transform: "translate(-50%)"}} >{`${date < 10 ? "0" : ""}${date}`}</h3>
+                    </div>
+                </foreignObject>}
+            </svg>
+        </div>
+        {open && <div className={"date-assignment-list"}>
+            {assignments.map(a => <AssignmentListEntry key={a.id} assignment={{...a, gameboard: a.gameboardId ? boardsById[a.gameboardId] : undefined}}/> )}
+        </div>}
+    </>
+}
+
+const monthHexagon = calculateHexagonProportions(12, 1);
+const shouldOpenMonth = (month: number) => {
+    return (new Date()).getUTCMonth() === month;
+}
+const MonthAssignmentList = ({month, datesAndAssignments}: {month: number, datesAndAssignments: [number, ValidAssignmentWithListingDate[]][]}) => {
+    const [open, setOpen] = useState<boolean>(shouldOpenMonth(month));
+    const assignmentCount = useMemo(() => datesAndAssignments.reduce((n, [_, as]) => n + as.length, 0), [datesAndAssignments]);
+    const {collapsed, setCollapsed, viewBy} = useContext(AssignmentScheduleContext);
+    useEffect(() => {
+        if (collapsed) setOpen(false);
+    }, [collapsed]);
+    return <>
+        <div tabIndex={0} role={"button"} aria-label={(open ? "Collapse" : "Expand") + ` list for ${MONTH_NAMES[month]}`}
+             className={"month-label w-100 text-right d-flex"} onKeyPress={(e) => {
+            if (e.key === "Enter") {
+                setOpen(o => !o);
+                setCollapsed(false);
+            }
+        }} onClick={() => {
+            setOpen(o => !o);
+            setCollapsed(false);
+        }}>
+            <div className={"h-100 text-center position-relative"} style={{width: dateHexagon.halfWidth * 2, paddingTop: 3}}>
+                <svg height={monthHexagon.quarterHeight * 4} width={monthHexagon.halfWidth * 2}>
+                    <Hexagon className={"fill-secondary"} {...monthHexagon}/>
+                    <svg x={monthHexagon.halfWidth - (open ? 7.4 : 3)} y={monthHexagon.quarterHeight * 2 - (open ? 4 : 6.5)}>
+                        <polygon fill={"#ffffff"} points="0 1.75 1.783 0 8.75 7 1.783 14 0 12.25 5.25 7"
+                                 transform={open ? "rotate(90 7 7.5)" : "rotate(0 7 7.5)"}/>
+                    </svg>
+                </svg>
+            </div>
+            <h4>{`${MONTH_NAMES[month]}`}</h4>
+            <div className={"mx-3 flex-grow-1 border-bottom"} style={{height: "1.1rem"}}/>
+            <span className={"pt-1 month-assignment-count"}>{assignmentCount} assignment{assignmentCount > 1 ? "s" : ""}{viewBy === "startDate" ? " set" : " due"}</span>
+        </div>
+        {open && datesAndAssignments.map(([d, as]) => <DateAssignmentList key={d} date={d} assignments={as}/>)}
+    </>;
+}
+
+interface AssignmentModalProps {
+    user: RegisteredUserDTO;
+    showAssignmentModal: boolean;
+    toggleAssignModal: () => void;
+    assignmentToCopy: AssignmentDTO | undefined;
+}
+const AssignmentModal = ({user, showAssignmentModal, toggleAssignModal, assignmentToCopy}: AssignmentModalProps) => {
+    const dispatch = useAppDispatch();
+    const [selectedGroups, setSelectedGroups] = useState<Item<number>[]>([]);
+    const [dueDate, setDueDate] = useState<Date>();
+    const [scheduledStartDate, setScheduledStartDate] = useState<Date>();
+    const [assignmentNotes, setAssignmentNotes] = useState<string>();
+
+    const [showGameboardPreview, setShowGameboardPreview] = useState<boolean>(false);
+    const toggleGameboardPreview = () => setShowGameboardPreview(o => !o);
+
+    const [selectedGameboard, setSelectedGameboard] = useState<Item<string>[]>();
+
+    const {boardsById, groups, gameboards, boardIdsByGroupId} = useContext(AssignmentScheduleContext);
+
+    useEffect(() => {
+        setSelectedGroups([]);
+        if (assignmentToCopy && assignmentToCopy.gameboardId) {
+            // Copy existing assignment
+            setSelectedGameboard([{value: assignmentToCopy.gameboardId, label: boardsById[assignmentToCopy.gameboardId]?.title ?? "No gameboard title"}]);
+            setScheduledStartDate(assignmentToCopy.scheduledStartDate ? new Date(assignmentToCopy.scheduledStartDate.valueOf()) : undefined);
+            setDueDate(assignmentToCopy.dueDate ? new Date(assignmentToCopy.dueDate.valueOf()) : undefined);
+            setAssignmentNotes(assignmentToCopy.notes);
+        } else {
+            // Create from scratch
+            setSelectedGameboard(undefined);
+            setScheduledStartDate(undefined);
+            setDueDate(undefined);
+            setAssignmentNotes(undefined);
+        }
+    }, [assignmentToCopy]);
+
+    const assign = useCallback(() => {
+        if (!selectedGameboard || !selectedGameboard[0]?.value) return;
+        dispatch(assignGameboard({
+            boardId: selectedGameboard[0]?.value,
+            groups: [...selectedGroups],
+            dueDate,
+            scheduledStartDate: scheduledStartDate && nthHourOf(7, scheduledStartDate),
+            notes: assignmentNotes
+        })).then((result) => {
+            if (assignGameboard.fulfilled.match(result)) {
+                setSelectedGroups([]);
+                setDueDate(undefined);
+                setScheduledStartDate(undefined);
+                setAssignmentNotes('');
+            }
+            // Fails silently if assignGameboard throws an error - we let it handle opening toasts for errors
+        });
+    }, [selectedGameboard, selectedGroups, dueDate,
+        scheduledStartDate, assignmentNotes, setSelectedGroups,
+        setDueDate, setScheduledStartDate, setAssignmentNotes]);
+
+    const yearRange = range(currentYear, currentYear + 5);
+    const currentMonth = (new Date()).getUTCMonth() + 1;
+
+    const dueDateInvalid = dueDate && scheduledStartDate ? scheduledStartDate.valueOf() >= dueDate.valueOf() : false;
+
+    useEffect(() => {
+        if (showAssignmentModal) setShowGameboardPreview(false);
+    }, [showAssignmentModal]);
+
+    const alreadyAssignedGroupNames = useMemo<string[]>(() => {
+        if (!selectedGameboard || selectedGameboard.length === 0 || !selectedGroups || selectedGroups.length === 0) return [];
+        return selectedGroups.filter(g => g.value && boardIdsByGroupId[g.value].includes(selectedGameboard[0]?.value)).map(g => g.label);
+    }, [selectedGroups, boardIdsByGroupId, selectedGameboard]);
+
+    return <Modal isOpen={showAssignmentModal} toggle={toggleAssignModal}>
+        <ModalHeader close={
+            <button className="close" onClick={toggleAssignModal}>
+                Close
+            </button>
+        }>
+            Set new assignment
+        </ModalHeader>
+        <ModalBody>
+            <Label className="w-100 pb-2">Group{isStaff(user) ? "(s)" : ""}:
+                <Select inputId="groups-to-assign" isMulti={isStaff(user)} isClearable placeholder="None"
+                        value={selectedGroups}
+                        closeMenuOnSelect={!isStaff(user)}
+                        onChange={selectOnChange(setSelectedGroups, false)}
+                        options={sortBy(groups, group => group.groupName && group.groupName.toLowerCase()).map(g => itemise(g.id as number, g.groupName))}
+                />
+            </Label>
+            <Label className="w-100 pb-2">Gameboard:
+                <Select inputId="gameboard-to-assign" isClearable placeholder="None"
+                        value={selectedGameboard}
+                        onChange={selectOnChange(setSelectedGameboard, false)}
+                        options={gameboards.map(g => itemise(g.id ?? "", g.title ?? "No gameboard title"))}
+                />
+                {alreadyAssignedGroupNames && alreadyAssignedGroupNames.length > 0 && <Alert color={"warning"} className={"my-1"}>
+                    This gameboard is already assigned to group{alreadyAssignedGroupNames.length > 1 ? "s" : ""}: {alreadyAssignedGroupNames.join(", ")}. You must delete the previous assignment{alreadyAssignedGroupNames.length > 1 ? "s" : ""} to set it again.
+                </Alert>}
+                {selectedGameboard && selectedGameboard?.[0]?.value && boardsById[selectedGameboard[0].value] && boardsById[selectedGameboard[0].value]?.contents && <Card className={"my-1"} >
+                    <CardHeader className={"text-right"}><Button color={"link"} onClick={toggleGameboardPreview}>{showGameboardPreview ? "Hide" : "Show"} gameboard preview</Button></CardHeader>
+                    {showGameboardPreview && <GameboardViewerInner gameboard={boardsById[selectedGameboard[0].value]}/>}
+                    {showGameboardPreview && <CardFooter className={"text-right"}><Button color={"link"} onClick={toggleGameboardPreview}>{showGameboardPreview ? "Hide" : "Show"} gameboard preview</Button></CardFooter>}
+                </Card>}
+            </Label>
+            <Label className="w-100 pb-2">Schedule an assignment start date <span className="text-muted"> (optional)</span>
+                <DateInput value={scheduledStartDate} placeholder="Select your scheduled start date..." yearRange={yearRange} defaultYear={currentYear} defaultMonth={currentMonth}
+                           onChange={(e: ChangeEvent<HTMLInputElement>) => setScheduledStartDate(e.target.valueAsDate as Date)} />
+            </Label>
+            <Label className="w-100 pb-2">Due date reminder <span className="text-muted"> (optional)</span>
+                <DateInput value={dueDate} placeholder="Select your due date..." yearRange={yearRange} defaultYear={currentYear} defaultMonth={currentMonth}
+                           onChange={(e: ChangeEvent<HTMLInputElement>) => setDueDate(e.target.valueAsDate as Date)} />
+                {dueDateInvalid && <small className={"pt-2 text-danger"}>Due date must be after start date.</small>}
+            </Label>
+            {isStaff(user) && <Label className="w-100 pb-2">Notes (optional):
+                <Input type="textarea"
+                       spellCheck={true}
+                       rows={3}
+                       value={assignmentNotes}
+                       onChange={(e: React.ChangeEvent<HTMLInputElement>) => setAssignmentNotes(e.target.value)}
+                />
+                <p className="mt-1 mb-0"><small>{(assignmentNotes || '').length}/500 characters</small></p>
+                {isDefined(assignmentNotes) && assignmentNotes.length > 500 &&
+                <p className="mt-0 mb-0 text-danger"><small>You have exceeded the maximum length.</small></p>
+                }
+            </Label>}
+            <Button
+                className="mt-2 mb-2"
+                block color={siteSpecific("secondary", "primary")}
+                onClick={assign}
+                disabled={selectedGroups.length === 0 || (isDefined(assignmentNotes) && assignmentNotes.length > 500) || !isDefined(selectedGameboard) || alreadyAssignedGroupNames.length === selectedGroups.length}
+            >
+                Assign to group{selectedGroups.length > 1 ? "s" : ""}
+            </Button>
+        </ModalBody>
+        <ModalFooter>
+            <Button block color="tertiary" onClick={toggleAssignModal}>Close</Button>
+        </ModalFooter>
+    </Modal>;
+}
+
+type AssignmentsGroupedByDate = [number, [number, [number, ValidAssignmentWithListingDate[]][]][]][];
+export const AssignmentSchedule = ({user}: {user: RegisteredUserDTO}) => {
+    // TODO replace with query hook after groups refactor
+    const dispatch = useAppDispatch();
+    const groups = useAppSelector(selectors.groups.active) ?? undefined;
+    useEffect(() => {
+        dispatch(loadGroups(false));
+    }, []);
+
+    const assignmentsSetByMeQuery = isaacApi.endpoints.getMySetAssignments.useQuery(undefined);
+    const { data: assignmentsSetByMe } = assignmentsSetByMeQuery;
+    const gameboardsQuery = isaacApi.endpoints.getGameboards.useQuery({startIndex: 0, limit: BoardLimit.All, sort: BoardOrder.created});
+    const { data: gameboards } = gameboardsQuery;
+
+    const [viewBy, setViewBy] = useState<"startDate" | "dueDate">("startDate");
+
+    // Empty list means all groups are included, non-empty means only those in the list are included
+    const [groupsToInclude, setGroupsToInclude] = useState<Item<number>[]>([]);
+
+    // --- Slow-to-calculate constant lookup maps for ease of locating gameboards, groups, etc. ---
+
+    const boardsById = useMemo<{[id: string]: GameboardDTO}>(() => {
+        return gameboards?.boards.reduce((acc, b) => b.id ? {...acc, [b.id]: b} : acc, {} as {[id: string]: GameboardDTO}) ?? {};
+    }, [gameboards]);
+
+    const groupsById = useMemo<{[id: number]: UserGroupDTO}>(() => {
+        return groups?.reduce((acc, g) => g.id ? {...acc, [g.id]: g} : acc, {} as {[id: number]: UserGroupDTO}) ?? {};
+    }, [groups]);
+
+    // Map from group id -> whether group should be included or not
+    const groupFilter = useMemo<{[id: number]: boolean}>(() => {
+        if (groupsToInclude.length === 0) {
+            return mapValues(groupsById, () => true);
+        }
+        return groupsToInclude.reduce((acc, n) => ({...acc, [n.value]: true}), {});
+    }, [groupsToInclude, groupsById]);
+
+    // Map from group id -> ids of boards they are assigned to
+    const boardIdsByGroupId = useMemo<{[id: number]: string[]}>(() => {
+        return assignmentsSetByMe?.reduce((acc, a) => {
+            if (!a.groupId || !a.gameboardId) return acc;
+            return a.groupId in acc ? {...acc, [a.groupId]: [...acc[a.groupId], a.gameboardId]} : {...acc, [a.groupId]: [a.gameboardId]};
+        }, {} as {[id: number]: string[]}) ?? {}
+    }, [assignmentsSetByMe]);
+
+    // Logic to handle showing older assignments - we show the "load older assignments" button if we haven't shown
+    // the oldest assignment yet
+    const [earliestShowDate, setEarliestShowDate] = useState<Date>(() => {
+        let d = new Date();
+        d.setUTCMonth(d.getUTCMonth() - 1);
+        d.setUTCDate(1);
+        d.setUTCHours(0, 0, 0, 0);
+        return d;
+    });
+    const oldestAssignmentDate = useMemo<Date>(() => new Date(
+        assignmentsSetByMe?.filter(a => a.id && a.gameboardId && a.groupId && groupFilter[a.groupId] && (viewBy === "startDate" || isDefined(a.dueDate)))
+            .reduce((oldest, a) => {
+                const assignmentTimestamp = a.scheduledStartDate?.valueOf() ?? a.creationDate?.valueOf() ?? Date.now();
+                return assignmentTimestamp < oldest
+                    ? assignmentTimestamp : oldest;
+            }, Date.now()) ?? Date.now()
+        )
+        , [assignmentsSetByMe, groupFilter, viewBy]);
+    const extendBackSixMonths = () => setEarliestShowDate(esd => {
+        const d = new Date(esd.valueOf());
+        d.setUTCMonth(d.getUTCMonth() - 6);
+        return d;
+    });
+
+    // The assignments that will be shown in the schedule, filtered and grouped by date
+    const assignmentsGroupedByDate = useMemo<AssignmentsGroupedByDate>(() => {
+        if (!assignmentsSetByMe) return [];
+        const sortedAssignments: ValidAssignmentWithListingDate[] = sortBy(
+            assignmentsSetByMe
+                .map((a) => ({...a, listingDate: new Date((viewBy === "startDate" ? getAssignmentStartDate(a) : (a.dueDate ?? 0)).valueOf())} as ValidAssignmentWithListingDate))
+                // IMPORTANT - filter ensures that id, gameboard id, and group id exist so the cast to ValidAssignmentWithListingDate was/will be valid
+                .filter(a => a.id && a.gameboardId && a.groupId && groupFilter[a.groupId] && (a.listingDate.valueOf() >= earliestShowDate.valueOf()) && (viewBy === "startDate" || isDefined(a.dueDate)))
+            , a => a.listingDate.valueOf()
+        );
+        function parseNumericKey<T>([k, v]: [string, T]): [number, T] { return [parseInt(k), v]; }
+        return Object.entries(mapValues(
+            groupBy(sortedAssignments, a => a.listingDate.getUTCFullYear()),
+            as => Object.entries(mapValues(
+                groupBy(as, a => a.listingDate.getUTCMonth()),
+                _as => Object.entries(groupBy(_as, a => a.listingDate.getUTCDate())).map(parseNumericKey)
+            )).map(parseNumericKey)
+        )).map(parseNumericKey);
+    }, [assignmentsSetByMe, groupFilter, earliestShowDate, viewBy]);
+
+    const notAllPastAssignmentsAreListed = earliestShowDate.valueOf() >= oldestAssignmentDate.valueOf();
+
+    // Modal logic
+    const [assignmentToCopy, setAssignmentToCopy] = useState<AssignmentDTO | undefined>();
+    const {hash} = useLocation();
+    const gameboardId = hash.includes("#") ? hash.slice(1) : undefined;
+    const [showAssignmentModal, setShowAssignmentModal] = useState<boolean>(false);
+    const openAssignmentModal = useCallback((assignment?: ValidAssignmentWithListingDate) => {
+        setAssignmentToCopy(assignment);
+        setShowAssignmentModal(true);
+    }, [setAssignmentToCopy, setShowAssignmentModal]);
+    useEffect(() => {
+        if (gameboardId) {
+            setAssignmentToCopy({gameboardId});
+            setShowAssignmentModal(true);
+        }
+    }, []);
+    const toggleAssignModal = () => setShowAssignmentModal(o => !o);
+
+    // Flag to notify children components to completely collapse all assignment sub-lists, so only months are showing
+    const [collapsed, setCollapsed] = useState<boolean>(false);
+
+    // --- Sticky header logic ---
+    const headerScrollerSentinel = useRef<HTMLDivElement>(null);
+    const headerScrollerFlag = useRef(false);
+    const headerScrollerObserver = useRef<IntersectionObserver>();
+    const stickyHeaderListContainer = useRef<HTMLDivElement>(null);
+
+    const headerScrollerCallback = (entries: IntersectionObserverEntry[], observer: IntersectionObserver) => {
+        for (const entry of entries) {
+            if (entry.target.id === 'header-sentinel') {
+                if (entry.isIntersecting) {
+                    stickyHeaderListContainer.current?.classList.remove('active');
+                } else {
+                    if (entry.boundingClientRect.top <= 0) {
+                        // Gone up
+                        stickyHeaderListContainer.current?.classList.add('active');
+                    } else if (entry.boundingClientRect.top > 0) {
+                        // Gone down
+                        stickyHeaderListContainer.current?.classList.remove('active');
+                    }
+                }
+            }
+        }
+    }
+    useEffect(() => {
+        if (headerScrollerSentinel.current && !headerScrollerObserver.current && !headerScrollerFlag.current) {
+            const options = {
+                root: null,
+                rootMargin: '0px',
+                threshold: 1.0,
+            }
+            headerScrollerObserver.current = new IntersectionObserver(headerScrollerCallback, options);
+            headerScrollerObserver.current.observe(headerScrollerSentinel.current);
+            headerScrollerFlag.current = true;
+            // Uncommenting this return, disconnects the observer. Not sure why.
+            // return () => alphabetScrollerObserver?.current?.disconnect();
+        }
+    });
+
+    const header = <Card className={"container py-2 px-3 w-100"}>
+        <Row>
+            <Col xs={6}>
+                {assignmentsSetByMe && assignmentsSetByMe.length > 0
+                    ? <>
+                        <Label className={"w-100"}>Filter by group:
+                            <Select inputId="groups-filter" isMulti isClearable placeholder="All"
+                                    value={groupsToInclude}
+                                    closeMenuOnSelect={!isStaff(user)}
+                                    onChange={selectOnChange(setGroupsToInclude, false)}
+                                    options={sortBy(groups, group => group.groupName && group.groupName.toLowerCase()).map(g => itemise(g.id as number, g.groupName))}
+                            />
+                        </Label>
+                        <Button className={"mt-2 mt-sm-0"} size={"xs"} color={"link"} block onClick={() => {
+                            setCollapsed(true);
+                            if (headerScrollerSentinel.current && headerScrollerSentinel.current.getBoundingClientRect().top < 0) {
+                                headerScrollerSentinel.current?.scrollIntoView();
+                            }
+                        }}>
+                            Collapse schedule
+                        </Button>
+                    </>
+                    : <div className={"mt-2"}>You have no assignments</div>
+                }
+            </Col>
+            <Col xs={6} className={"py-2"}>
+                <Button size={"sm"} block onClick={() => openAssignmentModal()}>
+                    <span className={"d-block d-md-none"}>Set assignment</span>
+                    <span className={"d-none d-md-block"}>Set new assignment</span>
+                </Button>
+                {assignmentsSetByMe && assignmentsSetByMe.length > 0 && <>
+                    <ButtonGroup className={"w-100 pt-3"}>
+                        <Button size={"sm"} className={"border-right-0"}
+                                color={viewBy === "startDate" ? "secondary" : "primary"}
+                                outline={viewBy !== "startDate"}
+                                onClick={() => setViewBy("startDate")}>
+                            By start date
+                        </Button>
+                        <Button size={"sm"} className={"border-left-0"}
+                                color={viewBy === "dueDate" ? "secondary" : "primary"}
+                                outline={viewBy !== "dueDate"}
+                                onClick={() => setViewBy("dueDate")}>
+                            By due date
+                        </Button>
+                    </ButtonGroup>
+                </>}
+            </Col>
+        </Row>
+    </Card>;
+    // --- End sticky header logic ---
+
+    const pageHelp = <span>
+        Use this page to set and manage assignments to your groups. You can assign any gameboard you have saved to your account.
+        <br/>
+        Students in the group will be emailed when you set a new assignment.
+    </span>;
+
+    return <Container>
+        <TitleAndBreadcrumb currentPageTitle={"Assignment Schedule"} help={pageHelp}/>
+        <AssignmentScheduleContext.Provider value={{boardsById, groupsById, groupFilter, boardIdsByGroupId, groups: groups ?? [], gameboards: gameboards?.boards ?? [], openAssignmentModal, collapsed, setCollapsed, viewBy}}>
+            {/*
+                Setting `combineResult` to `() => true` (3rd param of `combineQueries`) is a bit of a hack that lets you
+                skip the combine query step and throw away the two results. It has to be `true` otherwise the resulting
+                query will be handled as if it failed.
+            */}
+            <ShowLoadingQuery defaultErrorTitle={"Error loading assignments and/or gameboards"} query={combineQueries(assignmentsSetByMeQuery, gameboardsQuery, () => true)}>
+                <div className={"px-md-4 pl-2 pr-2 timeline-column mb-4 pt-2"}>
+                    {!isStaff(user) && <Alert className={"mt-2"} color={"info"}>
+                        The Assignment Schedule page is an alternate way to manage your assignments, focusing on the start and due dates of the assignments, rather than the assigned gameboard.
+                        <br/>
+                        It is a work in progress, and we would love to <a href={"/contact?subject=Assignment%20Schedule%20Feedback"}>hear your feedback</a>!
+                    </Alert>}
+                    <div className="no-print">
+                        <div id="header-sentinel" ref={headerScrollerSentinel}>&nbsp;</div>
+                        <div ref={stickyHeaderListContainer} id="stickyheader">
+                            {header}
+                        </div>
+                        {header}
+                    </div>
+
+                    {/* Groups-related alerts */}
+                    {groups && groups.length === 0 && <Alert color="warning">
+                        You have not created any groups to assign work to.
+                        Please <Link to="/groups">create a group here first.</Link>
+                    </Alert>}
+                    {groupsToInclude.length > 0 && <Alert color="warning" className={"mt-2"}>
+                        There are no assignments set to group{groupsToInclude.length > 1 ? "s" : ""}: {groupsToInclude.map(g => g.label).join(", ")}
+                    </Alert>}
+
+                    {assignmentsGroupedByDate.length > 0 && <Card className={"mt-2"}>
+                        <CardBody className={"pt-0"}>
+                            {notAllPastAssignmentsAreListed && <div className={"mt-3"}>
+                                <Button size={"sm"} onClick={extendBackSixMonths}>
+                                    Show assignments before {earliestShowDate.toDateString().split(" ").filter((_, i) => i % 2 === 1).join(" ")}
+                                </Button>
+                            </div>}
+                            <div className={classNames("timeline w-100", {"pt-2": !notAllPastAssignmentsAreListed})}>
+                                {assignmentsGroupedByDate.map(([y, ms]) =>
+                                    <Fragment key={y}>
+                                        <div className={"year-label w-100 text-right"}>
+                                            <h3 className={"mb-n3"}>{`${y}`}</h3>
+                                            <hr className={"ml-4"}/>
+                                        </div>
+                                        {ms.map(([m, ds]) => <MonthAssignmentList key={m} month={m} datesAndAssignments={ds}/>)}
+                                    </Fragment>
+                                )}
+                                <div className={classNames("bg-timeline", {"fade-in": !notAllPastAssignmentsAreListed})}/>
+                            </div>
+                        </CardBody>
+                    </Card>}
+                </div>
+                <AssignmentModal
+                    user={user}
+                    showAssignmentModal={showAssignmentModal}
+                    toggleAssignModal={toggleAssignModal}
+                    assignmentToCopy={assignmentToCopy}
+                />
+            </ShowLoadingQuery>
+        </AssignmentScheduleContext.Provider>
+    </Container>;
+}

--- a/src/app/components/pages/AssignmentSchedule.tsx
+++ b/src/app/components/pages/AssignmentSchedule.tsx
@@ -60,7 +60,7 @@ const AssignmentListEntry = ({assignment}: AssignmentListEntryProps) => {
     const assignmentStartDate = getAssignmentStartDate(assignment);
     return <Card className={"my-1"}>
         <CardHeader className={"pt-2 pb-0 d-flex text-break"}>
-            <h4><a target={"_blank"} href={assignment.gameboardId ? `/gameboards#${assignment.gameboardId}` : undefined}>{assignment.gameboard?.title ?? "No gameboard title"}</a></h4>
+            <h4><a target={"_blank"} rel={"noreferrer noopener"} href={assignment.gameboardId ? `/gameboards#${assignment.gameboardId}` : undefined}>{assignment.gameboard?.title ?? "No gameboard title"}</a></h4>
             <div className={"ml-auto text-right"}>
                 <Button color="link" size="sm" onClick={() => openAssignmentModal(assignment)}>
                     Copy
@@ -76,7 +76,7 @@ const AssignmentListEntry = ({assignment}: AssignmentListEntryProps) => {
             {viewBy === "dueDate" && assignmentStartDate && <div>Start date: <strong>{new Date(assignmentStartDate).toDateString()}</strong>{assignmentStartDate > TODAY().valueOf() && <span className={"text-muted"}> (not started)</span>}</div>}
             {assignment.gameboard && <div>By: <strong>{formatBoardOwner(user, assignment.gameboard)}</strong></div>}
             {assignment.listingDate <= TODAY() && <div>
-                <a color="link" target={"_blank"} href={`/${ASSIGNMENT_PROGRESS_PATH}/${assignment.id}`}>
+                <a color="link" target={"_blank"} rel={"noreferrer noopener"} href={`/${ASSIGNMENT_PROGRESS_PATH}/${assignment.id}`}>
                     View assignment progress <span className={"sr-only"}>(opens in new tab)</span>
                 </a>
             </div>}
@@ -266,7 +266,7 @@ const AssignmentModal = ({user, showAssignmentModal, toggleAssignModal, assignme
                 {selectedGameboard && selectedGameboard?.[0]?.value && boardsById[selectedGameboard[0].value] && boardsById[selectedGameboard[0].value]?.contents && <Card className={"my-1"} >
                     <CardHeader className={"text-right"}><Button color={"link"} onClick={toggleGameboardPreview}>{showGameboardPreview ? "Hide" : "Show"} gameboard preview</Button></CardHeader>
                     {showGameboardPreview && <GameboardViewerInner gameboard={boardsById[selectedGameboard[0].value]}/>}
-                    {showGameboardPreview && <CardFooter className={"text-right"}><Button color={"link"} onClick={toggleGameboardPreview}>{showGameboardPreview ? "Hide" : "Show"} gameboard preview</Button></CardFooter>}
+                    {showGameboardPreview && <CardFooter className={"text-right"}><Button color={"link"} onClick={toggleGameboardPreview}>Hide gameboard preview</Button></CardFooter>}
                 </Card>}
             </Label>
             <Label className="w-100 pb-2">Schedule an assignment start date <span className="text-muted"> (optional)</span>

--- a/src/app/components/pages/AssignmentSchedule.tsx
+++ b/src/app/components/pages/AssignmentSchedule.tsx
@@ -234,7 +234,7 @@ const AssignmentModal = ({user, showAssignmentModal, toggleAssignModal, assignme
 
     const alreadyAssignedGroupNames = useMemo<string[]>(() => {
         if (!selectedGameboard || selectedGameboard.length === 0 || !selectedGroups || selectedGroups.length === 0) return [];
-        return selectedGroups.filter(g => g.value && boardIdsByGroupId[g.value].includes(selectedGameboard[0]?.value)).map(g => g.label);
+        return selectedGroups.filter(g => g.value && boardIdsByGroupId[g.value]?.includes(selectedGameboard[0]?.value)).map(g => g.label);
     }, [selectedGroups, boardIdsByGroupId, selectedGameboard]);
 
     return <Modal isOpen={showAssignmentModal} toggle={toggleAssignModal}>

--- a/src/app/components/pages/AssignmentSchedule.tsx
+++ b/src/app/components/pages/AssignmentSchedule.tsx
@@ -354,9 +354,9 @@ export const AssignmentSchedule = ({user}: {user: RegisteredUserDTO}) => {
     // the oldest assignment yet
     const [earliestShowDate, setEarliestShowDate] = useState<Date>(() => {
         let d = new Date();
-        d.setUTCMonth(d.getUTCMonth() - 1);
-        d.setUTCDate(1);
-        d.setUTCHours(0, 0, 0, 0);
+        d.setMonth(d.getMonth() - 1);
+        d.setDate(1);
+        d.setHours(0, 0, 0, 0);
         return d;
     });
     const oldestAssignmentDate = useMemo<Date>(() => new Date(
@@ -370,7 +370,7 @@ export const AssignmentSchedule = ({user}: {user: RegisteredUserDTO}) => {
         , [assignmentsSetByMe, groupFilter, viewBy]);
     const extendBackSixMonths = () => setEarliestShowDate(esd => {
         const d = new Date(esd.valueOf());
-        d.setUTCMonth(d.getUTCMonth() - 6);
+        d.setMonth(d.getMonth() - 6);
         return d;
     });
 

--- a/src/app/components/pages/AssignmentSchedule.tsx
+++ b/src/app/components/pages/AssignmentSchedule.tsx
@@ -343,7 +343,7 @@ export const AssignmentSchedule = ({user}: {user: RegisteredUserDTO}) => {
     }, [groupsToInclude, groupsById]);
 
     // Map from group id -> ids of boards they are assigned to
-    const boardIdsByGroupId = useMemo<{[id: number]: string[]}>(() => {
+    const boardIdsByGroupId = useMemo<{[id: number]: string[] | undefined}>(() => {
         return assignmentsSetByMe?.reduce((acc, a) => {
             if (!a.groupId || !a.gameboardId) return acc;
             return a.groupId in acc ? {...acc, [a.groupId]: [...acc[a.groupId], a.gameboardId]} : {...acc, [a.groupId]: [a.gameboardId]};

--- a/src/app/services/assignments.ts
+++ b/src/app/services/assignments.ts
@@ -14,8 +14,8 @@ export const filterAssignmentsByStatus = (assignments: AssignmentDTO[] | undefin
     const fourWeeksAgo = new Date(now.valueOf() - (4 * 7 * 24 * 60 * 60 * 1000));
     // Midnight five days ago:
     const fiveDaysAgo = new Date(now);
-    fiveDaysAgo.setUTCDate(now.getDate() - 5);
-    fiveDaysAgo.setUTCHours(0, 0, 0, 0);
+    fiveDaysAgo.setDate(now.getDate() - 5);
+    fiveDaysAgo.setHours(0, 0, 0, 0);
 
     const myAssignments: {inProgressRecent: AssignmentDTO[]; inProgressOld: AssignmentDTO[]; completed: AssignmentDTO[]} = {
         inProgressRecent: [],

--- a/src/app/services/assignments.ts
+++ b/src/app/services/assignments.ts
@@ -14,8 +14,8 @@ export const filterAssignmentsByStatus = (assignments: AssignmentDTO[] | undefin
     const fourWeeksAgo = new Date(now.valueOf() - (4 * 7 * 24 * 60 * 60 * 1000));
     // Midnight five days ago:
     const fiveDaysAgo = new Date(now);
-    fiveDaysAgo.setDate(now.getDate() - 5);
-    fiveDaysAgo.setHours(0, 0, 0, 0);
+    fiveDaysAgo.setUTCDate(now.getDate() - 5);
+    fiveDaysAgo.setUTCHours(0, 0, 0, 0);
 
     const myAssignments: {inProgressRecent: AssignmentDTO[]; inProgressOld: AssignmentDTO[]; completed: AssignmentDTO[]} = {
         inProgressRecent: [],

--- a/src/app/services/assignments.ts
+++ b/src/app/services/assignments.ts
@@ -90,3 +90,5 @@ export const getDistinctAssignmentSetters = (assignments: AssignmentDTO[] | unde
     }
     return distinctFormattedAssignmentSetters
 }
+
+export const getAssignmentStartDate = (a: AssignmentDTO): number => (a.scheduledStartDate ?? a.creationDate ?? 0).valueOf();

--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -1091,3 +1091,5 @@ export const SEARCH_CHAR_LENGTH_LIMIT = 255;
 export const QUESTION_FINDER_CONCEPT_LABEL_PLACEHOLDER = "Loading...";
 
 export const FEATURED_NEWS_TAG = "featured";
+
+export const ASSIGNMENT_PROGRESS_PATH = siteSpecific("assignment_progress", "my_markbook");

--- a/src/app/services/dates.ts
+++ b/src/app/services/dates.ts
@@ -1,12 +1,12 @@
 export const TODAY = () => {
     const d = new Date();
-    d.setUTCHours(0,0,0,0);
+    d.setHours(0,0,0,0);
     return d;
 }
 
 export const nthHourOf = (n: number, d: Date) => {
     const newDate = new Date(d.valueOf());
-    newDate.setUTCHours(n, 0, 0, 0);
+    newDate.setHours(n, 0, 0, 0);
     return newDate;
 }
 

--- a/src/app/services/dates.ts
+++ b/src/app/services/dates.ts
@@ -1,0 +1,14 @@
+export const TODAY = () => {
+    const d = new Date();
+    d.setUTCHours(0,0,0,0);
+    return d;
+}
+
+export const nthHourOf = (n: number, d: Date) => {
+    const newDate = new Date(d.valueOf());
+    newDate.setUTCHours(n, 0, 0, 0);
+    return newDate;
+}
+
+export const MONTH_NAMES = [ "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December" ];

--- a/src/app/services/index.ts
+++ b/src/app/services/index.ts
@@ -4,6 +4,7 @@ export * from "./siteConstants";
 export * from "./clozeQuestionKeyboardSensor";
 export * from "./demoTools";
 export * from "./device";
+export * from "./dates";
 export * from "./polyfills";
 export * from "./highlightJs";
 export * from "./json";

--- a/src/app/services/miscUtils.ts
+++ b/src/app/services/miscUtils.ts
@@ -75,7 +75,7 @@ export function useIFrameMessages(uid: string, iFrameRef?: RefObject<HTMLIFrameE
 }
 
 // Type guard with checks for "defined"-ness and whether the resource was found or not
-export const isFound = <T>(resource: undefined | null | NOT_FOUND_TYPE | T): resource is T => {
+export const isFound = <T>(resource: undefined | null | NOT_FOUND_TYPE | T): resource is NonNullable<T> => {
     return isDefined(resource) && resource !== NOT_FOUND;
 };
 

--- a/src/app/state/slices/api/gameboards.ts
+++ b/src/app/state/slices/api/gameboards.ts
@@ -37,7 +37,7 @@ export const assignGameboard = createAsyncThunk(
 
         // TODO think about whether this can be done in the back-end too?
         if (dueDate !== undefined) {
-            dueDate?.setUTCHours(0, 0, 0, 0);
+            dueDate?.setHours(0, 0, 0, 0);
             if ((dueDate.valueOf() - today.valueOf()) < 0) {
                 appDispatch(showToast({color: "danger", title: `Gameboard assignment${groups.length > 1 ? "(s)" : ""} failed`, body: "Error: Due date cannot be in the past.", timeout: 5000}));
                 return rejectWithValue(null);

--- a/src/app/state/slices/api/gameboards.ts
+++ b/src/app/state/slices/api/gameboards.ts
@@ -1,4 +1,4 @@
-import {getValue, history, isAdminOrEventManager, isDefined, isTeacher, Item, toTuple} from "../../../services";
+import {getValue, history, isAdminOrEventManager, isDefined, isTeacher, Item, TODAY, toTuple} from "../../../services";
 import {createAsyncThunk} from "@reduxjs/toolkit";
 import {AssignmentDTO} from "../../../../IsaacApiTypes";
 import {
@@ -33,15 +33,14 @@ export const assignGameboard = createAsyncThunk(
             return rejectWithValue(null);
         }
 
-        const today = new Date();
-        today.setUTCHours(0, 0, 0, 0);
+        const today = TODAY();
 
         // TODO think about whether this can be done in the back-end too?
         if (dueDate !== undefined) {
             dueDate?.setUTCHours(0, 0, 0, 0);
             if ((dueDate.valueOf() - today.valueOf()) < 0) {
                 appDispatch(showToast({color: "danger", title: `Gameboard assignment${groups.length > 1 ? "(s)" : ""} failed`, body: "Error: Due date cannot be in the past.", timeout: 5000}));
-                return false;
+                return rejectWithValue(null);
             }
         }
 
@@ -49,14 +48,14 @@ export const assignGameboard = createAsyncThunk(
             // Unlike with the due date, we want to preserve the hour assigned at the UI level, unless we want to move that logic here.
             if (scheduledStartDate.valueOf() <= (new Date()).valueOf()) {
                 appDispatch(showToast({color: "danger", title: `Gameboard assignment${groups.length > 1 ? "(s)" : ""} failed`, body: "Error: Scheduled start date cannot be in the past.", timeout: 5000}));
-                return false;
+                return rejectWithValue(null);
             }
         }
 
         if (dueDate !== undefined && scheduledStartDate !== undefined) {
             if ((dueDate.valueOf() - scheduledStartDate.valueOf()) <= 0) {
                 appDispatch(showToast({color: "danger", title: `Gameboard assignment${groups.length > 1 ? "(s)" : ""} failed`, body: "Error: Due date must be strictly after scheduled start date.", timeout: 5000}));
-                return false;
+                return rejectWithValue(null);
             }
         }
 

--- a/src/scss/common/assignments.scss
+++ b/src/scss/common/assignments.scss
@@ -1,0 +1,99 @@
+.bg-timeline {
+  position: absolute;
+  top: 0;
+  left: 18px;
+  height: 100%;
+  z-index: 1;
+  width: 4px;
+  border-left: solid 4px;
+  opacity: 0.5;
+  border-image:
+          linear-gradient(
+                          to bottom,
+                          $secondary 0 calc(100% - 20px),
+                          rgba(0, 0, 0, 0)
+          ) 1 100%;
+  &.fade-in {
+    border-image:
+            linear-gradient(
+                            to bottom,
+                            rgba(0, 0, 0, 0),
+                            $secondary 60px calc(100% - 20px),
+                            rgba(0, 0, 0, 0)
+            ) 1 100% !important;
+  }
+}
+
+.timeline {
+  z-index: 0;
+  background-color: transparent;
+  position: relative;
+  //.month-label {
+  //  padding-left: 32px;
+  //}
+  .year-label, .month-label, .hexagon-date {
+    position: relative;
+    background-color: transparent;
+    z-index: 4;
+  }
+  .date-assignment-list {
+    position: relative;
+    z-index: 4;
+  }
+  .month-label:hover, .hexagon-date:hover, .month-label:focus, .hexagon-date:focus {
+    outline: none;
+    background: linear-gradient(
+                    to left,
+                    transparent 0,
+                    rgba(#636c73, 0.1) 90%,
+                    transparent 100%
+    );
+    .date-assignment-count, .date-toggle-arrow {
+      opacity: 1 !important;
+      color: black !important;
+    }
+  }
+  .month-label:focus, .hexagon-date:focus {
+    .date-assignment-count, .month-assignment-count {
+      font-weight: bold;
+    }
+  }
+  .date-toggle-arrow {
+    opacity: 0.5;
+    &.open {
+      opacity: 1;
+    }
+  }
+}
+
+.timeline-column {
+  position: relative;
+}
+
+#header-sentinel {
+  max-height: 1px;
+  overflow: hidden;
+  background: transparent;
+}
+
+#stickyheader {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  z-index: 255;
+  display: none;
+
+  .container {
+    border-top-left-radius: 0 !important;
+    border-top-right-radius: 0 !important;
+    border-top: none;
+  }
+
+  &.active {
+    display: flex;
+    .container {
+      box-shadow: 0px 5px 20px rgba(0,0,0,0.1);
+    }
+  }
+}

--- a/src/scss/common/icons.scss
+++ b/src/scss/common/icons.scss
@@ -63,3 +63,6 @@
   background-position: -50px 0px;
 }
 
+polygon.fill-secondary {
+  fill: $secondary;
+}

--- a/src/scss/cs/isaac.scss
+++ b/src/scss/cs/isaac.scss
@@ -132,6 +132,7 @@ $tertiary-font: 'arconrounded-regular', sans-serif;
 @import "homepage";
 @import "../common/login";
 @import "../common/registration";
+@import "../common/assignments";
 @import "../common/my-account";
 @import "../common/topic";
 @import "../common/search";

--- a/src/scss/phy/isaac.scss
+++ b/src/scss/phy/isaac.scss
@@ -127,6 +127,7 @@ $tertiary-font: 'arconrounded-regular', sans-serif;
 @import "homepage";
 @import "../common/login";
 @import "../common/registration";
+@import "../common/assignments";
 @import "../common/my-account";
 @import "../common/topic";
 @import "../common/search";


### PR DESCRIPTION
This implements a new page to manage assignments based on their start and due dates. It's accessed via `/assignment_schedule`.

The idea is that this is released to live and anyone with the link can access it, and then we add it to the navbar later on. It is probably going to remain separate to the set assignments page since it represents a different part of the assignment workflow.

I have yet to add buttons to add gameboard from books and "boards for lessons", but this shouldn't hold back merging because the whole page is a hidden beta feature subject to change. There also isn't yet functionality to modify your current assignments - this can also be done later since it requires an API change (probably a new endpoint).

There are a couple of changes to gameboards and dates which are transient bug fixes - the commits containing these are separate from the new additions. 