### PR TITLE
Avoid capturing Delta, delta, and d as differentials if they aren't followed by variables

### DIFF
--- a/src/app/components/elements/modals/inequality/utils.ts
+++ b/src/app/components/elements/modals/inequality/utils.ts
@@ -464,7 +464,8 @@ export function generateMenuItems({editorMode, logicSyntax, parsedAvailableSymbo
                 if (items.letters) {
                     customMenuItems.letters.push(...items.letters);
                 }
-            } else if (DIFFERENTIAL_REGEX.test(availableSymbol)) {
+            } else if (DIFFERENTIAL_REGEX.test(availableSymbol) && !/^(?:Delta|delta|d)$/.test(availableSymbol)) {
+                // The second clause makes sure we don't capture Delta, delta, and d as differentials but fall through to make them regular letters.
                 const items = generateMathsDifferentialAndLetters(availableSymbol);
                 if (items.differential) {
                     customMenuItems.mathsDerivatives.push(items.differential);


### PR DESCRIPTION
This avoids the case where you couldn't have `Delta`, `delta`, and `d` as individual letters instead of differentials without argument.