### PR TITLE
2023 Bundle Optimisations

### DIFF
--- a/config/webpack.config.common.js
+++ b/config/webpack.config.common.js
@@ -50,9 +50,6 @@ module.exports = (env) => {
         resolve: {
             modules: [path.resolve(__dirname), 'node_modules'],
             extensions: ['.ts', '.tsx', '.js', '.jsx', '.mjs'],
-            alias: {
-                'p5': 'p5/lib/p5.min.js'
-            },
             fallback: { "querystring": require.resolve("querystring-es3") }
         },
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "axios": "^0.26.0",
     "axios-mock-adapter": "^1.20.0",
     "billboard.js": "^1.12.11",
+    "core-js": "^3.30.0",
     "dayjs": "^1.10.7",
     "he": "^1.2.0",
     "highlight.js": "^11.5.1",
@@ -50,8 +51,7 @@
     "reactstrap": "^8.10.1",
     "redux": "^4.1.2",
     "redux-logger": "^3.0.6",
-    "remarkable": "^2.0.1",
-    "string.prototype.matchall": "^4.0.6"
+    "remarkable": "^2.0.1"
   },
   "scripts": {
     "build-phy": "webpack --env prod --config config/webpack.config.physics.js",

--- a/src/app/components/content/IsaacCodeSnippet.tsx
+++ b/src/app/components/content/IsaacCodeSnippet.tsx
@@ -2,7 +2,8 @@ import {CodeSnippetDTO, ContentDTO} from "../../../IsaacApiTypes";
 import React, {useEffect, useRef} from "react";
 import {Col, Row} from "reactstrap";
 import hljs from 'highlight.js/lib/core';
-import {highlightJsService, isAda} from "../../services";
+import {highlightJsService} from "../../services/highlightJs";
+import {isAda} from "../../services";
 import {ScrollShadows} from "../elements/ScrollShadows";
 import classNames from "classnames";
 import {useExpandContent} from "../elements/markup/portals/Tables";
@@ -12,6 +13,8 @@ import {logAction, selectors, useAppDispatch, useAppSelector} from "../../state"
 interface IsaacCodeProps {
     doc: CodeSnippetDTO;
 }
+
+highlightJsService.registerLanguages();
 
 const IsaacCodeSnippet = ({doc}: IsaacCodeProps) => {
     const dispatch = useAppDispatch();

--- a/src/app/components/content/IsaacInteractiveCodeSnippet.tsx
+++ b/src/app/components/content/IsaacInteractiveCodeSnippet.tsx
@@ -1,12 +1,13 @@
-import React, {useEffect, useRef, useState} from "react";
+import React, {lazy, useEffect, useRef, useState} from "react";
 import {InteractiveCodeSnippetDTO} from "../../../IsaacApiTypes";
 import {CODE_EDITOR_BASE_URL, SITE_TITLE_SHORT, useIFrameMessages} from "../../services";
 import {v4 as uuid_v4} from "uuid";
 import {logAction, selectors, useAppDispatch, useAppSelector} from "../../state";
-import IsaacCodeSnippet from "./IsaacCodeSnippet";
 import {Alert, Button} from "reactstrap";
 import {Loading} from "../handlers/IsaacSpinner";
 import {Link} from "react-router-dom";
+
+const IsaacCodeSnippet = lazy(() => import("./IsaacCodeSnippet"));
 
 interface IsaacInteractiveCodeProps {doc: InteractiveCodeSnippetDTO}
 

--- a/src/app/components/elements/Assignments.tsx
+++ b/src/app/components/elements/Assignments.tsx
@@ -1,6 +1,6 @@
 import {AssignmentDTO} from "../../../IsaacApiTypes";
 import React, {MouseEvent, useMemo} from "react";
-import {Button, Col, Row, Spinner, UncontrolledTooltip} from "reactstrap";
+import {Button, Col, Row} from "reactstrap";
 import {Link} from "react-router-dom";
 import {
     determineGameboardStagesAndDifficulties,
@@ -8,16 +8,15 @@ import {
     difficultyShortLabelMap,
     extractTeacherName,
     generateGameboardSubjectHexagons,
-    isDefined, PATHS, siteSpecific,
+    isDefined,
+    PATHS,
+    siteSpecific,
     stageLabelMap,
     TAG_ID,
     tags
 } from "../../services";
 import {formatDate} from "./DateString";
 import {Circle} from "./svg/Circle";
-import classNames from "classnames";
-import {sortBy} from "lodash";
-import indexOf from "lodash/indexOf";
 
 const midnightOf = (date: Date | number) => {
     const d = new Date(date);

--- a/src/app/components/elements/cards/BoardCard.tsx
+++ b/src/app/components/elements/cards/BoardCard.tsx
@@ -16,7 +16,7 @@ import {showErrorToast, unlinkUserFromGameboard, useAppDispatch} from "../../../
 import {GameboardDTO, RegisteredUserDTO} from "../../../../IsaacApiTypes";
 import {Circle} from "../svg/Circle";
 import classNames from "classnames";
-import {sortBy} from "lodash";
+import sortBy from "lodash/sortBy";
 import {formatDate} from "../DateString";
 import {ShareLink} from "../ShareLink";
 import {

--- a/src/app/components/elements/inputs/DateInput.tsx
+++ b/src/app/components/elements/inputs/DateInput.tsx
@@ -1,6 +1,6 @@
 import React, {ChangeEvent, MouseEvent, useEffect, useRef, useState} from 'react';
 import {Button, Input, InputGroup, InputProps} from "reactstrap";
-import {range} from 'lodash';
+import range from 'lodash/range';
 
 // @ts-ignore This value definition is a bit dodgy but should work.
 export interface DateInputProps extends InputProps {

--- a/src/app/components/elements/inputs/SchoolInput.tsx
+++ b/src/app/components/elements/inputs/SchoolInput.tsx
@@ -3,7 +3,7 @@ import AsyncCreatableSelect from "react-select/async-creatable";
 import * as RS from "reactstrap";
 import {School, ValidationUser} from "../../../../IsaacAppTypes";
 import {api, schoolNameWithPostcode, validateUserSchool} from "../../../services";
-import {throttle} from "lodash";
+import throttle from "lodash/throttle";
 import classNames from "classnames";
 import {Immutable} from "immer";
 

--- a/src/app/components/elements/modals/GroupsModalCreators.tsx
+++ b/src/app/components/elements/modals/GroupsModalCreators.tsx
@@ -9,7 +9,7 @@ import {
     useAppDispatch,
     mutationSucceeded,
 } from "../../../state";
-import {sortBy} from "lodash";
+import sortBy from "lodash/sortBy";
 import {history, isAda, isDefined, isTeacherOrAbove, PATHS, siteSpecific} from "../../../services";
 import {Jumbotron, Row, Col, Form, Input, Table, CustomInput, Alert} from "reactstrap";
 import {Button} from "reactstrap";

--- a/src/app/components/elements/modals/QuestionSearchModal.tsx
+++ b/src/app/components/elements/modals/QuestionSearchModal.tsx
@@ -9,7 +9,8 @@ import {
 } from "../../../state";
 import * as RS from "reactstrap";
 import {SortableTableHeader} from "../SortableTableHeader";
-import {debounce, isEqual} from "lodash";
+import debounce from "lodash/debounce";
+import isEqual from "lodash/isEqual"
 import {MultiValue} from "react-select";
 import {
     tags,

--- a/src/app/components/elements/modals/QuizSettingModal.tsx
+++ b/src/app/components/elements/modals/QuizSettingModal.tsx
@@ -11,7 +11,7 @@ import {
 } from "../../../state";
 import React, {useState} from "react";
 import {isDefined, Item, selectOnChange} from "../../../services";
-import {range} from "lodash";
+import range from "lodash/range";
 import {currentYear, DateInput} from "../inputs/DateInput";
 import * as RS from "reactstrap";
 import {IsaacSpinner} from "../../handlers/IsaacSpinner";

--- a/src/app/components/elements/modals/ReservationsModal.tsx
+++ b/src/app/components/elements/modals/ReservationsModal.tsx
@@ -32,7 +32,7 @@ import {api, bookingStatusMap, isLoggedIn, NOT_FOUND, schoolNameWithPostcode} fr
 import _orderBy from "lodash/orderBy";
 import {Link} from "react-router-dom";
 import classNames from "classnames";
-import {sortBy} from "lodash";
+import sortBy from "lodash/sortBy";
 
 const ReservationsModal = () => {
     const dispatch = useAppDispatch();

--- a/src/app/components/elements/modals/inequality/InequalityModal.tsx
+++ b/src/app/components/elements/modals/inequality/InequalityModal.tsx
@@ -19,7 +19,7 @@ import {
 } from "./constants";
 import {closeActiveModal, openActiveModal, store, useAppDispatch} from "../../../../state";
 import {PageFragment} from "../../PageFragment";
-import {uniq} from "lodash";
+import uniq from "lodash/uniq";
 import {
     generateChemicalElementMenuItem,
     generateMenuItems,
@@ -34,7 +34,7 @@ import {
 const MenuItem = (props: MenuItemProps) => {
     return <li
         data-item={JSON.stringify(props)} // TODO Come up with a better way than this.
-        className={classNames(props.menu.className, "menu-item")} 
+        className={classNames(props.menu.className, "menu-item")}
         style={{fontSize: props.menu.fontSize}}
     >
         <VShape/><Markup encoding={"latex"}>{`$${props.menu.label}$`}</Markup>
@@ -306,7 +306,7 @@ const InequalityModal = ({availableSymbols, logicSyntax, editorMode, close, onEd
 
     const [showQuestionReminder, setShowQuestionReminder] = useState<boolean>(true);
     const onQuestionReminderClick = () => setShowQuestionReminder(prev => !prev);
-    
+
     const [menuOpen, setMenuOpen] = useState<boolean>(false);
     const disableLetters = availableSymbols?.includes("_no_alphabet") ?? false;
 

--- a/src/app/components/elements/modals/inequality/utils.ts
+++ b/src/app/components/elements/modals/inequality/utils.ts
@@ -14,7 +14,8 @@ import {
 } from "./constants";
 import {GREEK_LETTERS_MAP, isDefined, sanitiseInequalityState} from "../../../../services";
 import React from "react";
-import {isEqual, uniqWith} from "lodash";
+import isEqual from "lodash/isEqual";
+import uniqWith from "lodash/uniqWith";
 import {Inequality, makeInequality, WidgetSpec} from "inequality";
 
 // This file contains helper functions used specifically in the Inequality modal

--- a/src/app/components/navigation/IsaacApp.tsx
+++ b/src/app/components/navigation/IsaacApp.tsx
@@ -79,7 +79,6 @@ import {GameboardFilter} from "../pages/GameboardFilter";
 
 const ContentEmails = lazy(() => import('../pages/ContentEmails'));
 const MyProgress = lazy(() => import('../pages/MyProgress'));
-const Equality = lazy(() => import('../pages/Equality'));
 const GameboardBuilder = lazy(() => import('../pages/GameboardBuilder'));
 
 export const IsaacApp = () => {

--- a/src/app/components/pages/AdminEmails.tsx
+++ b/src/app/components/pages/AdminEmails.tsx
@@ -3,7 +3,7 @@ import {AppState, getEmailTemplate, sendAdminEmailWithIds, useAppDispatch, useAp
 import * as RS from "reactstrap";
 import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
 import classnames from "classnames";
-import {debounce} from 'lodash';
+import debounce from 'lodash/debounce';
 import {isEventManager} from "../../services";
 
 interface AdminEmailsProps {

--- a/src/app/components/pages/AssignmentProgress.tsx
+++ b/src/app/components/pages/AssignmentProgress.tsx
@@ -30,7 +30,8 @@ import {
     Row,
     UncontrolledButtonDropdown
 } from "reactstrap"
-import {orderBy, sortBy} from "lodash";
+import orderBy from "lodash/orderBy";
+import sortBy from "lodash/sortBy";
 import {
     AppAssignmentProgress,
     AppGroup,

--- a/src/app/components/pages/AssignmentSchedule.tsx
+++ b/src/app/components/pages/AssignmentSchedule.tsx
@@ -1,6 +1,9 @@
 import {assignGameboard, isaacApi, selectors, useAppDispatch, useAppSelector} from "../../state";
 import {AssignmentDTO, GameboardDTO, RegisteredUserDTO, UserGroupDTO} from "../../../IsaacApiTypes";
-import {groupBy, mapValues, range, sortBy} from "lodash";
+import groupBy from "lodash/groupBy";
+import mapValues from "lodash/mapValues";
+import range from "lodash/range";
+import sortBy from "lodash/sortBy";
 import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
 import React, {ChangeEvent, useCallback, useContext, useEffect, useMemo, useRef, useState, Fragment} from "react";
 import {

--- a/src/app/components/pages/ContentEmails.tsx
+++ b/src/app/components/pages/ContentEmails.tsx
@@ -3,7 +3,7 @@ import {sendProvidedEmailWithUserIds, useAppDispatch} from "../../state";
 import * as RS from "reactstrap";
 import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
 import classnames from "classnames";
-import {debounce} from 'lodash';
+import debounce from 'lodash/debounce';
 import {convert} from 'html-to-text';
 import {siteSpecific} from "../../services";
 import {EmailTemplateDTO} from "../../../IsaacApiTypes";

--- a/src/app/components/pages/GameboardFilter.tsx
+++ b/src/app/components/pages/GameboardFilter.tsx
@@ -41,7 +41,7 @@ import {HierarchyFilterHexagonal, HierarchyFilterSummary, Tier} from "../element
 import {GroupBase} from "react-select";
 import {DifficultyFilter} from "../elements/svg/DifficultyFilter";
 import {ContentSummaryDTO, GameboardDTO} from "../../../IsaacApiTypes";
-import {debounce} from "lodash";
+import debounce from "lodash/debounce";
 import {History} from "history";
 import {IsaacSpinner} from "../handlers/IsaacSpinner";
 import {CanonicalHrefElement} from "../navigation/CanonicalHrefElement";

--- a/src/app/components/pages/Groups.tsx
+++ b/src/app/components/pages/Groups.tsx
@@ -33,7 +33,7 @@ import {
     mutationSucceeded
 } from "../../state";
 import {ShowLoading} from "../handlers/ShowLoading";
-import {sortBy} from "lodash";
+import sortBy from "lodash/sortBy";
 import {AppGroup, AppGroupMembership} from "../../../IsaacAppTypes";
 import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
 import {ifKeyIsEnter, isAda, isDefined, isPhy, isStaff, isTeacherOrAbove, siteSpecific} from "../../services";

--- a/src/app/components/pages/SetAssignments.tsx
+++ b/src/app/components/pages/SetAssignments.tsx
@@ -29,7 +29,8 @@ import {
     useAppSelector
 } from "../../state";
 import {ShowLoading} from "../handlers/ShowLoading";
-import {range, sortBy} from "lodash";
+import range from "lodash/range";
+import sortBy from "lodash/sortBy";
 import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
 import {currentYear, DateInput} from "../elements/inputs/DateInput";
 import {

--- a/src/app/components/pages/Support.tsx
+++ b/src/app/components/pages/Support.tsx
@@ -5,7 +5,7 @@ import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
 import {Redirect, RouteComponentProps} from "react-router";
 import {Tabs} from "../elements/Tabs";
 import {history, isAda, isDefined, siteSpecific} from "../../services";
-import {fromPairs} from "lodash";
+import fromPairs from "lodash/fromPairs";
 import {PageFragment} from "../elements/PageFragment";
 import {NotFound} from "./NotFound";
 import {MetaDescription} from "../elements/MetaDescription";

--- a/src/app/components/pages/quizzes/QuizTeacherFeedback.tsx
+++ b/src/app/components/pages/quizzes/QuizTeacherFeedback.tsx
@@ -25,7 +25,7 @@ import {formatDate} from "../../elements/DateString";
 import {Spacer} from "../../elements/Spacer";
 import {IsaacSpinner} from "../../handlers/IsaacSpinner";
 import {currentYear, DateInput} from "../../elements/inputs/DateInput";
-import {range} from "lodash";
+import range from "lodash/range";
 import {ResultsTable} from "../../elements/quiz/QuizProgressCommon";
 import {
     Alert,

--- a/src/app/components/site/cs/RoutesCS.tsx
+++ b/src/app/components/site/cs/RoutesCS.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, {lazy} from "react";
 import {TrackedRoute} from "../../navigation/TrackedRoute";
 import {AllTopics} from "../../pages/AllTopics";
 import StaticPageRoute from "../../navigation/StaticPageRoute";
@@ -8,8 +8,9 @@ import {isStaff, isTutorOrAbove} from "../../../services";
 import {SingleAssignmentProgress} from "../../pages/SingleAssignmentProgress";
 import {Glossary} from "../../pages/Glossary";
 import {ExamSpecifications} from "../../pages/ExamSpecifications";
-import Equality from "../../pages/Equality";
 import {News} from "../../pages/News";
+
+const Equality = lazy(() => import('../../pages/Equality'));
 
 let key = 0;
 export const RoutesCS = [

--- a/src/app/components/site/phy/RoutesPhy.tsx
+++ b/src/app/components/site/phy/RoutesPhy.tsx
@@ -7,7 +7,7 @@ import {PreUniMaths} from "../../pages/books/pre_uni_maths";
 import {Chemistry16} from "../../pages/books/chemistry_16";
 import StaticPageRoute from "../../navigation/StaticPageRoute";
 import {Redirect} from "react-router";
-import {isLoggedIn, isStaff, isTeacherOrAbove, isTutorOrAbove, PATHS} from "../../../services";
+import {isLoggedIn, isTeacherOrAbove, isTutorOrAbove, PATHS} from "../../../services";
 import {TeacherFeatures} from "../../pages/TeacherFeatures";
 import {TutorFeatures} from "../../pages/TutorFeatures";
 import {QuantumMechanicsPrimer} from "../../pages/books/QuantumMechanicsPrimer";
@@ -28,8 +28,8 @@ import {MyQuizzes} from "../../pages/quizzes/MyQuizzes";
 import {Events} from "../../pages/Events";
 import {RedirectToEvent} from "../../navigation/RedirectToEvent";
 import {AssignmentSchedule} from "../../pages/AssignmentSchedule";
-import Equality from "../../pages/Equality";
 
+const Equality = lazy(() => import('../../pages/Equality'));
 const EventDetails = lazy(() => import('../../pages/EventDetails'));
 const GraphSketcherPage = lazy(() => import("../../pages/GraphSketcher"));
 

--- a/src/app/services/assignments.ts
+++ b/src/app/services/assignments.ts
@@ -1,5 +1,5 @@
 import {AssignmentDTO} from "../../IsaacApiTypes";
-import {orderBy} from "lodash";
+import orderBy from "lodash/orderBy";
 import {EnhancedAssignment} from "../../IsaacAppTypes";
 import {API_PATH, extractTeacherName} from "./";
 

--- a/src/app/services/clozeQuestionKeyboardCoordinateGetter.ts
+++ b/src/app/services/clozeQuestionKeyboardCoordinateGetter.ts
@@ -4,7 +4,7 @@ import {
     KeyboardCoordinateGetter,
 } from '@dnd-kit/core';
 import {CLOZE_DROP_ZONE_ID_PREFIX, CLOZE_ITEM_SECTION_ID} from "./constants";
-import {sortBy} from "lodash";
+import sortBy from "lodash/sortBy";
 import {isDefined} from "./miscUtils";
 
 // Adapted from https://github.com/clauderic/dnd-kit/blob/5811986e7544a5e80039870a015e38df805eaad1/packages/sortable/src/sensors/keyboard/sortableKeyboardCoordinates.ts

--- a/src/app/services/gameboardBuilder.ts
+++ b/src/app/services/gameboardBuilder.ts
@@ -1,5 +1,5 @@
 import {determineAudienceViews, difficultiesOrdered, SortOrder, tags} from "./";
-import {orderBy} from "lodash";
+import orderBy from "lodash/orderBy";
 import {AudienceContext, ContentSummaryDTO, Difficulty, GameboardDTO, GameboardItem} from "../../IsaacApiTypes";
 import {ContentSummary, Tag} from "../../IsaacAppTypes";
 

--- a/src/app/services/index.ts
+++ b/src/app/services/index.ts
@@ -5,7 +5,7 @@ export * from "./demoTools";
 export * from "./device";
 export * from "./dates";
 export * from "./polyfills";
-export * from "./highlightJs";
+// export * from "./highlightJs";  // This is unnecessary and breaks bundle splitting!
 export * from "./json";
 export * from "./progress";
 export * from "./select";

--- a/src/app/services/polyfills.js
+++ b/src/app/services/polyfills.js
@@ -1,22 +1,4 @@
-import React from "react";
-import matchAll from 'string.prototype.matchall';
-
-React;  // lgtm [js/useless-expression]
-
-matchAll.shim();
-
-if (!Element.prototype.matches) {
-    Element.prototype.matches = Element.prototype.msMatchesSelector || Element.prototype.webkitMatchesSelector;
-}
-
-if (!Element.prototype.closest) {
-    Element.prototype.closest = function(s) {
-        var el = this;
-
-        do {
-            if (el.matches(s)) return el;
-            el = el.parentElement || el.parentNode;
-        } while (el !== null && el.nodeType === 1);
-        return null;
-    };
-}
+import 'core-js/full/string/match-all';
+import 'core-js/full/string/replace-all';
+import 'core-js/full/array/at';
+import 'core-js/full/array/flat-map';

--- a/src/app/services/quiz.ts
+++ b/src/app/services/quiz.ts
@@ -10,7 +10,7 @@ import {
     QuizSummaryDTO,
     RegisteredUserDTO
 } from "../../IsaacApiTypes";
-import {partition} from "lodash";
+import partition from "lodash/partition";
 
 export function extractQuestions(doc: ContentDTO | undefined): QuestionDTO[] {
     const qs: QuestionDTO[] = [];

--- a/src/app/state/slices/gameboards.ts
+++ b/src/app/state/slices/gameboards.ts
@@ -1,7 +1,7 @@
 import {createSlice} from "@reduxjs/toolkit";
 import {Boards} from "../../../IsaacAppTypes";
 import {isaacApi} from "../index"; // IMPORTANT - must import from index, don't shorten to "./api"
-import {unionWith} from "lodash";
+import unionWith from "lodash/unionWith";
 
 const mergeBoards = (boards: Boards, additional: Boards): Boards => ({
     totalResults: additional.totalResults || boards.totalResults,

--- a/src/index-ada-renderer.tsx
+++ b/src/index-ada-renderer.tsx
@@ -2,7 +2,7 @@ import "regenerator-runtime/runtime";
 import './scss/cs/isaac.scss';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {highlightJsService} from "./app/services";
+import {highlightJsService} from "./app/services/highlightJs";
 import {EditorRenderer} from "./app/components/elements/EditorRenderer";
 
 highlightJsService.registerLanguages();

--- a/src/index-ada.tsx
+++ b/src/index-ada.tsx
@@ -5,11 +5,10 @@ import ReactDOM from 'react-dom';
 import {Provider} from "react-redux";
 import {store} from "./app/state";
 import {IsaacApp} from './app/components/navigation/IsaacApp';
-import {printAsciiArtLogoToConsoleAda, highlightJsService} from "./app/services";
+import {printAsciiArtLogoToConsoleAda} from "./app/services";
 import {Helmet} from "react-helmet";
 
 printAsciiArtLogoToConsoleAda();
-highlightJsService.registerLanguages();
 
 ReactDOM.render(
     <React.StrictMode>

--- a/src/index-phy-renderer.tsx
+++ b/src/index-phy-renderer.tsx
@@ -2,7 +2,7 @@ import "regenerator-runtime/runtime";
 import './scss/phy/isaac.scss';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {highlightJsService} from "./app/services";
+import {highlightJsService} from "./app/services/highlightJs";
 import {EditorRenderer} from "./app/components/elements/EditorRenderer";
 
 highlightJsService.registerLanguages();

--- a/src/test/pages/Groups.test.tsx
+++ b/src/test/pages/Groups.test.tsx
@@ -11,7 +11,8 @@ import {
     buildMockUserSummaryWithGroupMembership
 } from "../../mocks/data";
 import {API_PATH, isDefined, siteSpecific} from "../../app/services";
-import {difference, isEqual} from "lodash";
+import difference from "lodash/difference";
+import isEqual from "lodash/isEqual";
 import userEvent from "@testing-library/user-event";
 import {ResponseResolver, rest} from "msw";
 import {

--- a/src/test/pages/IsaacApp.test.tsx
+++ b/src/test/pages/IsaacApp.test.tsx
@@ -2,11 +2,10 @@ import React from "react";
 import {screen, waitFor, within} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {IsaacApp} from "../../app/components/navigation/IsaacApp";
-import {reverse, zip} from "lodash";
-import {UserRole, USER_ROLES} from "../../IsaacApiTypes";
-import {renderTestEnvironment, NavBarMenus, NAV_BAR_MENU_TITLE} from "../utils";
-import {FEATURED_NEWS_TAG, isPhy, siteSpecific, history, isAda, SITE_SUBJECT, PATHS} from "../../app/services";
-import {mockNewsPods} from "../../mocks/data";
+import zip from "lodash/zip";
+import {USER_ROLES, UserRole} from "../../IsaacApiTypes";
+import {NAV_BAR_MENU_TITLE, NavBarMenus, renderTestEnvironment} from "../utils";
+import {history, isPhy, PATHS, SITE_SUBJECT, siteSpecific} from "../../app/services";
 
 const myIsaacLinks = siteSpecific(
     ["/account", PATHS.MY_GAMEBOARDS, PATHS.MY_ASSIGNMENTS, "/progress", "/tests"],

--- a/src/test/pages/SetAssignments.test.tsx
+++ b/src/test/pages/SetAssignments.test.tsx
@@ -36,6 +36,9 @@ describe("SetAssignments", () => {
             // Change view to "Card View"
             const viewDropdown = await screen.findByLabelText("Display in");
             await userEvent.selectOptions(viewDropdown, "Card View");
+            await waitFor(() => {
+                expect(screen.queryByText("Loading...")).toBeNull();
+            });
         }
         expect(screen.queryAllByTestId("gameboard-card")).toHaveLength(6);
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3407,10 +3407,10 @@ core-js-pure@^3.25.1:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.26.1.tgz#653f4d7130c427820dcecd3168b594e8bb095a33"
   integrity sha512-VVXcDpp/xJ21KdULRq/lXdLzQAtX7+37LzpyfFM973il0tWSsDEoyzG38G14AjTpK9VTfiNM9jnFauq/CpaWGQ==
 
-core-js@^3.19.2, core-js@^3.19.3:
-  version "3.26.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.26.1.tgz#7a9816dabd9ee846c1c0fe0e8fcad68f3709134e"
-  integrity sha512-21491RRQVzUn0GGM9Z1Jrpr6PNPxPi+Za8OM9q4tksTSnlbXXGKK1nXNg/QvwFYettXvSX6zWKCtHHfjN4puyA==
+core-js@^3.19.2, core-js@^3.30.0:
+  version "3.30.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.30.0.tgz#64ac6f83bc7a49fd42807327051701d4b1478dea"
+  integrity sha512-hQotSSARoNh1mYPi9O2YaWeiq/cEB95kOrFb4NCrO4RIFt1qqNpKsaE+vy/L3oiqvND5cThqXzUU3r9F7Efztg==
 
 core-util-is@~1.0.0:
   version "1.0.3"
@@ -4818,11 +4818,6 @@ highlight.js@^9.7.0:
   version "9.18.5"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.5.tgz#d18a359867f378c138d6819edfc2a8acd5f29825"
   integrity sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==
-
-highlightjs-vba@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/highlightjs-vba/-/highlightjs-vba-0.2.1.tgz#7503d5e7be805c5884f5ad06455488c520c9725f"
-  integrity sha512-GBYOjoF8Lk+LFmC4aSvjfwQEFwf/ckdNbAqnO2YYiH6ariHQh1LZ4IUD039DCx7Y3R0ZfhmYnQxrczUJJoTBfQ==
 
 history@^4.10.1, history@^4.9.0:
   version "4.10.1"
@@ -6740,9 +6735,9 @@ p-try@^2.0.0:
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
 p5@^1.4.1:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/p5/-/p5-1.5.0.tgz#a38915c8f1a1bab6a6a2d7c31c5b887e6a966b6e"
-  integrity sha512-zZFMVUmGkXe2G5H6Sw7xsVhgdxMyEN/6SZnZqYdQ51513kTqPslLnukkwTbGf8YtW0RetTU0FTjYQMXnFD7KnQ==
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/p5/-/p5-1.6.0.tgz#eaf4e69e377d6a5e91041ca485743b0fc53d9dfb"
+  integrity sha512-RowF+RxfVUhJm/YKXL5TCFzTqnwAIwK6W1VGs9LAqSf3PCmLz9Igbxzlf0Ry5IMV71L42wipCdH/bDiNsqAstA==
 
 param-case@^3.0.4:
   version "3.0.4"
@@ -8020,7 +8015,7 @@ string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-string.prototype.matchall@^4.0.6, string.prototype.matchall@^4.0.8:
+string.prototype.matchall@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz#3bf85722021816dcd1bf38bb714915887ca79fd3"
   integrity sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==


### PR DESCRIPTION
My latest round of fighting with Webpack, only this time I found that Webpack was way smarter than I thought it was and it was _our_ code that caused the issue. I wanted to remove the p5 library from every page load, and this PR achieves that. The main entrypoint is now 1.2MB smaller 🎉

I'm pretty sure I have not broken the `/equality` page nor the equation editor or syntax highlighting, but those would be the areas to focus on testing.

It also adds back core-js, but only importing those few polyfills that we need to address errors real users are seeing.