### PR TITLE
Prevent doubling of copy-pasted maths keeping A11Y

### DIFF
--- a/src/app/components/elements/markup/latexRendering.ts
+++ b/src/app/components/elements/markup/latexRendering.ts
@@ -290,7 +290,7 @@ export function katexify(html: string, user: Immutable<PotentialUser> | null, bo
                 // If katex-a11y fails, generate MathML using KaTeX for accessibility
                 if (screenReaderText) {
                     katexRenderResult = katexRenderResult.replace('<span class="katex">',
-                        `<span class="katex"><span class="sr-only">${screenReaderText}</span>`);
+                        `<span class="katex"><span class="sr-only" aria-label="${screenReaderText}" role="text"></span>`);
                 } else {
                     const katexMathML = katex.renderToString(latexMunged.replace(dropZoneRegex, "clickable drop zone"), {...katexOptions, output: "mathml"})
                         .replace(`class="katex"`, `class="katex-mathml"`);


### PR DESCRIPTION
This is difficult. The sr-only class does not stop the contents from appearing on the clipboard, which is a different sort of accessibility violation in itself, because it makes the pasted text (e.g. for conversion into Braille or to be used elsewhere) confusing.

The obvious fix is to replace the span text with an aria-label. But aria-label is prohibited on non-interactive content like spans: https://w3c.github.io/aria/#aria-label

To fix this, we can add an aria-role to the KaTeX element. The obvious one is role="math". This works fine for NVDA on Chrome/Firefox but breaks VoiceOver because that just states "maths" and ignores the label. Breaking VoiceOver is a no-go, since that is basically the main option on MacOS and iOS.

Fortunately, most browsers and screenreaders ignore the ARIA spec and will respect aria-label on a non-interactive element. This means that the role can be left out and we can still use a span. But VoiceOver still ignores the maths, or else reads it out followed by "empty group". Using the non-standard role="text" fixes this on Safari and iOS for VoiceOver, but Chrome on MacOS still gets the annoying "empty group".

Since everything here is non-standards-compliant, I don't know what to do. This proposal gives the best experience for a novice user with screenreader settings "out-of-the-box", and that is our target audience. This is a dramatic improvement for everyone not using a screenreader, and will only be noticeable to VoiceOver users on Chrome on MacOS. I think that is the best we can do unless/until VoiceOver is fixed.

KaTeX makes accessibility really hard, as does poor cross-browser standardisation for maths generally . . .