### PR TITLE
Add book board and gameboard builder buttons to assignment schedule

### DIFF
--- a/src/app/components/handlers/AddGameboard.tsx
+++ b/src/app/components/handlers/AddGameboard.tsx
@@ -1,17 +1,13 @@
 import React, {useEffect} from "react";
 import {PotentialUser} from "../../../IsaacAppTypes";
 import {saveGameboard, useAppDispatch} from "../../state";
-import {RouteComponentProps, withRouter} from "react-router-dom";
+import {useParams} from "react-router-dom";
 import {IsaacSpinner} from "./IsaacSpinner";
 import {history} from "../../services";
 import {Container} from "reactstrap";
 
-interface AddGameboardProps extends RouteComponentProps<{ gameboardId: string; gameboardTitle: string }> {
-    user: PotentialUser;
-}
-
-const AddGameboardComponent = (props: AddGameboardProps) => {
-    const {user, match: {params: {gameboardId, gameboardTitle}}} = props;
+export const AddGameboard = ({user}: {user: PotentialUser}) => {
+    const {gameboardId, gameboardTitle} = useParams<{gameboardId: string; gameboardTitle: string}>();
     const dispatch = useAppDispatch();
 
     useEffect(() => {
@@ -31,5 +27,3 @@ const AddGameboardComponent = (props: AddGameboardProps) => {
         <IsaacSpinner size={"lg"} displayText={"Adding gameboard..."}/>
     </Container>;
 };
-
-export const AddGameboard = withRouter(AddGameboardComponent);

--- a/src/app/components/pages/AssignmentSchedule.tsx
+++ b/src/app/components/pages/AssignmentSchedule.tsx
@@ -2,9 +2,7 @@ import {
     assignGameboard,
     isaacApi,
     loadGroups,
-    openIsaacBooksModal,
     selectors,
-    setAssignBoardPath,
     useAppDispatch,
     useAppSelector
 } from "../../state";
@@ -53,6 +51,7 @@ import {currentYear, DateInput} from "../elements/inputs/DateInput";
 import {GameboardViewerInner} from "./Gameboard";
 import {Link, useLocation} from "react-router-dom";
 import {combineQueries, ShowLoadingQuery} from "../handlers/ShowLoadingQuery";
+import {AddGameboardButtons} from "./SetAssignments";
 
 interface AssignmentListEntryProps {
     assignment: ValidAssignmentWithListingDate;
@@ -525,33 +524,7 @@ export const AssignmentSchedule = ({user}: {user: RegisteredUserDTO}) => {
         <h4 className="mt-4 mb-3">
             Assign a gameboard from...
         </h4>
-        <Row className="mb-4">
-            <Col md={6} lg={4} className="pt-1">
-                {siteSpecific(
-                    // Physics
-                    <Button role={"link"} onClick={() => {
-                        setAssignBoardPath("/assignment_schedule");
-                        dispatch(openIsaacBooksModal());
-                    }} color="secondary" block className="px-3">
-                        our books
-                    </Button>,
-                    // Computer science
-                    <Button tag={Link} to={"/pages/gameboards"} onClick={() => setAssignBoardPath("/assignment_schedule")} color="secondary" block>
-                        Pre-made gameboards
-                    </Button>
-                )}
-            </Col>
-            <Col md={6} lg={4} className="pt-1">
-                <Button tag={Link} to={siteSpecific("/pages/pre_made_gameboards", "/topics")} onClick={() => setAssignBoardPath("/assignment_schedule")} color="secondary" block>
-                    {siteSpecific("our Boards for Lessons", "Topics list")}
-                </Button>
-            </Col>
-            <Col md={12} lg={4} className="pt-1">
-                <Button tag={Link} to={"/gameboard_builder"} onClick={() => setAssignBoardPath("/assignment_schedule")} color="secondary" block>
-                    {siteSpecific("create a gameboard", "Create gameboard")}
-                </Button>
-            </Col>
-        </Row>
+        <AddGameboardButtons className={"mb-4"} redirectBackTo={"/assignment_schedule"}/>
         <AssignmentScheduleContext.Provider value={{boardsById, groupsById, groupFilter, boardIdsByGroupId, groups: groups ?? [], gameboards: gameboards?.boards ?? [], openAssignmentModal, collapsed, setCollapsed, viewBy}}>
             {/*
                 Setting `combineResult` to `() => true` (3rd param of `combineQueries`) is a bit of a hack that lets you

--- a/src/app/components/pages/AssignmentSchedule.tsx
+++ b/src/app/components/pages/AssignmentSchedule.tsx
@@ -1,4 +1,13 @@
-import {assignGameboard, isaacApi, loadGroups, selectors, useAppDispatch, useAppSelector} from "../../state";
+import {
+    assignGameboard,
+    isaacApi,
+    loadGroups,
+    openIsaacBooksModal,
+    selectors,
+    setAssignBoardPath,
+    useAppDispatch,
+    useAppSelector
+} from "../../state";
 import {AssignmentDTO, GameboardDTO, RegisteredUserDTO, UserGroupDTO} from "../../../IsaacApiTypes";
 import {groupBy, mapValues, range, sortBy} from "lodash";
 import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
@@ -513,6 +522,36 @@ export const AssignmentSchedule = ({user}: {user: RegisteredUserDTO}) => {
 
     return <Container>
         <TitleAndBreadcrumb currentPageTitle={"Assignment Schedule"} help={pageHelp}/>
+        <h4 className="mt-4 mb-3">
+            Assign a gameboard from...
+        </h4>
+        <Row className="mb-4">
+            <Col md={6} lg={4} className="pt-1">
+                {siteSpecific(
+                    // Physics
+                    <Button role={"link"} onClick={() => {
+                        setAssignBoardPath("/assignment_schedule");
+                        dispatch(openIsaacBooksModal());
+                    }} color="secondary" block className="px-3">
+                        our books
+                    </Button>,
+                    // Computer science
+                    <Button tag={Link} to={"/pages/gameboards"} onClick={() => setAssignBoardPath("/assignment_schedule")} color="secondary" block>
+                        Pre-made gameboards
+                    </Button>
+                )}
+            </Col>
+            <Col md={6} lg={4} className="pt-1">
+                <Button tag={Link} to={siteSpecific("/pages/pre_made_gameboards", "/topics")} onClick={() => setAssignBoardPath("/assignment_schedule")} color="secondary" block>
+                    {siteSpecific("our Boards for Lessons", "Topics list")}
+                </Button>
+            </Col>
+            <Col md={12} lg={4} className="pt-1">
+                <Button tag={Link} to={"/gameboard_builder"} onClick={() => setAssignBoardPath("/assignment_schedule")} color="secondary" block>
+                    {siteSpecific("create a gameboard", "Create gameboard")}
+                </Button>
+            </Col>
+        </Row>
         <AssignmentScheduleContext.Provider value={{boardsById, groupsById, groupFilter, boardIdsByGroupId, groups: groups ?? [], gameboards: gameboards?.boards ?? [], openAssignmentModal, collapsed, setCollapsed, viewBy}}>
             {/*
                 Setting `combineResult` to `() => true` (3rd param of `combineQueries`) is a bit of a hack that lets you
@@ -524,7 +563,7 @@ export const AssignmentSchedule = ({user}: {user: RegisteredUserDTO}) => {
                     {!isStaff(user) && <Alert className={"mt-2"} color={"info"}>
                         The Assignment Schedule page is an alternate way to manage your assignments, focusing on the start and due dates of the assignments, rather than the assigned gameboard.
                         <br/>
-                        It is a work in progress, and we would love to <a href={"/contact?subject=Assignment%20Schedule%20Feedback"}>hear your feedback</a>!
+                        It is a work in progress, and we would love to <a target={"_blank"} href={"/contact?subject=Assignment%20Schedule%20Feedback"}>hear your feedback</a>!
                     </Alert>}
                     <div className="no-print">
                         <div id="header-sentinel" ref={headerScrollerSentinel}>&nbsp;</div>

--- a/src/app/components/pages/AssignmentSchedule.tsx
+++ b/src/app/components/pages/AssignmentSchedule.tsx
@@ -520,23 +520,23 @@ export const AssignmentSchedule = ({user}: {user: RegisteredUserDTO}) => {
     </span>;
 
     return <Container>
-        <TitleAndBreadcrumb currentPageTitle={"Assignment Schedule"} help={pageHelp}/>
+        <TitleAndBreadcrumb currentPageTitle="Assignment Schedule" help={pageHelp}/>
         <h4 className="mt-4 mb-3">
             Assign a gameboard from...
         </h4>
-        <AddGameboardButtons className={"mb-4"} redirectBackTo={"/assignment_schedule"}/>
+        <AddGameboardButtons className="mb-4" redirectBackTo="/assignment_schedule"/>
         <AssignmentScheduleContext.Provider value={{boardsById, groupsById, groupFilter, boardIdsByGroupId, groups: groups ?? [], gameboards: gameboards?.boards ?? [], openAssignmentModal, collapsed, setCollapsed, viewBy}}>
             {/*
                 Setting `combineResult` to `() => true` (3rd param of `combineQueries`) is a bit of a hack that lets you
                 skip the combine query step and throw away the two results. It has to be `true` otherwise the resulting
                 query will be handled as if it failed.
             */}
-            <ShowLoadingQuery defaultErrorTitle={"Error loading assignments and/or gameboards"} query={combineQueries(assignmentsSetByMeQuery, gameboardsQuery, () => true)}>
-                <div className={"px-md-4 pl-2 pr-2 timeline-column mb-4 pt-2"}>
-                    {!isStaff(user) && <Alert className={"mt-2"} color={"info"}>
+            <ShowLoadingQuery defaultErrorTitle="Error loading assignments and/or gameboards" query={combineQueries(assignmentsSetByMeQuery, gameboardsQuery, () => true)}>
+                <div className="px-md-4 pl-2 pr-2 timeline-column mb-4 pt-2">
+                    {!isStaff(user) && <Alert className="mt-2" color="info">
                         The Assignment Schedule page is an alternate way to manage your assignments, focusing on the start and due dates of the assignments, rather than the assigned gameboard.
                         <br/>
-                        It is a work in progress, and we would love to <a target={"_blank"} href={"/contact?subject=Assignment%20Schedule%20Feedback"}>hear your feedback</a>!
+                        It is a work in progress, and we would love to <a target="_blank" href="/contact?subject=Assignment%20Schedule%20Feedback">hear your feedback</a>!
                     </Alert>}
                     <div className="no-print">
                         <div id="header-sentinel" ref={headerScrollerSentinel}>&nbsp;</div>
@@ -551,23 +551,23 @@ export const AssignmentSchedule = ({user}: {user: RegisteredUserDTO}) => {
                         You have not created any groups to assign work to.
                         Please <Link to="/groups">create a group here first.</Link>
                     </Alert>}
-                    {groupsToInclude.length > 0 && <Alert color="warning" className={"mt-2"}>
+                    {groupsToInclude.length > 0 && <Alert color="warning" className="mt-2">
                         There are no assignments set to group{groupsToInclude.length > 1 ? "s" : ""}: {groupsToInclude.map(g => g.label).join(", ")}
                     </Alert>}
 
-                    {assignmentsGroupedByDate.length > 0 && <Card className={"mt-2"}>
-                        <CardBody className={"pt-0"}>
-                            {notAllPastAssignmentsAreListed && <div className={"mt-3"}>
-                                <Button size={"sm"} onClick={extendBackSixMonths}>
+                    {assignmentsGroupedByDate.length > 0 && <Card className="mt-2">
+                        <CardBody className="pt-0">
+                            {notAllPastAssignmentsAreListed && <div className="mt-3">
+                                <Button size="sm" onClick={extendBackSixMonths}>
                                     Show assignments before {earliestShowDate.toDateString().split(" ").filter((_, i) => i % 2 === 1).join(" ")}
                                 </Button>
                             </div>}
                             <div className={classNames("timeline w-100", {"pt-2": !notAllPastAssignmentsAreListed})}>
                                 {assignmentsGroupedByDate.map(([y, ms]) =>
                                     <Fragment key={y}>
-                                        <div className={"year-label w-100 text-right"}>
-                                            <h3 className={"mb-n3"}>{`${y}`}</h3>
-                                            <hr className={"ml-4"}/>
+                                        <div className="year-label w-100 text-right">
+                                            <h3 className="mb-n3">{`${y}`}</h3>
+                                            <hr className="ml-4"/>
                                         </div>
                                         {ms.map(([m, ds]) => <MonthAssignmentList key={m} month={m} datesAndAssignments={ds}/>)}
                                     </Fragment>

--- a/src/app/components/pages/Gameboard.tsx
+++ b/src/app/components/pages/Gameboard.tsx
@@ -3,6 +3,7 @@ import {
     isaacApi,
     logAction,
     selectors,
+    setAssignBoardPath,
     useAppDispatch,
     useAppSelector
 } from "../../state";
@@ -201,7 +202,10 @@ export const Gameboard = withRouter(({ location }) => {
                             </RS.Row>
                             : gameboard && gameboard !== NOT_FOUND && !gameboard.savedToCurrentUser && <RS.Row>
                                 <RS.Col className="mt-4" sm={{size: 8, offset: 2}} md={{size: 4, offset: 4}}>
-                                    <RS.Button tag={Link} to={`/add_gameboard/${gameboardId}`} color="primary" outline className="btn-block">
+                                    <RS.Button tag={Link} to={`/add_gameboard/${gameboardId}`}
+                                               onClick={() => setAssignBoardPath("/set_assignments")}
+                                               color="primary" outline className="btn-block"
+                                    >
                                         {siteSpecific("Save to My Gameboards", "Save to My gameboards")}
                                     </RS.Button>
                                 </RS.Col>

--- a/src/app/components/pages/GameboardFilter.tsx
+++ b/src/app/components/pages/GameboardFilter.tsx
@@ -4,6 +4,7 @@ import {
     extractDataFromQueryResponse,
     fetchConcepts,
     isaacApi,
+    setAssignBoardPath,
     useAppDispatch,
     useAppSelector
 } from "../../state";
@@ -633,7 +634,10 @@ export const GameboardFilter = withRouter(({location}: RouteComponentProps) => {
                 </>
             )}
             <RS.Col xs={8} lg={"auto"} className="ml-auto text-right">
-                <RS.Button tag={Link} color="secondary" to={`/add_gameboard/${gameboard.id}/${customBoardTitle ?? gameboard.title}`}>
+                <RS.Button tag={Link} color="secondary"
+                           to={`/add_gameboard/${gameboard.id}/${customBoardTitle ?? gameboard.title}`}
+                           onClick={() => setAssignBoardPath("/set_assignments")}
+                >
                     Save to My&nbsp;Gameboards
                 </RS.Button>
             </RS.Col>

--- a/src/app/components/pages/SetAssignments.tsx
+++ b/src/app/components/pages/SetAssignments.tsx
@@ -27,6 +27,7 @@ import {
     loadGroups,
     openIsaacBooksModal,
     selectors,
+    setAssignBoardPath,
     showErrorToast,
     unlinkUserFromGameboard,
     useAppDispatch,
@@ -369,16 +370,6 @@ export const SetAssignments = () => {
         boardTitleFilter, setBoardTitleFilter
     } = useGameboards(BoardViews.card, BoardLimit.six);
 
-    const isaacAssignmentButtons = {
-        second: {
-            link: siteSpecific("/pages/pre_made_gameboards", "/topics"),
-            text: siteSpecific("our Boards for Lessons", "Topics list")
-        },
-        third: {
-            text: siteSpecific("create a gameboard", "Create gameboard")
-        }
-    };
-
     const switchView = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
         setBoardView(e.target.value as BoardViews);
     }, [setBoardView]);
@@ -398,23 +389,26 @@ export const SetAssignments = () => {
             <Col md={6} lg={4} className="pt-1">
                 {siteSpecific(
                     // Physics
-                    <Button role={"link"} onClick={() => dispatch(openIsaacBooksModal())} color="secondary" block className="px-3">
+                    <Button role={"link"} onClick={() => {
+                        setAssignBoardPath("/set_assignments");
+                        dispatch(openIsaacBooksModal());
+                    }} color="secondary" block className="px-3">
                         our books
                     </Button>,
                     // Computer science
-                    <Button tag={Link} to={"/pages/gameboards"} color="secondary" block>
+                    <Button tag={Link} to={"/pages/gameboards"} onClick={() => setAssignBoardPath("/set_assignments")} color="secondary" block>
                         Pre-made gameboards
                     </Button>
                 )}
             </Col>
             <Col md={6} lg={4} className="pt-1">
-                <Button tag={Link} to={isaacAssignmentButtons.second.link} color="secondary" block>
-                    {isaacAssignmentButtons.second.text}
+                <Button tag={Link} to={siteSpecific("/pages/pre_made_gameboards", "/topics")} onClick={() => setAssignBoardPath("/set_assignments")} color="secondary" block>
+                    {siteSpecific("our Boards for Lessons", "Topics list")}
                 </Button>
             </Col>
             <Col md={12} lg={4} className="pt-1">
-                <Button tag={Link} to={"/gameboard_builder"} color="secondary" block>
-                    {isaacAssignmentButtons.third.text}
+                <Button tag={Link} to={"/gameboard_builder"} onClick={() => setAssignBoardPath("/set_assignments")} color="secondary" block>
+                    {siteSpecific("create a gameboard", "Create gameboard")}
                 </Button>
             </Col>
         </Row>

--- a/src/app/components/pages/SetAssignments.tsx
+++ b/src/app/components/pages/SetAssignments.tsx
@@ -338,6 +338,37 @@ const Board = (props: BoardProps) => {
     </>;
 };
 
+export const AddGameboardButtons = ({className, redirectBackTo}: {className: string, redirectBackTo: string}) => {
+    const dispatch = useAppDispatch();
+    return <Row className={className}>
+        <Col md={6} lg={4} className="pt-1">
+            {siteSpecific(
+                // Physics
+                <Button role={"link"} onClick={() => {
+                    setAssignBoardPath(redirectBackTo);
+                    dispatch(openIsaacBooksModal());
+                }} color="secondary" block className="px-3">
+                    our books
+                </Button>,
+                // Computer science
+                <Button tag={Link} to={"/pages/gameboards"} onClick={() => setAssignBoardPath(redirectBackTo)} color="secondary" block>
+                    Pre-made gameboards
+                </Button>
+            )}
+        </Col>
+        <Col md={6} lg={4} className="pt-1">
+            <Button tag={Link} to={siteSpecific("/pages/pre_made_gameboards", "/topics")} onClick={() => setAssignBoardPath(redirectBackTo)} color="secondary" block>
+                {siteSpecific("our Boards for Lessons", "Topics list")}
+            </Button>
+        </Col>
+        <Col md={12} lg={4} className="pt-1">
+            <Button tag={Link} to={"/gameboard_builder"} onClick={() => setAssignBoardPath(redirectBackTo)} color="secondary" block>
+                {siteSpecific("create a gameboard", "Create gameboard")}
+            </Button>
+        </Col>
+    </Row>;
+};
+
 export const SetAssignments = () => {
     const dispatch = useAppDispatch();
     // We know the user is logged in and is at least a teacher in order to visit this page
@@ -385,33 +416,7 @@ export const SetAssignments = () => {
         <h4 className="mt-4 mb-3">
             Add a gameboard from ...
         </h4>
-        <Row className="mb-4">
-            <Col md={6} lg={4} className="pt-1">
-                {siteSpecific(
-                    // Physics
-                    <Button role={"link"} onClick={() => {
-                        setAssignBoardPath("/set_assignments");
-                        dispatch(openIsaacBooksModal());
-                    }} color="secondary" block className="px-3">
-                        our books
-                    </Button>,
-                    // Computer science
-                    <Button tag={Link} to={"/pages/gameboards"} onClick={() => setAssignBoardPath("/set_assignments")} color="secondary" block>
-                        Pre-made gameboards
-                    </Button>
-                )}
-            </Col>
-            <Col md={6} lg={4} className="pt-1">
-                <Button tag={Link} to={siteSpecific("/pages/pre_made_gameboards", "/topics")} onClick={() => setAssignBoardPath("/set_assignments")} color="secondary" block>
-                    {siteSpecific("our Boards for Lessons", "Topics list")}
-                </Button>
-            </Col>
-            <Col md={12} lg={4} className="pt-1">
-                <Button tag={Link} to={"/gameboard_builder"} onClick={() => setAssignBoardPath("/set_assignments")} color="secondary" block>
-                    {siteSpecific("create a gameboard", "Create gameboard")}
-                </Button>
-            </Col>
-        </Row>
+        <AddGameboardButtons className={"mb-4"} redirectBackTo={"/set_assignments"}/>
         {groups && groups.length === 0 && <Alert color="warning">
             You have not created any groups to assign work to.
             Please <Link to="/groups">create a group here first.</Link>

--- a/src/app/services/localStorage.ts
+++ b/src/app/services/localStorage.ts
@@ -10,6 +10,7 @@ export enum KEY {
     ANONYMISE_USERS = "anonymiseUsers",
     MOST_RECENT_ALL_TOPICS_PATH = "mostRecentAllTopicsPath",
     FIRST_ANON_QUESTION = "firstAnonQuestion",
+    ASSIGN_BOARD_PATH = "assignBoardPath",
 }
 
 export const LOADING_FAILURE_VALUE = null;

--- a/src/app/state/actions/index.tsx
+++ b/src/app/state/actions/index.tsx
@@ -1705,3 +1705,7 @@ export const handleServerError = () => {
 export const handleApiGoneAway = () => {
     store.dispatch(errorSlice.actions.apiGoneAway);
 };
+
+export const setAssignBoardPath = (path: string) => {
+    persistence.save(KEY.ASSIGN_BOARD_PATH, path);
+};

--- a/src/app/state/slices/api/gameboards.ts
+++ b/src/app/state/slices/api/gameboards.ts
@@ -1,4 +1,15 @@
-import {getValue, history, isAdminOrEventManager, isDefined, isTeacher, Item, TODAY, toTuple} from "../../../services";
+import {
+    getValue,
+    history,
+    isAdminOrEventManager,
+    isDefined,
+    isTeacher,
+    Item,
+    KEY,
+    persistence,
+    TODAY,
+    toTuple
+} from "../../../services";
 import {createAsyncThunk} from "@reduxjs/toolkit";
 import {AssignmentDTO} from "../../../../IsaacApiTypes";
 import {
@@ -6,6 +17,7 @@ import {
     AppState,
     isaacApi,
     mutationSucceeded,
+    setAssignBoardPath,
     showErrorToast,
     showRTKQueryErrorToastIfNeeded,
     showSuccessToast,
@@ -190,9 +202,9 @@ interface SaveGameboardParams {
     redirectOnSuccess?: boolean
 }
 
-export const saveGameboard = createAsyncThunk(
+export const saveGameboard = createAsyncThunk<{boardId: string, boardTitle?: string}, SaveGameboardParams, {state: AppState}>(
     "gameboards/saveGameboard",
-    async ({boardId, user, boardTitle, redirectOnSuccess}: SaveGameboardParams, {dispatch, rejectWithValue}) => {
+    async ({boardId, user, boardTitle, redirectOnSuccess}, {dispatch, rejectWithValue}) => {
         try {
             if (boardTitle) {
                 // If the user wants a custom title, we can use the `renameAndSaveGameboard` endpoint. This is a redesign
@@ -210,7 +222,9 @@ export const saveGameboard = createAsyncThunk(
             }
             if (redirectOnSuccess) {
                 if (isTeacher(user)) {
-                    history.push(`/set_assignments#${boardId}`);
+                    const assignBoardPath = persistence.load(KEY.ASSIGN_BOARD_PATH) ?? "/set_assignments";
+                    history.push(`${assignBoardPath}#${boardId}`);
+                    setAssignBoardPath("/set_assignments");
                 } else {
                     history.push(`/my_gameboards#${boardId}`);
                 }


### PR DESCRIPTION
Requires redirecting user back to assignment setting page they originally pressed these buttons from - I save the path to redirect to in local storage and default to `/set_assignments` if it is missing. 
It won't (shouldn't) be possible for a user to accidentally be redirected to the assignment schedule unless they've visited it already in that session and take a weird path through the app.