### PR TITLE
Pass dataUrl through to code editor in interactive code snippet

### DIFF
--- a/src/IsaacApiTypes.tsx
+++ b/src/IsaacApiTypes.tsx
@@ -423,6 +423,7 @@ export interface InteractiveCodeSnippetDTO extends CodeSnippetDTO {
     testCode?: string;
     expectedResult?: string;
     wrapCodeInMain?: boolean;
+    dataUrl?: string;
 }
 
 export interface GraphChoiceDTO extends ChoiceDTO {

--- a/src/app/components/content/IsaacInteractiveCodeSnippet.tsx
+++ b/src/app/components/content/IsaacInteractiveCodeSnippet.tsx
@@ -26,7 +26,8 @@ export const IsaacInteractiveCodeSnippet = ({doc}: IsaacInteractiveCodeProps) =>
             setup: doc.setupCode,
             test: doc.testCode,
             wrapCodeInMain: doc.wrapCodeInMain,
-            language: doc.language
+            language: doc.language,
+            dataUrl: doc.dataUrl
         });
     }
 

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -25,7 +25,7 @@ export const mockUser = {
             examBoard: "all"
         }
     ],
-    registeredContextsLastConfirmed: DAYS_AGO(3),
+    registeredContextsLastConfirmed: DAYS_AGO(-1),
     firstLogin: false,
     lastUpdated: DAYS_AGO(1),
     lastSeen: DAYS_AGO(1),

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -48,7 +48,7 @@ export const buildMockStudent = <T extends number>(id: T extends (typeof mockUse
             stage: "all",
             examBoard: "all"
         }],
-        registeredContextsLastConfirmed: DAYS_AGO(3),
+        registeredContextsLastConfirmed: DAYS_AGO(-1),
         firstLogin: false,
         lastUpdated: DAYS_AGO(1),
         lastSeen: DAYS_AGO(1),
@@ -72,7 +72,7 @@ export const buildMockTeacher = <T extends number>(id: T extends (typeof mockUse
             stage: "all",
             examBoard: "all"
         }],
-        registeredContextsLastConfirmed: DAYS_AGO(3),
+        registeredContextsLastConfirmed: DAYS_AGO(-1),
         firstLogin: false,
         lastUpdated: DAYS_AGO(1),
         lastSeen: DAYS_AGO(1),

--- a/src/test/pages/UserContextReconfirmationModal.test.tsx
+++ b/src/test/pages/UserContextReconfirmationModal.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import {screen, waitFor, within} from "@testing-library/react";
+import {screen} from "@testing-library/react";
 import {MOST_RECENT_AUGUST} from "../../app/state";
 import produce from "immer";
 import {renderTestEnvironment} from "../utils";

--- a/src/test/setupTests.ts
+++ b/src/test/setupTests.ts
@@ -16,68 +16,64 @@ jest.mock("../app/services/reactRouterExtension", () => ({
     useQueryParams: jest.fn(() => ({})),
 }));
 
