### PR TITLE
Make sure that text isn't obscured by background graphics

### DIFF
--- a/src/app/components/pages/Concept.tsx
+++ b/src/app/components/pages/Concept.tsx
@@ -37,59 +37,57 @@ export const Concept = withRouter(({match: {params}, location: {search}, concept
 
     return <ShowLoading until={doc} thenRender={supertypedDoc => {
         const doc = supertypedDoc as IsaacQuestionPageDTO & DocumentSubject;
-        return <div className={classNames(doc.subjectId)}>
-            <GameboardContext.Provider value={navigation.currentGameboard}>
-                <Container>
-                    <TitleAndBreadcrumb
-                        intermediateCrumbs={navigation.breadcrumbHistory}
-                        currentPageTitle={doc.title as string}
-                        collectionType={navigation.collectionType}
-                        subTitle={doc.subtitle as string}
-                    />
-                    <MetaDescription description={doc.summary} />
-                    <CanonicalHrefElement />
-                    <div className="no-print d-flex align-items-center">
-                        <EditContentButton doc={doc} />
-                        <div className="mt-3 mr-sm-1 ml-auto">
-                            <UserContextPicker className="no-print text-right" />
-                        </div>
-                        <div className="question-actions">
-                            <ShareLink linkUrl={`/concepts/${conceptId}${search || ""}`} />
-                        </div>
-                        <div className="question-actions not-mobile">
-                            <PrintButton />
-                        </div>
-                        <div className="question-actions">
-                            <ReportButton pageId={conceptId}/>
-                        </div>
+        return <GameboardContext.Provider value={navigation.currentGameboard}>
+            <Container className={classNames(doc.subjectId)}>
+                <TitleAndBreadcrumb
+                    intermediateCrumbs={navigation.breadcrumbHistory}
+                    currentPageTitle={doc.title as string}
+                    collectionType={navigation.collectionType}
+                    subTitle={doc.subtitle as string}
+                />
+                <MetaDescription description={doc.summary} />
+                <CanonicalHrefElement />
+                <div className="no-print d-flex align-items-center">
+                    <EditContentButton doc={doc} />
+                    <div className="mt-3 mr-sm-1 ml-auto">
+                        <UserContextPicker className="no-print text-right" />
                     </div>
+                    <div className="question-actions">
+                        <ShareLink linkUrl={`/concepts/${conceptId}${search || ""}`} />
+                    </div>
+                    <div className="question-actions not-mobile">
+                        <PrintButton />
+                    </div>
+                    <div className="question-actions">
+                        <ReportButton pageId={conceptId}/>
+                    </div>
+                </div>
 
-                    <Row className="concept-content-container">
-                        <Col className={classNames("py-4", {"mw-760": isAda})}>
+                <Row className="concept-content-container">
+                    <Col className={classNames("py-4", {"mw-760": isAda})}>
 
-                            <SupersededDeprecatedWarningBanner doc={doc} />
+                        <SupersededDeprecatedWarningBanner doc={doc} />
 
-                            <IntendedAudienceWarningBanner doc={doc} />
+                        <IntendedAudienceWarningBanner doc={doc} />
 
-                            <WithFigureNumbering doc={doc}>
-                                <IsaacContent doc={doc} />
-                            </WithFigureNumbering>
+                        <WithFigureNumbering doc={doc}>
+                            <IsaacContent doc={doc} />
+                        </WithFigureNumbering>
 
-                            {doc.attribution && <p className="text-muted">
-                                <Markup trusted-markup-encoding={"markdown"}>
-                                    {doc.attribution}
-                                </Markup>
-                            </p>}
+                        {doc.attribution && <p className="text-muted">
+                            <Markup trusted-markup-encoding={"markdown"}>
+                                {doc.attribution}
+                            </Markup>
+                        </p>}
 
-                            {isAda && doc.relatedContent && <RelatedContent conceptId={conceptId} content={doc.relatedContent} parentPage={doc} />}
+                        {isAda && doc.relatedContent && <RelatedContent conceptId={conceptId} content={doc.relatedContent} parentPage={doc} />}
 
-                            <NavigationLinks navigation={navigation} />
+                        <NavigationLinks navigation={navigation} />
 
-                            {isPhy && doc.relatedContent && <RelatedContent conceptId={conceptId} content={doc.relatedContent} parentPage={doc} />}
-                        </Col>
-                    </Row>
-                </Container>
-            </GameboardContext.Provider>
-        </div>
+                        {isPhy && doc.relatedContent && <RelatedContent conceptId={conceptId} content={doc.relatedContent} parentPage={doc} />}
+                    </Col>
+                </Row>
+            </Container>
+        </GameboardContext.Provider>
     }}/>;
 });

--- a/src/app/components/pages/Generic.tsx
+++ b/src/app/components/pages/Generic.tsx
@@ -38,30 +38,28 @@ export const Generic = withRouter(({pageIdOverride, match: {params}}: GenericPag
 
     return <ShowLoading until={doc} thenRender={supertypedDoc => {
         const doc = supertypedDoc as IsaacQuestionPageDTO & DocumentSubject;
-        return <div className={doc.subjectId || ""}>
-            <Container>
-                <TitleAndBreadcrumb currentPageTitle={doc.title as string} />
-                <MetaDescription description={doc.summary} />
-                <div className="no-print d-flex align-items-center">
-                    <EditContentButton doc={doc} />
-                    <div className="question-actions question-actions-leftmost mt-3">
-                        <ShareLink linkUrl={`/pages/${doc.id}`}/>
-                    </div>
-                    <div className="question-actions mt-3 not-mobile">
-                        <PrintButton/>
-                    </div>
+        return <Container className={doc.subjectId || ""}>
+            <TitleAndBreadcrumb currentPageTitle={doc.title as string} />
+            <MetaDescription description={doc.summary} />
+            <div className="no-print d-flex align-items-center">
+                <EditContentButton doc={doc} />
+                <div className="question-actions question-actions-leftmost mt-3">
+                    <ShareLink linkUrl={`/pages/${doc.id}`}/>
                 </div>
+                <div className="question-actions mt-3 not-mobile">
+                    <PrintButton/>
+                </div>
+            </div>
 
-                <Row className="generic-content-container">
-                    <Col className={classNames("py-4", {"mw-760": isAda && !CS_FULL_WIDTH_OVERRIDE[pageId]})}>
-                        <WithFigureNumbering doc={doc}>
-                            <IsaacContent doc={doc} />
-                        </WithFigureNumbering>
-                    </Col>
-                </Row>
+            <Row className="generic-content-container">
+                <Col className={classNames("py-4", {"mw-760": isAda && !CS_FULL_WIDTH_OVERRIDE[pageId]})}>
+                    <WithFigureNumbering doc={doc}>
+                        <IsaacContent doc={doc} />
+                    </WithFigureNumbering>
+                </Col>
+            </Row>
 
-                {doc.relatedContent && <RelatedContent content={doc.relatedContent} parentPage={doc} />}
-            </Container>
-        </div>
+            {doc.relatedContent && <RelatedContent content={doc.relatedContent} parentPage={doc} />}
+        </Container>
     }}/>;
 });

--- a/src/app/components/pages/Question.tsx
+++ b/src/app/components/pages/Question.tsx
@@ -70,63 +70,61 @@ export const Question = withRouter(({questionIdOverride, match, location}: Quest
 
         const isFastTrack = doc && doc.type === DOCUMENT_TYPE.FAST_TRACK_QUESTION;
 
-        return <div className={`${doc.subjectId || ""}`}>
-            <GameboardContext.Provider value={navigation.currentGameboard}>
-                <Container>
-                    {/*High contrast option*/}
-                    <TitleAndBreadcrumb
-                        currentPageTitle={generateQuestionTitle(doc)}
-                        intermediateCrumbs={[...navigation.breadcrumbHistory, ...getTags(doc.tags)]}
-                        collectionType={navigation.collectionType}
-                        audienceViews={determineAudienceViews(doc.audience, navigation.creationContext)}
-                    >
-                        {isFastTrack && fastTrackProgressEnabledBoards.includes(gameboardId || "") && <FastTrackProgress doc={doc} search={location.search} />}
-                    </TitleAndBreadcrumb>
-                    <CanonicalHrefElement />
-                    <div className="no-print d-flex flex-wrap align-items-center mt-3">
-                        <EditContentButton doc={doc} />
-                        <div className="question-actions ml-auto">
-                            <ShareLink linkUrl={`/questions/${questionId}${location.search || ""}`} clickAwayClose />
-                        </div>
-                        <div className="question-actions not-mobile">
-                            <PrintButton questionPage />
-                        </div>
-                        <div className="question-actions">
-                            <ReportButton pageId={questionId}/>
-                        </div>
+        return <GameboardContext.Provider value={navigation.currentGameboard}>
+            <Container className={`${doc.subjectId || ""}`}>
+                {/*High contrast option*/}
+                <TitleAndBreadcrumb
+                    currentPageTitle={generateQuestionTitle(doc)}
+                    intermediateCrumbs={[...navigation.breadcrumbHistory, ...getTags(doc.tags)]}
+                    collectionType={navigation.collectionType}
+                    audienceViews={determineAudienceViews(doc.audience, navigation.creationContext)}
+                >
+                    {isFastTrack && fastTrackProgressEnabledBoards.includes(gameboardId || "") && <FastTrackProgress doc={doc} search={location.search} />}
+                </TitleAndBreadcrumb>
+                <CanonicalHrefElement />
+                <div className="no-print d-flex flex-wrap align-items-center mt-3">
+                    <EditContentButton doc={doc} />
+                    <div className="question-actions ml-auto">
+                        <ShareLink linkUrl={`/questions/${questionId}${location.search || ""}`} clickAwayClose />
                     </div>
-                    <Row className="question-content-container">
-                        <Col className={classNames("py-4 question-panel", {"mw-760": isAda})}>
+                    <div className="question-actions not-mobile">
+                        <PrintButton questionPage />
+                    </div>
+                    <div className="question-actions">
+                        <ReportButton pageId={questionId}/>
+                    </div>
+                </div>
+                <Row className="question-content-container">
+                    <Col className={classNames("py-4 question-panel", {"mw-760": isAda})}>
 
-                            <SupersededDeprecatedWarningBanner doc={doc} />
+                        <SupersededDeprecatedWarningBanner doc={doc} />
 
-                            <IntendedAudienceWarningBanner doc={doc} />
+                        <IntendedAudienceWarningBanner doc={doc} />
 
-                            <WithFigureNumbering doc={doc}>
-                                <IsaacContent doc={doc}/>
-                            </WithFigureNumbering>
+                        <WithFigureNumbering doc={doc}>
+                            <IsaacContent doc={doc}/>
+                        </WithFigureNumbering>
 
-                            {doc.supersededBy && isStudent(user) && <div className="alert alert-warning">
-                                This question {" "}
-                                <RS.Button color="link" className="align-baseline" onClick={() => dispatch(goToSupersededByQuestion(doc))}>
-                                    has been replaced
-                                </RS.Button>.<br />
-                                However, if you were assigned this version, you should complete it.
-                            </div>}
+                        {doc.supersededBy && isStudent(user) && <div className="alert alert-warning">
+                            This question {" "}
+                            <RS.Button color="link" className="align-baseline" onClick={() => dispatch(goToSupersededByQuestion(doc))}>
+                                has been replaced
+                            </RS.Button>.<br />
+                            However, if you were assigned this version, you should complete it.
+                        </div>}
 
-                            {doc.attribution && <p className="text-muted">
-                                <Markup trusted-markup-encoding={"markdown"}>
-                                    {doc.attribution}
-                                </Markup>
-                            </p>}
+                        {doc.attribution && <p className="text-muted">
+                            <Markup trusted-markup-encoding={"markdown"}>
+                                {doc.attribution}
+                            </Markup>
+                        </p>}
 
-                            <NavigationLinks navigation={navigation}/>
+                        <NavigationLinks navigation={navigation}/>
 
-                            {doc.relatedContent && !isFastTrack && <RelatedContent content={doc.relatedContent} parentPage={doc} />}
-                        </Col>
-                    </Row>
-                </Container>
-            </GameboardContext.Provider>
-        </div>}
+                        {doc.relatedContent && !isFastTrack && <RelatedContent content={doc.relatedContent} parentPage={doc} />}
+                    </Col>
+                </Row>
+            </Container>
+        </GameboardContext.Provider>}
     } />;
 });

--- a/src/scss/phy/isaac.scss
+++ b/src/scss/phy/isaac.scss
@@ -217,3 +217,8 @@ body {
     background-repeat: repeat-x;
     background-position: bottom;
 }
+
+.content-body > .container {
+    background-color: #f5f5f5;
+    box-shadow: 0 0 200px 35px #f5f5f5;
+}


### PR DESCRIPTION
I decided to try and impact the style of the site less by using the same grey background colour, instead of white. This way, we also don't need to handle pages with cards any differently, since the background change is subtle.

It uses `box-shadow` to fade into the background graphic nicely, which has been supported on all browsers for a long time.

`/concepts/cm_roots_of_polynomials` is a good page to compare before and after:

Before:
![image](https://github.com/isaacphysics/isaac-react-app/assets/33040507/231d7437-2015-4b39-a00c-445a66acb5d1)

After:
![image](https://github.com/isaacphysics/isaac-react-app/assets/33040507/458bd45a-428a-474a-90e9-8534acd77428)
