### PR TITLE
Assignment schedule: improve assignment filtering by date when switching between views

### DIFF
--- a/src/app/components/pages/AssignmentSchedule.tsx
+++ b/src/app/components/pages/AssignmentSchedule.tsx
@@ -569,9 +569,9 @@ export const AssignmentSchedule = ({user}: {user: RegisteredUserDTO}) => {
 
     return <Container>
         <TitleAndBreadcrumb currentPageTitle="Assignment Schedule" help={pageHelp}/>
-        <h4 className="mt-4 mb-3">
-            Assign a {siteSpecific("gameboard", "quiz")} from...
-        </h4>
+        {/*<h4 className="mt-4 mb-3">*/}
+        {/*    Assign a {siteSpecific("gameboard", "quiz")} from...*/}
+        {/*</h4>*/}
         <PhyAddGameboardButtons className="mb-4" redirectBackTo="/assignment_schedule"/>
         <ShowLoadingQuery
             defaultErrorTitle="Error loading assignments and/or gameboards"

--- a/src/app/components/pages/AssignmentSchedule.tsx
+++ b/src/app/components/pages/AssignmentSchedule.tsx
@@ -6,6 +6,7 @@ import {
     useGetGameboardsQuery,
     useGetGroupsQuery,
     useGetMySetAssignmentsQuery,
+    useLazyGetGameboardByIdQuery,
     useUnassignGameboardMutation
 } from "../../state";
 import {AssignmentDTO, GameboardDTO, RegisteredUserDTO, UserGroupDTO} from "../../../IsaacApiTypes";
@@ -27,10 +28,6 @@ import {
     Container,
     Input,
     Label,
-    Modal,
-    ModalBody,
-    ModalFooter,
-    ModalHeader,
     Row
 } from "reactstrap";
 import {
@@ -69,7 +66,6 @@ interface HeaderProps {
     openAssignmentModal: (assignment?: ValidAssignmentWithListingDate) => void;
     collapse: () => void;
 }
-
 const AssignmentScheduleStickyHeader = ({user, groups, assignmentsSetByMe, viewBy, setViewBy, setGroupsToInclude, groupsToInclude, openAssignmentModal, collapse}: HeaderProps) => {
 
     const headerScrollerSentinel = useRef<HTMLDivElement>(null);
@@ -185,7 +181,7 @@ const AssignmentListEntry = ({assignment}: AssignmentListEntryProps) => {
     };
     const assignmentOwnedByMe = assignment.ownerUserId === user.id;
     const assignmentStartDate = getAssignmentStartDate(assignment);
-    const gameboardTitle = assignment.gameboard?.title ?? `No ${siteSpecific("gameboard", "quiz")} title`;
+    const gameboardTitle = assignment.gameboard?.title ?? `Unknown ${siteSpecific("gameboard", "quiz")} (may belong to another user)`;
     const gameboardLink = assignment.gameboardId ? `${PATHS.GAMEBOARD}#${assignment.gameboardId}` : undefined;
     return <Card className={"my-1"}>
         <CardHeader className={"pt-2 pb-0 d-flex text-break"}>
@@ -297,11 +293,11 @@ const MonthAssignmentList = ({month, datesAndAssignments}: {month: number, dates
 
 interface AssignmentModalProps {
     user: RegisteredUserDTO;
-    showAssignmentModal: boolean;
-    toggleAssignModal: () => void;
+    showSetAssignmentUI: boolean;
+    toggleSetAssignmentUI: () => void;
     assignmentToCopy: AssignmentDTO | undefined;
 }
-const AssignmentModal = ({user, showAssignmentModal, toggleAssignModal, assignmentToCopy}: AssignmentModalProps) => {
+const AssignmentModal = ({user, showSetAssignmentUI, toggleSetAssignmentUI, assignmentToCopy}: AssignmentModalProps) => {
     const dispatch = useAppDispatch();
     const [selectedGroups, setSelectedGroups] = useState<Item<number>[]>([]);
     const [dueDate, setDueDate] = useState<Date>();
@@ -318,8 +314,9 @@ const AssignmentModal = ({user, showAssignmentModal, toggleAssignModal, assignme
     useEffect(() => {
         setSelectedGroups([]);
         if (assignmentToCopy && assignmentToCopy.gameboardId) {
+            const displayTitle = (assignmentToCopy.gameboard?.title ?? boardsById[assignmentToCopy.gameboardId]?.title ?? `Unknown ${siteSpecific("gameboard", "quiz")}`) + (assignmentToCopy.gameboard?.ownerUserId === user.id ? "" : ` (belongs to another user)`);
             // Copy existing assignment
-            setSelectedGameboard([{value: assignmentToCopy.gameboardId, label: boardsById[assignmentToCopy.gameboardId]?.title ?? "No gameboard title"}]);
+            setSelectedGameboard([{value: assignmentToCopy.gameboardId, label: displayTitle}]);
             setScheduledStartDate(assignmentToCopy.scheduledStartDate ? new Date(assignmentToCopy.scheduledStartDate.valueOf()) : undefined);
             setDueDate(assignmentToCopy.dueDate ? new Date(assignmentToCopy.dueDate.valueOf()) : undefined);
             setAssignmentNotes(assignmentToCopy.notes);
@@ -339,7 +336,8 @@ const AssignmentModal = ({user, showAssignmentModal, toggleAssignModal, assignme
             groups: [...selectedGroups],
             dueDate,
             scheduledStartDate: scheduledStartDate && nthHourOf(7, scheduledStartDate),
-            notes: assignmentNotes
+            notes: assignmentNotes,
+            userId: user.id
         })).then((result) => {
             if (assignGameboard.fulfilled.match(result)) {
                 setSelectedGroups([]);
@@ -358,82 +356,93 @@ const AssignmentModal = ({user, showAssignmentModal, toggleAssignModal, assignme
     const dueDateInvalid = dueDate && scheduledStartDate ? scheduledStartDate.valueOf() > dueDate.valueOf() : false;
 
     useEffect(() => {
-        if (showAssignmentModal) setShowGameboardPreview(false);
-    }, [showAssignmentModal]);
+        if (showSetAssignmentUI) setShowGameboardPreview(false);
+    }, [showSetAssignmentUI]);
 
     const alreadyAssignedGroupNames = useMemo<string[]>(() => {
         if (!selectedGameboard || selectedGameboard.length === 0 || !selectedGroups || selectedGroups.length === 0) return [];
         return selectedGroups.filter(g => g.value && boardIdsByGroupId[g.value]?.includes(selectedGameboard[0]?.value)).map(g => g.label);
     }, [selectedGroups, boardIdsByGroupId, selectedGameboard]);
 
-    const gameboardToPreview = selectedGameboard?.[0]?.value ? boardsById[selectedGameboard[0].value] : undefined;
+    // This logic means that even if a user doesn't have a gameboard saved to their account, they can still preview it.
+    // Very useful for copying assignments from other users.
+    const [getGameboardById, {currentData: gameboardSearch, isLoading, isFetching, }] = useLazyGetGameboardByIdQuery();
+    let gameboardToPreview = undefined;
+    if (selectedGameboard?.[0]?.value) {
+        gameboardToPreview = boardsById[selectedGameboard[0].value];
+        if (!gameboardToPreview) {
+            if (gameboardSearch?.id === selectedGameboard[0].value) {
+                gameboardToPreview = gameboardSearch;
+            } else if (!isLoading && !isFetching) {
+                getGameboardById(selectedGameboard[0].value);
+            }
+        }
+    }
 
-    return <Modal isOpen={showAssignmentModal} toggle={toggleAssignModal}>
-        <ModalHeader close={
-            <button className="close" onClick={toggleAssignModal}>
-                Close
-            </button>
-        }>
-            Set new assignment
-        </ModalHeader>
-        <ModalBody>
-            <Label className="w-100 pb-2">Group(s):
-                <StyledSelect inputId="groups-to-assign" isMulti isClearable placeholder="None"
-                        value={selectedGroups}
-                        closeMenuOnSelect={false}
-                        onChange={selectOnChange(setSelectedGroups, false)}
-                        options={sortBy(groups, group => group.groupName && group.groupName.toLowerCase()).map(g => itemise(g.id as number, g.groupName))}
-                />
-            </Label>
-            <Label className="w-100 pb-2">Gameboard:
-                <StyledSelect inputId="gameboard-to-assign" isClearable placeholder="None"
-                        value={selectedGameboard}
-                        onChange={selectOnChange(setSelectedGameboard, false)}
-                        options={gameboards.map(g => itemise(g.id ?? "", g.title ?? "No gameboard title"))}
-                />
-                {alreadyAssignedGroupNames && alreadyAssignedGroupNames.length > 0 && <Alert color={"warning"} className={"my-1"}>
-                    This {siteSpecific("gameboard", "quiz")} is already assigned to group{alreadyAssignedGroupNames.length > 1 ? "s" : ""}: {alreadyAssignedGroupNames.join(", ")}. You must delete the previous assignment{alreadyAssignedGroupNames.length > 1 ? "s" : ""} to set it again.
-                </Alert>}
-                {selectedGameboard && selectedGameboard?.[0]?.value && boardsById[selectedGameboard[0].value] && boardsById[selectedGameboard[0].value]?.contents && <Card className={"my-1"} >
-                    <CardHeader className={"text-right"}><Button color={"link"} onClick={toggleGameboardPreview}>{showGameboardPreview ? "Hide" : "Show"}{" "}{siteSpecific("gameboard", "quiz")} preview</Button></CardHeader>
-                    {showGameboardPreview && gameboardToPreview && <GameboardViewerInner gameboard={gameboardToPreview}/>}
-                    {showGameboardPreview && <CardFooter className={"text-right"}><Button color={"link"} onClick={toggleGameboardPreview}>Hide {siteSpecific("gameboard", "quiz")} preview</Button></CardFooter>}
-                </Card>}
-            </Label>
-            <Label className="w-100 pb-2 mt-5">Schedule an assignment start date <span className="text-muted"> (optional)</span>
-                <DateInput value={scheduledStartDate} placeholder="Select your scheduled start date..." yearRange={yearRange}
-                           onChange={(e: ChangeEvent<HTMLInputElement>) => setScheduledStartDate(e.target.valueAsDate as Date)} />
-            </Label>
-            <Label className="w-100 pb-2">Due date reminder <span className="text-muted"> (optional)</span>
-                <DateInput value={dueDate} placeholder="Select your due date..." yearRange={yearRange}
-                           onChange={(e: ChangeEvent<HTMLInputElement>) => setDueDate(e.target.valueAsDate as Date)} />
-                {dueDateInvalid && <small className={"pt-2 text-danger"}>Due date must be on or after start date.</small>}
-            </Label>
-            {isStaff(user) && <Label className="w-100 pb-2">Notes (optional):
-                <Input type="textarea"
-                       spellCheck={true}
-                       rows={3}
-                       value={assignmentNotes}
-                       onChange={(e: React.ChangeEvent<HTMLInputElement>) => setAssignmentNotes(e.target.value)}
-                />
-                <p className="mt-1 mb-0"><small>{(assignmentNotes || '').length}/500 characters</small></p>
-                {isDefined(assignmentNotes) && assignmentNotes.length > 500 &&
+    return <>
+        <h3>
+            Set new assignment{assignmentToCopy ? " (from existing)" : ""}
+        </h3>
+        <Label className="w-100 pb-2">Group(s):
+            <StyledSelect inputId="groups-to-assign" isMulti isClearable placeholder="None"
+                          value={selectedGroups}
+                          closeMenuOnSelect={false}
+                          onChange={selectOnChange(setSelectedGroups, false)}
+                          options={sortBy(groups, group => group.groupName && group.groupName.toLowerCase()).map(g => itemise(g.id as number, g.groupName))}
+            />
+        </Label>
+        <Label className="w-100 pb-2">Gameboard:
+            <StyledSelect inputId="gameboard-to-assign" isClearable placeholder="None"
+                          value={selectedGameboard}
+                          onChange={selectOnChange(setSelectedGameboard, false)}
+                          options={gameboards.map(g => itemise(g.id ?? "", g.title ?? `Unknown ${siteSpecific("gameboard", "quiz")} (may belong to another user)`))}
+            />
+            {alreadyAssignedGroupNames && alreadyAssignedGroupNames.length > 0 && <Alert color={"warning"} className={"my-1"}>
+                This {siteSpecific("gameboard", "quiz")} is already assigned to group{alreadyAssignedGroupNames.length > 1 ? "s" : ""}: {alreadyAssignedGroupNames.join(", ")}. You must delete the previous assignment{alreadyAssignedGroupNames.length > 1 ? "s" : ""} to set it again.
+            </Alert>}
+            {gameboardToPreview?.contents && <Card className={"my-1"} >
+                <CardHeader className={"text-right"}><Button color={"link"} onClick={toggleGameboardPreview}>{showGameboardPreview ? "Hide" : "Show"}{" "}{siteSpecific("gameboard", "quiz")} preview</Button></CardHeader>
+                {showGameboardPreview && gameboardToPreview && <GameboardViewerInner gameboard={gameboardToPreview}/>}
+                {showGameboardPreview && <CardFooter className={"text-right"}><Button color={"link"} onClick={toggleGameboardPreview}>Hide {siteSpecific("gameboard", "quiz")} preview</Button></CardFooter>}
+            </Card>}
+        </Label>
+        <Label className="w-100 pb-2">Schedule an assignment start date <span className="text-muted"> (optional)</span>
+            <DateInput value={scheduledStartDate} placeholder="Select your scheduled start date..." yearRange={yearRange}
+                       onChange={(e: ChangeEvent<HTMLInputElement>) => setScheduledStartDate(e.target.valueAsDate as Date)} />
+        </Label>
+        <Label className="w-100 pb-2">Due date reminder <span className="text-muted"> (optional)</span>
+            <DateInput value={dueDate} placeholder="Select your due date..." yearRange={yearRange}
+                       onChange={(e: ChangeEvent<HTMLInputElement>) => setDueDate(e.target.valueAsDate as Date)} />
+            {dueDateInvalid && <small className={"pt-2 text-danger"}>Due date must be on or after start date.</small>}
+        </Label>
+        {isStaff(user) && <Label className="w-100 pb-2">Notes (optional):
+            <Input type="textarea"
+                   spellCheck={true}
+                   rows={3}
+                   value={assignmentNotes}
+                   onChange={(e: React.ChangeEvent<HTMLInputElement>) => setAssignmentNotes(e.target.value)}
+            />
+            <p className="mt-1 mb-0"><small>{(assignmentNotes || '').length}/500 characters</small></p>
+            {isDefined(assignmentNotes) && assignmentNotes.length > 500 &&
                 <p className="mt-0 mb-0 text-danger"><small>You have exceeded the maximum length.</small></p>
-                }
-            </Label>}
-            <Button
-                className="mt-2 mb-2"
-                block color={siteSpecific("secondary", "primary")}
-                onClick={assign}
-                disabled={selectedGroups.length === 0 || (isDefined(assignmentNotes) && assignmentNotes.length > 500) || !isDefined(selectedGameboard) || alreadyAssignedGroupNames.length === selectedGroups.length}
-            >
-                Assign to group{selectedGroups.length > 1 ? "s" : ""}
-            </Button>
-        </ModalBody>
-        <ModalFooter>
-            <Button block color="tertiary" onClick={toggleAssignModal}>Close</Button>
-        </ModalFooter>
-    </Modal>;
+            }
+        </Label>}
+        <Row className={"mt-3"}>
+            <Col xs={12} sm={6}>
+                <Button
+                    className="mb-2 mb-sm-0"
+                    block color={siteSpecific("secondary", "primary")}
+                    onClick={assign}
+                    disabled={selectedGroups.length === 0 || (isDefined(assignmentNotes) && assignmentNotes.length > 500) || !isDefined(selectedGameboard) || alreadyAssignedGroupNames.length === selectedGroups.length}
+                >
+                    Assign to group{selectedGroups.length > 1 ? "s" : ""}
+                </Button>
+            </Col>
+            <Col xs={12} sm={6}>
+                <Button block color="tertiary" onClick={toggleSetAssignmentUI}>Back to schedule</Button>
+            </Col>
+        </Row>
+    </>;
 }
 
 type AssignmentsGroupedByDate = [number, [number, [number, ValidAssignmentWithListingDate[]][]][]][];
@@ -536,18 +545,18 @@ export const AssignmentSchedule = ({user}: {user: RegisteredUserDTO}) => {
     const [assignmentToCopy, setAssignmentToCopy] = useState<AssignmentDTO | undefined>();
     const {hash} = useLocation();
     const gameboardId = hash.includes("#") ? hash.slice(1) : undefined;
-    const [showAssignmentModal, setShowAssignmentModal] = useState<boolean>(false);
+    const [showSetAssignmentUI, setShowSetAssignmentUI] = useState<boolean>(false);
     const openAssignmentModal = useCallback((assignment?: ValidAssignmentWithListingDate) => {
         setAssignmentToCopy(assignment);
-        setShowAssignmentModal(true);
-    }, [setAssignmentToCopy, setShowAssignmentModal]);
+        setShowSetAssignmentUI(true);
+    }, [setAssignmentToCopy, setShowSetAssignmentUI]);
     useEffect(() => {
         if (gameboardId) {
             setAssignmentToCopy({gameboardId});
-            setShowAssignmentModal(true);
+            setShowSetAssignmentUI(true);
         }
     }, []);
-    const toggleAssignModal = () => setShowAssignmentModal(o => !o);
+    const toggleSetAssignmentUI = () => setShowSetAssignmentUI(o => !o);
 
     // Flag to notify children components to completely collapse all assignment sub-lists, so only months are showing
     const [collapsed, setCollapsed] = useState<boolean>(false);
@@ -575,15 +584,15 @@ export const AssignmentSchedule = ({user}: {user: RegisteredUserDTO}) => {
                         <br/>
                         It is a work in progress, and we would love to <a target="_blank" href="/contact?subject=Assignment%20Schedule%20Feedback">hear your feedback</a>!
                     </Alert>}
-                    <AssignmentScheduleStickyHeader
+                    {!showSetAssignmentUI && <AssignmentScheduleStickyHeader
                         assignmentsSetByMe={assignmentsSetByMe}
                         groupsToInclude={groupsToInclude} setGroupsToInclude={setGroupsToInclude}
                         viewBy={viewBy} setViewBy={setViewBy}
                         openAssignmentModal={openAssignmentModal} collapse={() => setCollapsed(true)}
                         groups={groups} user={user}
-                    />
+                    />}
                     <Card className="mt-2">
-                        <CardBody className="pt-0">
+                        <CardBody className="pt-0" hidden={showSetAssignmentUI}>
                             {/* Groups-related alerts */}
                             {groups && groups.length === 0 && <div className="mt-3">
                                 You have not created any groups to assign work to.
@@ -610,14 +619,16 @@ export const AssignmentSchedule = ({user}: {user: RegisteredUserDTO}) => {
                                 <div className={classNames("bg-timeline", {"fade-in": !notAllPastAssignmentsAreListed})}/>
                             </div>}
                         </CardBody>
+                        <CardBody className="pt-3" hidden={!showSetAssignmentUI}>
+                            <AssignmentModal
+                                user={user}
+                                showSetAssignmentUI={showSetAssignmentUI}
+                                toggleSetAssignmentUI={toggleSetAssignmentUI}
+                                assignmentToCopy={assignmentToCopy}
+                            />
+                        </CardBody>
                     </Card>
                 </div>
-                <AssignmentModal
-                    user={user}
-                    showAssignmentModal={showAssignmentModal}
-                    toggleAssignModal={toggleAssignModal}
-                    assignmentToCopy={assignmentToCopy}
-                />
             </AssignmentScheduleContext.Provider>
         </ShowLoadingQuery>
     </Container>;

--- a/src/app/components/pages/SetAssignments.tsx
+++ b/src/app/components/pages/SetAssignments.tsx
@@ -78,13 +78,13 @@ const AssignGroup = ({groups, board}: AssignGroupProps) => {
     const [dueDate, setDueDate] = useState<Date>();
     const [scheduledStartDate, setScheduledStartDate] = useState<Date>();
     const [assignmentNotes, setAssignmentNotes] = useState<string>();
-    const user = useAppSelector(selectors.user.orNull);
+    const user = useAppSelector(selectors.user.loggedInOrNull);
     const dispatch = useAppDispatch();
 
     if (!board) return <Loading/>;
 
     function assign() {
-        dispatch(assignGameboard({boardId: board?.id as string, groups: selectedGroups, dueDate, scheduledStartDate, notes: assignmentNotes})).then(success => {
+        dispatch(assignGameboard({boardId: board?.id as string, groups: selectedGroups, dueDate, scheduledStartDate, notes: assignmentNotes, userId: user?.id})).then(success => {
             if (success) {
                 setSelectedGroups([]);
                 setDueDate(undefined);

--- a/src/app/state/slices/api/gameboards.ts
+++ b/src/app/state/slices/api/gameboards.ts
@@ -34,11 +34,12 @@ export interface AssignmentSpec {
     dueDate?: Date;
     scheduledStartDate?: Date;
     notes?: string;
+    userId?: number;
 }
 
 export const assignGameboard = createAsyncThunk(
     "gameboards/assignBoard",
-    async ({boardId, groups, dueDate, scheduledStartDate, notes}: AssignmentSpec, {dispatch, rejectWithValue}) => {
+    async ({boardId, groups, dueDate, scheduledStartDate, notes, userId}: AssignmentSpec, {dispatch, rejectWithValue}) => {
         const appDispatch = dispatch as AppDispatch;
         if (groups.length === 0) {
             appDispatch(showErrorToast(
@@ -92,6 +93,7 @@ export const assignGameboard = createAsyncThunk(
                 creationDate: (new Date()).valueOf() as unknown as Date,
                 dueDate: dueDate?.valueOf() as unknown as Date | undefined,
                 scheduledStartDate: scheduledStartDate?.valueOf() as unknown as Date | undefined,
+                ownerUserId: userId,
                 notes
             }));
             const successfulIds = newAssignments.map(a => a.groupId);

--- a/src/scss/common/assignments.scss
+++ b/src/scss/common/assignments.scss
@@ -24,6 +24,16 @@
   }
 }
 
+#start-date-button {
+  border-top-right-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
+}
+
+#due-date-button {
+  border-top-left-radius: 0 !important;
+  border-bottom-left-radius: 0 !important;
+}
+
 .timeline {
   z-index: 0;
   background-color: transparent;


### PR DESCRIPTION
If you switch from start date to due date view or visa versa, sometimes the earliest show date needs to be brought back in order for any assignments to be shown. This implements that.