### PR TITLE
Use new path for long-term caching of content images

### DIFF
--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -3,6 +3,7 @@ import {
     API_PATH,
     EventStageFilter,
     EventTypeFilter,
+    IMAGE_PATH,
     securePadCredentials,
     securePadPasswordReset,
     TAG_ID
@@ -65,7 +66,7 @@ export const apiHelper = {
         if ((path.indexOf("http") > -1) || (path.indexOf("/assets/") > -1)) {
             return path;
         } else {
-            return API_PATH + "/images/" + path;
+            return `${IMAGE_PATH}/${path}`;
         }
     }
 };

--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -35,6 +35,13 @@ if (document.location.hostname === "localhost") {
 } else if (document.location.hostname.endsWith(".eu.ngrok.io")) {
     apiPath = "https://isaacscience.eu.ngrok.io/isaac-api/api";
 }
+let imagePath = `${apiPath}/images`;
+if (apiPath.indexOf(`/api/${API_VERSION}/api`) > -1) {
+    // If the API contains a version number, use a special Nginx
+    // route to allow better caching:
+    imagePath = apiPath.replace(`/api/${API_VERSION}/api`, '/images');
+}
+
 export const isTest = document.location.hostname.startsWith("test.");
 export const isStaging = document.location.hostname.startsWith("staging.");
 
@@ -42,6 +49,7 @@ export const isStaging = document.location.hostname.startsWith("staging.");
 export const envSpecific = <L, T, S, D>(live: L, test: T, staging: S, dev: D) => isTest ? test : (process.env.NODE_ENV === 'production' ? live : (isStaging ? staging : dev));
 
 export const API_PATH: string = apiPath;
+export const IMAGE_PATH: string = imagePath;
 
 export const EDITOR_ORIGIN = siteSpecific(
     "https://editor.isaacphysics.org",


### PR DESCRIPTION
In cases where the image path contains an API version number, then images from the content cannot be cached for long since the version number changes each release.
This instead uses a new route that gives the images a URL which does not change from release to release, added in: https://github.com/isaacphysics/isaac-router/commit/b0fb97aaf5cae95012c91d916c7696cb8b17dd3e