### PR TITLE
Add group event booking contact form to manage group reservations modal

### DIFF
--- a/src/IsaacApiTypes.tsx
+++ b/src/IsaacApiTypes.tsx
@@ -107,6 +107,7 @@ export interface IsaacEventPageDTO extends ContentDTO {
     eventStatus?: EventStatus;
     placesAvailable?: number;
     endDate?: Date;
+    userBookingStatus?: BookingStatus;
 }
 
 export interface IsaacFastTrackQuestionPageDTO extends IsaacQuestionPageDTO {
@@ -717,7 +718,7 @@ export interface MisuseStatisticDTO {
 
 export type GameboardCreationMethod = "FILTER" | "BUILDER";
 
-export type EventStatus = "OPEN" | "FULLY_BOOKED" | "CANCELLED" | "CLOSED" | "WAITING_LIST_ONLY";
+export type EventStatus = "OPEN" | "FULLY_BOOKED" | "CANCELLED" | "CLOSED" | "WAITING_LIST_ONLY" | "RESERVATION_ONLY";
 
 export type FastTrackConceptState = "ft_top_ten" | "ft_upper" | "ft_lower";
 

--- a/src/IsaacAppTypes.tsx
+++ b/src/IsaacAppTypes.tsx
@@ -657,10 +657,10 @@ export interface AugmentedEvent extends ApiTypes.IsaacEventPageDTO {
     isStudentOnly?: boolean;
     isRecurring?: boolean;
     isWaitingListOnly?: boolean;
+    isReservationOnly?: boolean;
     isNotClosed?: boolean;
     isCancelled?: boolean;
     field?: "physics" | "maths";
-    userBookingStatus?: ApiTypes.BookingStatus;
 }
 
 export interface EventOverview {

--- a/src/app/components/elements/modals/ReservationsModal.tsx
+++ b/src/app/components/elements/modals/ReservationsModal.tsx
@@ -247,6 +247,8 @@ const ReservationsModal = () => {
         return true;
     };
 
+    const allowedToReserve = Object.values(userCheckboxes).some(v => v) && !isReservationLimitReached() && groupSupervisorContactName && groupSupervisorContactEmail;
+
     return <React.Fragment>
         <div id="reservation-modal">
             {!selectedEvent?.allowGroupReservations && <p>This event does not allow group reservations.</p>}
@@ -394,6 +396,7 @@ const ReservationsModal = () => {
                                         <Input
                                             id="contact-name" name="contact-name" type="text" value={groupSupervisorContactName}
                                             onChange={event => setGroupSupervisorContactName(event.target.value)}
+                                            invalid={!groupSupervisorContactName}
                                         />
                                     </Col>
                                     <Col md={6}>
@@ -403,6 +406,7 @@ const ReservationsModal = () => {
                                         <Input
                                             id="contact-email" name="contact-email" type="text" value={groupSupervisorContactEmail}
                                             onChange={event => setGroupSupervisorContactEmail(event.target.value)}
+                                            invalid={!groupSupervisorContactEmail || !groupSupervisorContactEmail.includes('@')}
                                         />
                                     </Col>
                                 </Row>
@@ -425,7 +429,7 @@ const ReservationsModal = () => {
                                         You can only reserve a maximum of {selectedEvent && selectedEvent.groupReservationLimit} group members onto this event.
                                     </p>}
                                     <div className="text-center">
-                                        <Button color="primary" disabled={!Object.values(userCheckboxes).some(v => v) || isReservationLimitReached()} onClick={requestReservations}>
+                                        <Button color="primary" disabled={!allowedToReserve} onClick={requestReservations}>
                                             Reserve places
                                         </Button>
                                     </div>

--- a/src/app/components/elements/modals/ReservationsModal.tsx
+++ b/src/app/components/elements/modals/ReservationsModal.tsx
@@ -416,9 +416,10 @@ const ReservationsModal = () => {
                             <div className={"mt-2 mb-3"}>
                                 <h4>Additional booking information</h4>
                                 <p>
-                                    Add additional information about the group booking, for example contact details of
-                                    other group supervisors. Please be aware that there is a maximum of students that
-                                    are allowed to be supervised by a single teacher.
+                                    Add additional information about the group booking, for example contact details of other group supervisors.{" "}
+                                    Please be aware that the students will remain the responsibility of the accompanying teachers.{" "}
+                                    Please make sure that you have enough staff for the number of students you are bringing.{" "}
+                                    We recommend at least 2 members of staff per group.
                                 </p>
                                 <Input type={"textarea"} value={additionalBookingNotes} onChange={e => setAdditionalBookingNotes(e.target.value)} />
                             </div>

--- a/src/app/components/elements/modals/ReservationsModal.tsx
+++ b/src/app/components/elements/modals/ReservationsModal.tsx
@@ -7,7 +7,8 @@ import {
     getEventBookingsForGroup,
     isaacApi,
     reserveUsersOnEvent,
-    store, submitMessage,
+    store,
+    submitMessage,
     useAppDispatch,
     useAppSelector
 } from "../../../state";

--- a/src/app/components/elements/modals/ReservationsModal.tsx
+++ b/src/app/components/elements/modals/ReservationsModal.tsx
@@ -7,11 +7,23 @@ import {
     getEventBookingsForGroup,
     isaacApi,
     reserveUsersOnEvent,
-    store,
+    store, submitMessage,
     useAppDispatch,
     useAppSelector
 } from "../../../state";
-import {Button, Col, CustomInput, Dropdown, DropdownItem, DropdownMenu, DropdownToggle, Row, Table} from "reactstrap";
+import {
+    Button,
+    Col,
+    CustomInput,
+    Dropdown,
+    DropdownItem,
+    DropdownMenu,
+    DropdownToggle,
+    Input,
+    Label,
+    Row,
+    Table
+} from "reactstrap";
 import {ShowLoading} from "../../handlers/ShowLoading";
 import {ActiveModal, AppGroup, AppGroupMembership} from "../../../../IsaacAppTypes";
 import {RegisteredUserDTO} from "../../../../IsaacApiTypes";
@@ -49,6 +61,11 @@ const ReservationsModal = () => {
     const [checkAllCancelReservationsCheckbox, setCheckAllCancelReservationsCheckbox] = useState<boolean>();
     const [groupDropdownOpen, setGroupDropdownOpen] = useState(false);
     const [unbookedUsersById, setUnbookedUsersById] = useState<{[id: number]: AppGroupMembership}>({});
+
+    // Group booking contact form state
+    const [groupSupervisorContactName, setGroupSupervisorContactName] = useState<string>(`${user?.givenName}${user?.familyName ? " " + user?.familyName : ""}`);
+    const [groupSupervisorContactEmail, setGroupSupervisorContactEmail] = useState<string>(user?.email ?? "");
+    const [additionalBookingNotes, setAdditionalBookingNotes] = useState<string>();
 
     useEffect(() => {
         setUnbookedUsersById(unbookedUsers.reduce((acc: {[id: number]: AppGroupMembership}, u) => ({...acc, [u.id as number]: u}), {}));
@@ -181,6 +198,20 @@ const ReservationsModal = () => {
         if (selectedEvent && selectedEvent.id && selectedGroup && selectedGroup.id) {
             const reservableIds = Object.entries(userCheckboxes).filter(c => c[1]).map(c => parseInt(c[0]));
             dispatch(reserveUsersOnEvent(selectedEvent.id, reservableIds, selectedGroup.id));
+            // Send contact form with details of the group booking
+            const subject = `Event group booking: ${selectedEvent.id}:${selectedGroup.id}`;
+            const message = `
+            Event: ${selectedEvent.title} (id: ${selectedEvent.id})
+            Group id: ${selectedGroup.id}
+            Students reserved: ${reservableIds.join(", ")}
+            
+            Main supervisor contact: ${groupSupervisorContactName}, ${groupSupervisorContactEmail}
+            
+            Additional booking information
+            ---
+            ${additionalBookingNotes}
+            `;
+            dispatch(submitMessage({firstName: user?.givenName ?? "[Unknown]", lastName: user?.familyName ?? "[Teacher]", emailAddress: user?.email ?? "[Unknown]", subject, message}));
         }
         setCheckAllCheckbox(false);
     };
@@ -349,6 +380,43 @@ const ReservationsModal = () => {
                                     })}
                                 </tbody>
                             </Table>
+
+                            {/* Contact details for main supervisor */}
+                            <div className={"mt-2 mb-3"}>
+                                <h4>Contact details for main group supervisor</h4>
+                                <p>Change these if a teacher other than yourself is going to be supervising the students at this event.</p>
+                                <Row>
+                                    <Col md={6}>
+                                        <Label htmlFor="contact-name" className="form-required">
+                                            Contact name
+                                        </Label>
+                                        <Input
+                                            id="contact-name" name="contact-name" type="text" value={groupSupervisorContactName}
+                                            onChange={event => setGroupSupervisorContactName(event.target.value)}
+                                        />
+                                    </Col>
+                                    <Col md={6}>
+                                        <Label htmlFor="contact-email" className="form-required">
+                                            Contact email
+                                        </Label>
+                                        <Input
+                                            id="contact-email" name="contact-email" type="text" value={groupSupervisorContactEmail}
+                                            onChange={event => setGroupSupervisorContactEmail(event.target.value)}
+                                        />
+                                    </Col>
+                                </Row>
+                            </div>
+
+                            {/* Additional booking information for teachers */}
+                            <div className={"mt-2 mb-3"}>
+                                <h4>Additional booking information</h4>
+                                <p>
+                                    Add additional information about the group booking, for example contact details of
+                                    other group supervisors. Please be aware that there is a maximum of students that
+                                    are allowed to be supervised by a single teacher.
+                                </p>
+                                <Input type={"textarea"} value={additionalBookingNotes} onChange={e => setAdditionalBookingNotes(e.target.value)} />
+                            </div>
 
                             <Row className="toolbar">
                                 <Col>

--- a/src/app/components/elements/modals/ReservationsModal.tsx
+++ b/src/app/components/elements/modals/ReservationsModal.tsx
@@ -28,7 +28,7 @@ import {
 import {ShowLoading} from "../../handlers/ShowLoading";
 import {ActiveModal, AppGroup, AppGroupMembership} from "../../../../IsaacAppTypes";
 import {RegisteredUserDTO} from "../../../../IsaacApiTypes";
-import {bookingStatusMap, isLoggedIn, NOT_FOUND} from "../../../services";
+import {api, bookingStatusMap, isLoggedIn, NOT_FOUND, schoolNameWithPostcode} from "../../../services";
 import _orderBy from "lodash/orderBy";
 import {Link} from "react-router-dom";
 import classNames from "classnames";
@@ -67,6 +67,7 @@ const ReservationsModal = () => {
     const [groupSupervisorContactName, setGroupSupervisorContactName] = useState<string>(`${user?.givenName}${user?.familyName ? " " + user?.familyName : ""}`);
     const [groupSupervisorContactEmail, setGroupSupervisorContactEmail] = useState<string>(user?.email ?? "");
     const [additionalBookingNotes, setAdditionalBookingNotes] = useState<string>();
+    const [school, setSchool] = useState<string>();
 
     useEffect(() => {
         setUnbookedUsersById(unbookedUsers.reduce((acc: {[id: number]: AppGroupMembership}, u) => ({...acc, [u.id as number]: u}), {}));
@@ -195,6 +196,16 @@ const ReservationsModal = () => {
         setCancelReservationCheckboxes(checkboxes);
     };
 
+    useEffect(function fetchUsersSchool() {
+        if (user?.schoolId && user?.schoolId !== "") {
+            api.schools.getByUrn(user?.schoolId).then(({data}) => {
+                setSchool(schoolNameWithPostcode(data[0]));
+            });
+        } else if (user?.schoolOther) {
+            setSchool(user.schoolOther);
+        }
+    }, [user]);
+
     const requestReservations = () => {
         if (selectedEvent && selectedEvent.id && selectedGroup && selectedGroup.id) {
             const reservableIds = Object.entries(userCheckboxes).filter(c => c[1]).map(c => parseInt(c[0]));
@@ -205,6 +216,7 @@ const ReservationsModal = () => {
             Event: ${selectedEvent.title} (id: ${selectedEvent.id})
             Group id: ${selectedGroup.id}
             Students reserved: ${reservableIds.join(", ")}
+            School: ${school}
             
             Main supervisor contact: ${groupSupervisorContactName}, ${groupSupervisorContactEmail}
             

--- a/src/app/components/pages/EventDetails.tsx
+++ b/src/app/components/pages/EventDetails.tsx
@@ -330,7 +330,9 @@ const EventDetails = ({match: {params: {eventId}}, location: {pathname}}: EventD
                                 {/* Options for logged-in users */}
                                 {isLoggedIn(user) && !event.hasExpired && <React.Fragment>
                                     {event.isReservationOnly && !canReserveSpaces && !isTeacherOrAbove(user) && !userBookedReservedOrOnWaitingList(user, event) && <Alert color={"warning"}>
-                                        Places on this event can only be reserved by teachers. Please ask your teacher to reserve a place for you.
+                                        Places on this event can only be reserved by teachers.{" "}
+                                        Please ask your teacher to reserve a place for you.{" "}
+                                        You will need to be accompanied by a teacher to the event.{" "}
                                     </Alert>}
                                     {(canMakeABooking || canBeAddedToWaitingList) && !bookingFormOpen && !['CONFIRMED'].includes(event.userBookingStatus || '') &&
                                     <Button onClick={() => {

--- a/src/app/components/pages/EventDetails.tsx
+++ b/src/app/components/pages/EventDetails.tsx
@@ -43,7 +43,8 @@ import {
     zeroOrLess,
     isAdminOrEventManager,
     isEventLeader,
-    isPhy
+    isPhy,
+    userBookedReservedOrOnWaitingList
 } from "../../services";
 import {AdditionalInformation} from "../../../IsaacAppTypes";
 import {DateString} from "../elements/DateString";
@@ -328,6 +329,9 @@ const EventDetails = ({match: {params: {eventId}}, location: {pathname}}: EventD
 
                                 {/* Options for logged-in users */}
                                 {isLoggedIn(user) && !event.hasExpired && <React.Fragment>
+                                    {event.isReservationOnly && !canReserveSpaces && !isTeacherOrAbove(user) && !userBookedReservedOrOnWaitingList(user, event) && <Alert color={"warning"}>
+                                        Places on this event can only be reserved by teachers. Please ask your teacher to reserve a place for you.
+                                    </Alert>}
                                     {(canMakeABooking || canBeAddedToWaitingList) && !bookingFormOpen && !['CONFIRMED'].includes(event.userBookingStatus || '') &&
                                     <Button onClick={() => {
                                         setBookingFormOpen(true)

--- a/src/app/services/events.tsx
+++ b/src/app/services/events.tsx
@@ -1,4 +1,14 @@
-import {apiHelper, atLeastOne, isTeacherOrAbove, siteSpecific, STAGE, STAGES_CS, STAGES_PHY, zeroOrLess} from "./";
+import {
+    apiHelper,
+    atLeastOne,
+    isDefined,
+    isTeacherOrAbove,
+    siteSpecific,
+    STAGE,
+    STAGES_CS,
+    STAGES_PHY,
+    zeroOrLess
+} from "./";
 import {IsaacEventPageDTO} from "../../IsaacApiTypes";
 import {AugmentedEvent, PotentialUser} from "../../IsaacAppTypes";
 import {DateString, FRIENDLY_DATE, TIME_ONLY} from "../components/elements/DateString";
@@ -48,6 +58,7 @@ export const augmentEvent = (event: IsaacEventPageDTO): AugmentedEvent => {
     augmentedEvent.isNotClosed = !["CLOSED", "CANCELLED"].includes(event.eventStatus as string);
     augmentedEvent.isCancelled = event.eventStatus === "CANCELLED";
     augmentedEvent.isWaitingListOnly = event.eventStatus === "WAITING_LIST_ONLY";
+    augmentedEvent.isReservationOnly = event.eventStatus === "RESERVATION_ONLY";
 
     // we have to fix the event image url.
     if(augmentedEvent.eventThumbnail && augmentedEvent.eventThumbnail.src) {
@@ -166,12 +177,21 @@ export const userIsTeacherAtAStudentEvent = (user: Immutable<PotentialUser> | nu
     return event.isAStudentEvent && isTeacherOrAbove(user);
 }
 
+export const userBookedReservedOrOnWaitingList = (user: Immutable<PotentialUser> | null, event: AugmentedEvent) => {
+    return isDefined(event.userBookingStatus) && ["WAITING_LIST", "CONFIRMED", "RESERVED"].includes(event.userBookingStatus);
+}
+
+export const ifEventIsReservationsOnlyThenUserIsTeacherOrUserIsReserved = (user: Immutable<PotentialUser> | null, event: AugmentedEvent) => {
+    return event.isReservationOnly ? isTeacherOrAbove(user) : event.userBookingStatus === "RESERVED";
+}
+
 export const userCanMakeEventBooking = (user: Immutable<PotentialUser> | null, event: AugmentedEvent) => {
     return event.isNotClosed &&
         event.isWithinBookingDeadline &&
         !event.isWaitingListOnly &&
         event.userBookingStatus !== "CONFIRMED" &&
         userSatisfiesStudentOnlyRestrictionForEvent(user, event) &&
+        ifEventIsReservationsOnlyThenUserIsTeacherOrUserIsReserved(user, event) &&
         (atLeastOne(event.placesAvailable) || userIsTeacherAtAStudentEvent(user, event) ||
             event.userBookingStatus === "RESERVED");
 }
@@ -180,8 +200,8 @@ export const userCanBeAddedToEventWaitingList = (user: Immutable<PotentialUser> 
     return !userCanMakeEventBooking(user, event) &&
         event.isNotClosed &&
         !event.hasExpired &&
-        (event.userBookingStatus === undefined ||
-            !["WAITING_LIST", "CONFIRMED", "RESERVED"].includes(event.userBookingStatus)) &&
+        ifEventIsReservationsOnlyThenUserIsTeacherOrUserIsReserved(user, event) &&
+        !userBookedReservedOrOnWaitingList(user, event) &&
         userSatisfiesStudentOnlyRestrictionForEvent(user, event)
 }
 

--- a/src/app/services/events.tsx
+++ b/src/app/services/events.tsx
@@ -182,7 +182,7 @@ export const userBookedReservedOrOnWaitingList = (user: Immutable<PotentialUser>
 }
 
 export const ifEventIsReservationsOnlyThenUserIsTeacherOrUserIsReserved = (user: Immutable<PotentialUser> | null, event: AugmentedEvent) => {
-    return event.isReservationOnly ? isTeacherOrAbove(user) : event.userBookingStatus === "RESERVED";
+    return event.isReservationOnly ? (isTeacherOrAbove(user) || event.userBookingStatus === "RESERVED") : true;
 }
 
 export const userCanMakeEventBooking = (user: Immutable<PotentialUser> | null, event: AugmentedEvent) => {

--- a/src/app/services/events.tsx
+++ b/src/app/services/events.tsx
@@ -200,7 +200,7 @@ export const userCanBeAddedToEventWaitingList = (user: Immutable<PotentialUser> 
     return !userCanMakeEventBooking(user, event) &&
         event.isNotClosed &&
         !event.hasExpired &&
-        ifEventIsReservationsOnlyThenUserIsTeacherOrUserIsReserved(user, event) &&
+        !event.isReservationOnly &&
         !userBookedReservedOrOnWaitingList(user, event) &&
         userSatisfiesStudentOnlyRestrictionForEvent(user, event)
 }

--- a/src/test/services/events.test.tsx
+++ b/src/test/services/events.test.tsx
@@ -289,7 +289,7 @@ describe("Teachers can make event bookings when conditions are met", () => {
         event.isReservationOnly = true;
 
         // Act
-        const canMakeEventBooking = userCanMakeEventBooking(studentUser, event);
+        const canMakeEventBooking = userCanMakeEventBooking(teacherUser, event);
 
         // Assert
         expect(canMakeEventBooking).toEqual(true);

--- a/src/test/services/events.test.tsx
+++ b/src/test/services/events.test.tsx
@@ -137,6 +137,29 @@ beforeEach(() => {
         // Assert
         expect(canBook).toEqual(false)
     })
+
+    it("Returns false for a reservations-only event", () => {
+        // Arrange
+        event.isReservationOnly = true;
+
+        // Act
+        const canMakeEventBooking = userCanMakeEventBooking(studentUser, event);
+
+        // Assert
+        expect(canMakeEventBooking).toEqual(false);
+    })
+
+    it("Returns true for a reservations-only event, if the user is already reserved", () => {
+        // Arrange
+        event.isReservationOnly = true;
+        event.userBookingStatus = 'RESERVED';
+
+        // Act
+        const canMakeEventBooking = userCanMakeEventBooking(studentUser, event);
+
+        // Assert
+        expect(canMakeEventBooking).toEqual(true);
+    })
 }));
 
 describe("Teachers can make event bookings when conditions are met", () => {
@@ -260,6 +283,17 @@ describe("Teachers can make event bookings when conditions are met", () => {
         // Assert
         expect(canBook).toEqual(false)
     })
+
+    it("Returns true for a reservations-only event", () => {
+        // Arrange
+        event.isReservationOnly = true;
+
+        // Act
+        const canMakeEventBooking = userCanMakeEventBooking(studentUser, event);
+
+        // Assert
+        expect(canMakeEventBooking).toEqual(true);
+    })
 })
 
 describe("Teachers can make event reservations when conditions are met", () => {
@@ -313,6 +347,17 @@ describe("Teachers can make event reservations when conditions are met", () => {
 
         // Assert
         expect(canReserve).toEqual(false)
+    })
+
+    it("Returns true for a reservation-only event", () => {
+        // Arrange
+        event.isReservationOnly = true;
+
+        // Act
+        const canReserve = userCanReserveEventSpaces(teacherUser, event);
+
+        // Assert
+        expect(canReserve).toEqual(true);
     })
 
     it("Returns false for a student user", () => {


### PR DESCRIPTION
Needs copy.

---

The `RESERVED_ONLY` event status displays the following for students:

![image](https://user-images.githubusercontent.com/33040507/229146386-e88b85ea-1eb3-40d9-a8d9-f7b3cfcd65df.png)

and makes no difference to the teacher view. An event that is both `RESERVED_ONLY` but not group booking doesn't make any sense, but I haven't handled this case because it's fundamentally a content error (and a by-product of the overcomplicated way we categorise events)