-// Repeating this definition here so we don't have to import it from services
-export enum KEY {
-    AFTER_AUTH_PATH = "afterAuthPath",
-    CURRENT_USER_ID = "currentUserId",
-    FIRST_LOGIN = "firstLogin",
-    REQUIRED_MODAL_SHOWN_TIME = "requiredModalShownTime",
-    RECONFIRM_USER_CONTEXT_SHOWN_TIME = "reconfirmStageExamBoardShownTime",
-    LOGIN_OR_SIGN_UP_MODAL_SHOWN_TIME = "loginOrSignUpModalShownTime",
-    LAST_NOTIFICATION_TIME = "lastNotificationTime",
-    ANONYMISE_USERS = "anonymiseUsers",
-    ANONYMISE_GROUPS = "anonymiseGroups",
-    MOST_RECENT_ALL_TOPICS_PATH = "mostRecentAllTopicsPath",
-    FIRST_ANON_QUESTION = "firstAnonQuestion",
-    ASSIGN_BOARD_PATH = "assignBoardPath",
-}
-
-let mockSessionStorage: {[key: string]: string} = {};
-let mockLocalStorage: {[key: string]: string} = {};
-
-global.window.sessionStorage.removeItem = jest.fn((key: string) => {
-    delete mockSessionStorage[key];
-});
-global.window.sessionStorage.getItem = jest.fn((key: string) => {
-    return mockSessionStorage[key];
-});
-global.window.sessionStorage.setItem = jest.fn((key: string, value: string) => {
-    mockSessionStorage[key] = value;
-});
-global.window.sessionStorage.clear = jest.fn(() => {
-    mockSessionStorage = {};
-});
-global.window.localStorage.removeItem = jest.fn((key: string) => {
-    delete mockLocalStorage[key];
-});
-global.window.localStorage.getItem = jest.fn((key: string) => {
-    if (key === KEY.REQUIRED_MODAL_SHOWN_TIME || key === KEY.RECONFIRM_USER_CONTEXT_SHOWN_TIME) {
-        return new Date().toString();
-    }
-    return mockLocalStorage[key];
-});
-global.window.localStorage.setItem = jest.fn((key: string, value: string) => {
-    mockLocalStorage[key] = value;
-});
-global.window.localStorage.clear = jest.fn(() => {
-    mockLocalStorage = {};
-});
-
-jest.mock("../app/services/localStorage", () => ({
-    ...jest.requireActual("../app/services/localStorage"),
-    persistence: {
-        ...jest.requireActual("../app/services/localStorage").persistence,
-        load: jest.fn((key: string) => {
-            if (key === KEY.REQUIRED_MODAL_SHOWN_TIME || key === KEY.RECONFIRM_USER_CONTEXT_SHOWN_TIME) {
-                return new Date().toString();
-            }
-            return mockLocalStorage[key];
-        }),
-        save: jest.fn((key: string, value: string) => {
-            mockLocalStorage[key] = value;
-        })
-    }
-}));
+// TODO mock localStorage and sessionStorage like this (currently broken for some reason)
+//
+// // Repeating this definition here so we don't have to import it from services
+// export enum KEY {
+//     AFTER_AUTH_PATH = "afterAuthPath",
+//     CURRENT_USER_ID = "currentUserId",
+//     FIRST_LOGIN = "firstLogin",
+//     REQUIRED_MODAL_SHOWN_TIME = "requiredModalShownTime",
+//     RECONFIRM_USER_CONTEXT_SHOWN_TIME = "reconfirmStageExamBoardShownTime",
+//     LOGIN_OR_SIGN_UP_MODAL_SHOWN_TIME = "loginOrSignUpModalShownTime",
+//     LAST_NOTIFICATION_TIME = "lastNotificationTime",
+//     ANONYMISE_USERS = "anonymiseUsers",
+//     ANONYMISE_GROUPS = "anonymiseGroups",
+//     MOST_RECENT_ALL_TOPICS_PATH = "mostRecentAllTopicsPath",
+//     FIRST_ANON_QUESTION = "firstAnonQuestion",
+//     ASSIGN_BOARD_PATH = "assignBoardPath",
+// }
+//
+// let mockSessionStorage: {[key: string]: string} = {};
+// let mockLocalStorage: {[key: string]: string} = {};
+//
+// global.window.sessionStorage.removeItem = jest.fn((key: string) => {
+//     delete mockSessionStorage[key];
+// });
+// global.window.sessionStorage.getItem = jest.fn((key: string) => {
+//     return mockSessionStorage[key];
+// });
+// global.window.sessionStorage.setItem = jest.fn((key: string, value: string) => {
+//     mockSessionStorage[key] = value;
+// });
+// global.window.sessionStorage.clear = jest.fn(() => {
+//     mockSessionStorage = {};
+// });
+// global.window.localStorage.removeItem = jest.fn((key: string) => {
+//     delete mockLocalStorage[key];
+// });
+// global.window.localStorage.getItem = jest.fn((key: string) => {
+//     return mockLocalStorage[key];
+// });
+// global.window.localStorage.setItem = jest.fn((key: string, value: string) => {
+//     mockLocalStorage[key] = value;
+// });
+// global.window.localStorage.clear = jest.fn(() => {
+//     mockLocalStorage = {};
+// });
+//
+// jest.mock("../app/services/localStorage", () => ({
+//     ...jest.requireActual("../app/services/localStorage"),
+//     persistence: {
+//         ...jest.requireActual("../app/services/localStorage").persistence,
+//         load: jest.fn((key: string) => {
+//             return mockLocalStorage[key];
+//         }),
+//         save: jest.fn((key: string, value: string) => {
+//             mockLocalStorage[key] = value;
+//         })
+//     }
+// }));
 
 jest.setTimeout(10000); // 10 seconds (default is 5 seconds)
 

