### PR TITLE
Hotfix/stop redirecting to auth on oauth sign in

### DIFF
--- a/src/app/state/actions/index.tsx
+++ b/src/app/state/actions/index.tsx
@@ -411,7 +411,7 @@ export const handleProviderCallback = (provider: AuthenticationProvider, paramet
         // On first login (registration), redirect to /account if there is no after-auth path.
         // After-auth path should take presedence for the case where users register while following a group invite - /account?authToken=GROUP1, for example.
         // They will see the required account information modal either way on registration.
-        const nextPage = persistence.pop(KEY.AFTER_AUTH_PATH)?.replace("#!", "");
+        const nextPage = persistence.pop(KEY.AFTER_AUTH_PATH);
         const defaultNextPage = providerResponse.data.firstLogin ? "/account" : "/";
         history.push(nextPage || defaultNextPage);
     } catch (error: any) {

--- a/src/app/state/actions/index.tsx
+++ b/src/app/state/actions/index.tsx
@@ -405,11 +405,17 @@ export const handleProviderCallback = (provider: AuthenticationProvider, paramet
                         provider: provider,
                     }
                 }
-            )
+            );
         }
-        const nextPage = persistence.load(KEY.AFTER_AUTH_PATH);
-        persistence.remove(KEY.AFTER_AUTH_PATH);
-        history.push(nextPage?.replace("#!", "") || "/account");
+
+        // On first login, redirect to /account unless the "next page" already contains "account".
+        // This is to handle the case of a user registering while following a group invite - /account?authToken=GROUP1
+        const nextPage = persistence.pop(KEY.AFTER_AUTH_PATH)?.replace("#!", "") || "/";
+        if (providerResponse.data.firstLogin && !nextPage.includes("account")) {
+            history.push('/account');
+        } else {
+            history.push(nextPage);
+        }
     } catch (error: any) {
         history.push("/auth_error", { errorMessage: extractMessage(error) });
         dispatch({type: ACTION_TYPE.USER_LOG_IN_RESPONSE_FAILURE, errorMessage: "Login Failed"});

--- a/src/app/state/actions/index.tsx
+++ b/src/app/state/actions/index.tsx
@@ -408,14 +408,12 @@ export const handleProviderCallback = (provider: AuthenticationProvider, paramet
             );
         }
 
-        // On first login, redirect to /account unless the "next page" already contains "account".
-        // This is to handle the case of a user registering while following a group invite - /account?authToken=GROUP1
-        const nextPage = persistence.pop(KEY.AFTER_AUTH_PATH)?.replace("#!", "") || "/";
-        if (providerResponse.data.firstLogin && !nextPage.includes("account")) {
-            history.push('/account');
-        } else {
-            history.push(nextPage);
-        }
+        // On first login (registration), redirect to /account if there is no after-auth path.
+        // After-auth path should take presedence for the case where users register while following a group invite - /account?authToken=GROUP1, for example.
+        // They will see the required account information modal either way on registration.
+        const nextPage = persistence.pop(KEY.AFTER_AUTH_PATH)?.replace("#!", "");
+        const defaultNextPage = providerResponse.data.firstLogin ? "/account" : "/";
+        history.push(nextPage || defaultNextPage);
     } catch (error: any) {
         history.push("/auth_error", { errorMessage: extractMessage(error) });
         dispatch({type: ACTION_TYPE.USER_LOG_IN_RESPONSE_FAILURE, errorMessage: "Login Failed"});


### PR DESCRIPTION
This fix stops 3rd party auth users from being redirected to /account on login except for the case of on initial registration.
The logic seems to have been removed accidentally during a [refactor ](https://github.com/isaacphysics/isaac-react-app/commit/d2d3254f97b5d1bfcacf031f79279e86a1aad215).