### PR TITLE
Hotfix/show required fields modal on registration after logout

### DIFF
--- a/src/app/state/middleware/notificationManager.ts
+++ b/src/app/state/middleware/notificationManager.ts
@@ -20,11 +20,12 @@ export const notificationCheckerMiddleware: Middleware = (middlewareApi: Middlew
     const state = middlewareApi.getState();
     if([ACTION_TYPE.CURRENT_USER_RESPONSE_SUCCESS, routerPageChange.type].includes(action.type)) {
         // Get user object either from the action or state
-        const user = action.type === ACTION_TYPE.CURRENT_USER_RESPONSE_SUCCESS
-            ? action.user
-            : (state && isLoggedIn(state.user)
-                ? state.user
-                : undefined);
+        let user = undefined;
+        if (action.type === ACTION_TYPE.CURRENT_USER_RESPONSE_SUCCESS) {
+            user = action.user;
+        } else if (isLoggedIn(state?.user)) {
+            user = state.user;
+        }
 
         if (isDefined(user)) {
             // Required account info modal - takes precedence over stage/exam board re-confirmation modal, and is only


### PR DESCRIPTION
Registering after logging out was not showing the required fields modal.

Previously, on logging out, the userConsistencyChecker middleware would clear local storage, redirect the user home, and then it would pass the action on to redux to process. When Redux processed the action the `userState` reducer would change the user's state to `{loggedIn: false}`.
Unfortunately for us, the userConsistencyChecker's redirect throws its own action which the notificationChecker middleware uses to decide whether or not to show the required fields modal. This happens after local storage was cleared but before the user in Redux state is logged out so it flashes the modal and records the current time in local storage as the `requiredModalShownTime`.
If a user was to register (or log in) less than 50 mins after this, the required fields modal would not be shown because the `requiredModalShownTime` was in local storage.

What this PR does to fix this is to alter the middleware so that it redirects the user after the redux state has been updated to reflect that the user has logged out. An alternative solution would be to redirect the user home before clearing local storage and updating redux, but logging out then redirecting felt closer to the initial intentions.
