### PR TITLE
Run Google Analytics 4 alongside current Universal Analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react-dom": "^17.0.2",
     "react-error-boundary": "^3.1.4",
     "react-ga": "^3.3.0",
+    "react-ga4": "^2.0.0",
     "react-helmet": "^6.1.0",
     "react-redux": "^7.2.6",
     "react-router-dom": "^5.3.0",

--- a/src/app/components/content/IsaacVideo.tsx
+++ b/src/app/components/content/IsaacVideo.tsx
@@ -3,6 +3,7 @@ import {VideoDTO} from "../../../IsaacApiTypes";
 import {logAction, selectors, useAppDispatch, useAppSelector} from "../../state";
 import {NOT_FOUND} from "../../services";
 import ReactGA from "react-ga";
+import ReactGA4 from "react-ga4";
 import {AccordionSectionContext} from "../../../IsaacAppTypes";
 
 interface IsaacVideoProps {
@@ -84,6 +85,10 @@ export function IsaacVideo(props: IsaacVideoProps) {
             } catch (error: any) {
                 console.error("Error with YouTube library: ", error, error.stack);
                 ReactGA.exception({
+                    description: `youtube_error: ${error?.message || 'problem with YT library'}`,
+                    fatal: false
+                });
+                ReactGA4.gtag("event", "exception", {
                     description: `youtube_error: ${error?.message || 'problem with YT library'}`,
                     fatal: false
                 });

--- a/src/app/components/navigation/IsaacApp.tsx
+++ b/src/app/components/navigation/IsaacApp.tsx
@@ -86,7 +86,7 @@ import {Loading} from "../handlers/IsaacSpinner";
 import {AssignmentSchedule} from "../pages/AssignmentSchedule";
 import {ExternalRedirect} from "../handlers/ExternalRedirect";
 import {TutorRequest} from "../pages/TutorRequest";
-import {TeacherOrTutorRequest} from "../pages/TeacherOrTutorRequest";
+import ReactGA4 from "react-ga4";
 
 const ContentEmails = lazy(() => import('../pages/ContentEmails'));
 const MyProgress = lazy(() => import('../pages/MyProgress'));

--- a/src/app/components/navigation/IsaacApp.tsx
+++ b/src/app/components/navigation/IsaacApp.tsx
@@ -86,7 +86,6 @@ import {Loading} from "../handlers/IsaacSpinner";
 import {AssignmentSchedule} from "../pages/AssignmentSchedule";
 import {ExternalRedirect} from "../handlers/ExternalRedirect";
 import {TutorRequest} from "../pages/TutorRequest";
-import ReactGA4 from "react-ga4";
 
 const ContentEmails = lazy(() => import('../pages/ContentEmails'));
 const MyProgress = lazy(() => import('../pages/MyProgress'));

--- a/src/app/components/navigation/TrackedRoute.tsx
+++ b/src/app/components/navigation/TrackedRoute.tsx
@@ -1,11 +1,13 @@
 import React, {useEffect} from "react";
 import {Redirect, Route, RouteComponentProps, RouteProps} from "react-router";
 import ReactGA, {FieldsObject} from "react-ga";
+import ReactGA4 from "react-ga4";
 import {FigureNumberingContext, PotentialUser} from "../../../IsaacAppTypes";
 import {ShowLoading} from "../handlers/ShowLoading";
 import {selectors, useAppSelector} from "../../state";
 import {
     GOOGLE_ANALYTICS_ACCOUNT_ID,
+    GOOGLE_ANALYTICS_4_MEASUREMENT_ID,
     isTeacherOrAbove,
     isTutorOrAbove,
     KEY,
@@ -15,11 +17,15 @@ import {Unauthorised} from "../pages/Unauthorised";
 import {Immutable} from "immer";
 
 ReactGA.initialize(GOOGLE_ANALYTICS_ACCOUNT_ID);
+ReactGA4.initialize(GOOGLE_ANALYTICS_4_MEASUREMENT_ID);
 ReactGA.set({ anonymizeIp: true });
+ReactGA4.set({ anonymizeIp: true });
 
 const trackPage = (page: string, options?: FieldsObject) => {
     ReactGA.set({ page, ...options });
+    ReactGA4.set({ page, ...options });
     ReactGA.pageview(page);
+    ReactGA4.send({ hitType: "pageview", page });
 };
 
 interface UserFilterProps {

--- a/src/app/components/pages/ClientError.tsx
+++ b/src/app/components/pages/ClientError.tsx
@@ -3,6 +3,7 @@ import {Link} from "react-router-dom";
 import {Col, Container, Row} from "reactstrap";
 import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
 import ReactGA from "react-ga";
+import ReactGA4 from "react-ga4";
 import {WEBMASTER_EMAIL} from "../../services";
 import {FallbackProps} from "react-error-boundary";
 import {logAction, selectors, useAppDispatch, useAppSelector} from "../../state";
@@ -20,6 +21,10 @@ export const ClientError = ({resetErrorBoundary, error}: FallbackProps) => {
     const dispatch = useAppDispatch();
     const user = useAppSelector(selectors.user.orNull);
     ReactGA.exception({
+        description: `client_error: ${error?.message || 'unknown'}`,
+        fatal: true
+    });
+    ReactGA4.gtag("event", "exception", {
         description: `client_error: ${error?.message || 'unknown'}`,
         fatal: true
     });

--- a/src/app/components/pages/Registration.tsx
+++ b/src/app/components/pages/Registration.tsx
@@ -2,6 +2,7 @@ import React, {useState} from 'react';
 import {selectors, updateCurrentUser, useAppDispatch, useAppSelector} from "../../state";
 import {Link} from "react-router-dom";
 import ReactGA from "react-ga";
+import ReactGA4 from "react-ga4";
 import {
     Alert,
     Card,
@@ -92,6 +93,11 @@ export const Registration = withRouter(({location}:  RouteComponentProps<{}, {},
             dispatch(updateCurrentUser(registrationUser, {}, undefined, null, (Object.assign(registrationUser, {loggedIn: true})), true));
             // FIXME - the below ought to be in an action, but we don't know that the update actually registration:
             ReactGA.event({
+                category: 'user',
+                action: 'registration',
+                label: 'Create Account (SEGUE)',
+            });
+            ReactGA4.event({
                 category: 'user',
                 action: 'registration',
                 label: 'Create Account (SEGUE)',

--- a/src/app/components/pages/ServerError.tsx
+++ b/src/app/components/pages/ServerError.tsx
@@ -3,11 +3,16 @@ import {Link} from "react-router-dom";
 import {Container} from "reactstrap";
 import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
 import ReactGA from "react-ga";
+import ReactGA4 from "react-ga4";
 import {WEBMASTER_EMAIL} from "../../services";
 
 export const ServerError = () => {
 
     ReactGA.exception({
+        description: 'server_error',
+        fatal: true
+    });
+    ReactGA4.gtag("event", "exception", {
         description: 'server_error',
         fatal: true
     });

--- a/src/app/components/pages/SessionExpired.tsx
+++ b/src/app/components/pages/SessionExpired.tsx
@@ -2,11 +2,16 @@ import React from "react";
 import {Container} from "reactstrap";
 import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
 import ReactGA from "react-ga";
+import ReactGA4 from "react-ga4";
 import {WEBMASTER_EMAIL} from "../../services";
 
 export const SessionExpired = () => {
 
     ReactGA.exception({
+        description: 'session_expired',
+        fatal: true
+    });
+    ReactGA4.gtag("event", "exception", {
         description: 'session_expired',
         fatal: true
     });

--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -42,6 +42,10 @@ export const GOOGLE_ANALYTICS_ACCOUNT_ID = siteSpecific(
     "UA-122616705-1",
     "UA-137475074-1"
 );
+export const GOOGLE_ANALYTICS_4_MEASUREMENT_ID = siteSpecific(
+    "G-VE7RLWEL60",
+    "G-H95WP5C8DR"
+);
 
 export const SOCIAL_LINKS = siteSpecific(
     {

--- a/src/app/state/actions/index.tsx
+++ b/src/app/state/actions/index.tsx
@@ -56,6 +56,7 @@ import {
 } from "../../components/elements/modals/TeacherConnectionModalCreators";
 import {AxiosError} from "axios";
 import ReactGA from "react-ga";
+import ReactGA4 from "react-ga4";
 import {EventOverviewFilter} from "../../components/elements/panels/EventOverviews";
 import {isaacBooksModal} from "../../components/elements/modals/IsaacBooksModal";
 import {
@@ -95,6 +96,9 @@ export function showAxiosErrorToastIfNeeded(error: string, e: any) {
             }
         } else {
             ReactGA.exception({
+                description: `load_fail: ${error}`
+            });
+            ReactGA4.gtag("event", "exception", {
                 description: `load_fail: ${error}`
             });
             return showToast({
@@ -412,6 +416,11 @@ export const handleProviderCallback = (provider: AuthenticationProvider, paramet
         dispatch({type: ACTION_TYPE.USER_LOG_IN_RESPONSE_SUCCESS, user: providerResponse.data});
         if (providerResponse.data.firstLogin) {
             ReactGA.event({
+                category: 'user',
+                action: 'registration',
+                label: `Create Account (${provider})`,
+            });
+            ReactGA4.event({
                 category: 'user',
                 action: 'registration',
                 label: `Create Account (${provider})`,

--- a/src/app/state/actions/popups.ts
+++ b/src/app/state/actions/popups.ts
@@ -3,6 +3,7 @@ import {Dispatch} from "react";
 import {Action, ActiveModal, Toast} from "../../../IsaacAppTypes";
 import {ACTION_TYPE, API_REQUEST_FAILURE_MESSAGE} from "../../services";
 import ReactGA from "react-ga";
+import ReactGA4 from "react-ga4";
 
 // Toasts
 const removeToast = (toastId: string) => (dispatch: Dispatch<Action>) => {
@@ -51,6 +52,9 @@ export function showRTKQueryErrorToastIfNeeded(error: string, response: any) {
             }
         } else {
             ReactGA.exception({
+                description: `load_fail: ${error}`
+            });
+            ReactGA4.gtag("event", "exception", {
                 description: `load_fail: ${error}`
             });
             return showErrorToast(error, API_REQUEST_FAILURE_MESSAGE);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7078,6 +7078,11 @@ react-fast-compare@^3.1.1:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
+react-ga4@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-ga4/-/react-ga4-2.0.0.tgz#d125807cc30b087a6aa24401ec5f1f1c2d176fe9"
+  integrity sha512-WHi98hMunzh4ngRdNil8NN6Qly3ZZUkprhbgSqA+NFzovp8zqpYV3jcbKL9FnMdeBQHGhv8AVNCT2oFEE+EFXA==
+
 react-ga@^3.3.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-3.3.1.tgz#d8e1f4e05ec55ed6ff944dcb14b99011dfaf9504"


### PR DESCRIPTION
This just runs both versions of ReactGA alongside one another. 

The new version is a bit crusty but does the job fine (it's essentially just a light wrapper around `gtag.js`) - by this I mean the convenience methods `pageview` and `exception` now no longer exist but you can just use the base `gtag` method to send GA the same message.

I've created a GA4 "property" for each site - the measurement ids in this PR are not placeholders. 