### PR TITLE
Add ability to set scheduled start date for quizzes (tests)

### DIFF
--- a/src/IsaacApiTypes.tsx
+++ b/src/IsaacApiTypes.tsx
@@ -40,9 +40,6 @@ export interface AssignmentDTO extends IAssignmentLike {
     ownerUserId?: number;
     assignerSummary?: UserSummaryDTO;
     notes?: string;
-    creationDate?: Date;
-    dueDate?: Date;
-    scheduledStartDate?: Date;
 }
 
 export interface AssignmentFeedbackDTO {
@@ -607,6 +604,7 @@ export interface IAssignmentLike {
     id?: number;
     creationDate?: Date;
     dueDate?: Date;
+    scheduledStartDate?: Date;
     ownerUserId?: number;
 }
 

--- a/src/app/components/elements/modals/QuizSettingModal.tsx
+++ b/src/app/components/elements/modals/QuizSettingModal.tsx
@@ -38,13 +38,14 @@ const feedbackOptionsMap = feedbackOptionsList.reduce((obj, option) => {
 type ControlName = 'group' | 'dueDate' | 'scheduledStartDate' | 'feedbackMode';
 
 interface QuizSettingModalProps {
+    allowedToSchedule?: boolean;
     quiz: ContentSummaryDTO | IsaacQuizDTO;
     dueDate?: Date | null;
     scheduledStartDate?: Date | null;
     feedbackMode?: QuizFeedbackMode | null;
 }
 
-export function QuizSettingModal({quiz, dueDate: initialDueDate, scheduledStartDate: initialScheduledStartDate, feedbackMode: initialFeedbackMode}: QuizSettingModalProps) {
+export function QuizSettingModal({allowedToSchedule, quiz, dueDate: initialDueDate, scheduledStartDate: initialScheduledStartDate, feedbackMode: initialFeedbackMode}: QuizSettingModalProps) {
     const dispatch: AppDispatch = useAppDispatch();
     const groupsQuery = useGetGroupsQuery(false);
 
@@ -115,7 +116,7 @@ export function QuizSettingModal({quiz, dueDate: initialDueDate, scheduledStartD
             />
             {feedbackModeInvalid && <FormFeedback className="d-block" valid={false}>You must select a feedback mode</FormFeedback>}
         </Label>
-        <Label className="w-100 mb-4">Set an optional start date:<span id={scheduledQuizHelpTooltipId} className="icon-help"/><br/>
+        {allowedToSchedule && <Label className="w-100 mb-4">Set an optional start date:<span id={scheduledQuizHelpTooltipId} className="icon-help"/><br/>
             <DateInput value={scheduledStartDate ?? undefined} invalid={scheduledStartDateInvalid || undefined}
                        yearRange={yearRange}
                        onChange={(e: ChangeEvent<HTMLInputElement>) => setScheduledStartDate(e.target.valueAsDate)}
@@ -126,11 +127,11 @@ export function QuizSettingModal({quiz, dueDate: initialDueDate, scheduledStartD
                 If you do not set a start date, the test will be visible immediately.
             </UncontrolledTooltip>
             {scheduledStartDateInvalid && <small className={"pt-2 text-danger"}>Start date must be today, or in the future.</small>}
-        </Label>
+        </Label>}
         <Label className="w-100 mb-4">Set an optional due date:<br/>
             <DateInput invalid={dueDateInvalid || undefined} value={dueDate ?? undefined} yearRange={yearRange}
                        onChange={(e) => setDueDate(e.target.valueAsDate)}/>
-            {dueDateInvalid && <small className={"pt-2 text-danger"}>Due date must be on, or after the start date.</small>}
+            {dueDateInvalid && <small className={"pt-2 text-danger"}>{allowedToSchedule ? "Due date must be on, or after the start date." : "Due date must be after today."}</small>}
         </Label>
         <div className="text-right">
             <Button disabled={selectedGroups.length === 0 || !feedbackMode || submitting || dueDateInvalid || scheduledStartDateInvalid}
@@ -143,12 +144,15 @@ export function QuizSettingModal({quiz, dueDate: initialDueDate, scheduledStartD
                                scheduledStartDate: scheduledStartDate ? nthHourOf(7, scheduledStartDate) : undefined,
                                quizFeedbackMode: feedbackMode ?? undefined,
                            };
+                           if (!allowedToSchedule) {
+                               delete assignment.scheduledStartDate;
+                           }
                            let toastId: string | null;
                            const again = () => {
                                if (toastId) {
                                    dispatch(hideToast(toastId));
                                }
-                               dispatch(showQuizSettingModal(quiz, dueDate, scheduledStartDate, feedbackMode));
+                               dispatch(showQuizSettingModal(quiz, allowedToSchedule, dueDate, scheduledStartDate, feedbackMode));
                            };
                            try {
                                setSubmitting(true);

--- a/src/app/components/elements/modals/QuizSettingModal.tsx
+++ b/src/app/components/elements/modals/QuizSettingModal.tsx
@@ -1,22 +1,21 @@
+import React, {ChangeEvent, useState} from "react";
 import {ContentSummaryDTO, IsaacQuizDTO, QuizFeedbackMode} from "../../../../IsaacApiTypes";
 import {
     AppDispatch,
-    closeActiveModal,
-    hideToast,
-    setQuiz,
-    showQuizSettingModal,
+    closeActiveModal, hideToast,
+    setQuiz, showQuizSettingModal,
     showToast,
     useAppDispatch,
     useGetGroupsQuery
 } from "../../../state";
-import React, {useState} from "react";
-import {isDefined, Item, selectOnChange} from "../../../services";
+import {isDefined, Item, nthHourOf, selectOnChange, TODAY} from "../../../services";
 import range from "lodash/range";
 import {currentYear, DateInput} from "../inputs/DateInput";
-import * as RS from "reactstrap";
 import {IsaacSpinner} from "../../handlers/IsaacSpinner";
 import {ShowLoadingQuery} from "../../handlers/ShowLoadingQuery";
 import {StyledSelect} from "../inputs/StyledSelect";
+import {Button, FormFeedback, Label, UncontrolledTooltip} from "reactstrap";
+
 
 type QuizFeedbackOption = Item<QuizFeedbackMode>;
 const feedbackOptions = {
@@ -36,15 +35,16 @@ const feedbackOptionsMap = feedbackOptionsList.reduce((obj, option) => {
     return obj;
 }, {} as {[key in QuizFeedbackMode]: QuizFeedbackOption});
 
-type ControlName = 'group' | 'dueDate' | 'feedbackMode';
+type ControlName = 'group' | 'dueDate' | 'scheduledStartDate' | 'feedbackMode';
 
 interface QuizSettingModalProps {
     quiz: ContentSummaryDTO | IsaacQuizDTO;
     dueDate?: Date | null;
+    scheduledStartDate?: Date | null;
     feedbackMode?: QuizFeedbackMode | null;
 }
 
-export function QuizSettingModal({quiz, dueDate: initialDueDate, feedbackMode: initialFeedbackMode}: QuizSettingModalProps) {
+export function QuizSettingModal({quiz, dueDate: initialDueDate, scheduledStartDate: initialScheduledStartDate, feedbackMode: initialFeedbackMode}: QuizSettingModalProps) {
     const dispatch: AppDispatch = useAppDispatch();
     const groupsQuery = useGetGroupsQuery(false);
 
@@ -52,10 +52,10 @@ export function QuizSettingModal({quiz, dueDate: initialDueDate, feedbackMode: i
     const [submitting, setSubmitting] = useState(false);
     const [selectedGroups, setSelectedGroups] = useState<Item<number>[]>([]);
     const [dueDate, setDueDate] = useState<Date | null>(initialDueDate ?? null);
+    const [scheduledStartDate, setScheduledStartDate] = useState<Date | null>(initialScheduledStartDate ?? null);
     const [feedbackMode, setFeedbackMode] = useState<QuizFeedbackMode | null>(initialFeedbackMode ?? null);
 
     const yearRange = range(currentYear, currentYear + 5);
-    const now = new Date();
 
     function addValidated(what: ControlName) {
         setValidated(validated => {
@@ -64,11 +64,14 @@ export function QuizSettingModal({quiz, dueDate: initialDueDate, feedbackMode: i
     }
 
     const groupInvalid = validated.has('group') && selectedGroups.length === 0;
-    const dueDateInvalid = isDefined(dueDate) && dueDate.getTime() < now.getTime();
+    const dueDateInvalid = isDefined(dueDate) && ((scheduledStartDate ? scheduledStartDate.valueOf() > dueDate.valueOf() : false) || dueDate.valueOf() < Date.now());
+    const scheduledStartDateInvalid = isDefined(scheduledStartDate) && scheduledStartDate.valueOf() <= TODAY().valueOf();
     const feedbackModeInvalid = validated.has('feedbackMode') && feedbackMode === null;
 
+    const scheduledQuizHelpTooltipId = "scheduled-quiz-help-tooltip";
+
     return <div className="mb-4">
-        <RS.Label className="w-100 mb-4">Set test to the following groups:<br/>
+        <Label className="w-100 mb-4">Set test to the following group:<br/>
             <ShowLoadingQuery
                 query={groupsQuery}
                 defaultErrorTitle={"Error fetching groups"}
@@ -90,14 +93,9 @@ export function QuizSettingModal({quiz, dueDate: initialDueDate, feedbackMode: i
                     />
                 }}
             />
-            {groupInvalid && <RS.FormFeedback className="d-block" valid={false}>You must select a group</RS.FormFeedback>}
-        </RS.Label>
-        <RS.Label className="w-100 mb-4">Set an optional due date:<br/>
-            <DateInput invalid={dueDateInvalid || undefined} value={dueDate ?? undefined} yearRange={yearRange}
-                       onChange={(e) => setDueDate(e.target.valueAsDate)}/>
-            {dueDateInvalid && <small className={"pt-2 text-danger"}>Due date must be after today.</small>}
-        </RS.Label>
-        <RS.Label className="w-100 mb-4">What level of feedback should students get:<br/>
+            {groupInvalid && <FormFeedback className="d-block" valid={false}>You must select a group</FormFeedback>}
+        </Label>
+        <Label className="w-100 mb-4">What level of feedback should students get:<br/>
             <StyledSelect
                 value={feedbackMode ? feedbackOptionsMap[feedbackMode] : null}
                 onChange={(s) => {
@@ -115,16 +113,34 @@ export function QuizSettingModal({quiz, dueDate: initialDueDate, feedbackMode: i
                     menuPortal: base => ({...base, zIndex: 9999}),
                 }}
             />
-            {feedbackModeInvalid && <RS.FormFeedback className="d-block" valid={false}>You must select a feedback mode</RS.FormFeedback>}
-        </RS.Label>
+            {feedbackModeInvalid && <FormFeedback className="d-block" valid={false}>You must select a feedback mode</FormFeedback>}
+        </Label>
+        <Label className="w-100 mb-4">Set an optional start date:<span id={scheduledQuizHelpTooltipId} className="icon-help"/><br/>
+            <DateInput value={scheduledStartDate ?? undefined} invalid={scheduledStartDateInvalid || undefined}
+                       yearRange={yearRange}
+                       onChange={(e: ChangeEvent<HTMLInputElement>) => setScheduledStartDate(e.target.valueAsDate)}
+            />
+            <UncontrolledTooltip placement="top" autohide={false} target={scheduledQuizHelpTooltipId}>
+                You can schedule a test to appear in the future by setting a start date.
+                The test will be visible to students from this date onwards.<br/>
+                If you do not set a start date, the test will be visible immediately.
+            </UncontrolledTooltip>
+            {scheduledStartDateInvalid && <small className={"pt-2 text-danger"}>Start date must be today, or in the future.</small>}
+        </Label>
+        <Label className="w-100 mb-4">Set an optional due date:<br/>
+            <DateInput invalid={dueDateInvalid || undefined} value={dueDate ?? undefined} yearRange={yearRange}
+                       onChange={(e) => setDueDate(e.target.valueAsDate)}/>
+            {dueDateInvalid && <small className={"pt-2 text-danger"}>Due date must be on, or after the start date.</small>}
+        </Label>
         <div className="text-right">
-            <RS.Button disabled={selectedGroups.length === 0 || !feedbackMode || submitting}
+            <Button disabled={selectedGroups.length === 0 || !feedbackMode || submitting || dueDateInvalid || scheduledStartDateInvalid}
                        onMouseEnter={() => setValidated(new Set(['group', 'feedbackMode']))}
                        onClick={async () => {
                            const assignment = {
                                quizId: quiz.id,
                                groupId: selectedGroups[0].value,
                                dueDate: dueDate ?? undefined,
+                               scheduledStartDate: scheduledStartDate ? nthHourOf(7, scheduledStartDate) : undefined,
                                quizFeedbackMode: feedbackMode ?? undefined,
                            };
                            let toastId: string | null;
@@ -132,14 +148,14 @@ export function QuizSettingModal({quiz, dueDate: initialDueDate, feedbackMode: i
                                if (toastId) {
                                    dispatch(hideToast(toastId));
                                }
-                               dispatch(showQuizSettingModal(quiz, dueDate, feedbackMode));
+                               dispatch(showQuizSettingModal(quiz, dueDate, scheduledStartDate, feedbackMode));
                            };
                            try {
                                setSubmitting(true);
                                await dispatch(setQuiz(assignment));
                                toastId = await dispatch(showToast({
                                    color: "success", title: "Test set", body: "Test set to " + selectedGroups[0].label + " successfully", timeout: 7000,
-                                   buttons: [<RS.Button key="again" onClick={again}>Set to another group</RS.Button>]
+                                   buttons: [<Button key="again" onClick={again}>Set to another group</Button>]
                                }));
                            } catch (e) {
                                return;
@@ -150,7 +166,7 @@ export function QuizSettingModal({quiz, dueDate: initialDueDate, feedbackMode: i
                        }}
             >
                 {submitting ? <IsaacSpinner /> : "Set test"}
-            </RS.Button>
+            </Button>
         </div>
     </div>;
 }

--- a/src/app/components/pages/quizzes/QuizTeacherFeedback.tsx
+++ b/src/app/components/pages/quizzes/QuizTeacherFeedback.tsx
@@ -16,7 +16,7 @@ import {AssignmentProgressLegend} from '../AssignmentProgress';
 import {
     extractTeacherName,
     getQuizAssignmentCSVDownloadLink,
-    isDefined,
+    isDefined, nthHourOf, TODAY,
     useAssignmentProgressAccessibilitySettings
 } from "../../../services";
 import {AssignmentProgressPageSettingsContext, QuizFeedbackModes} from "../../../../IsaacAppTypes";
@@ -78,7 +78,9 @@ export const QuizTeacherFeedback = ({user}: {user: RegisteredUserDTO}) => {
 
     const assignment = assignmentState && 'assignment' in assignmentState ? assignmentState.assignment : null;
     const error = assignmentState && 'error' in assignmentState ? assignmentState.error : null;
-    const quizTitle = (assignment?.quiz?.title || assignment?.quiz?.id || "Test") + " results";
+    const assignmentStartDate = assignment?.scheduledStartDate ?? assignment?.creationDate;
+    const assignmentNotYetStarted = assignmentStartDate && nthHourOf(0, assignmentStartDate) > TODAY();
+    const quizTitle = (assignment?.quiz?.title || assignment?.quiz?.id || "Test") + (assignmentNotYetStarted ? ` (starts ${formatDate(assignmentStartDate)})` : " results");
 
     // Date input variables
     const yearRange = range(currentYear, currentYear + 5);
@@ -116,12 +118,16 @@ export const QuizTeacherFeedback = ({user}: {user: RegisteredUserDTO}) => {
         <ShowLoading until={assignmentState}>
             {assignment && <>
                 <TitleAndBreadcrumb currentPageTitle={quizTitle} help={pageHelp} intermediateCrumbs={teacherQuizzesCrumbs}/>
-                <p className="d-flex">
+                <div className="d-flex mb-4">
                     <span>
                         Set by: {extractTeacherName(assignment.assignerSummary ?? null)} on {formatDate(assignment.creationDate)}
                     </span>
                     {isDefined(assignment.dueDate) && <><Spacer/>Due: {formatDate(assignment.dueDate)}</>}
-                </p>
+                </div>
+                {assignmentNotYetStarted && <div className="mb-4">
+                    <h4 className="alert-heading">This test has not yet started</h4>
+                    <p>It will be released to your group on {formatDate(assignmentStartDate)}.</p>
+                </div>}
                 <Row>
                     {assignment.dueDate && <Col xs={12} sm={6} md={4}>
                         <Label for="dueDate" className="pr-1">Extend the due date:

--- a/src/app/components/pages/quizzes/SetQuizzes.tsx
+++ b/src/app/components/pages/quizzes/SetQuizzes.tsx
@@ -21,8 +21,8 @@ import {
     isEventLeaderOrStaff,
     isPhy,
     MANAGE_QUIZ_TAB,
-    NOT_FOUND,
-    siteSpecific,
+    NOT_FOUND, nthHourOf,
+    siteSpecific, TODAY,
     useDeviceSize,
     useFilteredQuizzes
 } from "../../../services";
@@ -55,24 +55,33 @@ function QuizAssignment({user, assignment}: QuizAssignmentProps) {
             dispatch(markQuizAsCancelled(assignment.id as number));
         }
     };
+    const assignmentNotYetStarted = assignment?.scheduledStartDate && nthHourOf(0, assignment?.scheduledStartDate) > TODAY();
+    const quizTitle = (assignment.quizSummary?.title || assignment.quizId) + (assignmentNotYetStarted ? ` (starts ${formatDate(assignment?.scheduledStartDate)})` : "");
     // TODO RTKQ quiz refactor use isPending from use mutation hook to re-implement this (markQuizAsCancelled would be
     //  the mutation trigger)
     const isCancelling = 'cancelling' in assignment && (assignment as {cancelling: boolean}).cancelling;
     return <div className="p-2">
         <RS.Card className="card-neat">
             <RS.CardBody>
-                <h4 className="border-bottom pb-3 mb-3">{assignment.quizSummary?.title || assignment.quizId}</h4>
+                <h4 className="border-bottom pb-3 mb-3">{quizTitle}</h4>
 
                 <p>Set to: <strong>{assignment.groupName ?? "Unknown"}</strong></p>
-                <p>{assignment.dueDate ? <>Due date: <strong>{formatDate(assignment.dueDate)}</strong></> : <>No due date</>}</p>
                 <p>Set on: <strong>{formatDate(assignment.creationDate)} by {formatAssignmentOwner(user, assignment)}</strong></p>
+                <RS.Row>
+                    {assignment.scheduledStartDate && <RS.Col>
+                        <p>Start date: <strong>{formatDate(assignment.scheduledStartDate)}</strong></p>
+                    </RS.Col>}
+                    <RS.Col>
+                        <p>{assignment.dueDate ? <>Due date: <strong>{formatDate(assignment.dueDate)}</strong></> : <>No due date</>}</p>
+                    </RS.Col>
+                </RS.Row>
 
                 <div className="mt-4 text-right">
                     <RS.Button color="tertiary" size="sm" outline onClick={cancel} disabled={isCancelling} className="mr-1 bg-light">
                         {isCancelling ? <><IsaacSpinner size="sm" /> Cancelling...</> : siteSpecific("Cancel Test", "Cancel test")}
                     </RS.Button>
                     <RS.Button tag={Link} to={`/quiz/assignment/${assignment.id}/feedback`} disabled={isCancelling} color={isCancelling ? "tertiary" : undefined} size="sm" className="ml-1">
-                        {siteSpecific("View Results", "View results")}
+                        View {assignmentNotYetStarted ? siteSpecific("Details", "details") : siteSpecific("Results", "results")}
                     </RS.Button>
                 </div>
             </RS.CardBody>

--- a/src/app/components/pages/quizzes/SetQuizzes.tsx
+++ b/src/app/components/pages/quizzes/SetQuizzes.tsx
@@ -19,7 +19,7 @@ import {AppQuizAssignment} from "../../../../IsaacAppTypes";
 import {
     below,
     isEventLeaderOrStaff,
-    isPhy,
+    isPhy, isStaff,
     MANAGE_QUIZ_TAB,
     NOT_FOUND, nthHourOf,
     siteSpecific, TODAY,
@@ -155,7 +155,7 @@ const SetQuizzesPageComponent = ({user, location}: SetQuizzesPageProps) => {
                                     {roleVisibilitySummary(quiz)}
                                     {quiz.summary && <div className="small text-muted d-none d-md-block">{quiz.summary}</div>}
                                     <Spacer />
-                                    <RS.Button className={below["md"](deviceSize) ? "btn-sm" : ""} onClick={() => dispatch(showQuizSettingModal(quiz))}>
+                                    <RS.Button className={below["md"](deviceSize) ? "btn-sm" : ""} onClick={() => dispatch(showQuizSettingModal(quiz, isStaff(user)))}>
                                         {siteSpecific("Set Test", "Set test")}
                                     </RS.Button>
                                 </div>

--- a/src/app/state/actions/quizzes.tsx
+++ b/src/app/state/actions/quizzes.tsx
@@ -31,6 +31,7 @@ export const setQuiz = (assignment: QuizAssignmentDTO) => async (dispatch: Dispa
         return newAssignment;
     } catch (e) {
         dispatch(showAxiosErrorToastIfNeeded("Test setting failed", e));
+        throw e;
     }
 };
 

--- a/src/app/state/actions/quizzes.tsx
+++ b/src/app/state/actions/quizzes.tsx
@@ -31,17 +31,16 @@ export const setQuiz = (assignment: QuizAssignmentDTO) => async (dispatch: Dispa
         return newAssignment;
     } catch (e) {
         dispatch(showAxiosErrorToastIfNeeded("Test setting failed", e));
-        throw e;
     }
 };
 
-export const showQuizSettingModal = (quiz: ContentSummaryDTO | IsaacQuizDTO, dueDate?: Date | null, feedbackMode?: QuizFeedbackMode | null) => (dispatch: AppDispatch) => {
+export const showQuizSettingModal = (quiz: ContentSummaryDTO | IsaacQuizDTO, dueDate?: Date | null, scheduledStartDate?: Date | null, feedbackMode?: QuizFeedbackMode | null) => (dispatch: AppDispatch) => {
     dispatch(openActiveModal({
         closeAction: () => {
             dispatch(closeActiveModal())
         },
         title: `Setting test '${quiz.title ?? quiz.id}'`,
-        body: <QuizSettingModal quiz={quiz} dueDate={dueDate} feedbackMode={feedbackMode}/>
+        body: <QuizSettingModal quiz={quiz} dueDate={dueDate} scheduledStartDate={scheduledStartDate} feedbackMode={feedbackMode}/>
     }));
 }
 

--- a/src/app/state/actions/quizzes.tsx
+++ b/src/app/state/actions/quizzes.tsx
@@ -35,13 +35,13 @@ export const setQuiz = (assignment: QuizAssignmentDTO) => async (dispatch: Dispa
     }
 };
 
-export const showQuizSettingModal = (quiz: ContentSummaryDTO | IsaacQuizDTO, dueDate?: Date | null, scheduledStartDate?: Date | null, feedbackMode?: QuizFeedbackMode | null) => (dispatch: AppDispatch) => {
+export const showQuizSettingModal = (quiz: ContentSummaryDTO | IsaacQuizDTO, allowedToSchedule?: boolean, dueDate?: Date | null, scheduledStartDate?: Date | null, feedbackMode?: QuizFeedbackMode | null) => (dispatch: AppDispatch) => {
     dispatch(openActiveModal({
         closeAction: () => {
             dispatch(closeActiveModal())
         },
         title: `Setting test '${quiz.title ?? quiz.id}'`,
-        body: <QuizSettingModal quiz={quiz} dueDate={dueDate} scheduledStartDate={scheduledStartDate} feedbackMode={feedbackMode}/>
+        body: <QuizSettingModal quiz={quiz} dueDate={dueDate} scheduledStartDate={scheduledStartDate} feedbackMode={feedbackMode} allowedToSchedule={allowedToSchedule}/>
     }));
 }
 


### PR DESCRIPTION
And display this information on "manage tests" and "test feedback" pages.

Feature is only available for staff users currently.