### PR TITLE
Ignore 'hide previous answers' setting for tests

### DIFF
--- a/src/IsaacAppTypes.tsx
+++ b/src/IsaacAppTypes.tsx
@@ -201,7 +201,7 @@ export type Action =
     | {type: ACTION_TYPE.GLOSSARY_TERMS_RESPONSE_SUCCESS; terms: ApiTypes.GlossaryTermDTO[]}
     | {type: ACTION_TYPE.GLOSSARY_TERMS_RESPONSE_FAILURE}
 
-    | {type: ACTION_TYPE.QUESTION_REGISTRATION; questions: ApiTypes.QuestionDTO[]; accordionClientId?: string}
+    | {type: ACTION_TYPE.QUESTION_REGISTRATION; questions: ApiTypes.QuestionDTO[]; accordionClientId?: string, isQuiz?: boolean}
     | {type: ACTION_TYPE.QUESTION_DEREGISTRATION; questionIds: string[]}
     | {type: ACTION_TYPE.QUESTION_ATTEMPT_REQUEST; questionId: string; attempt: Immutable<ApiTypes.ChoiceDTO>}
     | {type: ACTION_TYPE.QUESTION_ATTEMPT_RESPONSE_SUCCESS; questionId: string; response: ApiTypes.QuestionValidationResponseDTO}

--- a/src/app/services/quiz.ts
+++ b/src/app/services/quiz.ts
@@ -72,7 +72,7 @@ export function useCurrentQuizAttempt(studentId?: number) {
     const dispatch = useAppDispatch();
     useEffect( () => {
         // All register questions does is store the questions in redux WITH SOME EXTRA CALCULATED STRUCTURE
-        dispatch(registerQuestions(questions));
+        dispatch(registerQuestions(questions, undefined, true));
         return () => dispatch(deregisterQuestions(questions.map(q => q.id as string)));
     }, [dispatch, questions]);
 

--- a/src/app/state/actions/index.tsx
+++ b/src/app/state/actions/index.tsx
@@ -757,8 +757,8 @@ export const fetchGlossaryTerms = () => async (dispatch: Dispatch<Action>) => {
 };
 
 // Questions
-export const registerQuestions = (questions: QuestionDTO[], accordionClientId?: string) => (dispatch: Dispatch<Action>) => {
-    dispatch({type: ACTION_TYPE.QUESTION_REGISTRATION, questions, accordionClientId});
+export const registerQuestions = (questions: QuestionDTO[], accordionClientId?: string, isQuiz?: boolean) => (dispatch: Dispatch<Action>) => {
+    dispatch({type: ACTION_TYPE.QUESTION_REGISTRATION, questions, accordionClientId, isQuiz});
 };
 
 export const deregisterQuestions = (questionIds: string[]) => (dispatch: Dispatch<Action>) => {

--- a/src/app/state/middleware/hidePreviousQuestionAttempt.ts
+++ b/src/app/state/middleware/hidePreviousQuestionAttempt.ts
@@ -6,7 +6,7 @@ import {ACTION_TYPE} from "../../services";
 export const hidePreviousQuestionAttemptMiddleware: Middleware = (middlewareApi: MiddlewareAPI) => (dispatch: Dispatch) => async (action: Action) => {
     if (action.type === ACTION_TYPE.QUESTION_REGISTRATION) {
         const state = middlewareApi.getState();
-        if (state.userPreferences?.DISPLAY_SETTING?.HIDE_QUESTION_ATTEMPTS) {
+        if (!action.isQuiz && state.userPreferences?.DISPLAY_SETTING?.HIDE_QUESTION_ATTEMPTS) {
             return dispatch({
                 type: ACTION_TYPE.QUESTION_REGISTRATION,
                 questions: action.questions.map(q => ({


### PR DESCRIPTION
The "hide previous answers" beta feature misbehaves with quiz questions, making them unanswerable. This PR makes quiz questions ignore the setting.