### PR TITLE
Upgrade KaTeX to 0.16.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "inequality-grammar": "0.11.0",
     "isaac-graph-sketcher": "0.9.5",
     "js-cookie": "^3.0.1",
-    "katex": "^0.15.1",
+    "katex": "^0.16.2",
     "leaflet": "^1.7.1",
     "lodash": "^4.17.21",
     "p5": "^1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5840,10 +5840,10 @@ json5@2.x, json5@^2.1.2, json5@^2.2.1:
     array-includes "^3.1.5"
     object.assign "^4.1.3"
 
-katex@^0.15.1:
-  version "0.15.6"
-  resolved "https://registry.yarnpkg.com/katex/-/katex-0.15.6.tgz#c4e2f6ced2ac4de1ef6f737fe7c67d3026baa0e5"
-  integrity sha512-UpzJy4yrnqnhXvRPhjEuLA4lcPn6eRngixW7Q3TJErjg3Aw2PuLFBzTkdUb89UtumxjhHTqL3a5GDGETMSwgJA==
+katex@^0.16.2:
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/katex/-/katex-0.16.2.tgz#9d3dc2a7e65fb8aa31101b1f86888ec40eed7b24"
+  integrity sha512-70DJdQAyh9EMsthw3AaQlDyFf54X7nWEUIa5W+rq8XOpEk//w5Th7/8SqFqpvi/KZ2t6MHUj4f9wLmztBmAYQA==
   dependencies:
     commander "^8.0.0"
 


### PR DESCRIPTION
Fixes matrix determinant rendering issues: `/concepts/cm_matrices_determinants` is a great example page to compare before and after.

Having read the changelogs for the [recent KaTeX releases](https://github.com/KaTeX/KaTeX/releases) it doesn't look like there are any breaking changes for us.