### PR TITLE
Feature/always allow adding dob on registration

### DIFF
--- a/src/app/components/pages/Registration.tsx
+++ b/src/app/components/pages/Registration.tsx
@@ -21,6 +21,7 @@ import {PasswordFeedback} from "../../../IsaacAppTypes";
 import {
     FIRST_LOGIN_STATE,
     isCS,
+    isDefined,
     isDobOverTen,
     isDobOverThirteen,
     isPhy,
@@ -78,6 +79,8 @@ export const Registration = withRouter(({location}:  RouteComponentProps<{}, {},
     const confirmedTenToTwelve = confirmedOverTen && !confirmedOverThirteen;
     const confirmedOldEnoughForSite = siteSpecific(confirmedOverTen, confirmedOverThirteen)
     const consentGivenOrNotRequired = isCS || (confirmedTenToTwelve === parentalConsentCheckboxChecked);
+    const isOldEnoughForSite = siteSpecific(isDobOverTen, isDobOverThirteen);
+    const dobTooYoung = isDefined(registrationUser.dateOfBirth) && !isOldEnoughForSite(registrationUser.dateOfBirth);
 
     // Form's submission method
     const register = (event: React.FormEvent<HTMLFormElement>) => {
@@ -250,10 +253,14 @@ export const Registration = withRouter(({location}:  RouteComponentProps<{}, {},
                                     <Col lg={siteSpecific(12, 6)} xs={12}>
                                         <DateInput
                                             id="dob-input" name="date-of-birth"
-                                            invalid={!siteSpecific(confirmedOverTen, confirmedOverThirteen) && attemptedSignUp}
-                                            disabled={(isPhy && dob10To12CheckboxChecked) || dobOver13CheckboxChecked}
+                                            invalid={
+                                                dobTooYoung || (attemptedSignUp && !confirmedOldEnoughForSite)
+                                            }
                                             onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
                                                 assignToRegistrationUser({dateOfBirth: event.target.valueAsDate});
+                                                // DOB takes priority over age confirmation
+                                                setDobOver13CheckboxChecked(false);
+                                                setDob10To12CheckboxChecked(false);
                                             }}
                                             labelSuffix=" of birth"
                                         />
@@ -267,6 +274,7 @@ export const Registration = withRouter(({location}:  RouteComponentProps<{}, {},
                                             label="I am at least 13 years old"
                                             disabled={(isPhy && dob10To12CheckboxChecked) || registrationUser.dateOfBirth}
                                             onChange={(e) => setDobOver13CheckboxChecked(e?.target.checked)}
+                                            invalid={dobTooYoung}
                                         />
                                         {isPhy && <CustomInput
                                             id="age-10-to-12-confirmation-input" name="age-10-to-12-confirmation" type="checkbox"
@@ -276,6 +284,7 @@ export const Registration = withRouter(({location}:  RouteComponentProps<{}, {},
                                             label="I am aged 10 to 12 years old"
                                             disabled={dobOver13CheckboxChecked || registrationUser.dateOfBirth}
                                             onChange={(e) => setDob10To12CheckboxChecked(e?.target.checked)}
+                                            invalid={dobTooYoung}
                                         />}
                                     </Col>
                                 </Row>

--- a/src/app/components/pages/Registration.tsx
+++ b/src/app/components/pages/Registration.tsx
@@ -76,6 +76,7 @@ export const Registration = withRouter(({location}:  RouteComponentProps<{}, {},
     const confirmedOverThirteen = dobOver13CheckboxChecked || isDobOverThirteen(registrationUser.dateOfBirth);
     const confirmedOverTen = dob10To12CheckboxChecked || isDobOverTen(registrationUser.dateOfBirth) || confirmedOverThirteen;
     const confirmedTenToTwelve = confirmedOverTen && !confirmedOverThirteen;
+    const confirmedOldEnoughForSite = siteSpecific(confirmedOverTen, confirmedOverThirteen)
     const consentGivenOrNotRequired = isCS || (confirmedTenToTwelve === parentalConsentCheckboxChecked);
 
     // Form's submission method
@@ -83,7 +84,7 @@ export const Registration = withRouter(({location}:  RouteComponentProps<{}, {},
         event.preventDefault();
         setAttemptedSignUp(true);
 
-        if (familyNameIsValid && givenNameIsValid && passwordIsValid && emailIsValid && siteSpecific(confirmedOverTen, confirmedOverThirteen) && consentGivenOrNotRequired) {
+        if (familyNameIsValid && givenNameIsValid && passwordIsValid && emailIsValid && confirmedOldEnoughForSite && consentGivenOrNotRequired) {
             persistence.session.save(KEY.FIRST_LOGIN, FIRST_LOGIN_STATE.FIRST_LOGIN);
             Object.assign(registrationUser, {loggedIn: false});
             dispatch(updateCurrentUser(registrationUser, {}, undefined, null, (Object.assign(registrationUser, {loggedIn: true})), true));
@@ -292,7 +293,7 @@ export const Registration = withRouter(({location}:  RouteComponentProps<{}, {},
                                 </h4>
                             }
                             <h4 role="alert" className="text-danger text-left">
-                                {!siteSpecific(confirmedOverTen, confirmedOverThirteen) && attemptedSignUp ?
+                                {attemptedSignUp && !confirmedOldEnoughForSite ?
                                     `You must be over ${siteSpecific("10", "13")} years old to create an account.` :
                                     errorMessage}
                             </h4>


### PR DESCRIPTION
It should always be possible to set the user's DOB on registration, even if they have already checked the box confirming that they are 13 or older or between 10 and 12. In the case where there has been a checkbox age confirmation before the DOB entry, the DOB entry takes precedence and will be used to compute which check box to mark.