### PR TITLE
Add assignment notes and gameboard info to assignment schedule cards

### DIFF
--- a/src/app/components/pages/AssignmentSchedule.tsx
+++ b/src/app/components/pages/AssignmentSchedule.tsx
@@ -172,7 +172,7 @@ interface AssignmentListEntryProps {
 }
 const AssignmentListEntry = ({assignment}: AssignmentListEntryProps) => {
     const user = useAppSelector(selectors.user.orNull) as RegisteredUserDTO;
-    const {openAssignmentModal, viewBy, boardsById} = useContext(AssignmentScheduleContext);
+    const {openAssignmentModal, boardsById} = useContext(AssignmentScheduleContext);
     const [ unassignGameboard ] = useUnassignGameboardMutation();
     const [showMore, setShowMore] = useState(false);
     const [showGameboardPreview, setShowGameboardPreview] = useState(false);

--- a/src/app/components/pages/AssignmentSchedule.tsx
+++ b/src/app/components/pages/AssignmentSchedule.tsx
@@ -202,7 +202,6 @@ const AssignmentListEntry = ({assignment}: AssignmentListEntryProps) => {
 
     const boardStagesAndDifficulties = determineGameboardStagesAndDifficulties(gameboardToPreview);
 
-    console.log(gameboardToPreview);
 
     return <Card className={"my-1"}>
         <CardHeader className={"pt-2 pb-0 d-flex text-break"}>

--- a/src/app/services/gameboards.tsx
+++ b/src/app/services/gameboards.tsx
@@ -106,9 +106,11 @@ export const showWildcard = (board: GameboardDTO) => {
     return board?.id && (re.test(board.id) || isaacPhysicsBoard)
 };
 
-export const determineGameboardSubjects = (board: GameboardDTO) => {
+export const determineGameboardSubjects = (board?: GameboardDTO) => {
     if (isAda) {
         return ["compsci"];
+    } else if (!board) {
+        return ["physics"];
     }
     const subjects = ["physics", "maths", "chemistry", "biology"];
     let allSubjects: string[] = [];

--- a/src/scss/common/assignments.scss
+++ b/src/scss/common/assignments.scss
@@ -107,3 +107,15 @@
     }
   }
 }
+
+.assignment-card-footer {
+  background-color: white;
+  button, a {
+    &:focus {
+      outline: none;
+    }
+    &:focus-visible {
+      outline: 3px solid black;
+    }
+  }
+}

--- a/src/test/pages/MyGameboards.test.tsx
+++ b/src/test/pages/MyGameboards.test.tsx
@@ -18,7 +18,7 @@ describe("MyGameboards", () => {
     it('should start in table view', async () => {
         renderMyGameboards();
         await waitFor(() => {
-            expect(screen.queryByText("Loading...")).toBeNull();
+            expect(screen.queryAllByText("Loading...")).toBeEmpty();
         });
         const viewDropdown: HTMLInputElement = await screen.findByLabelText("Display in");
         expect(viewDropdown.value).toEqual("Table View");

--- a/src/test/pages/MyGameboards.test.tsx
+++ b/src/test/pages/MyGameboards.test.tsx
@@ -18,7 +18,7 @@ describe("MyGameboards", () => {
     it('should start in table view', async () => {
         renderMyGameboards();
         await waitFor(() => {
-            expect(screen.queryAllByText("Loading...")).toBeEmpty();
+            expect(screen.queryAllByText("Loading...")).toHaveLength(0);
         });
         const viewDropdown: HTMLInputElement = await screen.findByLabelText("Display in");
         expect(viewDropdown.value).toEqual("Table View");


### PR DESCRIPTION
All of this extra info is hidden unless "Show more" is clicked.

The extra info is hidden once the card is hidden, which keeps the view compact unless the user explicitly wants to see more details.

Collapsed:
![image](https://github.com/isaacphysics/isaac-react-app/assets/33040507/6cfa8d28-2810-4b4c-a23d-15d3e5b0d5e1)

Expanded:
![image](https://github.com/isaacphysics/isaac-react-app/assets/33040507/b5a07692-020b-4b59-ab5d-4fd399bb9a16)
