### PR TITLE
Fix sorting of immutable event booking lists

### DIFF
--- a/src/app/components/elements/panels/EventAttendance.tsx
+++ b/src/app/components/elements/panels/EventAttendance.tsx
@@ -98,7 +98,7 @@ export const EventAttendance = ({user, eventId, event, eventBookings, userIdToSc
                         </tr>
                     </thead>
                     <tbody>
-                        {eventBookings?.sort(sortOnPredicateAndReverse(sortPredicate, reverse))
+                        {[...eventBookings]?.sort(sortOnPredicateAndReverse(sortPredicate, reverse))
                             .filter(filterOnSurname)
                             .map(booking => {
                                 const userBooked = booking.userBooked as UserSummaryWithEmailAddressDTO;

--- a/src/app/components/elements/panels/ManageExistingBookings.tsx
+++ b/src/app/components/elements/panels/ManageExistingBookings.tsx
@@ -150,7 +150,7 @@ export const ManageExistingBookings = ({user, eventId, eventBookings, userIdToSc
                         </tr>
                     </thead>
                     <tbody>
-                        {augmentedEventBookings?.sort(sortOnPredicateAndReverse(sortPredicate, reverse))
+                        {[...augmentedEventBookings]?.sort(sortOnPredicateAndReverse(sortPredicate, reverse))
                             .map(booking => {
                                 const userId = booking.userBooked && booking.userBooked.id;
                                 return !isDefined(userId) ? RenderNothing : <tr key={booking.bookingId}>


### PR DESCRIPTION
Arrays of items retrieved using RTK Query are readonly. JS's .sort() mutates the array, so the solution is to either use underscore's orderBy(...) or to copy the readonly array before mutating it.