### PR TITLE
Move assignments modal to top level `SetAssignments` component

### DIFF
--- a/src/app/components/pages/SetAssignments.tsx
+++ b/src/app/components/pages/SetAssignments.tsx
@@ -1,4 +1,4 @@
-import React, {ChangeEvent, useCallback, useMemo, useState} from "react";
+import React, {ChangeEvent, useCallback, useEffect, useMemo, useState} from "react";
 import {
     Alert,
     Button,
@@ -66,23 +66,18 @@ import {
 } from "../../services";
 import {formatDate} from "../elements/DateString";
 import {ShareLink} from "../elements/ShareLink";
-import {IsaacSpinner} from "../handlers/IsaacSpinner";
+import {IsaacSpinner, Loading} from "../handlers/IsaacSpinner";
 import {AggregateDifficultyIcons} from "../elements/svg/DifficultyIcons";
 import Select from "react-select";
 import {GameboardDTO, RegisteredUserDTO, UserGroupDTO} from "../../../IsaacApiTypes";
 import {BoardAssignee, BoardOrder, Boards} from "../../../IsaacAppTypes";
 
-type BoardProps = {
-    user: RegisteredUserDTO;
-    allowScheduling: boolean;
+interface AssignGroupProps {
     groups: UserGroupDTO[];
-    board: GameboardDTO;
-    assignees: BoardAssignee[];
-    boardView: BoardViews;
-    boards?: Boards;
+    allowScheduling: boolean;
+    board: GameboardDTO | undefined;
 }
-
-const AssignGroup = ({groups, board, allowScheduling}: BoardProps) => {
+const AssignGroup = ({groups, board, allowScheduling}: AssignGroupProps) => {
     const [selectedGroups, setSelectedGroups] = useState<Item<number>[]>([]);
     const [dueDate, setDueDate] = useState<Date>();
     const [scheduledStartDate, setScheduledStartDate] = useState<Date>();
@@ -90,8 +85,10 @@ const AssignGroup = ({groups, board, allowScheduling}: BoardProps) => {
     const user = useAppSelector(selectors.user.orNull);
     const dispatch = useAppDispatch();
 
+    if (!board) return <Loading/>;
+
     function assign() {
-        dispatch(assignGameboard({boardId: board.id as string, groups: selectedGroups, dueDate, scheduledStartDate, notes: assignmentNotes})).then(success => {
+        dispatch(assignGameboard({boardId: board?.id as string, groups: selectedGroups, dueDate, scheduledStartDate, notes: assignmentNotes})).then(success => {
             if (success) {
                 setSelectedGroups([]);
                 setDueDate(undefined);
@@ -176,14 +173,94 @@ const HexagonGroupsButton = ({toggleAssignModal, boardSubjects, assignees, id}: 
             </span>
     </button>;
 
-const Board = (props: BoardProps) => {
-    const {user, allowScheduling, board, assignees, boardView} = props;
-    const dispatch = useAppDispatch();
-    const {hash} = useLocation();
-    const hashAnchor = hash.includes("#") ? hash.slice(1) : "";
-    const deviceSize = useDeviceSize();
+type SetAssignmentsModalProps = {
+    user: RegisteredUserDTO;
+    isOpen: boolean;
+    toggle: () => void;
+    allowScheduling: boolean;
+    groups: UserGroupDTO[];
+    board: GameboardDTO | undefined;
+    assignees: BoardAssignee[];
+    boards?: Boards;
+};
+const SetAssignmentsModal = (props: SetAssignmentsModalProps) => {
+    const {isOpen, toggle, allowScheduling, board, assignees} = props;
 
     const [ unassignBoard ] = isaacApi.endpoints.unassignGameboard.useMutation();
+
+    const hasStarted = (a : {startDate?: Date | number}) => !a.startDate || (Date.now() > a.startDate.valueOf());
+
+    const startedAssignees = useMemo(() => allowScheduling ? assignees.filter(hasStarted) : assignees, [assignees]);
+    const scheduledAssignees = useMemo(() => assignees.filter(a => !hasStarted(a)), [assignees]);
+
+    function confirmUnassignBoard(groupId: number, groupName?: string) {
+        if (board?.id && confirm(`Are you sure you want to unassign this gameboard from ${groupName ? `group ${groupName}` : "this group"}?`)) {
+            unassignBoard({boardId: board?.id, groupId});
+        }
+    }
+
+    return <Modal isOpen={isOpen} data-testid={"set-assignment-modal"} toggle={toggle}>
+        <ModalHeader data-testid={"modal-header"} role={"heading"} className={"text-break"} close={
+            <button role={"button"} className={"close text-nowrap"} onClick={toggle}>
+                Close
+            </button>
+        }>
+            {board?.title}
+        </ModalHeader>
+        <ModalBody>
+            <p className="px-1">Manage assignment of groups to the selected gameboard</p>
+            <hr className="text-center" />
+            <AssignGroup {...props} />
+            <hr className="text-center" />
+            <div className="py-2 border-bottom">
+                <Label>Board currently assigned to:</Label>
+                {startedAssignees.length > 0
+                    ? <Container className="mb-4">{startedAssignees.map(assignee =>
+                        <Row data-testid={"current-assignment"} key={assignee.groupId} className="px-1">
+                            <span className="flex-grow-1">{assignee.groupName}</span>
+                            <button className="close" aria-label="Unassign group" onClick={() => confirmUnassignBoard(assignee.groupId, assignee.groupName)}>×</button>
+                        </Row>
+                    )}</Container>
+                    : <p>No groups.</p>}
+            </div>
+            {allowScheduling && <div className="py-2">
+                <Label>Pending assignments: <span className="icon-help mx-1" id={`pending-assignments-help-${board?.id}`}/></Label>
+                <UncontrolledTooltip placement="left" autohide={false} target={`pending-assignments-help-${board?.id}`}>
+                    Assignments that are scheduled to begin at a future date. Once the start date passes, students
+                    will be able to see the assignment, and will receive a notification email.
+                </UncontrolledTooltip>
+                {scheduledAssignees.length > 0
+                    ? <Container className="mb-4">{scheduledAssignees.map(assignee =>
+                        <Row data-testid={"pending-assignment"} key={assignee.groupId} className="px-1">
+                            <span className="flex-grow-1">{assignee.groupName}</span>
+                            {assignee.startDate && <>
+                                    <span id={`start-date-${assignee.groupId}`} className="ml-auto mr-2">🕑 {(typeof assignee.startDate === "number"
+                                        ? new Date(assignee.startDate)
+                                        : assignee.startDate).toDateString()}
+                                    </span>
+                            </>}
+                            <button className="close" aria-label="Unassign group" onClick={() => confirmUnassignBoard(assignee.groupId, assignee.groupName)}>×</button>
+                        </Row>
+                    )}</Container>
+                    : <p>No groups.</p>}
+            </div>}
+        </ModalBody>
+        <ModalFooter>
+            <Button block color="tertiary" onClick={toggle}>Close</Button>
+        </ModalFooter>
+    </Modal>;
+}
+
+type BoardProps = {
+    user: RegisteredUserDTO;
+    board: GameboardDTO;
+    assignees: BoardAssignee[];
+    boardView: BoardViews;
+    toggleAssignModal: () => void;
+};
+const Board = ({user, board, assignees, boardView, toggleAssignModal}: BoardProps) => {
+    const dispatch = useAppDispatch();
+    const deviceSize = useDeviceSize();
 
     const assignmentLink = `/assignment/${board.id}`;
     const hasAssignedGroups = assignees && assignees.length > 0;
@@ -203,77 +280,13 @@ const Board = (props: BoardProps) => {
         }
     }
 
-    function confirmUnassignBoard(groupId: number, groupName?: string) {
-        if (board.id && confirm(`Are you sure you want to unassign this gameboard from ${groupName ? `group ${groupName}` : "this group"}?`)) {
-            unassignBoard({boardId: board.id, groupId});
-        }
-    }
-
-    const [modal, setModal] = useState(board.id === hashAnchor);
-    const toggleAssignModal = useCallback(() => setModal(s => !s), [setModal]);
-
     const hexagonId = `board-hex-${board.id}`;
 
     const boardSubjects = useMemo(() => determineGameboardSubjects(board), [board]);
     const boardStages = useMemo(() => allPropertiesFromAGameboard(board, "stage", stagesOrdered), [board]);
     const boardDifficulties = useMemo(() => allPropertiesFromAGameboard(board, "difficulty", difficultiesOrdered), [board]);
 
-    const hasStarted = (a : {startDate?: Date | number}) => !a.startDate || (Date.now() > a.startDate.valueOf());
-
-    const startedAssignees = useMemo(() => allowScheduling ? assignees.filter(hasStarted) : assignees, [assignees]);
-    const scheduledAssignees = useMemo(() => assignees.filter(a => !hasStarted(a)), [assignees]);
-
     return <>
-        <Modal isOpen={modal} data-testid={"set-assignment-modal"} toggle={toggleAssignModal}>
-            <ModalHeader data-testid={"modal-header"} role={"heading"} className={"text-break"} close={
-                <button role={"button"} className={"close text-nowrap"} onClick={toggleAssignModal}>
-                    Close
-                </button>
-            }>
-                {board.title}
-            </ModalHeader>
-            <ModalBody>
-                <p className="px-1">Manage assignment of groups to the selected gameboard</p>
-                <hr className="text-center" />
-                <AssignGroup {...props} />
-                <hr className="text-center" />
-                <div className="py-2 border-bottom">
-                    <Label>Board currently assigned to:</Label>
-                    {startedAssignees.length > 0
-                        ? <Container className="mb-4">{startedAssignees.map(assignee =>
-                            <Row data-testid={"current-assignment"} key={assignee.groupId} className="px-1">
-                                <span className="flex-grow-1">{assignee.groupName}</span>
-                                <button className="close" aria-label="Unassign group" onClick={() => confirmUnassignBoard(assignee.groupId, assignee.groupName)}>×</button>
-                            </Row>
-                        )}</Container>
-                        : <p>No groups.</p>}
-                </div>
-                {allowScheduling && <div className="py-2">
-                    <Label>Pending assignments: <span className="icon-help mx-1" id={`pending-assignments-help-${board.id}`}/></Label>
-                    <UncontrolledTooltip placement="left" autohide={false} target={`pending-assignments-help-${board.id}`}>
-                        Assignments that are scheduled to begin at a future date. Once the start date passes, students
-                        will be able to see the assignment, and will receive a notification email.
-                    </UncontrolledTooltip>
-                    {scheduledAssignees.length > 0
-                        ? <Container className="mb-4">{scheduledAssignees.map(assignee =>
-                            <Row data-testid={"pending-assignment"} key={assignee.groupId} className="px-1">
-                                <span className="flex-grow-1">{assignee.groupName}</span>
-                                {assignee.startDate && <>
-                                    <span id={`start-date-${assignee.groupId}`} className="ml-auto mr-2">🕑 {(typeof assignee.startDate === "number"
-                                        ? new Date(assignee.startDate)
-                                        : assignee.startDate).toDateString()}
-                                    </span>
-                                </>}
-                                <button className="close" aria-label="Unassign group" onClick={() => confirmUnassignBoard(assignee.groupId, assignee.groupName)}>×</button>
-                            </Row>
-                        )}</Container>
-                        : <p>No groups.</p>}
-                </div>}
-            </ModalBody>
-            <ModalFooter>
-                <Button block color="tertiary" onClick={toggleAssignModal}>Close</Button>
-            </ModalFooter>
-        </Modal>
         {boardView == BoardViews.table ?
             // Table view
             <tr className="board-card" data-testid={"assignment-gameboard-table-row"}>
@@ -406,6 +419,33 @@ export const SetAssignments = () => {
     // Whether to let the user schedule assignments for the future
     const allowScheduling = isStaff(user) || (userPreferences?.BETA_FEATURE?.SCHEDULE_ASSIGNMENTS ?? false);
 
+    // Logic for set assignments modal.
+    // hashAnchor acts as a buffer for a modal that needs to be opened. If it is set, the next time we get boards from
+    // the API, a modal will be open with the gameboard specified by hashAnchor, **and then hashAnchor will be cleared**.
+    const {hash} = useLocation();
+    const [hashAnchor, setHashAnchor] = useState<string | undefined>();
+    useEffect(() => {
+        setHashAnchor(hash.includes("#") ? hash.slice(1) : undefined);
+    }, [hash]);
+
+    const [modalBoard, setModalBoard] = useState<GameboardDTO>();
+    const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+    const openAssignModal = (board: GameboardDTO) => {
+        setModalBoard(board);
+        setIsModalOpen(true);
+    };
+
+    useEffect(() => {
+        if (boards && hashAnchor) {
+            setHashAnchor(undefined);
+            const board = boards.boards.find(b => b.id === hashAnchor);
+            if (board) {
+                openAssignModal(board);
+            }
+        }
+    }, [boards, hashAnchor]);
+
+    // Page help
     const pageHelp = <span>
         Use this page to set assignments to your groups. You can assign any gameboard you have saved to your account.
         <br/>
@@ -413,6 +453,16 @@ export const SetAssignments = () => {
     </span>;
 
     return <Container>
+
+        <SetAssignmentsModal
+            isOpen={isModalOpen}
+            toggle={() => setIsModalOpen(false)}
+            allowScheduling={allowScheduling} user={user}
+            groups={groups ?? []}
+            board={modalBoard}
+            assignees={(isDefined(modalBoard) && isDefined(modalBoard?.id) && groupsByGameboard[modalBoard.id]) || []}
+        />
+
         <TitleAndBreadcrumb currentPageTitle="Set assignments" help={pageHelp} modalId="set_assignments_help"/>
         <h4 className="mt-4 mb-3">
             Add a gameboard from ...
@@ -437,8 +487,8 @@ export const SetAssignments = () => {
                     <Col sm={6} lg={3} xl={2}>
                         <Label className="w-100">
                             Display in <Input type="select" value={boardView} onChange={switchView}>
-                            {Object.values(BoardViews).map(view => <option key={view} value={view}>{view}</option>)}
-                        </Input>
+                                {Object.values(BoardViews).map(view => <option key={view} value={view}>{view}</option>)}
+                            </Input>
                         </Label>
                     </Col>
                     <div className="d-lg-none w-100"/>
@@ -447,15 +497,15 @@ export const SetAssignments = () => {
                         <Col xs={6} lg={{size: 2, offset: 3}} xl={{size: 2, offset: 4}}>
                             <Label className="w-100">
                                 Show <Input type="select" value={boardLimit} onChange={e => setBoardLimit(e.target.value as BoardLimit)}>
-                                {Object.values(BoardLimit).map(limit => <option key={limit} value={limit}>{limit}</option>)}
-                            </Input>
+                                    {Object.values(BoardLimit).map(limit => <option key={limit} value={limit}>{limit}</option>)}
+                                </Input>
                             </Label>
                         </Col>
                         <Col xs={6} lg={4}>
                             <Label className="w-100">
                                 Sort by <Input type="select" value={boardOrder} onChange={e => setBoardOrder(e.target.value as BoardOrder)}>
-                                {Object.values(BoardOrder).map(order => <option key={order} value={order}>{BOARD_ORDER_NAMES[order]}</option>)}
-                            </Input>
+                                    {Object.values(BoardOrder).map(order => <option key={order} value={order}>{BOARD_ORDER_NAMES[order]}</option>)}
+                                </Input>
                             </Label>
                         </Col>
                     </>}
@@ -470,11 +520,10 @@ export const SetAssignments = () => {
                                         <Col key={board.id}>
                                             <Board
                                                 user={user}
-                                                groups={groups ?? []}
                                                 board={board}
                                                 boardView={boardView}
                                                 assignees={(isDefined(board?.id) && groupsByGameboard[board.id]) || []}
-                                                allowScheduling={allowScheduling}
+                                                toggleAssignModal={() => openAssignModal(board)}
                                             />
                                         </Col>)}
                                 </Row>
@@ -557,13 +606,11 @@ export const SetAssignments = () => {
                                                 .map(board =>
                                                     <Board
                                                         key={board.id}
-                                                        groups={groups ?? []}
                                                         user={user}
                                                         board={board}
                                                         boardView={boardView}
-                                                        boards={boards}
                                                         assignees={(isDefined(board?.id) && groupsByGameboard[board.id]) || []}
-                                                        allowScheduling={allowScheduling}
+                                                        toggleAssignModal={() => openAssignModal(board)}
                                                     />)
                                             }
                                             </tbody>


### PR DESCRIPTION
And only try to open it once per new hash anchor.

This fixes the issue with the modal opening again if you change the view of the gameboards. 
This is because changing the view causes the gameboards to be fetched again, which unmounts and remounts each `Board` component. The "open modal if hash anchor matches this board" logic was inside `Board` and ran on component mount, and we didn't have a nice way to work out whether a given mount was the first time the board had been loaded. 

This fix future-proofs the code a fair bit - we had one modal component per gameboard beforehand which could easily go wrong (multiple modals open at once for example) if the code was changed slightly.

**It looks like a lot of lines changed, but it is mostly just moving large-ish completely separate blocks of logic into different places.** 