### PR TITLE
Allow teachers to view students test answers

### DIFF
--- a/src/app/components/elements/quiz/QuizAttemptComponent.tsx
+++ b/src/app/components/elements/quiz/QuizAttemptComponent.tsx
@@ -130,7 +130,11 @@ function QuizHeader({attempt, preview, user}: QuizAttemptProps) {
                 {isDefined(assignment.dueDate) && <><Spacer/>{isDefined(attempt.completedDate) ? "Was due:" : "Due:"}&nbsp;{formatDate(assignment.dueDate)}</>}
             </p>
             {assignment?.creationDate && assignment?.creationDate.valueOf() > QUIZ_VIEW_STUDENT_ANSWERS_RELEASE_TIMESTAMP && <p>
-                Please be aware that your <b>test answers will be visible to your teacher(s)</b> after you submit this test.
+                Please be aware that for <i>tests</i> your answer to each question <b>will be visible to your teacher(s) after
+                you submit your test</b> so that they can provide further feedback and support if they wish to do so.
+
+                <i>Assignments</i> are different. We <b><i>do not</i> share with your teachers</b> any of your entered answers or the
+                number of your attempts to questions in assignments.
             </p>}
         </>;
     } else {

--- a/src/app/components/elements/quiz/QuizAttemptComponent.tsx
+++ b/src/app/components/elements/quiz/QuizAttemptComponent.tsx
@@ -129,13 +129,13 @@ function QuizHeader({attempt, preview, user}: QuizAttemptProps) {
                 </span>
                 {isDefined(assignment.dueDate) && <><Spacer/>{isDefined(attempt.completedDate) ? "Was due:" : "Due:"}&nbsp;{formatDate(assignment.dueDate)}</>}
             </p>
-            {assignment?.creationDate && assignment?.creationDate.valueOf() > QUIZ_VIEW_STUDENT_ANSWERS_RELEASE_TIMESTAMP && <p>
-                Please be aware that for <i>tests</i> your answer to each question <b>will be visible to your teacher(s) after
+            {assignment?.creationDate && assignment?.creationDate.valueOf() > QUIZ_VIEW_STUDENT_ANSWERS_RELEASE_TIMESTAMP && <Alert color="info">
+                Please be aware that for tests your answer to each question <b>will be visible to your teacher(s) after
                 you submit your test</b> so that they can provide further feedback and support if they wish to do so.
-
-                <i>Assignments</i> are different. We <b><i>do not</i> share with your teachers</b> any of your entered answers or the
+                <br />
+                Assignments are different. We do not share with your teachers any of your entered answers or the
                 number of your attempts to questions in assignments.
-            </p>}
+            </Alert>}
         </>;
     } else {
         return <p>You {attempt.completedDate ? "freely attempted" : "are freely attempting"} this test.</p>

--- a/src/app/components/elements/quiz/QuizAttemptComponent.tsx
+++ b/src/app/components/elements/quiz/QuizAttemptComponent.tsx
@@ -12,6 +12,7 @@ import {
     isAda,
     isDefined,
     isTeacherOrAbove,
+    QUIZ_VIEW_STUDENT_ANSWERS_RELEASE_TIMESTAMP,
     siteSpecific,
     useDeviceSize
 } from "../../../services";
@@ -26,10 +27,8 @@ import {TitleAndBreadcrumb} from "../TitleAndBreadcrumb";
 import {
     closeActiveModal,
     openActiveModal,
-    selectors,
     showQuizSettingModal,
     useAppDispatch,
-    useAppSelector
 } from "../../../state";
 import {IsaacContentValueOrChildren} from "../../content/IsaacContentValueOrChildren";
 import {UserContextPicker} from "../inputs/UserContextPicker";
@@ -122,13 +121,18 @@ function QuizHeader({attempt, preview, user}: QuizAttemptProps) {
             </div>
         </>;
     } else if (isDefined(assignment)) {
-        return <p className="d-flex">
-            <span>
-                Set by: {extractTeacherName(assignment.assignerSummary ?? null)}
-                {isDefined(attempt.completedDate) && <><br />Completed:&nbsp;{formatDate(attempt.completedDate)}</>}
-            </span>
-            {isDefined(assignment.dueDate) && <><Spacer/>{isDefined(attempt.completedDate) ? "Was due:" : "Due:"}&nbsp;{formatDate(assignment.dueDate)}</>}
-        </p>;
+        return <>
+            <p className="d-flex">
+                <span>
+                    Set by: {extractTeacherName(assignment.assignerSummary ?? null)}
+                    {isDefined(attempt.completedDate) && <><br />Completed:&nbsp;{formatDate(attempt.completedDate)}</>}
+                </span>
+                {isDefined(assignment.dueDate) && <><Spacer/>{isDefined(attempt.completedDate) ? "Was due:" : "Due:"}&nbsp;{formatDate(assignment.dueDate)}</>}
+            </p>
+            {assignment?.creationDate && assignment?.creationDate.valueOf() > QUIZ_VIEW_STUDENT_ANSWERS_RELEASE_TIMESTAMP && <p>
+                Please be aware that your <b>test answers will be visible to your teacher(s)</b> after you submit this test.
+            </p>}
+        </>;
     } else {
         return <p>You {attempt.completedDate ? "freely attempted" : "are freely attempting"} this test.</p>
     }

--- a/src/app/components/pages/quizzes/QuizAttemptFeedback.tsx
+++ b/src/app/components/pages/quizzes/QuizAttemptFeedback.tsx
@@ -82,7 +82,7 @@ export const QuizAttemptFeedback = ({user}: {user: RegisteredUserDTO}) => {
     }, [quizAttemptId, quizAssignmentId, studentId]);
 
     const subProps: QuizAttemptProps = {attempt: attempt as QuizAttemptDTO, page: pageNumber,
-        questions, sections, pageLink, pageHelp, studentUser, user};
+        questions, sections, pageLink, pageHelp, studentUser, user, quizAssignmentId};
 
     return <Container className={`mb-5 ${attempt?.quiz?.subjectId}`}>
         <ShowLoading until={attempt || error}>

