### PR TITLE
Wrap month and year properly when setting day in date inputs

### DIFF
--- a/src/app/components/elements/inputs/DobInput.tsx
+++ b/src/app/components/elements/inputs/DobInput.tsx
@@ -21,6 +21,7 @@ export const DobInput = ({userToUpdate, setUserToUpdate, submissionAttempted, ed
             onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
                 setUserToUpdate(Object.assign({}, userToUpdate, {dateOfBirth: event.target.valueAsDate}))
             }}
+            disableDefaults
             aria-describedby="age-validation-message"
             labelSuffix=" of birth"
         />

--- a/src/app/components/elements/modals/QuizSettingModal.tsx
+++ b/src/app/components/elements/modals/QuizSettingModal.tsx
@@ -56,8 +56,6 @@ export function QuizSettingModal({quiz, dueDate: initialDueDate, feedbackMode: i
 
     const yearRange = range(currentYear, currentYear + 5);
     const now = new Date();
-    const currentMonth = now.getMonth() + 1;
-    const currentDay = now.getDate();
 
     function addValidated(what: ControlName) {
         setValidated(validated => {
@@ -95,8 +93,8 @@ export function QuizSettingModal({quiz, dueDate: initialDueDate, feedbackMode: i
             {groupInvalid && <RS.FormFeedback className="d-block" valid={false}>You must select a group</RS.FormFeedback>}
         </RS.Label>
         <RS.Label className="w-100 mb-4">Set an optional due date:<br/>
-            <DateInput invalid={dueDateInvalid || undefined} value={dueDate ?? undefined} yearRange={yearRange} defaultYear={currentYear}
-                       defaultMonth={(day) => (day && day <= currentDay) ? currentMonth + 1 : currentMonth} onChange={(e) => setDueDate(e.target.valueAsDate)}/>
+            <DateInput invalid={dueDateInvalid || undefined} value={dueDate ?? undefined} yearRange={yearRange}
+                       onChange={(e) => setDueDate(e.target.valueAsDate)}/>
             {dueDateInvalid && <small className={"pt-2 text-danger"}>Due date must be after today.</small>}
         </RS.Label>
         <RS.Label className="w-100 mb-4">What level of feedback should students get:<br/>

--- a/src/app/components/pages/AssignmentSchedule.tsx
+++ b/src/app/components/pages/AssignmentSchedule.tsx
@@ -229,7 +229,6 @@ const AssignmentModal = ({user, showAssignmentModal, toggleAssignModal, assignme
         setDueDate, setScheduledStartDate, setAssignmentNotes]);
 
     const yearRange = range(currentYear, currentYear + 5);
-    const currentMonth = (new Date()).getMonth() + 1;
 
     const dueDateInvalid = dueDate && scheduledStartDate ? scheduledStartDate.valueOf() > dueDate.valueOf() : false;
 
@@ -277,11 +276,11 @@ const AssignmentModal = ({user, showAssignmentModal, toggleAssignModal, assignme
                 </Card>}
             </Label>
             <Label className="w-100 pb-2">Schedule an assignment start date <span className="text-muted"> (optional)</span>
-                <DateInput value={scheduledStartDate} placeholder="Select your scheduled start date..." yearRange={yearRange} defaultYear={currentYear} defaultMonth={currentMonth}
+                <DateInput value={scheduledStartDate} placeholder="Select your scheduled start date..." yearRange={yearRange}
                            onChange={(e: ChangeEvent<HTMLInputElement>) => setScheduledStartDate(e.target.valueAsDate as Date)} />
             </Label>
             <Label className="w-100 pb-2">Due date reminder <span className="text-muted"> (optional)</span>
-                <DateInput value={dueDate} placeholder="Select your due date..." yearRange={yearRange} defaultYear={currentYear} defaultMonth={currentMonth}
+                <DateInput value={dueDate} placeholder="Select your due date..." yearRange={yearRange}
                            onChange={(e: ChangeEvent<HTMLInputElement>) => setDueDate(e.target.valueAsDate as Date)} />
                 {dueDateInvalid && <small className={"pt-2 text-danger"}>Due date must be on or after start date.</small>}
             </Label>

--- a/src/app/components/pages/SetAssignments.tsx
+++ b/src/app/components/pages/SetAssignments.tsx
@@ -94,7 +94,6 @@ const AssignGroup = ({groups, board, allowScheduling}: AssignGroupProps) => {
     }
 
     const yearRange = range(currentYear, currentYear + 5);
-    const currentMonth = (new Date()).getMonth() + 1;
     const dueDateInvalid = dueDate && scheduledStartDate ? nthHourOf(0, scheduledStartDate).valueOf() > dueDate.valueOf() : false;
 
     function setScheduledStartDateAtSevenAM(e: ChangeEvent<HTMLInputElement>) {
@@ -118,11 +117,11 @@ const AssignGroup = ({groups, board, allowScheduling}: AssignGroupProps) => {
             />
         </Label>
         {allowScheduling && <Label className="w-100 pb-2">Schedule an assignment start date <span className="text-muted"> (optional)</span>
-            <DateInput value={scheduledStartDate} placeholder="Select your scheduled start date..." yearRange={yearRange} defaultYear={currentYear} defaultMonth={currentMonth}
+            <DateInput value={scheduledStartDate} placeholder="Select your scheduled start date..." yearRange={yearRange}
                        onChange={setScheduledStartDateAtSevenAM} />
         </Label>}
         <Label className="w-100 pb-2">Due date reminder <span className="text-muted"> (optional)</span>
-            <DateInput value={dueDate} placeholder="Select your due date..." yearRange={yearRange} defaultYear={currentYear} defaultMonth={currentMonth}
+            <DateInput value={dueDate} placeholder="Select your due date..." yearRange={yearRange}
                 onChange={(e: ChangeEvent<HTMLInputElement>) => setDueDate(e.target.valueAsDate as Date)} /> {/* DANGER here with force-casting Date|null to Date */}
             {dueDateInvalid && <small className={"pt-2 text-danger"}>Due date must be on or after start date.</small>}
         </Label>

--- a/src/app/components/pages/quizzes/QuizTeacherFeedback.tsx
+++ b/src/app/components/pages/quizzes/QuizTeacherFeedback.tsx
@@ -82,9 +82,6 @@ export const QuizTeacherFeedback = ({user}: {user: RegisteredUserDTO}) => {
 
     // Date input variables
     const yearRange = range(currentYear, currentYear + 5);
-    const now = new Date();
-    const currentMonth = now.getMonth() + 1;
-    const currentDay = now.getDate();
 
     const [settingDueDate, setSettingDueDate] = useState<boolean>(false);
     const [dueDate, setDueDate] = useState<Date | null>( null);
@@ -128,8 +125,8 @@ export const QuizTeacherFeedback = ({user}: {user: RegisteredUserDTO}) => {
                 <Row>
                     {assignment.dueDate && <Col xs={12} sm={6} md={4}>
                         <Label for="dueDate" className="pr-1">Extend the due date:
-                            <DateInput id="dueDate" value={dueDate ?? undefined} invalid={(dueDate && (dueDate < assignment.dueDate)) ?? undefined} yearRange={yearRange} defaultYear={currentYear} noClear
-                                       defaultMonth={(day) => (day && day <= currentDay) ? currentMonth + 1 : currentMonth} onChange={(e) => setDueDate(e.target.valueAsDate)}/>
+                            <DateInput id="dueDate" value={dueDate ?? undefined} invalid={(dueDate && (dueDate < assignment.dueDate)) ?? undefined}
+                                       yearRange={yearRange} noClear onChange={(e) => setDueDate(e.target.valueAsDate)}/>
                         </Label>
                         <div className={"mt-2 w-100 text-center mb-2"}>
                             {dueDate && (dueDate > assignment.dueDate) && <Button color="primary" outline className={"btn-md"} onClick={() => setValidDueDate(dueDate)}>


### PR DESCRIPTION
New behaviour: 
- If the day is 09/12/2023 and you input 5 as the day, the date input defaults to 05/01/2024
- If the day is 09/05/2023 and you input 5 as the day, the date input defaults to 05/06/2023
- If the day is 01/09/2023 and you input 5 as the month, the date input defaults to --/05/2024

This was harder than we thought! IMO we need a new date input method (I actually have a "nicer" one in a branch somewhere) because rolling your own is tricky.

Would benefit from someone testing it again locally