### PR TITLE
Add assignment sorting dropdown to top of markbook/assignment progress page

### DIFF
--- a/src/IsaacAppTypes.tsx
+++ b/src/IsaacAppTypes.tsx
@@ -25,7 +25,7 @@ import {
     DOCUMENT_TYPE,
     EXAM_BOARD,
     MEMBERSHIP_STATUS,
-    PROGRAMMING_LANGUAGE,
+    PROGRAMMING_LANGUAGE, SortOrder,
     STAGE,
     TAG_ID,
     TAG_LEVEL
@@ -556,6 +556,22 @@ export enum BoardOrder {
     "-completion" = "-completion"
 }
 
+export enum AssignmentOrderType {
+    Title = "Title",
+    StartDate = "Start date",
+    DueDate = "Due date"
+}
+export type AssignmentOrderSpec = {type: AssignmentOrderType; order: SortOrder};
+
+export const AssignmentOrder = {
+    titleAscending: {type: AssignmentOrderType.Title, order: SortOrder.ASC},
+    titleDescending: {type: AssignmentOrderType.Title, order: SortOrder.DESC},
+    startDateAscending: {type: AssignmentOrderType.StartDate, order: SortOrder.ASC},
+    startDateDescending: {type: AssignmentOrderType.StartDate, order: SortOrder.DESC},
+    dueDateAscending: {type: AssignmentOrderType.DueDate, order: SortOrder.ASC},
+    dueDateDescending: {type: AssignmentOrderType.DueDate, order: SortOrder.DESC},
+};
+
 export type NumberOfBoards = number | "ALL";
 
 export interface Boards {
@@ -619,7 +635,7 @@ export const ClozeDropRegionContext = React.createContext<{
 export const QuizAttemptContext = React.createContext<{quizAttempt: QuizAttemptDTO | null; questionNumbers: {[questionId: string]: number}}>({quizAttempt: null, questionNumbers: {}});
 export const ExpandableParentContext = React.createContext<boolean>(false);
 export const ConfidenceContext = React.createContext<{recordConfidence: boolean}>({recordConfidence: false});
-export const AssignmentProgressPageSettingsContext = React.createContext<PageSettings>({colourBlind: false, formatAsPercentage: false, setColourBlind: () => {}, setFormatAsPercentage: () => {}, isTeacher: false});
+export const AssignmentProgressPageSettingsContext = React.createContext<PageSettings>({colourBlind: false, formatAsPercentage: false, setColourBlind: () => {}, setFormatAsPercentage: () => {}, isTeacher: false, assignmentOrder: AssignmentOrder.startDateDescending});
 export const GameboardContext = React.createContext<GameboardDTO | undefined>(undefined);
 export const AssignmentScheduleContext = React.createContext<{
     boardsById: {[id: string]: GameboardDTO | undefined};
@@ -888,6 +904,7 @@ export interface PageSettings {
     formatAsPercentage: boolean;
     setFormatAsPercentage: (newValue: boolean) => void;
     isTeacher: boolean;
+    assignmentOrder?: AssignmentOrderSpec;
 }
 
 export type FasttrackConceptsState = {gameboardId: string; concept: string; items: GameboardItem[]} | null;

--- a/src/app/components/pages/SingleAssignmentProgress.tsx
+++ b/src/app/components/pages/SingleAssignmentProgress.tsx
@@ -55,7 +55,7 @@ export const SingleAssignmentProgress = ({user}: {user: RegisteredUserDTO}) => {
         <Container>
             <TitleAndBreadcrumb
                 intermediateCrumbs={[ASSIGNMENT_PROGRESS_CRUMB]}
-                currentPageTitle={`Assignment Progress${assignment?.gameboard?.title && (": " + assignment?.gameboard?.title)}`}
+                currentPageTitle={`Assignment Progress${(assignment?.gameboard?.title && (": " + assignment?.gameboard?.title)) ?? ""}`}
                 className="mb-4"
             />
         </Container>

--- a/src/app/services/gameboardBuilder.ts
+++ b/src/app/services/gameboardBuilder.ts
@@ -1,46 +1,11 @@
-import {determineAudienceViews, difficultiesOrdered, SortOrder, tags} from "./";
+import {determineAudienceViews, difficultiesOrdered, SortOrder, sortStringsNumerically, tags} from "./";
 import orderBy from "lodash/orderBy";
 import {AudienceContext, ContentSummaryDTO, Difficulty, GameboardDTO, GameboardItem} from "../../IsaacApiTypes";
 import {ContentSummary, Tag} from "../../IsaacAppTypes";
 
-const bookSort = (a: string, b: string) => {
-    const splitRegex = /(\d+)/;
-    const sectionsA = a.split(splitRegex).filter((x) => x != "." && x != "");
-    const sectionsB = b.split(splitRegex).filter((x) => x != "." && x != "");
-
-    for (let i = 0; i < Math.min(sectionsA.length, sectionsB.length); i++) {
-        const isNumberA = sectionsA[i].search(/\d/) != -1;
-        const isNumberB = sectionsB[i].search(/\d/) != -1;
-
-        if (isNumberA && isNumberB) {
-            const numbersA = sectionsA[i].split(/\./).map((x) => parseInt(x));
-            const numbersB = sectionsB[i].split(/\./).map((x) => parseInt(x));
-
-            for (let j = 0; j < Math.min(numbersA.length, numbersB.length); j++) {
-                const comparison = numbersA[j] - numbersB[j];
-                if (comparison) {
-                    return comparison;
-                }
-            }
-
-            if (numbersA.length != numbersB.length) {
-                return numbersB.length - numbersA.length;
-            }
-        } else if (!isNumberA && !isNumberB) {
-            const comparison = sectionsA[i].localeCompare(sectionsB[i]);
-            if (comparison) {
-                return comparison;
-            }
-        } else {
-            return isNumberA ? 1 : -1;
-        }
-    }
-    return sectionsB.length - sectionsA.length;
-};
-
 export const sortQuestions = (sortState: {[s: string]: string}, creationContext?: AudienceContext) => (questions: ContentSummaryDTO[]) => {
     if (sortState["title"] && sortState["title"] != SortOrder.NONE) {
-        const sortedQuestions = questions.sort((a, b) => bookSort(a.title || "", b.title || ""));
+        const sortedQuestions = questions.sort((a, b) => sortStringsNumerically(a.title || "", b.title || ""));
         return sortState["title"] == SortOrder.ASC ? sortedQuestions : sortedQuestions.reverse();
     }
     if (sortState.difficulty && sortState.difficulty != SortOrder.NONE) {

--- a/src/app/services/sorting.ts
+++ b/src/app/services/sorting.ts
@@ -36,3 +36,38 @@ export function sortByStringValue<T>(field: keyof T, undefinedFirst: boolean = f
         return aValue.localeCompare(bValue, undefined, {numeric: true, sensitivity: 'base'});
     };
 }
+
+export const sortStringsNumerically = (a: string, b: string) => {
+    const splitRegex = /(\d+)/;
+    const sectionsA = a.split(splitRegex).filter((x) => x != "." && x != "");
+    const sectionsB = b.split(splitRegex).filter((x) => x != "." && x != "");
+
+    for (let i = 0; i < Math.min(sectionsA.length, sectionsB.length); i++) {
+        const isNumberA = sectionsA[i].search(/\d/) != -1;
+        const isNumberB = sectionsB[i].search(/\d/) != -1;
+
+        if (isNumberA && isNumberB) {
+            const numbersA = sectionsA[i].split(/\./).map((x) => parseInt(x));
+            const numbersB = sectionsB[i].split(/\./).map((x) => parseInt(x));
+
+            for (let j = 0; j < Math.min(numbersA.length, numbersB.length); j++) {
+                const comparison = numbersA[j] - numbersB[j];
+                if (comparison) {
+                    return comparison;
+                }
+            }
+
+            if (numbersA.length != numbersB.length) {
+                return numbersB.length - numbersA.length;
+            }
+        } else if (!isNumberA && !isNumberB) {
+            const comparison = sectionsA[i].localeCompare(sectionsB[i]);
+            if (comparison) {
+                return comparison;
+            }
+        } else {
+            return isNumberA ? 1 : -1;
+        }
+    }
+    return sectionsB.length - sectionsA.length;
+};

--- a/src/app/state/slices/api/assignments.ts
+++ b/src/app/state/slices/api/assignments.ts
@@ -1,14 +1,14 @@
 import {isaacApi, selectors, useAppSelector} from "../../index";
-import {isFound, SortOrder} from "../../../services";
+import {isFound, SortOrder, sortStringsNumerically} from "../../../services";
 import {
     AppQuizAssignment,
     AssignmentOrderSpec,
     AssignmentOrderType,
     EnhancedAssignment
 } from "../../../../IsaacAppTypes";
-import {useCallback} from "react";
 import {GameboardDTO, IsaacQuizDTO} from "../../../../IsaacApiTypes";
 import sortBy from "lodash/sortBy";
+import produce from "immer";
 
 // Returns summary assignment objects without data on gameboard contents - much faster to request these from the API
 // than those returned from useGroupAssignments
@@ -30,34 +30,37 @@ export const useGroupAssignmentSummary = (groupId?: number) => {
     };
 };
 
+// This looks a bit odd, but it means that we can use the same sort function for both gameboard and quiz assignments
+type SortFuncInputType = {creationDate?: Date, dueDate?: Date, scheduledStartDate?: Date, gameboard?: GameboardDTO, quiz?: IsaacQuizDTO};
+const sortAssignments = (as: SortFuncInputType[] | undefined, sortOrder: AssignmentOrderSpec) => {
+    let sortedAs;
+    switch (sortOrder?.type) {
+        case AssignmentOrderType.DueDate:
+            sortedAs = sortBy(as, a => a.dueDate?.valueOf() ?? a.creationDate?.valueOf() ?? 0);
+            break;
+        case AssignmentOrderType.StartDate:
+            sortedAs = sortBy(as, a => a.scheduledStartDate?.valueOf() ?? a.creationDate?.valueOf() ?? 0);
+            break;
+        case AssignmentOrderType.Title:
+            sortedAs = produce<SortFuncInputType[]>(x => x?.sort(
+                    (a, b) =>
+                        sortStringsNumerically(a.gameboard?.title ?? a.quiz?.title ?? "", b.gameboard?.title ?? b.quiz?.title ?? "")
+                ))(as);
+            break;
+        default:
+            sortedAs = as;
+    }
+    return sortOrder?.order === SortOrder.DESC ? sortedAs?.reverse() : sortedAs;
+}
+
 // Returns assignment objects with full gameboard and question part data
 export const useGroupAssignments = (groupId?: number, sortOrder?: AssignmentOrderSpec) => {
     const { data: assignments } = isaacApi.endpoints.getMySetAssignments.useQuery(groupId);
     const quizAssignments = useAppSelector(selectors.quizzes.assignments);
 
-    // This looks a bit odd, but it means that we can use the same sort function for both gameboard and quiz assignments
-    type SortFuncInputType = {creationDate?: Date, dueDate?: Date, scheduledStartDate?: Date, gameboard?: GameboardDTO, quiz?: IsaacQuizDTO};
-    const sortFunction = useCallback((as: SortFuncInputType[] | undefined) => {
-        let sortedAs;
-        switch (sortOrder?.type) {
-            case AssignmentOrderType.DueDate:
-                sortedAs = sortBy(as, a => a.dueDate?.valueOf() ?? a.creationDate?.valueOf() ?? 0);
-                break;
-            case AssignmentOrderType.StartDate:
-                sortedAs = sortBy(as, a => a.scheduledStartDate?.valueOf() ?? a.creationDate?.valueOf() ?? 0);
-                break;
-            case AssignmentOrderType.Title:
-                sortedAs = sortBy(as, a => a.gameboard?.title ?? a.quiz?.title ?? "");
-                break;
-            default:
-                sortedAs = as;
-        }
-        return sortOrder?.order === SortOrder.DESC ? sortedAs?.reverse() : sortedAs;
-    }, [sortOrder]);
-
-    const groupBoardAssignments = sortFunction(assignments) as EnhancedAssignment[] | undefined;
+    const groupBoardAssignments = sortAssignments(assignments, sortOrder) as EnhancedAssignment[] | undefined;
     const groupQuizAssignments = isFound(quizAssignments)
-        ? sortFunction(quizAssignments?.filter(a => a.groupId === groupId)) as AppQuizAssignment[] | undefined
+        ? sortAssignments(quizAssignments?.filter(a => a.groupId === groupId), sortOrder) as AppQuizAssignment[] | undefined
         : undefined;
 
     return {

--- a/src/app/state/slices/api/assignments.ts
+++ b/src/app/state/slices/api/assignments.ts
@@ -32,7 +32,7 @@ export const useGroupAssignmentSummary = (groupId?: number) => {
 
 // This looks a bit odd, but it means that we can use the same sort function for both gameboard and quiz assignments
 type SortFuncInputType = {creationDate?: Date, dueDate?: Date, scheduledStartDate?: Date, gameboard?: GameboardDTO, quiz?: IsaacQuizDTO};
-const sortAssignments = (as: SortFuncInputType[] | undefined, sortOrder: AssignmentOrderSpec) => {
+const sortAssignments = (as: SortFuncInputType[] | undefined, sortOrder?: AssignmentOrderSpec) => {
     let sortedAs;
     switch (sortOrder?.type) {
         case AssignmentOrderType.DueDate:

--- a/src/app/state/slices/api/assignments.ts
+++ b/src/app/state/slices/api/assignments.ts
@@ -1,6 +1,14 @@
-import {isaacApi, useAppSelector, selectors} from "../../index";
-import {isFound} from "../../../services";
-import {EnhancedAssignment} from "../../../../IsaacAppTypes";
+import {isaacApi, selectors, useAppSelector} from "../../index";
+import {isFound, SortOrder} from "../../../services";
+import {
+    AppQuizAssignment,
+    AssignmentOrderSpec,
+    AssignmentOrderType,
+    EnhancedAssignment
+} from "../../../../IsaacAppTypes";
+import {useCallback} from "react";
+import {GameboardDTO, IsaacQuizDTO} from "../../../../IsaacApiTypes";
+import sortBy from "lodash/sortBy";
 
 // Returns summary assignment objects without data on gameboard contents - much faster to request these from the API
 // than those returned from useGroupAssignments
@@ -23,15 +31,37 @@ export const useGroupAssignmentSummary = (groupId?: number) => {
 };
 
 // Returns assignment objects with full gameboard and question part data
-export const useGroupAssignments = (groupId?: number) => {
-    const { data: groupBoardAssignments } = isaacApi.endpoints.getMySetAssignments.useQuery(groupId);
+export const useGroupAssignments = (groupId?: number, sortOrder?: AssignmentOrderSpec) => {
+    const { data: assignments } = isaacApi.endpoints.getMySetAssignments.useQuery(groupId);
     const quizAssignments = useAppSelector(selectors.quizzes.assignments);
+
+    // This looks a bit odd, but it means that we can use the same sort function for both gameboard and quiz assignments
+    type SortFuncInputType = {creationDate?: Date, dueDate?: Date, scheduledStartDate?: Date, gameboard?: GameboardDTO, quiz?: IsaacQuizDTO};
+    const sortFunction = useCallback((as: SortFuncInputType[] | undefined) => {
+        let sortedAs;
+        switch (sortOrder?.type) {
+            case AssignmentOrderType.DueDate:
+                sortedAs = sortBy(as, a => a.dueDate?.valueOf() ?? a.creationDate?.valueOf() ?? 0);
+                break;
+            case AssignmentOrderType.StartDate:
+                sortedAs = sortBy(as, a => a.scheduledStartDate?.valueOf() ?? a.creationDate?.valueOf() ?? 0);
+                break;
+            case AssignmentOrderType.Title:
+                sortedAs = sortBy(as, a => a.gameboard?.title ?? a.quiz?.title ?? "");
+                break;
+            default:
+                sortedAs = as;
+        }
+        return sortOrder?.order === SortOrder.DESC ? sortedAs?.reverse() : sortedAs;
+    }, [sortOrder]);
+
+    const groupBoardAssignments = sortFunction(assignments) as EnhancedAssignment[] | undefined;
     const groupQuizAssignments = isFound(quizAssignments)
-        ? quizAssignments?.filter(a => a.groupId === groupId)
+        ? sortFunction(quizAssignments?.filter(a => a.groupId === groupId)) as AppQuizAssignment[] | undefined
         : undefined;
 
     return {
-        groupBoardAssignments: groupBoardAssignments as EnhancedAssignment[] | undefined,
+        groupBoardAssignments,
         groupQuizAssignments
     }
 };


### PR DESCRIPTION
Default sorting is now "start date descending", start date meaning the scheduled start date (if it exists - it is the creation date if not). 

Ascending and descending options exist for due date, start date, and title.

Isaac Physics:
 ![image](https://github.com/isaacphysics/isaac-react-app/assets/33040507/0e293172-5fb9-4a44-98f3-2ee383e29bd4)

Ada CS:
![image](https://github.com/isaacphysics/isaac-react-app/assets/33040507/d6ea3fc1-3813-420b-8ad9-8f9a556836e5)
