### PR TITLE
Set physics primary theme colour to `a11y_green`

### DIFF
--- a/src/scss/phy/isaac.scss
+++ b/src/scss/phy/isaac.scss
@@ -23,7 +23,7 @@ $green: #208838;
 $focus-blue: #3E59A3; // Used as focus indicator colour on inputs
 
 //Colours
-$primary: $phy_extra_force_yellow;
+$primary: $a11y_green;
 $secondary: $a11y_green;
 $theme-colors: (
     "primary": $primary,


### PR DESCRIPTION
This is now the same as the secondary colour, but we didn't want to use CS yellow any more on Physics.

I made this a PR as it is (in principle) a pretty big visual change, but in practice it doesn't make a big difference as it seems that we were avoiding the primary colour on Physics anyway. We tend to visually differentiate buttons by setting `outline={true}` on some of them, which removes the background colour anyway.