--- a/src/test/setupTests.ts
+++ b/src/test/setupTests.ts
@@ -16,7 +16,70 @@ jest.mock("../app/services/reactRouterExtension", () => ({
     useQueryParams: jest.fn(() => ({})),
 }));
 
-// TODO jest.mock("../app/services/localStorage"); <--- need to mock this effectively
+// Repeating this definition here so we don't have to import it from services
+export enum KEY {
+    AFTER_AUTH_PATH = "afterAuthPath",
+    CURRENT_USER_ID = "currentUserId",
+    FIRST_LOGIN = "firstLogin",
+    REQUIRED_MODAL_SHOWN_TIME = "requiredModalShownTime",
+    RECONFIRM_USER_CONTEXT_SHOWN_TIME = "reconfirmStageExamBoardShownTime",
+    LOGIN_OR_SIGN_UP_MODAL_SHOWN_TIME = "loginOrSignUpModalShownTime",
+    LAST_NOTIFICATION_TIME = "lastNotificationTime",
+    ANONYMISE_USERS = "anonymiseUsers",
+    ANONYMISE_GROUPS = "anonymiseGroups",
+    MOST_RECENT_ALL_TOPICS_PATH = "mostRecentAllTopicsPath",
+    FIRST_ANON_QUESTION = "firstAnonQuestion",
+    ASSIGN_BOARD_PATH = "assignBoardPath",
+}
+
+let mockSessionStorage: {[key: string]: string} = {};
+let mockLocalStorage: {[key: string]: string} = {};
+
+global.window.sessionStorage.removeItem = jest.fn((key: string) => {
+    delete mockSessionStorage[key];
+});
+global.window.sessionStorage.getItem = jest.fn((key: string) => {
+    return mockSessionStorage[key];
+});
+global.window.sessionStorage.setItem = jest.fn((key: string, value: string) => {
+    mockSessionStorage[key] = value;
+});
+global.window.sessionStorage.clear = jest.fn(() => {
+    mockSessionStorage = {};
+});
+global.window.localStorage.removeItem = jest.fn((key: string) => {
+    delete mockLocalStorage[key];
+});
+global.window.localStorage.getItem = jest.fn((key: string) => {
+    if (key === KEY.REQUIRED_MODAL_SHOWN_TIME || key === KEY.RECONFIRM_USER_CONTEXT_SHOWN_TIME) {
+        return new Date().toString();
+    }
+    return mockLocalStorage[key];
+});
+global.window.localStorage.setItem = jest.fn((key: string, value: string) => {
+    mockLocalStorage[key] = value;
+});
+global.window.localStorage.clear = jest.fn(() => {
+    mockLocalStorage = {};
+});
+
+jest.mock("../app/services/localStorage", () => ({
+    ...jest.requireActual("../app/services/localStorage"),
+    persistence: {
+        ...jest.requireActual("../app/services/localStorage").persistence,
+        load: jest.fn((key: string) => {
+            if (key === KEY.REQUIRED_MODAL_SHOWN_TIME || key === KEY.RECONFIRM_USER_CONTEXT_SHOWN_TIME) {
+                return new Date().toString();
+            }
+            return mockLocalStorage[key];
+        }),
+        save: jest.fn((key: string, value: string) => {
+            mockLocalStorage[key] = value;
+        })
+    }
+}));
+
+jest.setTimeout(10000); // 10 seconds (default is 5 seconds)
 
 // Establish API mocking before all tests.
 beforeAll(() => {


### PR DESCRIPTION
_The failing test has nothing to do with this_

Commit message "Set mock user registeredContextsLastConfirmed to -1 days in the future" should say "... -1 day in the past" - not too worried because the diff and extended commit message make it clear what the change was