### PR TITLE
Remove core-js and Safari 10 minimizer workaround

### DIFF
--- a/config/webpack.config.common.js
+++ b/config/webpack.config.common.js
@@ -145,13 +145,6 @@ module.exports = (env) => {
                 chunks: "all",
             },
             runtimeChunk: true,
-            minimizer: [
-                new TerserPlugin({
-                    terserOptions: {
-                        safari10: true,
-                    },
-                }),
-            ],
         },
 
         devtool : "source-map",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "axios": "^0.26.0",
     "axios-mock-adapter": "^1.20.0",
     "billboard.js": "^1.12.11",
-    "core-js": "^3.19.3",
     "dayjs": "^1.10.7",
     "he": "^1.2.0",
     "highlight.js": "^11.5.1",

--- a/src/index-ada-renderer.tsx
+++ b/src/index-ada-renderer.tsx
@@ -1,4 +1,3 @@
-import "core-js/stable";
 import "regenerator-runtime/runtime";
 import './scss/cs/isaac.scss';
 import React from 'react';

--- a/src/index-ada.tsx
+++ b/src/index-ada.tsx
@@ -1,4 +1,3 @@
-import "core-js/stable";
 import "regenerator-runtime/runtime";
 import './scss/cs/isaac.scss';
 import React from 'react';

--- a/src/index-phy-renderer.tsx
+++ b/src/index-phy-renderer.tsx
@@ -1,4 +1,3 @@
-import "core-js/stable";
 import "regenerator-runtime/runtime";
 import './scss/phy/isaac.scss';
 import React from 'react';

--- a/src/index-phy.tsx
+++ b/src/index-phy.tsx
@@ -1,4 +1,3 @@
-import "core-js/stable";
 import "regenerator-runtime/runtime";
 import './scss/phy/isaac.scss';
 import React from 'react';


### PR DESCRIPTION
We no longer support older browsers, and there is an Nginx-powered unsupported browser page to catch anyone trying to load the site in those browsers. So we shouldn't need to send everyone a chunk of unnecessary JS any more!