### PR TITLE
Item-by-item feedback style

### DIFF
--- a/src/app/components/content/IsaacNumericQuestion.tsx
+++ b/src/app/components/content/IsaacNumericQuestion.tsx
@@ -17,10 +17,11 @@ import {
     Row,
     UncontrolledTooltip
 } from "reactstrap";
-import {useCurrentQuestionAttempt} from "../../services";
+import {isDefined, useCurrentQuestionAttempt} from "../../services";
 import {v4 as uuid_v4} from 'uuid';
 import {IsaacQuestionProps} from "../../../IsaacAppTypes";
 import {Markup} from "../elements/markup";
+import classNames from "classnames";
 
 function selectUnits(doc: IsaacNumericQuestionDTO, questionId: string, units?: string[], userId?: number): (string|undefined)[] {
     const seedValue = userId + "|" + questionId;
@@ -163,10 +164,17 @@ const IsaacNumericQuestion = ({doc, questionId, validationResponse, readonly}: I
                         <Label className="w-100 ml-sm-2 ml-md-0 ml-lg-5">
                             Unit{noDisplayUnit && "s"} <br/>
                             <Dropdown disabled={readonly} isOpen={isOpen && noDisplayUnit} toggle={() => {setIsOpen(!isOpen);}}>
-                                <DropdownToggle disabled={readonly || !noDisplayUnit} className={`${noDisplayUnit ? "" : "border-dark display-unit"} px-2 py-1`} color={noDisplayUnit ? (currentAttemptUnitsWrong ? "danger" : undefined) : "white"}>
+                                <DropdownToggle
+                                    disabled={readonly || !noDisplayUnit}
+                                    className={classNames("feedback-zone px-2 py-1", {"border-dark display-unit": !noDisplayUnit, "feedback-showing": isDefined(validationResponse) && noDisplayUnit})}
+                                    color={noDisplayUnit ? undefined : "white"}
+                                >
                                     <Markup encoding={"latex"}>
                                         {wrapUnitForSelect(noDisplayUnit ? currentAttemptUnits : doc.displayUnit)}
                                     </Markup>
+                                    {isDefined(validationResponse) && noDisplayUnit && <div className={"feedback-box"}>
+                                        <span className={classNames("feedback", currentAttemptUnitsWrong ? "incorrect" : "correct")}>{currentAttemptUnitsWrong ? "✘" : "✔"}</span>
+                                    </div>}
                                 </DropdownToggle>
                                 <DropdownMenu right>
                                     {selectedUnits.map((unit) =>

--- a/src/app/components/content/IsaacNumericQuestion.tsx
+++ b/src/app/components/content/IsaacNumericQuestion.tsx
@@ -17,7 +17,7 @@ import {
     Row,
     UncontrolledTooltip
 } from "reactstrap";
-import {isDefined, useCurrentQuestionAttempt} from "../../services";
+import {useCurrentQuestionAttempt} from "../../services";
 import {v4 as uuid_v4} from 'uuid';
 import {IsaacQuestionProps} from "../../../IsaacAppTypes";
 import {Markup} from "../elements/markup";
@@ -169,7 +169,7 @@ const IsaacNumericQuestion = ({doc, questionId, validationResponse, readonly}: I
                             <Dropdown disabled={readonly} isOpen={isOpen && noDisplayUnit} toggle={() => {setIsOpen(!isOpen);}}>
                                 <DropdownToggle
                                     disabled={readonly || !noDisplayUnit}
-                                    className={classNames("feedback-zone px-2 py-1", {"border-dark display-unit": !noDisplayUnit, "feedback-showing": currentAttemptUnitsWrong})}
+                                    className={classNames("feedback-zone px-2 py-1", {"border-dark display-unit": !noDisplayUnit, "feedback-showing": currentAttemptUnitsWrong && noDisplayUnit})}
                                     color={noDisplayUnit ? undefined : "white"}
                                 >
                                     <Markup encoding={"latex"}>

--- a/src/app/components/content/IsaacNumericQuestion.tsx
+++ b/src/app/components/content/IsaacNumericQuestion.tsx
@@ -144,11 +144,11 @@ const IsaacNumericQuestion = ({doc, questionId, validationResponse, readonly}: I
                         <Label className="w-100">
                             Value <br />
                             <InputGroup className={"feedback-zone nq-feedback"}>
-                                <Input type="text" value={currentAttemptValue || ""}
+                                <Input type="text" value={currentAttemptValue || ""} invalid={currentAttemptValueWrong}
                                        onChange={updateValue} readOnly={readonly}
                                 />
                                 {currentAttemptValueWrong && <div className={"feedback-box"}>
-                                    <span className={"feedback incorrect"}>✘</span>
+                                    <span className={"feedback incorrect"}><b>!</b></span>
                                 </div>}
                                 {!readonly && <InputGroupAddon addonType="append">
                                     <Button type="button" className="numeric-help" size="sm" id={helpTooltipId}>?</Button>

--- a/src/app/components/content/IsaacNumericQuestion.tsx
+++ b/src/app/components/content/IsaacNumericQuestion.tsx
@@ -143,10 +143,13 @@ const IsaacNumericQuestion = ({doc, questionId, validationResponse, readonly}: I
                     <div className="numeric-value w-100 w-sm-50 w-md-100 w-lg-50">
                         <Label className="w-100">
                             Value <br />
-                            <InputGroup>
-                                <Input type="text" value={currentAttemptValue || ""} invalid={currentAttemptValueWrong || undefined}
+                            <InputGroup className={"feedback-zone nq-feedback"}>
+                                <Input type="text" value={currentAttemptValue || ""}
                                        onChange={updateValue} readOnly={readonly}
                                 />
+                                {currentAttemptValueWrong && <div className={"feedback-box"}>
+                                    <span className={"feedback incorrect"}>✘</span>
+                                </div>}
                                 {!readonly && <InputGroupAddon addonType="append">
                                     <Button type="button" className="numeric-help" size="sm" id={helpTooltipId}>?</Button>
                                     <UncontrolledTooltip placement="top" autohide={false} target={helpTooltipId}>
@@ -166,14 +169,14 @@ const IsaacNumericQuestion = ({doc, questionId, validationResponse, readonly}: I
                             <Dropdown disabled={readonly} isOpen={isOpen && noDisplayUnit} toggle={() => {setIsOpen(!isOpen);}}>
                                 <DropdownToggle
                                     disabled={readonly || !noDisplayUnit}
-                                    className={classNames("feedback-zone px-2 py-1", {"border-dark display-unit": !noDisplayUnit, "feedback-showing": isDefined(validationResponse) && noDisplayUnit})}
+                                    className={classNames("feedback-zone px-2 py-1", {"border-dark display-unit": !noDisplayUnit, "feedback-showing": currentAttemptUnitsWrong})}
                                     color={noDisplayUnit ? undefined : "white"}
                                 >
                                     <Markup encoding={"latex"}>
                                         {wrapUnitForSelect(noDisplayUnit ? currentAttemptUnits : doc.displayUnit)}
                                     </Markup>
-                                    {isDefined(validationResponse) && noDisplayUnit && <div className={"feedback-box"}>
-                                        <span className={classNames("feedback", currentAttemptUnitsWrong ? "incorrect" : "correct")}>{currentAttemptUnitsWrong ? "✘" : "✔"}</span>
+                                    {currentAttemptUnitsWrong && noDisplayUnit && <div className={"feedback-box"}>
+                                        <span className={"feedback incorrect"}>✘</span>
                                     </div>}
                                 </DropdownToggle>
                                 <DropdownMenu right>

--- a/src/app/components/elements/markup/portals/InlineDropZones.tsx
+++ b/src/app/components/elements/markup/portals/InlineDropZones.tsx
@@ -9,9 +9,9 @@ import {useDroppable} from "@dnd-kit/core";
 import {CSS} from "@dnd-kit/utilities";
 import {useSortable} from "@dnd-kit/sortable";
 import classNames from "classnames";
-import {CLOZE_DROP_ZONE_ID_PREFIX} from "../../../../services";
+import {CLOZE_DROP_ZONE_ID_PREFIX, isDefined} from "../../../../services";
 
-export function Item({item, id, type, overrideOver}: {item: Immutable<ItemDTO>, id: string, type: "drop-zone" | "item-section", overrideOver?: boolean}) {
+export function Item({item, id, type, overrideOver, isCorrect}: {item: Immutable<ItemDTO>, id: string, type: "drop-zone" | "item-section", overrideOver?: boolean, isCorrect?: boolean}) {
     const {attributes, listeners, setNodeRef, isDragging, isOver, transform, transition} = useSortable({
         id,
         attributes: {
@@ -35,13 +35,16 @@ export function Item({item, id, type, overrideOver}: {item: Immutable<ItemDTO>, 
         }
     }, [dropRegionContext?.shouldGetFocus]);
 
-    return <Badge id={id} className={classNames(type === "item-section" && "m-2", "p-2 cloze-item")} style={style} innerRef={setNodeRef} {...listeners} {...attributes}>
+    return <Badge id={id} className={classNames(type === "item-section" && "m-2", "p-2 cloze-item feedback-zone", isDefined(isCorrect) && "feedback-showing")} style={style} innerRef={setNodeRef} {...listeners} {...attributes}>
         <span className={"sr-only"}>{item.altText ?? item.value ?? "cloze item without a description"}</span>
         <span aria-hidden={true}>
             <IsaacContentValueOrChildren value={item.value} encoding={item.encoding || "html"}>
                 {item.children as ContentDTO[]}
             </IsaacContentValueOrChildren>
         </span>
+        {isDefined(isCorrect) && <div className={"feedback-box"}>
+            <span className={classNames("feedback", isCorrect ? "correct" : "incorrect")}>{isCorrect ? "✔" : "✘"}</span>
+        </div>}
     </Badge>;
 }
 
@@ -77,11 +80,11 @@ function InlineDropRegion({id, index, emptyWidth, emptyHeight, rootElement}: {id
         return ReactDOM.createPortal(
             <span
                 style={{minHeight: height, minWidth: width}}
-                className={classNames("d-inline-block cloze-drop-zone", !item && `rounded bg-grey border ${isOver ? "border-dark" : "border-light"}`, isCorrect === false && "incorrect")}
+                className={classNames("d-inline-block cloze-drop-zone", !item && `rounded bg-grey border ${isOver ? "border-dark" : "border-light"}`)}
                 ref={setNodeRef}
             >
                 {item
-                    ? <Item item={item} id={item.replacementId as string} type={"drop-zone"} overrideOver={isOver}/>
+                    ? <Item item={item} id={item.replacementId as string} isCorrect={isCorrect} type={"drop-zone"} overrideOver={isOver}/>
                     : <>&nbsp;<span className={"sr-only"}>drop zone</span></>
                 }
             </span>,

--- a/src/scss/common/questions.scss
+++ b/src/scss/common/questions.scss
@@ -349,6 +349,36 @@ button {
   }
 }
 
+.feedback-zone {
+  &.feedback-showing {
+    padding-right: 34px !important;
+  }
+  .feedback-box {
+    text-align: center;
+    position: absolute;
+    right: 3px;
+    top: 3px;
+    color: black;
+    border-radius: 2.5px; //
+    height: calc(100% - 6px);
+    padding-left: 6px;
+    padding-right: 6px;
+    background-color: white;
+    .feedback {
+      position: relative;
+      display: inline-block;
+      top: 50%;
+      transform: translateY(-50%);
+      &.correct {
+        color: green;
+      }
+      &.incorrect {
+        color: red;
+      }
+    }
+  }
+}
+
 // Could be used to display draggables when using drop zones in text or code (if we got rid of the purple blocks)
 //.cloze-item & .minimal {
 //  text-decoration: underline dashed $secondary;

--- a/src/scss/common/questions.scss
+++ b/src/scss/common/questions.scss
@@ -379,8 +379,12 @@ button {
     }
   }
   &.nq-feedback {
+    input {
+      background-image: none !important;
+    }
     .feedback-box {
-      right: 70px;
+      z-index: 3;
+      right: 75px;
     }
   }
 }

--- a/src/scss/common/questions.scss
+++ b/src/scss/common/questions.scss
@@ -350,6 +350,7 @@ button {
 }
 
 .feedback-zone {
+  position: relative;
   &.feedback-showing {
     padding-right: 34px !important;
   }
@@ -375,6 +376,11 @@ button {
       &.incorrect {
         color: red;
       }
+    }
+  }
+  &.nq-feedback {
+    .feedback-box {
+      right: 70px;
     }
   }
 }


### PR DESCRIPTION
This implements the preferred item-by-item feedback styling (decided by physics) for cloze questions and numeric questions.
The idea is to keep this style for other question types that need this kind of feedback going forwards, so that the user message is consistent.

![image](https://user-images.githubusercontent.com/33040507/205296845-1c1c9526-99d0-4ccd-bc30-fec567928b48.png)
![image](https://user-images.githubusercontent.com/33040507/205326890-fd2b066a-5f6d-4d8f-ad82-9d5a00ae096c.png)
