### PR TITLE
Stop overriding ES ranking in gameboard builder front-end

### DIFF
--- a/src/app/components/elements/modals/QuestionSearchModal.tsx
+++ b/src/app/components/elements/modals/QuestionSearchModal.tsx
@@ -78,7 +78,7 @@ export const QuestionSearchModal = ({originalSelectedQuestions, setOriginalSelec
 
     const [searchFastTrack, setSearchFastTrack] = useState<boolean>(false);
 
-    const [questionsSort, setQuestionsSort] = useState<Record<string, SortOrder>>({difficulty: SortOrder.ASC});
+    const [questionsSort, setQuestionsSort] = useState<Record<string, SortOrder>>({});
     const [selectedQuestions, setSelectedQuestions] = useState<Map<string, ContentSummary>>(new Map(originalSelectedQuestions));
     const [questionOrder, setQuestionOrder] = useState([...originalQuestionOrder]);
 
@@ -87,6 +87,9 @@ export const QuestionSearchModal = ({originalSelectedQuestions, setOriginalSelec
 
     const searchDebounce = useCallback(
         debounce((searchString: string, topics: string[], examBoards: string[], book: string[], stages: string[], difficulties: string[], fasttrack: boolean, startIndex: number) => {
+            // Clear front-end sorting so as not to override ElasticSearch's match ranking
+            setQuestionsSort({});
+
             const isBookSearch = book.length > 0; // Tasty.
             if ([searchString, topics, book, stages, difficulties, examBoards].every(v => v.length === 0) && !fasttrack) {
                 // Nothing to search for


### PR DESCRIPTION
On the Gameboard Builder page, we were defaulting to ordering question query results by difficulty in the front-end.
This overrode ElasticSearch's relevance ranking returned by the back-end service and caused odd behaviour like a question being ranked lower as more exact-match words were added to the query (i.e. try searching for the question with title "Combinatronics with isotopes" on the old version of the site).
This PR also clears any front-end sorting of results on re-querying the back-end service so that the default ranking is always by ElasticSearch's relevance score.