### PR TITLE
Stop admins from booking users onto cancelled events

### DIFF
--- a/src/app/components/elements/Accordion.tsx
+++ b/src/app/components/elements/Accordion.tsx
@@ -27,12 +27,13 @@ interface AccordionsProps extends RouteComponentProps {
     children?: React.ReactNode;
     startOpen?: boolean;
     deEmphasised?: boolean;
+    disabled?: string | boolean;
     audienceString?: string;
 }
 
 let nextClientId = 0;
 
-export const Accordion = withRouter(({id, trustedTitle, index, children, startOpen, deEmphasised, audienceString, location: {hash}}: AccordionsProps) => {
+export const Accordion = withRouter(({id, trustedTitle, index, children, startOpen, deEmphasised, disabled, audienceString, location: {hash}}: AccordionsProps) => {
     const dispatch = useAppDispatch();
     const userContext = useUserContext();
     const componentId = useRef(uuid_v4().slice(0, 4)).current;
@@ -41,7 +42,7 @@ export const Accordion = withRouter(({id, trustedTitle, index, children, startOp
     // Toggle
     const isFirst = index === 0;
     const openFirst = isCS || Boolean(page && page !== NOT_FOUND && page.type === DOCUMENT_TYPE.QUESTION);
-    const [open, setOpen] = useState(startOpen === undefined ? (openFirst && isFirst) : startOpen);
+    const [open, setOpen] = useState(disabled ? false : (startOpen === undefined ? (openFirst && isFirst) : startOpen));
 
     // If start open changes we need to update whether or not the accordion section should be open
     useEffect(() => {if (startOpen !== undefined) {setOpen(startOpen);}}, [setOpen, startOpen]);
@@ -138,21 +139,32 @@ export const Accordion = withRouter(({id, trustedTitle, index, children, startOp
 
     const isConceptPage = page && page != NOT_FOUND && page.type === DOCUMENT_TYPE.CONCEPT;
 
+    const isOpen = open && !disabled;
+
     return <div className="accordion">
         <div className="accordion-header">
             <RS.Button
                 id={anchorId || ""} block color="link"
-                className={"d-flex align-items-stretch " + classNames({"de-emphasised": deEmphasised, "active": open})}
+                tabIndex={disabled ? -1 : 0}
+                onFocus={(e) => {
+                    if (disabled) {
+                        e.target.blur();
+                    }
+                }}
+                className={"d-flex align-items-stretch " + classNames({"de-emphasised": deEmphasised || disabled, "active": isOpen})}
                 onClick={(event: any) => {
+                    if (disabled) {
+                        return;
+                    }
                     pauseAllVideos();
-                    const nextState = !open;
+                    const nextState = !isOpen;
                     setOpen(nextState);
                     if (nextState) {
                         logAccordionOpen();
                         scrollVerticallyIntoView(event.target);
                     }
                 }}
-                aria-expanded={open ? "true" : "false"}
+                aria-expanded={isOpen ? "true" : "false"}
             >
                 {isConceptPage && audienceString && <span className={"stage-label badge-secondary d-flex align-items-center " +
                     "justify-content-center " + classNames({[audienceStyle(audienceString)]: isCS})}>
@@ -167,10 +179,17 @@ export const Accordion = withRouter(({id, trustedTitle, index, children, startOp
                                 {trustedTitle}
                             </Markup>
                         </div>}
-                        {isCS  && deEmphasised && <div className="ml-auto mr-3 d-flex align-items-center">
+                        {isCS && deEmphasised && <div className="ml-auto mr-3 d-flex align-items-center">
                             <span id={`audience-help-${componentId}`} className="icon-help mx-1" />
                             <RS.UncontrolledTooltip placement="bottom" target={`audience-help-${componentId}`}>
                                 {`This content has ${notRelevantMessage(userContext)}.`}
+                            </RS.UncontrolledTooltip>
+                        </div>}
+                        {typeof disabled === "string" && disabled.length > 0 && <div className={"p-3"}>
+                            <span id={`disabled-tooltip-${componentId}`} className="icon-help" />
+                            <RS.UncontrolledTooltip placement="right" target={`disabled-tooltip-${componentId}`}
+                                                    modifiers={{preventOverflow: {boundariesElement: "viewport"}}}>
+                                {disabled}
                             </RS.UncontrolledTooltip>
                         </div>}
                     </RS.Row>
@@ -181,8 +200,8 @@ export const Accordion = withRouter(({id, trustedTitle, index, children, startOp
                 </span>}
             </RS.Button>
         </div>
-        <RS.Collapse isOpen={open} className="mt-1">
-            <AccordionSectionContext.Provider value={{id, clientId: clientId.current, open}}>
+        <RS.Collapse isOpen={isOpen} className="mt-1">
+            <AccordionSectionContext.Provider value={{id, clientId: clientId.current, open: isOpen}}>
                 <RS.Card>
                     <RS.CardBody>
                         {children}

--- a/src/app/components/elements/panels/AddUsersToBooking.tsx
+++ b/src/app/components/elements/panels/AddUsersToBooking.tsx
@@ -16,7 +16,7 @@ import {userBookingModal} from "../modals/UserBookingModal";
 export const AddUsersToBooking = () => {
     const dispatch = useAppDispatch();
     const userResults = useAppSelector(selectors.admin.userSearch) || [];
-    const selectedEvent = useAppSelector((state: AppState) => state && state.currentEvent || null);
+    const selectedEvent = useAppSelector((state: AppState) => (state && state.currentEvent !== NOT_FOUND) ? state.currentEvent : null);
     const userBookings = useAppSelector((state: AppState) =>
         state && state.eventBookings && state.eventBookings.map(b => b.userBooked && b.userBooked.id) as number[] || []
     );
@@ -34,7 +34,7 @@ export const AddUsersToBooking = () => {
         return (value !== defaultValue) ? value : null;
     }
 
-    return <Accordion trustedTitle="Add users to booking">
+    return <Accordion trustedTitle="Add users to booking" disabled={selectedEvent?.isCancelled && "You cannot add users to a cancelled event"}>
         <RS.Form onSubmit={userSearch}>
             <RS.Row>
                 <RS.Col md={6}>
@@ -94,7 +94,7 @@ export const AddUsersToBooking = () => {
                     </tr>
                 </thead>
                 <tbody>
-                    {selectedEvent && selectedEvent !== NOT_FOUND && userResults.map(result => <tr key={result.id}>
+                    {selectedEvent && userResults.map(result => <tr key={result.id}>
                         <td className="align-middle">
                             {!userBookings.includes(result.id as number) &&
                             <RS.Button color="primary" outline className="btn-sm" onClick={() => dispatch(openActiveModal(userBookingModal(result, selectedEvent, userBookings)))}>

--- a/src/app/components/elements/panels/EventAttendance.tsx
+++ b/src/app/components/elements/panels/EventAttendance.tsx
@@ -38,7 +38,7 @@ export const EventAttendance = ({user, eventId}: {user: PotentialUser; eventId: 
     }
 
     return <React.Fragment>
-        {canRecordAttendance && atLeastOne(bookings.length) && <Accordion trustedTitle="Record event attendance">
+        {canRecordAttendance && atLeastOne(bookings.length) && <Accordion trustedTitle="Record event attendance" disabled={selectedEvent?.isCancelled && "You cannot record attendance for a cancelled event"}>
             {isEventLeader(user) && <div className="bg-grey p-2 mb-3 text-center">
                 As an event leader, you are only able to see the bookings of users who have granted you access to their data.
             </div>}

--- a/src/app/components/elements/panels/SelectedEventDetails.tsx
+++ b/src/app/components/elements/panels/SelectedEventDetails.tsx
@@ -31,7 +31,7 @@ export const SelectedEventDetails = ({eventId}: {eventId: string}) => {
                 }
 
                 <strong>Event status: </strong>
-                {selectedEvent.eventStatus}
+                <span className={selectedEvent.isCancelled ? "text-danger font-weight-bold" : ""}>{selectedEvent.eventStatus}</span>
                 <br />
 
                 <strong>Event start: </strong>


### PR DESCRIPTION
Extends `Accordion` with a `disabled` attribute, that de-emphasises it and stops it from being opened.

This is used to disable the event admin page accordions for:
- Booking users onto events
- Promoting reserved users to booked

for events that have been cancelled.

This is for UX purposes: if they were to use these accordions in any capacity after [this back-end PR](https://github.com/isaacphysics/isaac-api/pull/493) goes in, they'll just get server errors.