### PR TITLE
Fix question finder loading infinitely on shuffle and reload

### DIFF
--- a/src/app/components/pages/GameboardFilter.tsx
+++ b/src/app/components/pages/GameboardFilter.tsx
@@ -485,9 +485,8 @@ export const GameboardFilter = withRouter(({location}: RouteComponentProps) => {
 
     useEffect(() => {
         if (gameboardIdAnchor && (!isFound(gameboard) || gameboardIdAnchor !== gameboard.id)) {
-            const newBoardPromise = loadGameboard(gameboardIdAnchor, true)
+            const newBoardPromise = loadGameboard(gameboardIdAnchor, true);
             newBoardPromise.then(extractDataFromQueryResponse).then(setGameboard);
-            newBoardPromise.unsubscribe();
         } else {
             setBoardStack([]);
             loadNewGameboard(stages, difficulties, concepts, examBoards, selections, customBoardTitle ?? defaultBoardTitle, history);
@@ -508,9 +507,8 @@ export const GameboardFilter = withRouter(({location}: RouteComponentProps) => {
         if (boardStack.length > 0) {
             const oldBoardId = boardStack.pop() as string;
             setBoardStack(boardStack);
-            const newBoardPromise = loadGameboard(oldBoardId, true)
+            const newBoardPromise = loadGameboard(oldBoardId, true);
             newBoardPromise.then(extractDataFromQueryResponse).then(setGameboard);
-            newBoardPromise.unsubscribe();
         }
     }
 


### PR DESCRIPTION
Fixed by not unsubscribing from the gameboard-fetching promise. I can't believe I missed this before... it doesn't look like this causes a ridiculous number of boards to be stored in Redux, so we can just remove the `unsubscribe` call.