### PR TITLE
Mark current question attempts as immutable

### DIFF
--- a/src/IsaacApiTypes.tsx
+++ b/src/IsaacApiTypes.tsx
@@ -4,6 +4,7 @@
 // Manually added/modified parts
 
 import {EXAM_BOARD} from "./app/services";
+import {Immutable} from "immer";
 
 export interface IsaacCardDTO extends ContentDTO {
     image?: ImageDTO;
@@ -467,7 +468,7 @@ export type BestAttemptHidden = null;
 export const BEST_ATTEMPT_HIDDEN: BestAttemptHidden = null;
 export interface QuestionDTO extends ContentDTO {
     hints?: ContentBaseDTO[];
-    bestAttempt?: QuestionValidationResponseDTO | BestAttemptHidden;
+    bestAttempt?: Immutable<QuestionValidationResponseDTO> | BestAttemptHidden;
 }
 
 export interface SeguePageDTO extends ContentDTO {

--- a/src/IsaacAppTypes.tsx
+++ b/src/IsaacAppTypes.tsx
@@ -31,6 +31,7 @@ import {
     TAG_LEVEL
 } from "./app/services";
 import {DropResult} from "react-beautiful-dnd";
+import {Immutable} from "immer";
 
 export type Action =
     | {type: ACTION_TYPE.TEST_ACTION}
@@ -203,11 +204,11 @@ export type Action =
 
     | {type: ACTION_TYPE.QUESTION_REGISTRATION; questions: ApiTypes.QuestionDTO[]; accordionClientId?: string}
     | {type: ACTION_TYPE.QUESTION_DEREGISTRATION; questionIds: string[]}
-    | {type: ACTION_TYPE.QUESTION_ATTEMPT_REQUEST; questionId: string; attempt: ApiTypes.ChoiceDTO}
+    | {type: ACTION_TYPE.QUESTION_ATTEMPT_REQUEST; questionId: string; attempt: Immutable<ApiTypes.ChoiceDTO>}
     | {type: ACTION_TYPE.QUESTION_ATTEMPT_RESPONSE_SUCCESS; questionId: string; response: ApiTypes.QuestionValidationResponseDTO}
     | {type: ACTION_TYPE.QUESTION_ATTEMPT_RESPONSE_FAILURE; questionId: string; lock?: Date}
     | {type: ACTION_TYPE.QUESTION_UNLOCK; questionId: string}
-    | {type: ACTION_TYPE.QUESTION_SET_CURRENT_ATTEMPT; questionId: string; attempt: ApiTypes.ChoiceDTO|ValidatedChoice<ApiTypes.ChoiceDTO>}
+    | {type: ACTION_TYPE.QUESTION_SET_CURRENT_ATTEMPT; questionId: string; attempt: Immutable<ApiTypes.ChoiceDTO | ValidatedChoice<ApiTypes.ChoiceDTO>>}
 
     | {type: ACTION_TYPE.QUESTION_SEARCH_REQUEST}
     | {type: ACTION_TYPE.QUESTION_SEARCH_RESPONSE_SUCCESS; questions: ApiTypes.ContentSummaryDTO[]}
@@ -449,8 +450,8 @@ export interface IsaacQuestionProps<T extends QuestionDTO> {
 }
 
 export interface AppQuestionDTO extends ApiTypes.QuestionDTO {
-    validationResponse?: ApiTypes.QuestionValidationResponseDTO;
-    currentAttempt?: ApiTypes.ChoiceDTO;
+    validationResponse?: Immutable<ApiTypes.QuestionValidationResponseDTO>;
+    currentAttempt?: Immutable<ApiTypes.ChoiceDTO>;
     canSubmit?: boolean;
     locked?: Date;
     accordionClientId?: string;
@@ -522,7 +523,7 @@ export interface ValidatedChoice<C extends ApiTypes.ChoiceDTO> {
     choice: C;
 }
 
-export function isValidatedChoice(choice: ApiTypes.ChoiceDTO|ValidatedChoice<ApiTypes.ChoiceDTO>): choice is ValidatedChoice<ApiTypes.ChoiceDTO> {
+export function isValidatedChoice(choice: Immutable<ApiTypes.ChoiceDTO | ValidatedChoice<ApiTypes.ChoiceDTO>>): choice is Immutable<ValidatedChoice<ApiTypes.ChoiceDTO>> {
     return choice.hasOwnProperty("frontEndValidation");
 }
 

--- a/src/app/components/content/IsaacClozeQuestion.tsx
+++ b/src/app/components/content/IsaacClozeQuestion.tsx
@@ -17,17 +17,18 @@ import {
 import {ClozeDropRegionContext, ClozeItemDTO, IsaacQuestionProps} from "../../../IsaacAppTypes";
 import {v4 as uuid_v4} from "uuid";
 import {Item} from "../elements/markup/portals/InlineDropZones";
+import {Immutable} from "immer";
 
-const augmentInlineItemWithUniqueReplacementID = (idv: ClozeItemDTO | undefined) => isDefined(idv) ? ({...idv, replacementId: `${idv?.id}-${uuid_v4()}`}) : undefined;
-const augmentNonSelectedItemWithReplacementID = (item: ClozeItemDTO) => ({...item, replacementId: item.id});
-const itemNotNullAndNotInAttempt = (currentAttempt: {items?: (ItemDTO | undefined)[]}) => (i: ClozeItemDTO | undefined) => i ? !currentAttempt.items?.map(si => si?.id).includes(i.id) : false;
+const augmentInlineItemWithUniqueReplacementID = (idv: Immutable<ClozeItemDTO> | undefined) => isDefined(idv) ? ({...idv, replacementId: `${idv?.id}-${uuid_v4()}`}) : undefined;
+const augmentNonSelectedItemWithReplacementID = (item: Immutable<ClozeItemDTO>) => ({...item, replacementId: item.id});
+const itemNotNullAndNotInAttempt = (currentAttempt: {items?: (Immutable<ItemDTO> | undefined)[]}) => (i: Immutable<ClozeItemDTO> | undefined) => i ? !currentAttempt.items?.map(si => si?.id).includes(i.id) : false;
 
 const NULL_CLOZE_ITEM_ID = "NULL_CLOZE_ITEM" as const;
 const NULL_CLOZE_ITEM: ItemDTO = {
     type: "item",
     id: NULL_CLOZE_ITEM_ID
 };
-const replaceNullItems = (items: ItemDTO[] | undefined) => items?.map(i => i.id === NULL_CLOZE_ITEM_ID ? undefined : i);
+const replaceNullItems = (items: readonly Immutable<ItemDTO>[] | undefined) => items?.map(i => i.id === NULL_CLOZE_ITEM_ID ? undefined : i);
 
 const IsaacClozeQuestion = ({doc, questionId, readonly}: IsaacQuestionProps<IsaacClozeQuestionDTO>) => {
 
@@ -39,13 +40,13 @@ const IsaacClozeQuestion = ({doc, questionId, readonly}: IsaacQuestionProps<Isaa
 
     const itemsSectionDroppableId = "non-selected-items";
 
-    const [nonSelectedItems, setNonSelectedItems] = useState<ClozeItemDTO[]>(doc.items ? [...doc.items].map(augmentNonSelectedItemWithReplacementID) : []);
+    const [nonSelectedItems, setNonSelectedItems] = useState<Immutable<ClozeItemDTO>[]>(doc.items ? [...doc.items].map(augmentNonSelectedItemWithReplacementID) : []);
 
     const registeredDropRegionIDs = useRef<Map<string, number>>(new Map()).current;
 
     const [borderMap, setBorderMap] = useState<{[dropId: string]: boolean}>({});
 
-    const [inlineDropValues, setInlineDropValues] = useState<(ClozeItemDTO | undefined)[]>(() => currentAttempt?.items || []);
+    const [inlineDropValues, setInlineDropValues] = useState<(Immutable<ClozeItemDTO> | undefined)[]>(() => currentAttempt?.items || []);
     // Whenever the inlineDropValues change or a drop region is added, computes a map from drop region id -> drop region value
     const inlineDropValueMap = useMemo(() => Array.from(registeredDropRegionIDs.entries()).reduce((dict, [dropId, i]) => Object.assign(dict, {[dropId]: inlineDropValues[i]}), {}), [inlineDropValues]);
 
@@ -114,9 +115,9 @@ const IsaacClozeQuestion = ({doc, questionId, readonly}: IsaacQuestionProps<Isaa
         const idvs = [...inlineDropValues];
 
         // The item that's being dragged (this is worked out below in each case)
-        let item : ClozeItemDTO;
+        let item : Immutable<ClozeItemDTO>;
         // A callback to put an item back into the source of the drag (if needed)
-        let replaceSource : (itemToReplace: ClozeItemDTO | undefined) => void = () => undefined;
+        let replaceSource : (itemToReplace: Immutable<ClozeItemDTO> | undefined) => void = () => undefined;
         // Whether the inline drop zones were updated or not
         let update = false;
 

--- a/src/app/components/content/IsaacContent.tsx
+++ b/src/app/components/content/IsaacContent.tsx
@@ -21,7 +21,6 @@ import {isQuestion} from "../../services";
 import {IsaacCodeTabs} from "./IsaacCodeTabs";
 import {IsaacInteractiveCodeSnippet} from "./IsaacInteractiveCodeSnippet";
 import {IsaacCallout} from "./IsaacCallout";
-import {Immutable} from "immer";
 const IsaacCodeSnippet = lazy(() => import("./IsaacCodeSnippet"));
 
 

--- a/src/app/components/content/IsaacContent.tsx
+++ b/src/app/components/content/IsaacContent.tsx
@@ -21,6 +21,7 @@ import {isQuestion} from "../../services";
 import {IsaacCodeTabs} from "./IsaacCodeTabs";
 import {IsaacInteractiveCodeSnippet} from "./IsaacInteractiveCodeSnippet";
 import {IsaacCallout} from "./IsaacCallout";
+import {Immutable} from "immer";
 const IsaacCodeSnippet = lazy(() => import("./IsaacCodeSnippet"));
 
 

--- a/src/app/components/content/IsaacItemQuestion.tsx
+++ b/src/app/components/content/IsaacItemQuestion.tsx
@@ -12,18 +12,18 @@ const IsaacItemQuestion = ({doc, questionId, readonly}: IsaacQuestionProps<Isaac
     function updateItems(changeEvent: ChangeEvent<HTMLInputElement>, item: ItemDTO) {
         const selected = changeEvent.target.checked;
         const currentItems = currentAttempt && currentAttempt.items || [];
-        const itemChoice: ItemChoiceDTO = {type: "itemChoice", items: currentItems};
-
-        if (selected) {
-            if (!itemChoice.items) {
-                itemChoice.items = [item];
-            } else if (itemChoice.items.filter(i => i.id == item.id).length == 0) {
-                itemChoice.items.push(item);
+        const makeNewItems = () => {
+            if (selected) {
+                if (!currentItems) {
+                    return [item];
+                } else if (currentItems.filter(i => i.id === item.id).length === 0) {
+                    return [...currentItems, item];
+                }
+            } else if (currentItems) {
+                return currentItems.filter(i => i.id !== item.id);
             }
-        } else if (itemChoice.items) {
-            itemChoice.items = itemChoice.items.filter(i => i.id !== item.id);
-        }
-        dispatchSetCurrentAttempt(itemChoice);
+        };
+        dispatchSetCurrentAttempt({type: "itemChoice", items: makeNewItems()});
     }
 
     return (

--- a/src/app/components/content/IsaacQuestion.tsx
+++ b/src/app/components/content/IsaacQuestion.tsx
@@ -10,7 +10,7 @@ import {
 } from "../../state";
 import {IsaacContent} from "./IsaacContent";
 import * as ApiTypes from "../../../IsaacApiTypes";
-import {BEST_ATTEMPT_HIDDEN} from "../../../IsaacApiTypes";
+import {BEST_ATTEMPT_HIDDEN, ContentDTO} from "../../../IsaacApiTypes";
 import * as RS from "reactstrap";
 import {
     determineFastTrackPrimaryAction,
@@ -134,7 +134,7 @@ export const IsaacQuestion = withRouter(({doc, location}: {doc: ApiTypes.Questio
                     </div>
                     {validationResponse.explanation && <div className="mb-2">
                         {invalidFormatError ? invalidFormatFeeback : tooManySigFigsError ? tooManySigFigsFeedback : tooFewSigFigsError ? tooFewSigFigsFeedback :
-                            <IsaacContent doc={validationResponse.explanation}/>
+                            <IsaacContent doc={validationResponse.explanation as ContentDTO}/>
                         }
                     </div>}
                 </div>}

--- a/src/app/components/content/IsaacReorderQuestion.tsx
+++ b/src/app/components/content/IsaacReorderQuestion.tsx
@@ -8,8 +8,9 @@ import {useCurrentQuestionAttempt} from "../../services";
 import {IsaacQuestionProps} from "../../../IsaacAppTypes";
 import classNames from "classnames";
 import {Markup} from "../elements/markup";
+import {Immutable} from "immer";
 
-const ReorderDraggableItem = ({item, index, inAvailableItems, readonly}: {item: ItemDTO; index: number; inAvailableItems?: boolean; readonly?: boolean}) => {
+const ReorderDraggableItem = ({item, index, inAvailableItems, readonly}: {item: Immutable<ItemDTO>; index: number; inAvailableItems?: boolean; readonly?: boolean}) => {
     return <Draggable
         key={item.id}
         draggableId={`${item.id || index}|reorder-item-choice`}
@@ -37,9 +38,9 @@ const IsaacReorderQuestion = ({doc, questionId, readonly} : IsaacQuestionProps<I
 
     const {currentAttempt, dispatchSetCurrentAttempt} = useCurrentQuestionAttempt<ItemChoiceDTO>(questionId);
 
-    const [availableItems, setAvailableItems] = useState<ItemDTO[]>([...doc.items ?? []]);
+    const [availableItems, setAvailableItems] = useState<Immutable<ItemDTO>[]>([...doc.items ?? []]);
 
-    const moveItem = (src: ItemDTO[] | undefined, fromIndex: number, dst: ItemDTO[] | undefined, toIndex: number) => {
+    const moveItem = (src: Immutable<ItemDTO>[] | undefined, fromIndex: number, dst: Immutable<ItemDTO>[] | undefined, toIndex: number) => {
         if (!src || !dst) return;
         const srcItem = src.splice(fromIndex, 1)[0];
         dst.splice(toIndex, 0, srcItem);
@@ -79,7 +80,7 @@ const IsaacReorderQuestion = ({doc, questionId, readonly} : IsaacQuestionProps<I
         }
     }
 
-    const onCurrentAttemptUpdate = (newCurrentAttempt?: ItemChoiceDTO, newAvailableItems?: ItemDTO[]) => {
+    const onCurrentAttemptUpdate = (newCurrentAttempt?: Immutable<ItemChoiceDTO>, newAvailableItems?: Immutable<ItemDTO>[]) => {
         if (!newCurrentAttempt) {
             const defaultAttempt: ItemChoiceDTO = {
                 type: "itemChoice",
@@ -93,7 +94,7 @@ const IsaacReorderQuestion = ({doc, questionId, readonly} : IsaacQuestionProps<I
             // and the current attempt is assigned afterwards, so we need to carve it out of the available items.
             // This also takes care of updating the two lists when a user moves items from one to the other.
             let fixedAvailableItems: ItemDTO[] = [];
-            const currentAttemptItems: ItemDTO[] = newCurrentAttempt.items || [];
+            const currentAttemptItems = newCurrentAttempt.items || [];
             if (doc.items) {
                 fixedAvailableItems = doc.items.filter(item => {
                     let found = false;
@@ -119,7 +120,7 @@ const IsaacReorderQuestion = ({doc, questionId, readonly} : IsaacQuestionProps<I
 
     useEffect(() => {
         onCurrentAttemptUpdate(currentAttempt, availableItems);
-    }, [currentAttempt, availableItems])
+    }, [currentAttempt, availableItems]);
 
     return <div className="parsons-question">
         <div className="question-content">

--- a/src/app/components/content/QuizQuestion.tsx
+++ b/src/app/components/content/QuizQuestion.tsx
@@ -7,6 +7,7 @@ import {IsaacContent} from "./IsaacContent";
 import * as ApiTypes from "../../../IsaacApiTypes";
 import {QuizAttemptContext} from "../../../IsaacAppTypes";
 import {Loading} from "../handlers/IsaacSpinner";
+import {ContentDTO} from "../../../IsaacApiTypes";
 
 export const QuizQuestion = ({doc}: { doc: ApiTypes.QuestionDTO }) => {
     const dispatch = useAppDispatch();
@@ -52,7 +53,7 @@ export const QuizQuestion = ({doc}: { doc: ApiTypes.QuestionDTO }) => {
                     <h1 className="m-0">{noAnswer ? "Not answered" : sigFigsError ? "Significant Figures" : correct ? "Correct!" : "Incorrect"}</h1>
                 </div>
                 {validationResponse && validationResponse.explanation && <div className="mb-1">
-                    <IsaacContent doc={validationResponse.explanation} />
+                    <IsaacContent doc={validationResponse.explanation as ContentDTO} />
                 </div>}
             </div>}
 

--- a/src/app/components/elements/inputs/ConfidenceQuestions.tsx
+++ b/src/app/components/elements/inputs/ConfidenceQuestions.tsx
@@ -5,6 +5,7 @@ import {ConfidenceType} from "../../../../IsaacAppTypes";
 import classNames from "classnames";
 import {isCS, isPhy, siteSpecific} from "../../../services";
 import {ChoiceDTO, ItemChoiceDTO, QuestionValidationResponseDTO} from "../../../../IsaacApiTypes";
+import {Immutable} from "immer";
 
 type ActiveConfidenceState = "initial" | "followUp"
 export type ConfidenceState = ActiveConfidenceState | "hidden";
@@ -76,7 +77,7 @@ interface ConfidenceQuestionsProps {
     identifier: any;
     disableInitialState?: boolean;
     type: ConfidenceType;
-    validationResponse?: QuestionValidationResponseDTO,
+    validationResponse?: Immutable<QuestionValidationResponseDTO>,
     answer?: any;
 }
 
@@ -185,11 +186,11 @@ export const ConfidenceQuestions = ({state, setState, validationPending, setVali
 // This and ConfidenceQuestions should be used together, with the values managed by this hook passed to an instance of
 // ConfidenceQuestions. This hook just abstracts away confidence-question-specific stuff so it is easy to remove and
 // doesn't have to hang around in IsaacQuestion and IsaacQuickQuestion.
-export const useConfidenceQuestionsValues = (show: boolean | undefined, type: ConfidenceType, onConfidenceStateChange?: (cs: ConfidenceState) => void, currentAttempt?: ChoiceDTO, canSubmit?: boolean, correct?: boolean, locked?: boolean) => {
+export const useConfidenceQuestionsValues = (show: boolean | undefined, type: ConfidenceType, onConfidenceStateChange?: (cs: ConfidenceState) => void, currentAttempt?: Immutable<ChoiceDTO>, canSubmit?: boolean, correct?: boolean, locked?: boolean) => {
     // Confidence question specific things
     const [confidenceState, setConfidenceState] = useState<ConfidenceState>("initial");
     const [validationPending, setValidationPending] = useState<ValidationPendingState>({pending: false});
-    const confidenceDisabled = type === "question" && (!canSubmit || !currentAttempt || (currentAttempt.value === "") || (Array.isArray((currentAttempt as ItemChoiceDTO).items) && (currentAttempt as ItemChoiceDTO).items?.length === 0));
+    const confidenceDisabled = type === "question" && (!canSubmit || !currentAttempt || (currentAttempt.value === "") || (Array.isArray((currentAttempt as Immutable<ItemChoiceDTO>).items) && (currentAttempt as Immutable<ItemChoiceDTO>).items?.length === 0));
     const showQuestionFeedback = confidenceState !== "initial" || !show || correct;
 
     // Reset question confidence on attempt change

--- a/src/app/components/elements/markup/portals/InlineDropZones.tsx
+++ b/src/app/components/elements/markup/portals/InlineDropZones.tsx
@@ -2,14 +2,15 @@ import {ClozeDropRegionContext} from "../../../../../IsaacAppTypes";
 import {Draggable, Droppable, DropResult} from "react-beautiful-dnd";
 import ReactDOM from "react-dom";
 import React, {useCallback, useContext, useEffect} from "react";
-import {ItemDTO} from "../../../../../IsaacApiTypes";
+import {ContentDTO, ItemDTO} from "../../../../../IsaacApiTypes";
 import {IsaacContentValueOrChildren} from "../../../content/IsaacContentValueOrChildren";
 import {Badge} from "reactstrap";
+import {Immutable} from "immer";
 
-export function Item({item}: {item: ItemDTO}) {
+export function Item({item}: {item: Immutable<ItemDTO>}) {
     return <Badge className="m-2 p-2 cloze-item">
         <IsaacContentValueOrChildren value={item.value} encoding={item.encoding || "html"}>
-            {item.children}
+            {item.children as ContentDTO[]}
         </IsaacContentValueOrChildren>
     </Badge>;
 }

--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -32,6 +32,7 @@ import {
 } from "../../IsaacAppTypes";
 import {handleApiGoneAway, handleServerError} from "../state";
 import {EventOverviewFilter} from "../components/elements/panels/EventOverviews";
+import {Immutable} from "immer";
 
 export const endpoint = axios.create({
     baseURL: API_PATH,
@@ -260,7 +261,7 @@ export const api = {
                 params: query,
             });
         },
-        answer: (id: string, answer: ApiTypes.ChoiceDTO): AxiosPromise<ApiTypes.QuestionValidationResponseDTO> => {
+        answer: (id: string, answer: Immutable<ApiTypes.ChoiceDTO>): AxiosPromise<ApiTypes.QuestionValidationResponseDTO> => {
             return endpoint.post(`/questions/${id}/answer`, answer);
         },
         answeredQuestionsByDate: (userId: number | string, fromDate: number, toDate: number, perDay: boolean): AxiosPromise<ApiTypes.AnsweredQuestionsByDate> => {
@@ -501,7 +502,7 @@ export const api = {
         loadQuizAssignmentAttempt: (quizAssignmentId: number): AxiosPromise<ApiTypes.QuizAttemptDTO> => {
             return endpoint.post(`/quiz/assignment/${quizAssignmentId}/attempt`);
         },
-        answer: (quizAttemptId: number, questionId: string, attempt: ApiTypes.ChoiceDTO): AxiosPromise<ApiTypes.QuestionValidationResponseDTO> => {
+        answer: (quizAttemptId: number, questionId: string, attempt: Immutable<ApiTypes.ChoiceDTO>): AxiosPromise<ApiTypes.QuestionValidationResponseDTO> => {
             return endpoint.post(`/quiz/attempt/${quizAttemptId}/answer/${questionId}`, attempt);
         },
         markQuizAttemptAsComplete: (quizAttemptId: number): AxiosPromise<ApiTypes.QuizAttemptDTO> => {

--- a/src/app/services/questions.ts
+++ b/src/app/services/questions.ts
@@ -3,6 +3,7 @@ import {AppQuestionDTO, IsaacQuestionProps, ValidatedChoice} from "../../IsaacAp
 import {DOCUMENT_TYPE, REVERSE_GREEK_LETTERS_MAP} from './';
 import {ChoiceDTO, ContentDTO, ContentSummaryDTO} from "../../IsaacApiTypes";
 import {selectors, setCurrentAttempt, useAppDispatch, useAppSelector} from "../state";
+import {Immutable} from "immer";
 const IsaacMultiChoiceQuestion = lazy(() => import("../components/content/IsaacMultiChoiceQuestion"));
 const IsaacItemQuestion = lazy(() => import("../components/content/IsaacItemQuestion"));
 const IsaacReorderQuestion = lazy(() => import("../components/content/IsaacReorderQuestion"));
@@ -154,8 +155,8 @@ export function useCurrentQuestionAttempt<T extends ChoiceDTO>(questionId: strin
     const pageQuestions = useAppSelector(selectors.questions.getQuestions);
     const questionPart = selectQuestionPart(pageQuestions, questionId);
     return {
-        currentAttempt: questionPart?.currentAttempt as (T | undefined),
-        dispatchSetCurrentAttempt: (attempt: T | ValidatedChoice<T>) => dispatch(setCurrentAttempt(questionId, attempt)),
+        currentAttempt: questionPart?.currentAttempt as (Immutable<T> | undefined),
+        dispatchSetCurrentAttempt: (attempt: Immutable<T | ValidatedChoice<T>>) => dispatch(setCurrentAttempt(questionId, attempt)),
         questionPart: questionPart
     };
 }

--- a/src/app/state/actions/index.tsx
+++ b/src/app/state/actions/index.tsx
@@ -81,6 +81,7 @@ import {
     showToast,
     store
 } from "../index";
+import {Immutable} from "immer";
 
 // Utility functions
 function isAxiosError(e: Error): e is AxiosError {
@@ -788,7 +789,7 @@ interface Attempt {
 }
 const attempts: {[questionId: string]: Attempt} = {};
 
-export const attemptQuestion = (questionId: string, attempt: ChoiceDTO, gameboardId?: string) => async (dispatch: AppDispatch, getState: () => AppState) => {
+export const attemptQuestion = (questionId: string, attempt: Immutable<ChoiceDTO>, gameboardId?: string) => async (dispatch: AppDispatch, getState: () => AppState) => {
     const state = getState();
     const isAnonymous = !(state && state.user && state.user.loggedIn);
     const timePeriod = isAnonymous ? 5 * 60 * 1000 : 15 * 60 * 1000;
@@ -843,9 +844,13 @@ export const attemptQuestion = (questionId: string, attempt: ChoiceDTO, gameboar
     }
 };
 
-export const setCurrentAttempt = (questionId: string, attempt: ChoiceDTO|ValidatedChoice<ChoiceDTO>) => (dispatch: Dispatch<Action>) => {
-    dispatch({type: ACTION_TYPE.QUESTION_SET_CURRENT_ATTEMPT, questionId, attempt});
-};
+export function setCurrentAttempt<T extends ChoiceDTO>(questionId: string, attempt: Immutable<T | ValidatedChoice<T>>) {
+    return (dispatch: Dispatch<Action>) => dispatch({
+        type: ACTION_TYPE.QUESTION_SET_CURRENT_ATTEMPT,
+        questionId,
+        attempt
+    });
+}
 
 let questionSearchCounter = 0;
 

--- a/src/app/state/reducers/quizState.ts
+++ b/src/app/state/reducers/quizState.ts
@@ -8,7 +8,7 @@ import {
     QuizAttemptFeedbackDTO,
     QuizSummaryDTO
 } from "../../../IsaacApiTypes";
-import produce from "immer";
+import produce, {Immutable} from "immer";
 
 type QuizState = {quizzes: QuizSummaryDTO[]; total: number} | null;
 export const quizzes = (quizzes: QuizState = null, action: Action) => {
@@ -122,7 +122,7 @@ export const quizAttemptedFreelyByMe = (quizAttempts: QuizAttemptedFreelyByMeSta
     }
 };
 
-const updateQuizAttemptQuestion = (questionId: string, questionAttempt: ChoiceDTO) => produce<{attempt: QuizAttemptDTO}>((quizAttempt) => {
+const updateQuizAttemptQuestion = (questionId: string, questionAttempt: Immutable<ChoiceDTO>) => produce<{attempt: QuizAttemptDTO}>((quizAttempt) => {
     const quizQuestions = extractQuestions(quizAttempt?.attempt.quiz);
     quizQuestions.forEach(question => {
         if (question.id === questionId && (question.bestAttempt === null || question.bestAttempt?.correct === undefined)) {


### PR DESCRIPTION
This threads the type change through the codebase. I didn't thread it through the `IsaacContent` component or anything related because it would be a huge faff, instead opting to cast immutable `ContentDTO`s to mutable ones where appropriate.

In the process, I fixed some potential state mutations in Parsons and reorder questions.