### PR TITLE
Qualtrics survey redirect

### DIFF
--- a/src/app/components/handlers/ExternalRedirect.tsx
+++ b/src/app/components/handlers/ExternalRedirect.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import {RegisteredUserDTO} from "../../../IsaacApiTypes";
+import {useParams} from "react-router-dom";
+import {Loading} from "./IsaacSpinner";
+import {Redirect} from "react-router";
+import {TrackedRoute} from "../navigation/TrackedRoute";
+import {PotentialUser} from "../../../IsaacAppTypes";
+
+interface ExternalRedirectBaseProps {
+    from: string;
+}
+type ExternalRedirectProps<Params extends { [K in keyof Params]: string }> = ExternalRedirectBaseProps & ({
+    to: (routeParams: Params) => `https://${string}`;
+    ifUser?: never;
+} | {
+    to: (routeParams: Params, user: RegisteredUserDTO) => `https://${string}`;
+    ifUser: (user: PotentialUser) => boolean;
+});
+export function ExternalRedirect<Params extends { [K in keyof Params]: string } = {}>({from, to, ifUser}: ExternalRedirectProps<Params>) {
+    const ExternalRedirectInner = ({user}: {user: RegisteredUserDTO}) => {
+        const params = useParams<Params>();
+        const redirectURL = ifUser ? to(params, user) : to(params);
+        if (redirectURL) {
+            window.location.replace(redirectURL);
+            return <Loading/>;
+        }
+        // Redirect to home page if the `redirectURL` cannot be built
+        console.error("Problem building external redirect URL, redirecting to homepage...");
+        return <Redirect to={"/"}/>;
+    };
+    return <TrackedRoute exact ifUser={ifUser} path={from} component={ExternalRedirectInner} />
+}

--- a/src/app/components/navigation/IsaacApp.tsx
+++ b/src/app/components/navigation/IsaacApp.tsx
@@ -84,6 +84,7 @@ import {QuizDoFreeAttempt} from "../pages/quizzes/QuizDoFreeAttempt";
 import {GameboardFilter} from "../pages/GameboardFilter";
 import {Loading} from "../handlers/IsaacSpinner";
 import {AssignmentSchedule} from "../pages/AssignmentSchedule";
+import {ExternalRedirect} from "../handlers/ExternalRedirect";
 
 const ContentEmails = lazy(() => import('../pages/ContentEmails'));
 const MyProgress = lazy(() => import('../pages/MyProgress'));
