### PR TITLE
Fix `undefined` quiz attempt id errors

### DIFF
--- a/src/app/components/pages/quizzes/QuizDoAssignment.tsx
+++ b/src/app/components/pages/quizzes/QuizDoAssignment.tsx
@@ -33,6 +33,7 @@ export const QuizDoAssignment = ({user}: {user: RegisteredUserDTO}) => {
         `/test/assignment/${quizAssignmentId}` + (isDefined(page) ? `/page/${page}` : "")
     , [quizAssignmentId]);
 
+    // Importantly, these are only used if attempt is defined
     const subProps: QuizAttemptProps = {attempt: attempt as QuizAttemptDTO, page: pageNumber, questions, sections, pageLink, pageHelp, user};
 
     return <Container className={`mb-5 ${attempt?.quiz?.subjectId}`}>

--- a/src/app/components/pages/quizzes/QuizDoFreeAttempt.tsx
+++ b/src/app/components/pages/quizzes/QuizDoFreeAttempt.tsx
@@ -36,6 +36,7 @@ export const QuizDoFreeAttempt = ({user}: {user: RegisteredUserDTO}) => {
         `/test/attempt/${quizId}` + (isDefined(page) ? `/page/${page}` : "")
     , [quizId]);
 
+    // Importantly, these are only used if attempt is defined
     const subProps: QuizAttemptProps = {attempt: attempt as QuizAttemptDTO, page: pageNumber, questions, sections, pageLink, pageHelp, user};
 
     return <Container className={`mb-5 ${attempt?.quiz?.subjectId}`}>

--- a/src/app/services/quiz.ts
+++ b/src/app/services/quiz.ts
@@ -104,8 +104,10 @@ export function useCurrentQuizAttempt(studentId?: number) {
     const [attempt, error] = studentId
         ? [studentAttempt, studentError]
         : [currentUserAttempt, currentUserError];
-    // Augment quiz object with subject id
-    const attemptWithQuizSubject = {...attempt, quiz: attempt?.quiz && tags.augmentDocWithSubject(attempt.quiz)};
+    // Augment quiz object with subject id, propagating undefined-ness
+    const attemptWithQuizSubject = attempt
+        ? {...attempt, quiz: attempt?.quiz && tags.augmentDocWithSubject(attempt.quiz)}
+        : undefined;
 
     const questions = useQuizQuestions(attempt);
     const sections = useQuizSections(attempt);


### PR DESCRIPTION
I believe this fixes the issue. It's hard/impossible to test this edge case as it has only turned up a few times in the server logs on live AFAIK, so I suggest we merge this and see whether any further errors turn up in the logs afterward. This is fine since the change is small and completely sensical.

The problem was in `useCurrentQuizAttempt`. The `attempt` object it returned was **always defined** because it augments the original attempt with the document subject: 
```typescript
const attemptWithQuizSubject = {...attempt, quiz: attempt?.quiz && tags.augmentDocWithSubject(attempt.quiz)}
...
return {attempt: attemptWithQuizSubject, error, studentUser, questions, sections};
```
The main reason this broke things is in `QuizDoFreeAttempt` and `QuizDoAssignment`:
```jsx
<ShowLoading until={attempt || error}>
      {attempt && <>
          <QuizAttemptComponent {...subProps} />
          <QuizAttemptFooter {...subProps} />
      </>}
      ...
</ShowLoading>
```
The `until` prop was always defined, so the quiz components would render whether the attempt data was inside the `attempt` object or not.

The fix was to propagate the `undefined`-ness of the current quiz attempt:
```typescript
const attemptWithQuizSubject = attempt
        ? {...attempt, quiz: attempt?.quiz && tags.augmentDocWithSubject(attempt.quiz)}
        : undefined;
...
return {attempt: attemptWithQuizSubject, error, studentUser, questions, sections};
```
which means that any checks that components using this hook perform on the defined-ness of `attempt` actually function as expected now. 