### PR TITLE
Redirect users to feedback page (if allowed) after quiz submission

### DIFF
--- a/src/app/components/elements/quiz/QuizAttemptComponent.tsx
+++ b/src/app/components/elements/quiz/QuizAttemptComponent.tsx
@@ -39,6 +39,7 @@ export interface QuizAttemptProps {
     questions: QuestionDTO[];
     sections: { [id: string]: IsaacQuizSectionDTO };
     pageLink: PageLinkCreator;
+    feedbackLink?: string;
     pageHelp: React.ReactElement;
     preview?: boolean;
     studentUser?: UserSummaryDTO;

--- a/src/app/components/elements/quiz/QuizAttemptComponent.tsx
+++ b/src/app/components/elements/quiz/QuizAttemptComponent.tsx
@@ -39,7 +39,6 @@ export interface QuizAttemptProps {
     questions: QuestionDTO[];
     sections: { [id: string]: IsaacQuizSectionDTO };
     pageLink: PageLinkCreator;
-    feedbackLink?: string;
     pageHelp: React.ReactElement;
     preview?: boolean;
     studentUser?: UserSummaryDTO;

--- a/src/app/components/elements/quiz/QuizAttemptFooter.tsx
+++ b/src/app/components/elements/quiz/QuizAttemptFooter.tsx
@@ -5,7 +5,7 @@ import React, {useState} from "react";
 import {Spacer} from "../Spacer";
 import {IsaacSpinner} from "../../handlers/IsaacSpinner";
 import {Button} from "reactstrap";
-import {siteSpecific} from "../../../services";
+import {isDefined, siteSpecific} from "../../../services";
 
 function extractSectionIdFromQuizQuestionId(questionId: string) {
     const ids = questionId.split("|", 3);
@@ -23,7 +23,9 @@ export function QuizAttemptFooter(props: QuizAttemptProps) {
             setSubmitting(true);
             if (await dispatch(markQuizAttemptAsComplete(attempt.id as number))) {
                 dispatch(showToast({color: "success", title: "Test submitted successfully", body: "Your answers have been submitted successfully.", timeout: 5000}));
-                history.goBack();
+                if (isDefined(props.feedbackLink)) {
+                    history.push(props.feedbackLink);
+                }
             }
         } finally {
             setSubmitting(false);

--- a/src/app/components/elements/quiz/QuizAttemptFooter.tsx
+++ b/src/app/components/elements/quiz/QuizAttemptFooter.tsx
@@ -5,14 +5,14 @@ import React, {useState} from "react";
 import {Spacer} from "../Spacer";
 import {IsaacSpinner} from "../../handlers/IsaacSpinner";
 import {Button} from "reactstrap";
-import {isDefined, siteSpecific} from "../../../services";
+import {siteSpecific} from "../../../services";
 
 function extractSectionIdFromQuizQuestionId(questionId: string) {
     const ids = questionId.split("|", 3);
     return ids[0] + "|" + ids[1];
 }
 
-export function QuizAttemptFooter(props: QuizAttemptProps) {
+export function QuizAttemptFooter(props: QuizAttemptProps & {feedbackLink: string}) {
     const {attempt, page, sections, questions, pageLink} = props;
     const dispatch = useAppDispatch();
     const history = useHistory();
@@ -23,9 +23,7 @@ export function QuizAttemptFooter(props: QuizAttemptProps) {
             setSubmitting(true);
             if (await dispatch(markQuizAttemptAsComplete(attempt.id as number))) {
                 dispatch(showToast({color: "success", title: "Test submitted successfully", body: "Your answers have been submitted successfully.", timeout: 5000}));
-                if (isDefined(props.feedbackLink)) {
-                    history.push(props.feedbackLink);
-                }
+                history.push(props.feedbackLink);
             }
         } finally {
             setSubmitting(false);

--- a/src/app/components/pages/quizzes/QuizDoAssignment.tsx
+++ b/src/app/components/pages/quizzes/QuizDoAssignment.tsx
@@ -36,7 +36,7 @@ export const QuizDoAssignment = ({user}: {user: RegisteredUserDTO}) => {
     const feedbackLink = attempt?.quizAssignment?.quizFeedbackMode !== "NONE" ? `/test/attempt/${attempt?.id}/feedback` : `/tests`;
 
     // Importantly, these are only used if attempt is defined
-    const subProps: QuizAttemptProps = {attempt: attempt as QuizAttemptDTO, page: pageNumber, questions, sections, pageLink, pageHelp, user, feedbackLink};
+    const subProps: QuizAttemptProps & {feedbackLink: string} = {attempt: attempt as QuizAttemptDTO, page: pageNumber, questions, sections, pageLink, pageHelp, user, feedbackLink};
 
     return <Container className={`mb-5 ${attempt?.quiz?.subjectId}`}>
         <ShowLoading until={attempt || error}>

--- a/src/app/components/pages/quizzes/QuizDoAssignment.tsx
+++ b/src/app/components/pages/quizzes/QuizDoAssignment.tsx
@@ -33,8 +33,10 @@ export const QuizDoAssignment = ({user}: {user: RegisteredUserDTO}) => {
         `/test/assignment/${quizAssignmentId}` + (isDefined(page) ? `/page/${page}` : "")
     , [quizAssignmentId]);
 
+    const feedbackLink = attempt?.quizAssignment?.quizFeedbackMode !== "NONE" ? `/test/attempt/${attempt?.id}/feedback` : `/tests`;
+
     // Importantly, these are only used if attempt is defined
-    const subProps: QuizAttemptProps = {attempt: attempt as QuizAttemptDTO, page: pageNumber, questions, sections, pageLink, pageHelp, user};
+    const subProps: QuizAttemptProps = {attempt: attempt as QuizAttemptDTO, page: pageNumber, questions, sections, pageLink, pageHelp, user, feedbackLink};
 
     return <Container className={`mb-5 ${attempt?.quiz?.subjectId}`}>
         <ShowLoading until={attempt || error}>

--- a/src/app/components/pages/quizzes/QuizDoFreeAttempt.tsx
+++ b/src/app/components/pages/quizzes/QuizDoFreeAttempt.tsx
@@ -36,8 +36,10 @@ export const QuizDoFreeAttempt = ({user}: {user: RegisteredUserDTO}) => {
         `/test/attempt/${quizId}` + (isDefined(page) ? `/page/${page}` : "")
     , [quizId]);
 
+    const feedbackLink = `/test/attempt/${attempt?.id}/feedback`;
+
     // Importantly, these are only used if attempt is defined
-    const subProps: QuizAttemptProps = {attempt: attempt as QuizAttemptDTO, page: pageNumber, questions, sections, pageLink, pageHelp, user};
+    const subProps: QuizAttemptProps = {attempt: attempt as QuizAttemptDTO, page: pageNumber, questions, sections, pageLink, pageHelp, user, feedbackLink};
 
     return <Container className={`mb-5 ${attempt?.quiz?.subjectId}`}>
         <ShowLoading until={attempt || error}>

--- a/src/app/components/pages/quizzes/QuizDoFreeAttempt.tsx
+++ b/src/app/components/pages/quizzes/QuizDoFreeAttempt.tsx
@@ -39,7 +39,7 @@ export const QuizDoFreeAttempt = ({user}: {user: RegisteredUserDTO}) => {
     const feedbackLink = `/test/attempt/${attempt?.id}/feedback`;
 
     // Importantly, these are only used if attempt is defined
-    const subProps: QuizAttemptProps = {attempt: attempt as QuizAttemptDTO, page: pageNumber, questions, sections, pageLink, pageHelp, user, feedbackLink};
+    const subProps: QuizAttemptProps & {feedbackLink: string} = {attempt: attempt as QuizAttemptDTO, page: pageNumber, questions, sections, pageLink, pageHelp, user, feedbackLink};
 
     return <Container className={`mb-5 ${attempt?.quiz?.subjectId}`}>
         <ShowLoading until={attempt || error}>

--- a/src/app/services/tagsAbstract.ts
+++ b/src/app/services/tagsAbstract.ts
@@ -5,7 +5,7 @@ import {ContentDTO} from "../../IsaacApiTypes";
 export abstract class AbstractBaseTagService {
     abstract getTagHierarchy(): TAG_LEVEL[];
     abstract getBaseTags(): BaseTag[];
-    abstract augmentDocWithSubject(doc: ContentDTO): ContentDTO & {subjectId: string};
+    abstract augmentDocWithSubject<T extends ContentDTO>(doc: T): T & {subjectId: string};
 
     // Augment base allTags
     public allTags: Tag[] = this.getBaseTags().map((baseTag) => {

--- a/src/app/services/tagsCS.ts
+++ b/src/app/services/tagsCS.ts
@@ -98,7 +98,7 @@ export class CsTagService extends AbstractBaseTagService {
     ];
     public getTagHierarchy() {return CsTagService.tagHierarchy;}
     public getBaseTags() {return CsTagService.baseTags;}
-    public augmentDocWithSubject(doc: ContentDTO) {
+    public augmentDocWithSubject<T extends ContentDTO>(doc: T) {
         return {...doc, subjectId: SUBJECTS.CS};
     }
 }

--- a/src/app/services/tagsPhy.ts
+++ b/src/app/services/tagsPhy.ts
@@ -172,7 +172,7 @@ export class PhysicsTagService extends AbstractBaseTagService {
     ];
     public getTagHierarchy() {return PhysicsTagService.tagHierarchy;}
     public getBaseTags() {return PhysicsTagService.baseTags;}
-    public augmentDocWithSubject(doc: ContentDTO) {
+    public augmentDocWithSubject<T extends ContentDTO>(doc: T) {
         const documentSubject = this.getPageSubjectTag((doc.tags || []) as TAG_ID[]);
         return {...doc, subjectId: documentSubject ? documentSubject.id : TAG_ID.physics};
     }


### PR DESCRIPTION
The generifying of `augmentDocWithSubject` was necessary for the types to work out in some other code to do with this PR - I removed that code (it was wrong) but kept the extra typing because it improves type inference and autocompletion if you're working with objects that have passed through that function. Beforehand, calling `augmentDocWithSubject(obj)` erases the type of `obj` to `ContentDTO & {subjectId: string}` (if `obj` is of type `QuizDTO` for example then this is annoying).