### PR TITLE
Persist cloze item validation after current attempt changes

### DIFF
--- a/src/IsaacAppTypes.tsx
+++ b/src/IsaacAppTypes.tsx
@@ -610,7 +610,7 @@ export const ClozeDropRegionContext = React.createContext<{
     register: (id: string, index: number) => void,
     questionPartId: string, readonly: boolean,
     inlineDropValueMap: {[p: string]: ClozeItemDTO},
-    dropZoneValidationMap: {[p: string]: boolean | undefined},
+    dropZoneValidationMap: {[p: string]: {correct?: boolean, itemId?: string} | undefined},
     shouldGetFocus: (id: string) => boolean
 } | undefined>(undefined);
 export const QuizAttemptContext = React.createContext<{quizAttempt: QuizAttemptDTO | null; questionNumbers: {[questionId: string]: number}}>({quizAttempt: null, questionNumbers: {}});

--- a/src/app/components/content/IsaacClozeQuestion.tsx
+++ b/src/app/components/content/IsaacClozeQuestion.tsx
@@ -149,14 +149,19 @@ const IsaacClozeQuestion = ({doc, questionId, readonly, validationResponse}: Isa
 
     const [inlineDropValues, setInlineDropValues] = useState<(Immutable<ClozeItemDTO> | undefined)[]>(() => currentAttempt?.items || []);
     // Whenever the inlineDropValues change or a drop region is added, computes a map from drop region id -> drop region value
-    const inlineDropValueMap = useMemo(() => Array.from(registeredDropRegionIDs.entries()).reduce((dict, [dropId, i]) => Object.assign(dict, {[dropId]: inlineDropValues[i]}), {}), [inlineDropValues]);
+    const inlineDropValueMap = useMemo<{[p: string]: ClozeItemDTO}>(() => Array.from(registeredDropRegionIDs.entries()).reduce((dict, [dropId, i]) => Object.assign(dict, {[dropId]: inlineDropValues[i]}), {}), [inlineDropValues]);
 
     // Compute map used to highlight each inline drop-zone with whether it is correct or not
     const itemsCorrect = validationResponse?.itemsCorrect;
-    const dropZoneValidationMap = useMemo<{[p: string]: boolean | undefined}>(() => isDefined(itemsCorrect)
-        ? Array.from(registeredDropRegionIDs.entries()).reduce((dict, [dropId, i]) => Object.assign(dict, {[dropId]: itemsCorrect.at(i)}), {})
-        : {}
-    , [itemsCorrect]);
+    const [dropZoneValidationMap, setDropZoneValidationMap] = useState<{[p: string]: {correct?: boolean, itemId?: string} | undefined}>({});
+    useEffect(() => {
+        if (isDefined(itemsCorrect)) {
+            // Tag each drop-zone validation with the id of the item currently in that zone. This means that we can
+            // conditionally show the validation based on whether it still applies to whatever item is in that
+            // drop-zone.
+            setDropZoneValidationMap(Array.from(registeredDropRegionIDs.entries()).reduce((dict, [dropId, i]) => Object.assign(dict, {[dropId]: {correct: itemsCorrect.at(i), itemId: inlineDropValueMap[dropId]?.id}}), {}));
+        }
+    }, [itemsCorrect, inlineDropValueMap]);
 
     // Manual management of which draggable item gets focus at the end of the drag. The new focus id is set in onDragEnd,
     // causing shouldGetFocus to be updated. shouldGetFocus is passed via the ClozeDropRegionContext to all draggable

--- a/src/app/components/elements/markup/portals/InlineDropZones.tsx
+++ b/src/app/components/elements/markup/portals/InlineDropZones.tsx
@@ -57,8 +57,11 @@ function InlineDropRegion({id, index, emptyWidth, emptyHeight, rootElement}: {id
 
     const item = dropRegionContext ? dropRegionContext.inlineDropValueMap[droppableId] : undefined;
 
-    // Only show if this drop zone is correct or not if it contains an item
-    const isCorrect = item && dropRegionContext ? dropRegionContext.dropZoneValidationMap[droppableId] : undefined;
+    // Only show if this drop zone is correct or not if it contains an item, and the validation entry in the map
+    // applies to this particular item
+    const isCorrect = item && dropRegionContext && dropRegionContext.dropZoneValidationMap[droppableId]?.itemId === item.id
+        ? dropRegionContext.dropZoneValidationMap[droppableId]?.correct
+        : undefined;
 
     const droppableTarget = rootElement?.querySelector(`#${id}`);
 


### PR DESCRIPTION
Only highlight a drop-zone if its validation entry still applies given the id of the item within it.