### PR TITLE
Allow assignments to be scheduled on the same date as they are due

### DIFF
--- a/src/app/components/pages/AssignmentSchedule.tsx
+++ b/src/app/components/pages/AssignmentSchedule.tsx
@@ -229,7 +229,7 @@ const AssignmentModal = ({user, showAssignmentModal, toggleAssignModal, assignme
     const yearRange = range(currentYear, currentYear + 5);
     const currentMonth = (new Date()).getMonth() + 1;
 
-    const dueDateInvalid = dueDate && scheduledStartDate ? scheduledStartDate.valueOf() >= dueDate.valueOf() : false;
+    const dueDateInvalid = dueDate && scheduledStartDate ? scheduledStartDate.valueOf() > dueDate.valueOf() : false;
 
     useEffect(() => {
         if (showAssignmentModal) setShowGameboardPreview(false);
@@ -281,7 +281,7 @@ const AssignmentModal = ({user, showAssignmentModal, toggleAssignModal, assignme
             <Label className="w-100 pb-2">Due date reminder <span className="text-muted"> (optional)</span>
                 <DateInput value={dueDate} placeholder="Select your due date..." yearRange={yearRange} defaultYear={currentYear} defaultMonth={currentMonth}
                            onChange={(e: ChangeEvent<HTMLInputElement>) => setDueDate(e.target.valueAsDate as Date)} />
-                {dueDateInvalid && <small className={"pt-2 text-danger"}>Due date must be after start date.</small>}
+                {dueDateInvalid && <small className={"pt-2 text-danger"}>Due date must be on or after start date.</small>}
             </Label>
             {isStaff(user) && <Label className="w-100 pb-2">Notes (optional):
                 <Input type="textarea"

--- a/src/app/components/pages/SetAssignments.tsx
+++ b/src/app/components/pages/SetAssignments.tsx
@@ -101,7 +101,7 @@ const AssignGroup = ({groups, board}: BoardProps) => {
 
     const yearRange = range(currentYear, currentYear + 5);
     const currentMonth = (new Date()).getMonth() + 1;
-    const dueDateInvalid = dueDate && scheduledStartDate ? scheduledStartDate.valueOf() > dueDate.valueOf() : false;
+    const dueDateInvalid = dueDate && scheduledStartDate ? new Date(scheduledStartDate.getFullYear(), scheduledStartDate.getMonth(), scheduledStartDate.getDate()).valueOf() > dueDate.valueOf() : false;
 
     function setScheduledStartDateAtSevenAM(e: ChangeEvent<HTMLInputElement>) {
         const utcDate = e.target.valueAsDate as Date;

--- a/src/app/components/pages/SetAssignments.tsx
+++ b/src/app/components/pages/SetAssignments.tsx
@@ -101,7 +101,7 @@ const AssignGroup = ({groups, board}: BoardProps) => {
 
     const yearRange = range(currentYear, currentYear + 5);
     const currentMonth = (new Date()).getMonth() + 1;
-    const dueDateInvalid = dueDate && scheduledStartDate ? scheduledStartDate.valueOf() >= dueDate.valueOf() : false;
+    const dueDateInvalid = dueDate && scheduledStartDate ? scheduledStartDate.valueOf() > dueDate.valueOf() : false;
 
     function setScheduledStartDateAtSevenAM(e: ChangeEvent<HTMLInputElement>) {
         const utcDate = e.target.valueAsDate as Date;
@@ -127,7 +127,7 @@ const AssignGroup = ({groups, board}: BoardProps) => {
         <Label className="w-100 pb-2">Due date reminder <span className="text-muted"> (optional)</span>
             <DateInput value={dueDate} placeholder="Select your due date..." yearRange={yearRange} defaultYear={currentYear} defaultMonth={currentMonth}
                 onChange={(e: ChangeEvent<HTMLInputElement>) => setDueDate(e.target.valueAsDate as Date)} /> {/* DANGER here with force-casting Date|null to Date */}
-            {dueDateInvalid && <small className={"pt-2 text-danger"}>Due date must be after start date.</small>}
+            {dueDateInvalid && <small className={"pt-2 text-danger"}>Due date must be on or after start date.</small>}
         </Label>
         {isStaff(user) && <Label className="w-100 pb-2">Notes (optional):
             <Input type="textarea"

--- a/src/app/components/pages/SetAssignments.tsx
+++ b/src/app/components/pages/SetAssignments.tsx
@@ -55,6 +55,7 @@ import {
     isStaff,
     Item,
     itemise,
+    nthHourOf,
     selectOnChange,
     siteSpecific,
     sortIcon,
@@ -101,13 +102,13 @@ const AssignGroup = ({groups, board}: BoardProps) => {
 
     const yearRange = range(currentYear, currentYear + 5);
     const currentMonth = (new Date()).getMonth() + 1;
-    const dueDateInvalid = dueDate && scheduledStartDate ? new Date(scheduledStartDate.getFullYear(), scheduledStartDate.getMonth(), scheduledStartDate.getDate()).valueOf() > dueDate.valueOf() : false;
+    const dueDateInvalid = dueDate && scheduledStartDate ? nthHourOf(0, scheduledStartDate).valueOf() > dueDate.valueOf() : false;
 
     function setScheduledStartDateAtSevenAM(e: ChangeEvent<HTMLInputElement>) {
         const utcDate = e.target.valueAsDate as Date;
         const scheduledDate = new Date(utcDate.getFullYear(), utcDate.getMonth(), utcDate.getDate(), 7);
         // Sets the scheduled date to 7AM in the timezone of the browser.
-        setScheduledStartDate(scheduledDate)
+        setScheduledStartDate(scheduledDate);
     }
 
     return <Container className="py-2">

--- a/src/app/services/dates.ts
+++ b/src/app/services/dates.ts
@@ -1,13 +1,11 @@
-export const TODAY = () => {
-    const d = new Date();
-    d.setHours(0,0,0,0);
-    return d;
-}
-
-export const nthHourOf = (n: number, d: Date) => {
+export const nthHourOf = (n: number, d: Date | number) => {
     const newDate = new Date(d.valueOf());
     newDate.setHours(n, 0, 0, 0);
     return newDate;
+}
+
+export const TODAY = () => {
+    return nthHourOf(0, new Date());
 }
 
 export const MONTH_NAMES = [ "January", "February", "March", "April", "May", "June",

--- a/src/app/state/slices/api/gameboards.ts
+++ b/src/app/state/slices/api/gameboards.ts
@@ -65,8 +65,10 @@ export const assignGameboard = createAsyncThunk(
         }
 
         if (dueDate !== undefined && scheduledStartDate !== undefined) {
-            if ((dueDate.valueOf() - scheduledStartDate.valueOf()) <= 0) {
-                appDispatch(showToast({color: "danger", title: `Gameboard assignment${groups.length > 1 ? "(s)" : ""} failed`, body: "Error: Due date must be strictly after scheduled start date.", timeout: 5000}));
+            const scheduledStartDay = new Date(scheduledStartDate.valueOf());
+            scheduledStartDay.setHours(0, 0, 0, 0);
+            if (scheduledStartDay.valueOf() > dueDate.valueOf()) {
+                appDispatch(showToast({color: "danger", title: `Gameboard assignment${groups.length > 1 ? "(s)" : ""} failed`, body: "Error: Due date must be on or after scheduled start date.", timeout: 5000}));
                 return rejectWithValue(null);
             }
         }

--- a/src/app/state/slices/api/gameboards.ts
+++ b/src/app/state/slices/api/gameboards.ts
@@ -66,9 +66,7 @@ export const assignGameboard = createAsyncThunk(
         }
 
         if (dueDate !== undefined && scheduledStartDate !== undefined) {
-            const scheduledStartDay = new Date(scheduledStartDate.valueOf());
-            scheduledStartDay.setHours(0, 0, 0, 0);
-            if (scheduledStartDay.valueOf() > dueDate.valueOf()) {
+            if (nthHourOf(0, scheduledStartDate).valueOf() > dueDate.valueOf()) {
                 appDispatch(showToast({color: "danger", title: `Gameboard assignment${groups.length > 1 ? "(s)" : ""} failed`, body: "Error: Due date must be on or after scheduled start date.", timeout: 5000}));
                 return rejectWithValue(null);
             }

--- a/src/app/state/slices/api/gameboards.ts
+++ b/src/app/state/slices/api/gameboards.ts
@@ -6,6 +6,7 @@ import {
     isTeacher,
     Item,
     KEY,
+    nthHourOf,
     persistence,
     TODAY,
     toTuple
@@ -57,8 +58,8 @@ export const assignGameboard = createAsyncThunk(
         }
 
         if (scheduledStartDate !== undefined) {
-            // Unlike with the due date, we want to preserve the hour assigned at the UI level, unless we want to move that logic here.
-            if (scheduledStartDate.valueOf() <= (new Date()).valueOf()) {
+            // Start date can be today, in which case the assignment will be immediately set (if it is past 7am)
+            if (nthHourOf(0, scheduledStartDate).valueOf() < nthHourOf(0, new Date()).valueOf()) {
                 appDispatch(showToast({color: "danger", title: `Gameboard assignment${groups.length > 1 ? "(s)" : ""} failed`, body: "Error: Scheduled start date cannot be in the past.", timeout: 5000}));
                 return rejectWithValue(null);
             }


### PR DESCRIPTION
By rounding down the scheduled start date to the nearest day in order to perform the comparison.

Should be merged with [the related API PR](https://github.com/isaacphysics/isaac-api/pull/496).