--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -1147,3 +1147,5 @@ export const CLOZE_ITEM_SECTION_ID = "non-selected-items";
 export const CLOZE_DROP_ZONE_ID_PREFIX = "drop-zone-";
 // Matches: [drop-zone], [drop-zone|w-50], [drop-zone|h-50] or [drop-zone|w-50h-200]
 export const dropZoneRegex = /\[drop-zone(?<params>\|(?<index>i-\d+?)?(?<width>w-\d+?)?(?<height>h-\d+?)?)?]/g;
+
+export const QUIZ_VIEW_STUDENT_ANSWERS_RELEASE_TIMESTAMP = Date.UTC(2023, 6, 5);

--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -1148,4 +1148,4 @@ export const CLOZE_DROP_ZONE_ID_PREFIX = "drop-zone-";
 // Matches: [drop-zone], [drop-zone|w-50], [drop-zone|h-50] or [drop-zone|w-50h-200]
 export const dropZoneRegex = /\[drop-zone(?<params>\|(?<index>i-\d+?)?(?<width>w-\d+?)?(?<height>h-\d+?)?)?]/g;
 
-export const QUIZ_VIEW_STUDENT_ANSWERS_RELEASE_TIMESTAMP = Date.UTC(2023, 6, 5);
+export const QUIZ_VIEW_STUDENT_ANSWERS_RELEASE_TIMESTAMP = Date.UTC(2023, 5, 12); // 12th June 2023

--- a/src/scss/common/quiz.scss
+++ b/src/scss/common/quiz.scss
@@ -33,14 +33,25 @@
 
 .quiz-student-menu {
   position: relative;
-  padding-right: 24px;
-  cursor: pointer;
+  width: 100%;
+  .quiz-student-name {
+    margin-right: 30px;
+    padding-left: 10px;
+    padding-right: 4px;
+    word-wrap: anywhere;
+  }
+  .quiz-student-menu-icon {
+    position: absolute;
+    top: calc(50% - 1px);
+    right: 5px;
+    transform: translateY(-50%);
+  }
 }
 .quiz-student-menu-icon {
   position: absolute;
   right: 0;
   top: 50%;
-  margin-top: -12px;
+  transform: translateY(-50%);
 }
 .quizFeedbackModeSpinner {
   vertical-align: middle;


### PR DESCRIPTION
For tests created after a specified date - this should be modified before the release.

Also modifies the student name buttons on quiz feedback a little (hence the SCSS changes and some JSX refactoring).

---

The text shown to students when attempting a test assignment will need to be updated based on the copy given by the content team.