### PR TITLE
Fix news not loading after logout

### DIFF
--- a/src/app/components/site/cs/HomepageCS.tsx
+++ b/src/app/components/site/cs/HomepageCS.tsx
@@ -14,7 +14,11 @@ import {MetaDescription} from "../../elements/MetaDescription";
 export const HomepageCS = () => {
     useEffect( () => {document.title = SITE_TITLE;}, []);
     const user = useAppSelector(selectors.user.orNull);
-    const {data: news} = isaacApi.endpoints.getNewsPodList.useQuery({subject: "news", orderDecending: true});
+    const [fetchNews, {data: news}] = isaacApi.endpoints.getNewsPodList.useLazyQuery();
+
+    useEffect(() => {
+        fetchNews({subject: "news", orderDecending: true});
+    }, [user]);
 
     return <>
         {/*<WarningBanner/>*/}

--- a/src/app/components/site/phy/HomepagePhy.tsx
+++ b/src/app/components/site/phy/HomepagePhy.tsx
@@ -8,9 +8,13 @@ import {WarningBanner} from "../../navigation/WarningBanner";
 
 export const HomepagePhy = () => {
     useEffect( () => {document.title = SITE_TITLE;}, []);
-    const {data: news} = isaacApi.endpoints.getNewsPodList.useQuery({subject: "physics"});
+    const [fetchNews, {data: news}] = isaacApi.endpoints.getNewsPodList.useLazyQuery();
     const user = useAppSelector(selectors.user.orNull);
     const deviceSize = useDeviceSize();
+
+    useEffect(() => {
+        fetchNews({subject: "physics"});
+    }, [user]);
 
     return <>
         {/*<WarningBanner/>*/}

--- a/src/app/state/reducers/index.ts
+++ b/src/app/state/reducers/index.ts
@@ -147,7 +147,7 @@ export const rootReducer = (state: AppState, action: AnyAction) => {
     if (action.type === ACTION_TYPE.USER_LOG_OUT_RESPONSE_SUCCESS
         || action.type === ACTION_TYPE.USER_LOG_OUT_EVERYWHERE_RESPONSE_SUCCESS
         || action.type === ACTION_TYPE.USER_CONSISTENCY_ERROR) {
-        isaacApi.util.resetApiState();
+        // Reset the state to undefined to clear the store
         return appReducer(undefined, action);
     }
     return appReducer(state, action);


### PR DESCRIPTION
This loads news on the homepage whenever the user object changes, which fixes the issue. 

It seems to be caused by a race condition between the homepage component mounting and fetching the news, and the logout action triggering the store to be cleared. I'm guessing that the RTK query API reducer needs a moment to recover after being set to `undefined` 🤷    