### PR TITLE
Explicitly cleanup p5 on component unmount

### DIFF
--- a/src/app/components/content/IsaacSymbolicLogicQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicLogicQuestion.tsx
@@ -107,10 +107,10 @@ const IsaacSymbolicLogicQuestion = ({doc, questionId, readonly}: IsaacQuestionPr
     const previewText = currentAttemptValue && currentAttemptValue.result && currentAttemptValue.result.tex;
 
     const hiddenEditorRef = useRef<HTMLDivElement | null>(null);
-    const sketchRef = useRef<Inequality>();
+    const sketchRef = useRef<Inequality | null | undefined>();
 
     useLayoutEffect(() => {
-        const { sketch } = makeInequality(
+        const { sketch, p } = makeInequality(
             hiddenEditorRef.current,
             100,
             0,
@@ -126,11 +126,21 @@ const IsaacSymbolicLogicQuestion = ({doc, questionId, readonly}: IsaacQuestionPr
         sketch.log = { initialState: [], actions: [] };
         sketch.onNewEditorState = updateState;
         sketch.onCloseMenus = () => undefined;
-        sketch.isUserPrivileged = () => { return true; };
+        sketch.isUserPrivileged = () => true;
         sketch.onNotifySymbolDrag = () => undefined;
-        sketch.isTrashActive = () => { return false; };
+        sketch.isTrashActive = () => false;
 
         sketchRef.current = sketch;
+
+        return () => {
+            if (sketchRef.current) {
+                sketchRef.current.onNewEditorState = () => null;
+                sketchRef.current.onCloseMenus = () => null;
+                sketchRef.current.isTrashActive = () => false;
+                sketchRef.current = null;
+            }
+            p.remove();
+        };
     }, [hiddenEditorRef.current]);
 
     const [errors, setErrors] = useState<string[]>();

--- a/src/app/components/pages/Equality.tsx
+++ b/src/app/components/pages/Equality.tsx
@@ -29,7 +29,7 @@ const Equality = withRouter(({location}: RouteComponentProps<{}, {}, {board?: st
 
     /*** Text based input stuff */
     const hiddenEditorRef = useRef<HTMLDivElement | null>(null);
-    const sketchRef = useRef<Inequality|null|undefined>();
+    const sketchRef = useRef<Inequality | null | undefined>();
     const debounceTimer = useRef<number|null>(null);
     const [inputState, setInputState] = useState(() => ({pythonExpression: '', userInput: '', valid: true}));
 
@@ -160,7 +160,7 @@ const Equality = withRouter(({location}: RouteComponentProps<{}, {}, {board?: st
     }, [editorSyntax]);
 
     useLayoutEffect(() => {
-        const {sketch} = makeInequality(
+        const {sketch, p} = makeInequality(
             hiddenEditorRef.current,
             100,
             0,
@@ -175,12 +175,22 @@ const Equality = withRouter(({location}: RouteComponentProps<{}, {}, {board?: st
 
         sketch.log = { initialState: [], actions: [] };
         sketch.onNewEditorState = updateState;
-        sketch.onCloseMenus = () => { void 0 };
-        sketch.isUserPrivileged = () => { return true; };
-        sketch.onNotifySymbolDrag = () => { void 0 };
-        sketch.isTrashActive = () => { return false; };
+        sketch.onCloseMenus = () => undefined;
+        sketch.isUserPrivileged = () => true;
+        sketch.onNotifySymbolDrag = () => undefined;
+        sketch.isTrashActive = () => false;
 
         sketchRef.current = sketch;
+
+        return () => {
+            if (sketchRef.current) {
+                sketchRef.current.onNewEditorState = () => null;
+                sketchRef.current.onCloseMenus = () => null;
+                sketchRef.current.isTrashActive = () => false;
+                sketchRef.current = null;
+            }
+            p.remove();
+        };
     }, [hiddenEditorRef.current]);
     /*** End of text based input stuff */
 


### PR DESCRIPTION
There was previously an issue in the inequality modal where multiple instances of p5 hung around sometimes - I'd already fixed it using this same pattern.

I _think_ that doing the same thing for the other mini instances of inequality (used to parse text input outside of the modal) will fix the strange "massive invisible p5 canvas at the top of the page" issue.

Even though those mini instances are created with `textEntry: true`, the canvas elements (that are given an initial height of 0px) associated with them **are still resized as if they were full-screen if the window size changes**. I have a hunch that this is the cause of (or is closely related to) the problem.