### PR TITLE
Use subject colour in test page UI

### DIFF
--- a/src/app/components/elements/quiz/QuizAttemptFooter.tsx
+++ b/src/app/components/elements/quiz/QuizAttemptFooter.tsx
@@ -5,6 +5,7 @@ import React, {useState} from "react";
 import {Spacer} from "../Spacer";
 import {IsaacSpinner} from "../../handlers/IsaacSpinner";
 import {Button} from "reactstrap";
+import {siteSpecific} from "../../../services";
 
 function extractSectionIdFromQuizQuestionId(questionId: string) {
     const ids = questionId.split("|", 3);
@@ -61,7 +62,7 @@ export function QuizAttemptFooter(props: QuizAttemptProps) {
                 <Spacer/>
                 All sections complete
                 <Spacer/>
-                <Button color="primary" onClick={submitQuiz}>{submitButton}</Button>
+                <Button color={siteSpecific("secondary", "primary")} onClick={submitQuiz}>{submitButton}</Button>
             </>;
         } else {
             prequel = <p>Click &lsquo;{primaryButton}&rsquo; when you are ready to {primaryDescription} the test.</p>;
@@ -72,12 +73,12 @@ export function QuizAttemptFooter(props: QuizAttemptProps) {
                         <Button onClick={() => window.confirm("Are you sure? You haven't answered all of the questions") && submitQuiz()}>{submitButton}</Button>
                     </div>
                     <Spacer/>
-                    <Button color="primary" tag={Link} replace to={pageLink(firstIncomplete + 1)}>{primaryButton}</Button>
+                    <Button color={siteSpecific("secondary", "primary")} tag={Link} replace to={pageLink(firstIncomplete + 1)}>{primaryButton}</Button>
                 </>;
             } else {
                 controls = <>
                     <Spacer/>
-                    <Button color="primary" tag={Link} replace to={pageLink(1)}>{primaryButton}</Button>
+                    <Button color={siteSpecific("secondary", "primary")} tag={Link} replace to={pageLink(1)}>{primaryButton}</Button>
                 </>;
             }
         }

--- a/src/app/components/pages/quizzes/QuizAttemptFeedback.tsx
+++ b/src/app/components/pages/quizzes/QuizAttemptFeedback.tsx
@@ -84,7 +84,7 @@ export const QuizAttemptFeedback = () => {
     const subProps: QuizAttemptProps = {attempt: attempt as QuizAttemptDTO, page: pageNumber,
         questions, sections, pageLink, pageHelp, studentUser};
 
-    return <Container className="mb-5">
+    return <Container className={`mb-5 ${attempt?.quiz?.subjectId}`}>
         <ShowLoading until={attempt || error}>
             {isDefined(attempt) && <>
                 <QuizAttemptComponent {...subProps} />

--- a/src/app/components/pages/quizzes/QuizDoAssignment.tsx
+++ b/src/app/components/pages/quizzes/QuizDoAssignment.tsx
@@ -35,7 +35,7 @@ export const QuizDoAssignment = () => {
 
     const subProps: QuizAttemptProps = {attempt: attempt as QuizAttemptDTO, page: pageNumber, questions, sections, pageLink, pageHelp};
 
-    return <Container className="mb-5">
+    return <Container className={`mb-5 ${attempt?.quiz?.subjectId}`}>
         <ShowLoading until={attempt || error}>
             {attempt && <>
                 <QuizAttemptComponent {...subProps} />

--- a/src/app/components/pages/quizzes/QuizDoFreeAttempt.tsx
+++ b/src/app/components/pages/quizzes/QuizDoFreeAttempt.tsx
@@ -38,7 +38,7 @@ export const QuizDoFreeAttempt = () => {
 
     const subProps: QuizAttemptProps = {attempt: attempt as QuizAttemptDTO, page: pageNumber, questions, sections, pageLink, pageHelp};
 
-    return <Container className="mb-5">
+    return <Container className={`mb-5 ${attempt?.quiz?.subjectId}`}>
         <ShowLoading until={attempt || error}>
             {attempt && <>
                 <QuizAttemptComponent {...subProps} />

--- a/src/app/services/quiz.ts
+++ b/src/app/services/quiz.ts
@@ -1,6 +1,6 @@
 import {useEffect, useMemo} from "react";
 import {deregisterQuestions, registerQuestions, selectors, useAppDispatch, useAppSelector} from "../state";
-import {API_PATH, isDefined, isQuestion} from "./";
+import {API_PATH, isDefined, isQuestion, tags} from "./";
 import {ContentDTO, IsaacQuizSectionDTO, QuestionDTO, QuizAssignmentDTO, QuizAttemptDTO} from "../../IsaacApiTypes";
 import {partition} from "lodash";
 
@@ -65,6 +65,8 @@ export function useCurrentQuizAttempt(studentId?: number) {
     const [attempt, error] = studentId
         ? [studentAttempt, studentError]
         : [currentUserAttempt, currentUserError];
+    // Augment quiz object with subject id
+    const attemptWithQuizSubject = {...attempt, quiz: attempt?.quiz && tags.augmentDocWithSubject(attempt.quiz)}
 
     const questions = useQuizQuestions(attempt);
     const sections = useQuizSections(attempt);
@@ -76,7 +78,7 @@ export function useCurrentQuizAttempt(studentId?: number) {
         return () => dispatch(deregisterQuestions(questions.map(q => q.id as string)));
     }, [dispatch, questions]);
 
-    return {attempt, error, studentUser, questions, sections};
+    return {attempt: attemptWithQuizSubject, error, studentUser, questions, sections};
 }
 
 export function getQuizAssignmentCSVDownloadLink(assignmentId: number) {

--- a/src/app/services/quiz.ts
+++ b/src/app/services/quiz.ts
@@ -66,7 +66,7 @@ export function useCurrentQuizAttempt(studentId?: number) {
         ? [studentAttempt, studentError]
         : [currentUserAttempt, currentUserError];
     // Augment quiz object with subject id
-    const attemptWithQuizSubject = {...attempt, quiz: attempt?.quiz && tags.augmentDocWithSubject(attempt.quiz)}
+    const attemptWithQuizSubject = {...attempt, quiz: attempt?.quiz && tags.augmentDocWithSubject(attempt.quiz)};
 
     const questions = useQuizQuestions(attempt);
     const sections = useQuizSections(attempt);

--- a/src/scss/phy/isaac.scss
+++ b/src/scss/phy/isaac.scss
@@ -23,7 +23,7 @@ $green: #208838;
 $focus-blue: #3E59A3; // Used as focus indicator colour on inputs
 
 //Colours
-$primary: $phy_extra_force_yellow;
+$primary: $a11y_green;
 $secondary: $a11y_green;
 $theme-colors: (
     "primary": $primary,


### PR DESCRIPTION
This makes the buttons etc. in the test attempt pages use the subject colour of the test. 
It defaults to physics if no subject tag is present - the subject tag needs to be added at the quiz DTO level.

As a side effect, this PR stops Physics UI elements from using the `phy_extra_force_yellow` colour, and makes them use `a11y_green` instead.