### PR TITLE
Stop cloze item dropping into off-screen drop-zone causing entire screen to offset

### DIFF
--- a/public/index-cs.html
+++ b/public/index-cs.html
@@ -28,7 +28,7 @@
     <title>Isaac Computer Science</title>
   </head>
   <body>
-    <div id="root" class="d-flex flex-column overflow-hidden min-vh-100">
+    <div id="root" class="d-flex flex-column overflow-clip min-vh-100">
       <!-- root element's children are cleared on first react render -->
       <noscript>
         <div class="fixed-top bg-primary">

--- a/public/index-phy.html
+++ b/public/index-phy.html
@@ -26,7 +26,7 @@
     <title>Isaac Physics</title>
   </head>
   <body>
-    <div id="root" class="d-flex flex-column overflow-hidden min-vh-100">
+    <div id="root" class="d-flex flex-column overflow-clip min-vh-100">
       <!-- root element's children are cleared on first react render -->
       <noscript>
         <div class="fixed-top bg-primary">

--- a/src/app/components/content/IsaacClozeQuestion.tsx
+++ b/src/app/components/content/IsaacClozeQuestion.tsx
@@ -186,7 +186,7 @@ const IsaacClozeQuestion = ({doc, questionId, readonly, validationResponse}: Isa
         return () => {
             root?.removeEventListener("scroll", resetScrollLeft);
         };
-    });
+    }, []);
 
     useEffect(function updateStateOnCurrentAttemptChange() {
         if (currentAttempt?.items) {

--- a/src/app/components/content/IsaacClozeQuestion.tsx
+++ b/src/app/components/content/IsaacClozeQuestion.tsx
@@ -175,6 +175,19 @@ const IsaacClozeQuestion = ({doc, questionId, readonly, validationResponse}: Isa
         return false;
     }, [focusId, setFocusId]);
 
+    // Force #root scrollLeft to be 0 - fixes issue with cloze drag and drop scolling the screen sideways if
+    // dragging from item section to a drop-zone off screen.
+    // This is an issue with how dnd-kit manages scroll contexts when `overflow: hidden`, can be fixed by setting
+    // `overflow: clip` but only very modern browsers support that.
+    useEffect(() => {
+        const root = document.querySelector<HTMLDivElement>("#root");
+        const resetScrollLeft = () => {if (root) {root.scrollLeft = 0;}};
+        root?.addEventListener("scroll", resetScrollLeft);
+        return () => {
+            root?.removeEventListener("scroll", resetScrollLeft);
+        };
+    });
+
     useEffect(function updateStateOnCurrentAttemptChange() {
         if (currentAttempt?.items) {
             setInlineDropValues(currentAttempt.items.map(augmentInlineItemWithUniqueReplacementID));

--- a/src/scss/common/isaac.scss
+++ b/src/scss/common/isaac.scss
@@ -2,3 +2,18 @@
     width: 100%;
     aspect-ratio: 1;
 }
+
+// If browser supports overflow: clip, use it because it prevents programmatic scrolling as well. This is important
+// for div#root, and fixes an issue with dnd-kit causing this element to scroll unexpectedly.
+@supports (overflow:clip) {
+    /* safe to use overflow: clip */
+    .overflow-clip {
+        overflow: clip !important;
+    }
+}
+@supports not (overflow:clip) {
+    /* default to overflow: hidden */
+    .overflow-clip {
+        overflow: hidden !important;
+    }
+}


### PR DESCRIPTION
There is an easy fix on newer browsers which consists of setting `overflow: clip` for the root div on both sites.

For all other browsers, we need to set `scrollLeft = 0` whenever the root div tries to scroll. This plays nicely with the fix for newer browsers and is fairly lightweight and self-contained. 

If the browser doesn't have `overflow: clip` support, there is a small discrepancy between where an item is dropped and where its drop animation indicates it will be dropped, but this only happens where the bug would occur previously and is a big improvement.