@@ -147,117 +148,118 @@ export const IsaacApp = () => {
             <ErrorBoundary FallbackComponent={ChunkOrClientError}>
                 <Suspense fallback={<Loading/>}>
                     <Switch>
-                    {/* Errors; these paths work but aren't really used */}
-                    <Route exact path={serverError ? undefined : "/error"} component={ServerError} />
-                    <Route exact path={goneAwayError ? undefined : "/error_stale"} component={SessionExpired} />
-                    <TrackedRoute exact path={"/auth_error"} component={AuthError} />
+                        {/* Errors; these paths work but aren't really used */}
+                        <Route exact path={serverError ? undefined : "/error"} component={ServerError} />
+                        <Route exact path={goneAwayError ? undefined : "/error_stale"} component={SessionExpired} />
+                        <TrackedRoute exact path={"/auth_error"} component={AuthError} />
 
-                    {/* Site specific pages */}
-                    {SiteSpecific.Routes}
+                        {/* Site specific pages */}
+                        {SiteSpecific.Routes}
 
-                    {/* Application pages */}
-                    <TrackedRoute exact path="/" component={SiteSpecific.Homepage} />
-                    <Redirect exact from="/home" to="/" /> {/* historic route which might get reintroduced with the introduction of dashboards */}
-                    <TrackedRoute exact path="/account" ifUser={isLoggedIn} component={MyAccount} />
-                    <TrackedRoute exact path="/search" component={Search} />
+                        {/* Application pages */}
+                        <TrackedRoute exact path="/" component={SiteSpecific.Homepage} />
+                        <Redirect exact from="/home" to="/" /> {/* historic route which might get reintroduced with the introduction of dashboards */}
+                        <TrackedRoute exact path="/account" ifUser={isLoggedIn} component={MyAccount} />
+                        <TrackedRoute exact path="/search" component={Search} />
 
-                    <TrackedRoute exact path="/pages/:pageId" component={Generic} />
-                    <TrackedRoute exact path="/concepts/:conceptId" component={Concept} />
-                    <TrackedRoute exact path="/questions/:questionId" component={Question} />
+                        <TrackedRoute exact path="/pages/:pageId" component={Generic} />
+                        <TrackedRoute exact path="/concepts/:conceptId" component={Concept} />
+                        <TrackedRoute exact path="/questions/:questionId" component={Question} />
 
-                    <TrackedRoute exact path="/gameboards" component={Gameboard} />
-                    <TrackedRoute exact path="/my_gameboards" ifUser={isLoggedIn} component={MyGameboards} />
-                    <TrackedRoute exact path="/gameboard_builder" ifUser={isTeacher} component={GameboardBuilder} />
-                    <TrackedRoute exact path="/assignment/:gameboardId" ifUser={isLoggedIn} component={RedirectToGameboard} />
-                    <TrackedRoute exact path="/add_gameboard/:gameboardId/:gameboardTitle?" ifUser={isLoggedIn} component={AddGameboard} />
-                    <TrackedRoute exact path="/gameboards/new" component={GameboardFilter} />
+                        <TrackedRoute exact path="/gameboards" component={Gameboard} />
+                        <TrackedRoute exact path="/my_gameboards" ifUser={isLoggedIn} component={MyGameboards} />
+                        <TrackedRoute exact path="/gameboard_builder" ifUser={isTeacher} component={GameboardBuilder} />
+                        <TrackedRoute exact path="/assignment/:gameboardId" ifUser={isLoggedIn} component={RedirectToGameboard} />
+                        <TrackedRoute exact path="/add_gameboard/:gameboardId/:gameboardTitle?" ifUser={isLoggedIn} component={AddGameboard} />
+                        <TrackedRoute exact path="/gameboards/new" component={GameboardFilter} />
 
-                    <TrackedRoute exact path='/events' component={Events}/>
-                    <TrackedRoute exact path='/events/:eventId' component={EventDetails}/>
-                    <TrackedRoute exact path='/eventbooking/:eventId' ifUser={isLoggedIn} component={RedirectToEvent} />
+                        <TrackedRoute exact path='/events' component={Events}/>
+                        <TrackedRoute exact path='/events/:eventId' component={EventDetails}/>
+                        <TrackedRoute exact path='/eventbooking/:eventId' ifUser={isLoggedIn} component={RedirectToEvent} />
 
-                    {/* Quiz pages */}
+                        {/* Quiz pages */}
+                        <TrackedRoute exact path="/test/assignment/:quizAssignmentId" ifUser={isLoggedIn} component={QuizDoAssignment} />
+                        <TrackedRoute exact path="/test/assignment/:quizAssignmentId/page/:page" ifUser={isLoggedIn} component={QuizDoAssignment} />
+                        <TrackedRoute exact path="/test/attempt/:quizAttemptId/feedback" ifUser={isLoggedIn} component={QuizAttemptFeedback} />
+                        <TrackedRoute exact path="/test/attempt/:quizAttemptId/feedback/:page" ifUser={isLoggedIn} component={QuizAttemptFeedback} />
+                        <TrackedRoute exact path="/test/attempt/feedback/:quizAssignmentId/:studentId" ifUser={isTeacher} component={QuizAttemptFeedback} />
+                        <TrackedRoute exact path="/test/attempt/feedback/:quizAssignmentId/:studentId/:page" ifUser={isTeacher} component={QuizAttemptFeedback} />
+                        <TrackedRoute exact path="/test/assignment/:quizAssignmentId/feedback" ifUser={isTeacher} component={QuizTeacherFeedback} />
+                        <TrackedRoute exact path="/test/preview/:quizId" ifUser={isTeacher} component={QuizPreview} />
+                        <TrackedRoute exact path="/test/preview/:quizId/page/:page" ifUser={isTeacher} component={QuizPreview} />
+                        <TrackedRoute exact path="/test/attempt/:quizId" ifUser={isLoggedIn} component={QuizDoFreeAttempt} />
+                        <TrackedRoute exact path="/test/attempt/:quizId/page/:page" ifUser={isLoggedIn} component={QuizDoFreeAttempt} />
+                        {/* The order of these redirects matters to prevent substring replacement */}
+                        <Redirect from="/quiz/assignment/:quizAssignmentId/feedback"   to="/test/assignment/:quizAssignmentId/feedback" />
+                        <Redirect from="/quiz/assignment/:quizAssignmentId/page/:page" to="/test/assignment/:quizAssignmentId/page/:page" />
+                        <Redirect from="/quiz/assignment/:quizAssignmentId"            to="/test/assignment/:quizAssignmentId" />
+                        <Redirect from="/quiz/attempt/feedback/:quizAssignmentId/:studentId/:page" to="/test/attempt/feedback/:quizAssignmentId/:studentId/:page" />
+                        <Redirect from="/quiz/attempt/feedback/:quizAssignmentId/:studentId" to="/test/attempt/feedback/:quizAssignmentId/:studentId" />
+                        <Redirect from="/quiz/attempt/:quizAttemptId/feedback/:page"   to="/test/attempt/:quizAttemptId/feedback/:page" />
+                        <Redirect from="/quiz/attempt/:quizAttemptId/feedback"         to="/test/attempt/:quizAttemptId/feedback" />
+                        <Redirect from="/quiz/preview/:quizId/page/:page"              to="/test/preview/:quizId/page/:page" />
+                        <Redirect from="/quiz/preview/:quizId"                         to="/test/preview/:quizId" />
+                        <Redirect from="/quiz/attempt/:quizId/page/:page"              to="/test/attempt/:quizId/page/:page" />
+                        <Redirect from="/quiz/attempt/:quizId"                         to="/test/attempt/:quizId" />
 
-                    <TrackedRoute exact path="/test/assignment/:quizAssignmentId" ifUser={isLoggedIn} component={QuizDoAssignment} />
-                    <TrackedRoute exact path="/test/assignment/:quizAssignmentId/page/:page" ifUser={isLoggedIn} component={QuizDoAssignment} />
-                    <TrackedRoute exact path="/test/attempt/:quizAttemptId/feedback" ifUser={isLoggedIn} component={QuizAttemptFeedback} />
-                    <TrackedRoute exact path="/test/attempt/:quizAttemptId/feedback/:page" ifUser={isLoggedIn} component={QuizAttemptFeedback} />
-                    <TrackedRoute exact path="/test/attempt/feedback/:quizAssignmentId/:studentId" ifUser={isTeacher} component={QuizAttemptFeedback} />
-                    <TrackedRoute exact path="/test/attempt/feedback/:quizAssignmentId/:studentId/:page" ifUser={isTeacher} component={QuizAttemptFeedback} />
-                    <TrackedRoute exact path="/test/assignment/:quizAssignmentId/feedback" ifUser={isTeacher} component={QuizTeacherFeedback} />
-                    <TrackedRoute exact path="/test/preview/:quizId" ifUser={isTeacher} component={QuizPreview} />
-                    <TrackedRoute exact path="/test/preview/:quizId/page/:page" ifUser={isTeacher} component={QuizPreview} />
-                    <TrackedRoute exact path="/test/attempt/:quizId" ifUser={isLoggedIn} component={QuizDoFreeAttempt} />
-                    <TrackedRoute exact path="/test/attempt/:quizId/page/:page" ifUser={isLoggedIn} component={QuizDoFreeAttempt} />
-                    {/* The order of these redirects matters to prevent substring replacement */}
-                    <Redirect from="/quiz/assignment/:quizAssignmentId/feedback"   to="/test/assignment/:quizAssignmentId/feedback" />
-                    <Redirect from="/quiz/assignment/:quizAssignmentId/page/:page" to="/test/assignment/:quizAssignmentId/page/:page" />
-                    <Redirect from="/quiz/assignment/:quizAssignmentId"            to="/test/assignment/:quizAssignmentId" />
-                    <Redirect from="/quiz/attempt/feedback/:quizAssignmentId/:studentId/:page" to="/test/attempt/feedback/:quizAssignmentId/:studentId/:page" />
-                    <Redirect from="/quiz/attempt/feedback/:quizAssignmentId/:studentId" to="/test/attempt/feedback/:quizAssignmentId/:studentId" />
-                    <Redirect from="/quiz/attempt/:quizAttemptId/feedback/:page"   to="/test/attempt/:quizAttemptId/feedback/:page" />
-                    <Redirect from="/quiz/attempt/:quizAttemptId/feedback"         to="/test/attempt/:quizAttemptId/feedback" />
-                    <Redirect from="/quiz/preview/:quizId/page/:page"              to="/test/preview/:quizId/page/:page" />
-                    <Redirect from="/quiz/preview/:quizId"                         to="/test/preview/:quizId" />
-                    <Redirect from="/quiz/attempt/:quizId/page/:page"              to="/test/attempt/:quizId/page/:page" />
-                    <Redirect from="/quiz/attempt/:quizId"                         to="/test/attempt/:quizId" />
+                        {/* Student pages */}
+                        <TrackedRoute exact path="/assignments" ifUser={isLoggedIn} component={MyAssignments} />
+                        <TrackedRoute exact path="/progress" ifUser={isLoggedIn} component={MyProgress} />
+                        <TrackedRoute exact path="/progress/:userIdOfInterest" ifUser={isLoggedIn} component={MyProgress} />
+                        <TrackedRoute exact path="/tests" ifUser={isLoggedIn} component={MyQuizzes} />
+                        <Redirect from="/quizzes" to="/tests" />
 
-                    {/* Student pages */}
-                    <TrackedRoute exact path="/assignments" ifUser={isLoggedIn} component={MyAssignments} />
-                    <TrackedRoute exact path="/progress" ifUser={isLoggedIn} component={MyProgress} />
-                    <TrackedRoute exact path="/progress/:userIdOfInterest" ifUser={isLoggedIn} component={MyProgress} />
-                    <TrackedRoute exact path="/tests" ifUser={isLoggedIn} component={MyQuizzes} />
-                    <Redirect from="/quizzes" to="/tests" />
+                        {/* Teacher pages */}
+                        <TrackedRoute exact path="/groups" ifUser={isTeacher} component={Groups} />
+                        <TrackedRoute exact path="/set_assignments" ifUser={isTeacher} component={SetAssignments} />
+                        <TrackedRoute exact path="/assignment_schedule" ifUser={isTeacher} component={AssignmentSchedule} /> {/* Currently in beta, not yet advertised or listed on navigation menus */}
+                        <TrackedRoute exact path="/set_tests" ifUser={isTeacher} component={SetQuizzes} />
+                        <Redirect from="/set_quizzes" to="/set_tests" />
 
-                    {/* Teacher pages */}
-                    <TrackedRoute exact path="/groups" ifUser={isTeacher} component={Groups} />
-                    <TrackedRoute exact path="/set_assignments" ifUser={isTeacher} component={SetAssignments} />
-                    <TrackedRoute exact path="/assignment_schedule" ifUser={isTeacher} component={AssignmentSchedule} /> {/* Currently in beta, not yet advertised or listed on navigation menus */}
-                    <TrackedRoute exact path="/set_tests" ifUser={isTeacher} component={SetQuizzes} />
-                    <Redirect from="/set_quizzes" to="/set_tests" />
+                        {/* Admin */}
+                        <TrackedRoute exact path="/admin" ifUser={isStaff} component={Admin} />
+                        <TrackedRoute exact path="/admin/usermanager" ifUser={isAdminOrEventManager} component={AdminUserManager} />
+                        <TrackedRoute exact path="/admin/events" ifUser={user => isAdminOrEventManager(user) || isEventLeader(user)} component={EventManager} />
+                        <TrackedRoute exact path="/admin/stats" ifUser={isStaff} component={AdminStats} />
+                        <TrackedRoute exact path="/admin/content_errors" ifUser={user => segueEnvironment === "DEV" || isStaff(user)} component={AdminContentErrors} />
+                        <TrackedRoute exact path="/admin/emails" ifUser={isAdminOrEventManager} component={AdminEmails} />
+                        <TrackedRoute exact path="/admin/direct_emails" ifUser={isAdminOrEventManager} component={ContentEmails} />
 
-                    {/* Admin */}
-                    <TrackedRoute exact path="/admin" ifUser={isStaff} component={Admin} />
-                    <TrackedRoute exact path="/admin/usermanager" ifUser={isAdminOrEventManager} component={AdminUserManager} />
-                    <TrackedRoute exact path="/admin/events" ifUser={user => isAdminOrEventManager(user) || isEventLeader(user)} component={EventManager} />
-                    <TrackedRoute exact path="/admin/stats" ifUser={isStaff} component={AdminStats} />
-                    <TrackedRoute exact path="/admin/content_errors" ifUser={user => segueEnvironment === "DEV" || isStaff(user)} component={AdminContentErrors} />
-                    <TrackedRoute exact path="/admin/emails" ifUser={isAdminOrEventManager} component={AdminEmails} />
-                    <TrackedRoute exact path="/admin/direct_emails" ifUser={isAdminOrEventManager} component={ContentEmails} />
+                        {/* Authentication */}
+                        <TrackedRoute exact path="/login" component={LogIn} />
+                        <TrackedRoute exact path="/logout" component={LogOutHandler} />
+                        <TrackedRoute exact path="/register" component={Registration} />
+                        <TrackedRoute exact path="/auth/:provider/callback" component={ProviderCallbackHandler} />
+                        <TrackedRoute exact path="/resetpassword/:token" component={ResetPasswordHandler}/>
+                        <TrackedRoute exact path="/verifyemail" component={EmailAlterHandler}/>
 
-                    {/* Authentication */}
-                    <TrackedRoute exact path="/login" component={LogIn} />
-                    <TrackedRoute exact path="/logout" component={LogOutHandler} />
-                    <TrackedRoute exact path="/register" component={Registration} />
-                    <TrackedRoute exact path="/auth/:provider/callback" component={ProviderCallbackHandler} />
-                    <TrackedRoute exact path="/resetpassword/:token" component={ResetPasswordHandler}/>
-                    <TrackedRoute exact path="/verifyemail" component={EmailAlterHandler}/>
+                        {/* Static pages */}
+                        <TrackedRoute exact path="/contact" component={Contact}/>
+                        <TrackedRoute exact path="/teacher_account_request" ifUser={isLoggedIn} component={TeacherRequest}/>
+                        <StaticPageRoute exact path="/privacy" pageId="privacy_policy" />
+                        <StaticPageRoute exact path="/terms" pageId="terms_of_use" />
+                        <StaticPageRoute exact path="/cookies" pageId="cookie_policy" />
+                        <StaticPageRoute exact path="/accessibility" pageId="accessibility_statement" />
+                        <StaticPageRoute exact path="/cyberessentials" />
 
-                    {/* Static pages */}
-                    <TrackedRoute exact path="/contact" component={Contact}/>
-                    <TrackedRoute exact path="/teacher_account_request" ifUser={isLoggedIn} component={TeacherRequest}/>
-                    <StaticPageRoute exact path="/privacy" pageId="privacy_policy" />
-                    <StaticPageRoute exact path="/terms" pageId="terms_of_use" />
-                    <StaticPageRoute exact path="/cookies" pageId="cookie_policy" />
-                    <StaticPageRoute exact path="/accessibility" pageId="accessibility_statement" />
-                    <StaticPageRoute exact path="/cyberessentials" />
+                        {/* External redirects */}
+                        <ExternalRedirect<{qId: string}> from={"/survey/:qId"} to={({qId}, user) => `https://cambridge.eu.qualtrics.com/jfe/form/${qId}?UID=${user.id}`} ifUser={isLoggedIn} />
 
-                    {/*
-                    // TODO: schools and other admin stats
-                    */}
+                        {/*
+                        // TODO: schools and other admin stats
+                        */}
 
-                    {/* Builder pages */}
+                        {/* Builder pages */}
+                        <TrackedRoute exact path="/equality" component={Equality} />
+                        <TrackedRoute exact path="/markdown" ifUser={isStaff} component={MarkdownBuilder} />
+                        <TrackedRoute exact path="/free_text" ifUser={isStaff} component={FreeTextBuilder} />
 
-                    <TrackedRoute exact path="/equality" component={Equality} />
-                    <TrackedRoute exact path="/markdown" ifUser={isStaff} component={MarkdownBuilder} />
-                    <TrackedRoute exact path="/free_text" ifUser={isStaff} component={FreeTextBuilder} />
+                        {/* Support pages */}
+                        <TrackedRoute exact path="/support/:type?/:category?" component={Support} />
 
-                    {/* Support pages */}
-                    <TrackedRoute exact path="/support/:type?/:category?" component={Support} />
-
-                    {/* Error pages */}
-                    <TrackedRoute component={NotFound} />
-                </Switch>
+                        {/* Error pages */}
+                        <TrackedRoute component={NotFound} />
+                    </Switch>
                 </Suspense>
             </ErrorBoundary>
         </main>

--- a/src/app/components/pages/LogIn.tsx
+++ b/src/app/components/pages/LogIn.tsx
@@ -26,6 +26,7 @@ import {
 import {history, isCS, SITE_SUBJECT_TITLE} from "../../services";
 import {Redirect} from "react-router";
 import {MetaDescription} from "../elements/MetaDescription";
+import {Loading} from "../handlers/IsaacSpinner";
 
 /* Interconnected state and functions providing a "logging in" API - intended to be used within a component that displays
  * email and password inputs, and a button to login, all inside a Form component. You will also need a TFAInput component,
@@ -222,7 +223,7 @@ export const LogIn = () => {
     }, [totpChallengePending]);
 
     if (user && user.loggedIn) {
-        return <Redirect to="/" />;
+        return logInAttempted ? <Loading/> : <Redirect to="/"/>;
     }
 
     const metaDescriptionCS = "Log in to your account. Access free GCSE and A level Computer Science resources. Use our materials to learn and revise for your exams.";

--- a/src/app/services/localStorage.ts
+++ b/src/app/services/localStorage.ts
@@ -44,6 +44,17 @@ const remove = function remove(key: KEY) {
     }
 };
 
+const pop = function pop(key: KEY) {
+    try {
+        const item = window.localStorage.getItem(key);
+        window.localStorage.removeItem(key);
+        return item;
+    } catch (e) {
+        console.error("Failed to pop from local storage. This might be a browser restriction.", e);
+        return undefined;
+    }
+};
+
 const clear = function clear() {
     try {
         window.localStorage.clear();
@@ -99,6 +110,7 @@ export const persistence = {
     save,
     load,
     remove,
+    pop,
     clear,
     session
 };

--- a/src/app/state/actions/index.tsx
+++ b/src/app/state/actions/index.tsx
@@ -175,9 +175,7 @@ export const unlinkAccount = (provider: AuthenticationProvider) => async (dispat
 export const submitTotpChallengeResponse = (mfaVerificationCode: string, rememberMe: boolean) => async (dispatch: Dispatch<Action>) => {
     dispatch({type: ACTION_TYPE.USER_AUTH_MFA_CHALLENGE_REQUEST});
     try {
-        const afterAuthPath = persistence.load(KEY.AFTER_AUTH_PATH) || '/';
         const result = await api.authentication.mfaCompleteLogin(mfaVerificationCode, rememberMe);
-
         // Request user preferences, as we do in the requestCurrentUser action:
         await Promise.all([
             dispatch(getUserAuthSettings() as any),
@@ -185,10 +183,7 @@ export const submitTotpChallengeResponse = (mfaVerificationCode: string, remembe
         ]);
         dispatch({type: ACTION_TYPE.USER_AUTH_MFA_CHALLENGE_SUCCESS});
         dispatch({type: ACTION_TYPE.USER_LOG_IN_RESPONSE_SUCCESS, user: result.data});
-        persistence.remove(KEY.AFTER_AUTH_PATH);
-
-        history.push(afterAuthPath);
-
+        history.replace(persistence.pop(KEY.AFTER_AUTH_PATH) || "/");
     } catch (e: any) {
         dispatch({type: ACTION_TYPE.USER_AUTH_MFA_CHALLENGE_FAILURE, errorMessage: extractMessage(e)});
         dispatch(showAxiosErrorToastIfNeeded("Error with verification code.", e));
@@ -265,9 +260,7 @@ export const updateCurrentUser = (
 
         const isFirstLogin = isFirstLoginInPersistence() || false;
         if (isFirstLogin) {
-            const afterAuthPath = persistence.load(KEY.AFTER_AUTH_PATH);
-            persistence.remove(KEY.AFTER_AUTH_PATH);
-            redirect && history.push(afterAuthPath || '/account', {firstLogin: isFirstLogin});
+            redirect && history.push(persistence.pop(KEY.AFTER_AUTH_PATH) || '/account', {firstLogin: isFirstLogin});
         } else if (!editingOtherUser) {
             dispatch(showToast({
                 title: "Account settings updated",
@@ -343,7 +336,6 @@ export const logOutUserEverywhere = () => async (dispatch: Dispatch<Action>) => 
 
 export const logInUser = (provider: AuthenticationProvider, credentials: CredentialsAuthDTO) => async (dispatch: Dispatch<Action>) => {
     dispatch({type: ACTION_TYPE.USER_LOG_IN_REQUEST, provider});
-    const afterAuthPath = persistence.load(KEY.AFTER_AUTH_PATH) || '/';
 
     try {
         const result = await api.authentication.login(provider, credentials);
@@ -359,9 +351,7 @@ export const logInUser = (provider: AuthenticationProvider, credentials: Credent
             dispatch(getUserPreferences() as any)
         ]);
         dispatch({type: ACTION_TYPE.USER_LOG_IN_RESPONSE_SUCCESS, user: result.data});
-        persistence.remove(KEY.AFTER_AUTH_PATH);
-        history.push(afterAuthPath);
-
+        history.replace(persistence.pop(KEY.AFTER_AUTH_PATH) || "/");
     } catch (e: any) {
         dispatch({type: ACTION_TYPE.USER_LOG_IN_RESPONSE_FAILURE, errorMessage: extractMessage(e)})
     }

--- a/src/app/state/actions/index.tsx
+++ b/src/app/state/actions/index.tsx
@@ -260,7 +260,9 @@ export const updateCurrentUser = (
 
         const isFirstLogin = isFirstLoginInPersistence() || false;
         if (isFirstLogin) {
-            redirect && history.push(persistence.pop(KEY.AFTER_AUTH_PATH) || '/account', {firstLogin: isFirstLogin});
+            if (redirect) {
+                history.push(persistence.pop(KEY.AFTER_AUTH_PATH) || '/account', {firstLogin: isFirstLogin});
+            }
         } else if (!editingOtherUser) {
             dispatch(showToast({
                 title: "Account settings updated",


### PR DESCRIPTION
This implements a general way to add external redirects to the site, and uses this pattern to add a redirect to Qualtrics survey pages via `/survey/:qId` where `qId` is the survey id.

Additionally, this refactors a couple of small things, and fixes a weird race condition involving the after auth redirect logic. You might want to review this with whitespace turned off: `?w=1`.
