### PR TITLE
Tutor pre-release changes

### DIFF
--- a/src/app/components/elements/inputs/UserContextAccountInput.tsx
+++ b/src/app/components/elements/inputs/UserContextAccountInput.tsx
@@ -11,7 +11,7 @@ import {
     isPhy,
     isTutorOrAbove,
     siteSpecific,
-    STAGE
+    STAGE, TEACHER_REQUEST_ROUTE
 } from "../../../services";
 import * as RS from "reactstrap";
 import {CustomInput, Input} from "reactstrap";
@@ -187,7 +187,7 @@ export function UserContextAccountInput({
 
                     {!tutorOrAbove && <><br/>
                         <small>
-                            If you are a teacher or tutor, <Link to={"/pages/contact_us_teacher"} target="_blank">upgrade your account</Link> to choose more than one {isCS && "exam board and "}stage.
+                            If you are a teacher or tutor, <Link to={TEACHER_REQUEST_ROUTE} target="_blank">upgrade your account</Link> to choose more than one {isCS && "exam board and "}stage.
                         </small>
                     </>}
                 </RS.FormGroup>

--- a/src/app/components/elements/inputs/UserContextAccountInput.tsx
+++ b/src/app/components/elements/inputs/UserContextAccountInput.tsx
@@ -187,7 +187,7 @@ export function UserContextAccountInput({
 
                     {!tutorOrAbove && <><br/>
                         <small>
-                            If you are a teacher or tutor, <Link to={"/request_account_upgrade"} target="_blank">upgrade your account</Link> to choose more than one {isCS && "exam board and "}stage.
+                            If you are a teacher or tutor, <Link to={"/pages/contact_us_teacher"} target="_blank">upgrade your account</Link> to choose more than one {isCS && "exam board and "}stage.
                         </small>
                     </>}
                 </RS.FormGroup>

--- a/src/app/components/elements/modals/RequiredAccountInformationModal.tsx
+++ b/src/app/components/elements/modals/RequiredAccountInformationModal.tsx
@@ -73,7 +73,7 @@ const RequiredAccountInfoBody = () => {
             {!isTutorOrAbove(user) && <div className="text-left mb-4">
                 Account type: <b>{user?.loggedIn && user.role && UserFacingRole[user.role]}</b> <span>
                     <small>(Are you a teacher or tutor? {" "}
-                        <Link to="/request_account_upgrade" target="_blank">
+                        <Link to="/pages/contact_us_teacher" target="_blank">
                             Upgrade your account
                         </Link>{".)"}
                     </small>

--- a/src/app/components/elements/modals/RequiredAccountInformationModal.tsx
+++ b/src/app/components/elements/modals/RequiredAccountInformationModal.tsx
@@ -12,7 +12,7 @@ import {
     isPhy,
     isTutor,
     isTutorOrAbove,
-    SITE_SUBJECT_TITLE,
+    SITE_SUBJECT_TITLE, TEACHER_REQUEST_ROUTE,
     UserFacingRole,
     validateEmailPreferences,
     validateUserContexts,
@@ -73,7 +73,7 @@ const RequiredAccountInfoBody = () => {
             {!isTutorOrAbove(user) && <div className="text-left mb-4">
                 Account type: <b>{user?.loggedIn && user.role && UserFacingRole[user.role]}</b> <span>
                     <small>(Are you a teacher or tutor? {" "}
-                        <Link to="/pages/contact_us_teacher" target="_blank">
+                        <Link to={TEACHER_REQUEST_ROUTE} target="_blank">
                             Upgrade your account
                         </Link>{".)"}
                     </small>

--- a/src/app/components/elements/panels/UserDetails.tsx
+++ b/src/app/components/elements/panels/UserDetails.tsx
@@ -60,7 +60,7 @@ export const UserDetails = (props: UserDetailsProps) => {
             <Col>
                 Account type: <b>{userToUpdate?.role && UserFacingRole[userToUpdate.role]}</b> {userToUpdate?.role == "STUDENT" && <span>
                     <small>(Are you a teacher or tutor? {" "}
-                        <Link to="/request_account_upgrade" target="_blank">
+                        <Link to="/pages/contact_us_teacher" target="_blank">
                             Upgrade your account
                         </Link>{".)"}</small>
                 </span>}

--- a/src/app/components/elements/panels/UserDetails.tsx
+++ b/src/app/components/elements/panels/UserDetails.tsx
@@ -4,7 +4,7 @@ import {
     isCS,
     isTutor,
     PROGRAMMING_LANGUAGE,
-    programmingLanguagesMap,
+    programmingLanguagesMap, TEACHER_REQUEST_ROUTE,
     UserFacingRole,
     validateEmail,
     validateName
@@ -60,7 +60,7 @@ export const UserDetails = (props: UserDetailsProps) => {
             <Col>
                 Account type: <b>{userToUpdate?.role && UserFacingRole[userToUpdate.role]}</b> {userToUpdate?.role == "STUDENT" && <span>
                     <small>(Are you a teacher or tutor? {" "}
-                        <Link to="/pages/contact_us_teacher" target="_blank">
+                        <Link to={TEACHER_REQUEST_ROUTE} target="_blank">
                             Upgrade your account
                         </Link>{".)"}</small>
                 </span>}

--- a/src/app/components/navigation/IsaacApp.tsx
+++ b/src/app/components/navigation/IsaacApp.tsx
@@ -239,7 +239,7 @@ export const IsaacApp = () => {
 
                         {/* Static pages */}
                         <TrackedRoute exact path="/contact" component={Contact}/>
-                        <TrackedRoute exact path="/request_account_upgrade" ifUser={isLoggedIn} component={TeacherOrTutorRequest}/>
+                        {/*<TrackedRoute exact path="/request_account_upgrade" ifUser={isLoggedIn} component={TeacherOrTutorRequest}/>*/}
                         <TrackedRoute exact path="/teacher_account_request" ifUser={isLoggedIn} component={TeacherRequest}/>
                         <TrackedRoute exact path="/tutor_account_request" ifUser={isLoggedIn} component={TutorRequest}/>
                         <StaticPageRoute exact path="/privacy" pageId="privacy_policy" />

--- a/src/app/components/navigation/TrackedRoute.tsx
+++ b/src/app/components/navigation/TrackedRoute.tsx
@@ -9,7 +9,7 @@ import {
     isTeacherOrAbove,
     isTutorOrAbove,
     KEY,
-    persistence
+    persistence, TEACHER_REQUEST_ROUTE
 } from "../../services";
 import {Unauthorised} from "../pages/Unauthorised";
 import {Immutable} from "immer";
@@ -56,7 +56,7 @@ export const TrackedRoute = function({component, trackingOptions, componentProps
                             persistence.save(KEY.AFTER_AUTH_PATH, props.location.pathname + props.location.search) && <Redirect to="/login"/>
                             :
                             user && !isTutorOrAbove(user) && userNeedsToBeTutorOrTeacher ?
-                                <Redirect to="/pages/contact_us_teacher"/>
+                                <Redirect to={TEACHER_REQUEST_ROUTE}/>
                                 :
                                 user && user.loggedIn && !ifUser(user) ?
                                     <Unauthorised/>

--- a/src/app/components/navigation/TrackedRoute.tsx
+++ b/src/app/components/navigation/TrackedRoute.tsx
@@ -56,7 +56,7 @@ export const TrackedRoute = function({component, trackingOptions, componentProps
                             persistence.save(KEY.AFTER_AUTH_PATH, props.location.pathname + props.location.search) && <Redirect to="/login"/>
                             :
                             user && !isTutorOrAbove(user) && userNeedsToBeTutorOrTeacher ?
-                                <Redirect to="/request_account_upgrade"/>
+                                <Redirect to="/pages/contact_us_teacher"/>
                                 :
                                 user && user.loggedIn && !ifUser(user) ?
                                     <Unauthorised/>

--- a/src/app/components/pages/TutorFeatures.tsx
+++ b/src/app/components/pages/TutorFeatures.tsx
@@ -61,9 +61,10 @@ export const TutorFeatures = () => {
             </Col>
         </Row>
         <Row className="card-deck isaac-cards-body mb-5 mt-2 px-3">
-            <IsaacCard doc={{ clickUrl: "/support/teacher/general",
+            <IsaacCard doc={{
                 image: {src: "/assets/phy/teacher_features_sprite.svg#teacher-forum"},
-                title: "Teacher FAQ",
+                title: "Tutor FAQ (coming soon)",
+                disabled: true,
                 verticalContent: true,
                 subtitle: "Answers to your questions and how-to guides."}}
                        imageClassName="teacher-features"

--- a/src/app/components/pages/TutorRequest.tsx
+++ b/src/app/components/pages/TutorRequest.tsx
@@ -160,10 +160,10 @@ export const TutorRequest = () => {
                                     <Row>
                                         <Col size={12}>
                                             <FormGroup>
-                                                <Label htmlFor="other-info-input">
+                                                <Label htmlFor="other-info-input" className="form-required">
                                                     Please tell us why you would like to apply for a tutor account
                                                 </Label>
-                                                <Input id="other-info-input" type="textarea" name="other-info"
+                                                <Input id="other-info-input" type="textarea" name="other-info" required
                                                     onChange={e => setReason(e.target.value)}/>
                                             </FormGroup>
                                         </Col>

--- a/src/app/components/site/phy/NavigationBarPhy.tsx
+++ b/src/app/components/site/phy/NavigationBarPhy.tsx
@@ -14,6 +14,7 @@ import {
     isLoggedIn,
     isStaff,
     isTeacherOrAbove,
+    isTutor,
     isTutorOrAbove
 } from "../../../services";
 
@@ -60,7 +61,9 @@ export const NavigationBarPhy = () => {
             <LinkItem to="/pages/how_to_videos">How-to Videos</LinkItem>
             <LinkItem to="/solving_problems">Problem Solving Guide</LinkItem>
             <LinkItem to="/support/student">Student FAQ</LinkItem>
-            <LinkItem to="/support/teacher">Teacher FAQ</LinkItem>
+            {isTutor(user)
+                ? <LinkItem to="/support/tutor" disabled>Tutor FAQ (coming soon)</LinkItem>
+                : <LinkItem to="/support/teacher">Teacher FAQ</LinkItem>}
             <LinkItem to="/contact">Contact Us</LinkItem>
         </NavigationSection>
 

--- a/src/test/pages/IsaacApp.test.tsx
+++ b/src/test/pages/IsaacApp.test.tsx
@@ -63,7 +63,7 @@ const navigationBarLinksPerRole: {[p in (UserRole | "ANONYMOUS")]: {[menu in Nav
         Teach: tutorLinks,
         Learn: learnLinks,
         Events: loggedInEventLinks,
-        Help: helpLinks,
+        Help: helpLinks.filter(l => l != "/support/teacher"),
         Admin: null
     },
     TEACHER: {

--- a/src/test/pages/authorisationRedirects.test.ts
+++ b/src/test/pages/authorisationRedirects.test.ts
@@ -24,7 +24,7 @@ describe("Visiting a tutor-only page", () => {
         for (const route of tutorOnlyRoutes) {
             history.replace(route);
             await waitFor(() => {
-                expect(history.location.pathname).toEqual("/request_account_upgrade");
+                expect(history.location.pathname).toEqual("/pages/contact_us_teacher");
             });
         }
     });

--- a/src/test/pages/authorisationRedirects.test.ts
+++ b/src/test/pages/authorisationRedirects.test.ts
@@ -1,6 +1,6 @@
 import {renderTestEnvironment} from "../utils";
 import {screen, waitFor} from "@testing-library/react";
-import {history} from "../../app/services";
+import {history, TEACHER_REQUEST_ROUTE} from "../../app/services";
 
 const tutorOnlyRoutes = ["/set_assignments", "/groups"];
 describe("Visiting a tutor-only page", () => {
@@ -24,7 +24,7 @@ describe("Visiting a tutor-only page", () => {
         for (const route of tutorOnlyRoutes) {
             history.replace(route);
             await waitFor(() => {
-                expect(history.location.pathname).toEqual("/pages/contact_us_teacher");
+                expect(history.location.pathname).toEqual(TEACHER_REQUEST_ROUTE);
             });
         }
     });


### PR DESCRIPTION
This does the following:
* Remove intermediate (are you teacher or tutor?) page
* Make "explain" a required field in the Tutor form
* In Tutor features, replace Teacher FAQ with greyed-out Tutor FAQ
* In Help, replace Teacher FAQ with greyed-out Tutor FAQ

We need to link to the tutor form page in text in `/pages/contact-us-teacher` (this is a content change and I believe content are on it)