### PR TITLE
Redesign manage groups UI

### DIFF
--- a/src/app/components/pages/Groups.tsx
+++ b/src/app/components/pages/Groups.tsx
@@ -200,7 +200,10 @@ const GroupEditor = ({group, user, createNewGroup, groupNameInputRef}: GroupCrea
     const bigGroup = group && group.members && group.members.length > 100;
 
     const usersInGroup = groupUserIds(group);
-    const additionalManagers = useMemo(() => group && sortBy(group.additionalManagers, manager => manager.familyName && manager.familyName.toLowerCase()) || [], [group]);
+    const additionalManagers = useMemo(() => {
+        const additionalManagers = group && sortBy(group.additionalManagers, manager => manager.familyName && manager.familyName.toLowerCase()) || [];
+        return group?.ownerSummary ? [group.ownerSummary, ...additionalManagers] : additionalManagers;
+    }, [group]);
 
     const canArchive = group && (isUserGroupOwner || group.additionalManagerPrivileges);
     const canEmailUsers = isStaff(user) && usersInGroup.length > 0;
@@ -269,7 +272,7 @@ const GroupEditor = ({group, user, createNewGroup, groupNameInputRef}: GroupCrea
                     {additionalManagers.map((manager, i) =>
                         <tr key={manager.email} data-testid={"group-manager"} className={classNames({"border-0 bg-transparent": isAda})}>
                             <td className={classNames("align-middle", {"border-top-0": i === 0, "border-0 p-2 bg-transparent": isAda})}>
-                                <span className="icon-group-table-person" />{manager.givenName} {manager.familyName} {user.id === manager.id && <span className={"text-muted"}>(you)</span>} ({manager.email})
+                                <span className="icon-group-table-person" />{manager.givenName} {manager.familyName} {manager.id === group.ownerId && "(group owner)"} {user.id === manager.id && "(you)"}
                             </td>
                         </tr>
                     )}

--- a/src/test/pages/Groups.test.tsx
+++ b/src/test/pages/Groups.test.tsx
@@ -216,10 +216,10 @@ describe("Groups", () => {
             expect(groupToRenameElement).toBeDefined();
             // Open group editor for group to rename
             await userEvent.click(within(groupToRenameElement).getByTestId("select-group"));
-            // Wait for "Edit group" panel to be open
+            // Wait for "Manage group" panel to be open
             const groupEditor = await screen.findByTestId("group-editor");
             await waitFor(async () => {
-                await within(groupEditor).findByText("Edit group");
+                await within(groupEditor).findByText("Manage group");
             });
             // Rename the group and click update
             const groupNameInput = await within(groupEditor).findByPlaceholderText(/Group [Nn]ame/);
@@ -286,7 +286,7 @@ describe("Groups", () => {
                 // We need to look within the element marked with the "group-editor" test ID, because there are actually
                 // two GroupEditor components in the DOM at once, one is just hidden (depending on screen size).
                 const groupEditor = await screen.findByTestId("group-editor");
-                const archiveButton = await within(groupEditor).findByRole("button", {name: `${activeOrArchived === "active" ? "A" : "Una"}rchive this group`});
+                const archiveButton = await within(groupEditor).findByRole("button", {name: `${activeOrArchived === "active" ? "A" : "Una"}rchive`});
                 await userEvent.click(archiveButton);
                 // Assert that the request was called, and the modified group no longer exists in the initial list of groups
                 await waitFor(() => {
@@ -369,7 +369,7 @@ describe("Groups", () => {
             const groupEditor = await screen.findByTestId("group-editor");
             // Neither variant of the button should show
             const addManagersButton = within(groupEditor).queryByRole("button", {name: "Add / remove group managers"});
-            const viewManagersButton = within(groupEditor).queryByRole("button", {name: "View all group managers"});
+            const viewManagersButton = within(groupEditor).queryByRole("button", {name: "More information"});
             expect(addManagersButton).toBeNull();
             expect(viewManagersButton).toBeNull();
         });
@@ -545,8 +545,8 @@ describe("Groups", () => {
         await userEvent.click(selectGroupButton);
         const groupEditor = await screen.findByTestId("group-editor");
 
-        // Text on button should have changed to "View all" rather than "Add / remove"
-        const addManagersButton = within(groupEditor).getByRole("button", {name: "View all group managers"});
+        // Text on button should have changed to "More info" rather than "Add / remove"
+        const addManagersButton = within(groupEditor).getByRole("button", {name: /More info\s?rmation/});
 
         await userEvent.click(addManagersButton);
 


### PR DESCRIPTION
Adds additional managers to the group overview, and moves buttons around to be more intuitive.

See pics for the (medium/large screen) layouts on Ada and physics - it is nicely responsive on small screens.
![image](https://github.com/isaacphysics/isaac-react-app/assets/33040507/17d70c4f-473d-452c-83c5-1f3e56645e99)
![image](https://github.com/isaacphysics/isaac-react-app/assets/33040507/6898658d-9a15-43b8-807e-43105e643265)
