### PR TITLE
Hotfix/mobile friendly graph sketcher

### DIFF
--- a/src/app/components/content/IsaacGraphSketcherQuestion.tsx
+++ b/src/app/components/content/IsaacGraphSketcherQuestion.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useEffect, useRef} from "react";
+import React, {useState, useEffect, useRef, useCallback} from "react";
 import {GraphChoiceDTO, IsaacGraphSketcherQuestionDTO} from "../../../IsaacApiTypes";
 import GraphSketcherModal from "../elements/modals/GraphSketcherModal";
 import {GraphSketcher, makeGraphSketcher, LineType, GraphSketcherState} from "isaac-graph-sketcher";
@@ -29,8 +29,16 @@ const IsaacGraphSketcherQuestion = ({doc, questionId, readonly}: IsaacQuestionPr
         !readonly && setModalVisible(true);
     }
 
+    const returnToScrollYPosition = useCallback(function(previousYPosition: number) {
+        return function() {
+            document.body.style.overflow = "initial";
+            window.scrollTo(0, previousYPosition);
+        }
+    }(window.scrollY), [modalVisible]); // Capture y position whenever modalVisible changes.
+
     function closeModal() {
         dispatchSetCurrentAttempt({type: 'graphChoice', value: JSON.stringify(pendingAttemptState)});
+        returnToScrollYPosition();
         setModalVisible(false);
     }
 

--- a/src/app/components/content/IsaacGraphSketcherQuestion.tsx
+++ b/src/app/components/content/IsaacGraphSketcherQuestion.tsx
@@ -48,13 +48,13 @@ const IsaacGraphSketcherQuestion = ({doc, questionId, readonly}: IsaacQuestionPr
         }
     }, []);
 
-    useEffect(() => {
+    useEffect(function setupPreviewSketch() {
         const { sketch, p } = makeGraphSketcher(previewRef.current || undefined, 600, 400, { previewMode: true, initialCurves: initialState?.curves });
         if (sketch) {
             sketch.selectedLineType = LineType.BEZIER;
             setPreviewSketch(sketch);
         }
-        return () => {
+        return function teardownPreviewSketch() {
             previewSketch?.teardown();
             setPreviewSketch(null);
             if (previewRef.current) {
@@ -83,7 +83,7 @@ const IsaacGraphSketcherQuestion = ({doc, questionId, readonly}: IsaacQuestionPr
                 {doc.children}
             </IsaacContentValueOrChildren>
         </div>
-        <div className="sketch-preview text-center" onClick={openModal} onKeyUp={openModal} role={readonly ? undefined : "button"}
+        <div className="sketch-preview d-flex justify-content-center overflow-auto" onClick={openModal} onKeyUp={openModal} role={readonly ? undefined : "button"}
              tabIndex={readonly ? undefined : 0}>
             <div ref={previewRef} className={`${questionId}-graph-sketcher-preview`} />
         </div>

--- a/src/app/components/elements/modals/GraphSketcherModal.tsx
+++ b/src/app/components/elements/modals/GraphSketcherModal.tsx
@@ -22,6 +22,7 @@ import {isStaff} from "../../../services";
 import {Immutable} from "immer";
 import {PotentialUser} from "../../../../IsaacAppTypes";
 import {IsaacContentValueOrChildren} from "../../content/IsaacContentValueOrChildren";
+import {fillScreenWithModal} from "./inequality/utils";
 
 interface GraphSketcherModalProps {
     user: Immutable<PotentialUser> | null;
@@ -72,17 +73,20 @@ const GraphSketcherModal = (props: GraphSketcherModalProps) => {
     }, [modalSketch, updateGraphSketcherState]);
 
     // Setup and teardown of the graph sketcher p5 instance
-    useEffect(() => {
+    useEffect(function setupOfGraphSketcherP5Instance() {
         const { sketch, p } = makeGraphSketcher(graphSketcherContainer.current ?? undefined, window.innerWidth, window.innerHeight, { previewMode: false, initialCurves: initialState?.curves, allowMultiValuedFunctions: isStaff(user) });
 
         if (sketch) {
             sketch.selectedLineType = LineType.BEZIER;
             setModalSketch(sketch);
         }
+        fillScreenWithModal(true);
 
-        return () => {
+        return function teardown() {
+            fillScreenWithModal(false);
             sketch?.teardown();
             setModalSketch(null);
+
             if (graphSketcherContainer.current) {
                 for (const canvas of graphSketcherContainer.current.getElementsByTagName('canvas')) {
                     graphSketcherContainer.current.removeChild(canvas);

--- a/src/app/components/elements/modals/GraphSketcherModal.tsx
+++ b/src/app/components/elements/modals/GraphSketcherModal.tsx
@@ -18,7 +18,7 @@ import {
     useGenerateAnswerSpecificationMutation
 } from "../../../state";
 import {PageFragment} from "../PageFragment";
-import {isStaff} from "../../../services";
+import {above, isStaff, useDeviceSize} from "../../../services";
 import {Immutable} from "immer";
 import {PotentialUser} from "../../../../IsaacAppTypes";
 import {IsaacContentValueOrChildren} from "../../content/IsaacContentValueOrChildren";
@@ -124,7 +124,8 @@ const GraphSketcherModal = (props: GraphSketcherModalProps) => {
 
     const redo = () => modalSketch?.redo();
 
-    const hexagonSize = 74;
+    const deviceSize = useDeviceSize();
+    const hexagonSize = above['sm'](deviceSize) ? 74 : 48;
     const colourHexagon = calculateHexagonProportions(hexagonSize/4, 3);
 
     const copySpecificationToClipboard = useCallback(() => {

--- a/src/app/components/elements/modals/inequality/utils.ts
+++ b/src/app/components/elements/modals/inequality/utils.ts
@@ -367,6 +367,28 @@ export const generateDefaultMenuItems = (parsedAvailableSymbols: string[], logic
 
 // --- Callback/effect definitions ---
 
+export function fillScreenWithModal(fullScreen: boolean) {
+    if (fullScreen) {
+        document.documentElement.style.overflow = "hidden";
+        document.documentElement.style.width = '100vw';
+        document.documentElement.style.height = '100vh';
+        document.documentElement.style.touchAction = 'none';
+        document.body.style.overflow = "hidden";
+        document.body.style.width = '100vw';
+        document.body.style.height = '100vh';
+        document.body.style.touchAction = 'none';
+    } else {
+        document.documentElement.style.width = '';
+        document.documentElement.style.height = '';
+        document.documentElement.style.overflow = '';
+        document.documentElement.style.touchAction = 'auto';
+        document.body.style.width = '';
+        document.body.style.height = '';
+        document.body.style.overflow = '';
+        document.body.style.touchAction = 'auto';
+    }
+}
+
 interface InequalityHandlers {
     onTouchStart: (e: TouchEvent) => void;
     handleKeyPress: (ev: KeyboardEvent) => void;
@@ -388,14 +410,7 @@ export function setupAndTeardownDocStyleAndListeners({onCursorMoveEnd, onMouseMo
     document.body.addEventListener("mouseup", onCursorMoveEnd);
     document.body.addEventListener("touchend", onCursorMoveEnd);
 
-    document.documentElement.style.overflow = "hidden";
-    document.documentElement.style.width = '100vw';
-    document.documentElement.style.height = '100vh';
-    document.documentElement.style.touchAction = 'none';
-    document.body.style.overflow = "hidden";
-    document.body.style.width = '100vw';
-    document.body.style.height = '100vh';
-    document.body.style.touchAction = 'none';
+    fillScreenWithModal(true);
 
     return () => {
         window.removeEventListener("keyup", handleKeyPress);
@@ -410,14 +425,7 @@ export function setupAndTeardownDocStyleAndListeners({onCursorMoveEnd, onMouseMo
         document.body.removeEventListener("mouseup", onCursorMoveEnd);
         document.body.removeEventListener("touchend", onCursorMoveEnd);
 
-        document.documentElement.style.width = '';
-        document.documentElement.style.height = '';
-        document.documentElement.style.overflow = '';
-        document.documentElement.style.touchAction = 'auto';
-        document.body.style.width = '';
-        document.body.style.height = '';
-        document.body.style.overflow = '';
-        document.body.style.touchAction = 'auto';
+        fillScreenWithModal(false);
 
         const canvas = inequalityModalRef.current?.getElementsByTagName('canvas')[0];
         if (canvas) {

--- a/src/scss/common/graph-sketcher-modal.scss
+++ b/src/scss/common/graph-sketcher-modal.scss
@@ -300,8 +300,9 @@
                 &#graph-sketcher-ui-linear-button {
                     top: 2 * $button-spacing;
                     left: 2 * $button-spacing;
-                }    
+                }
             }
+
             div#graph-sketcher-ui-color-select-hexagons {
                 top: 2 * $button-spacing;
                 left: 4 * $button-spacing + 2 * $button-size;
@@ -312,7 +313,6 @@
                     height: $button-size;                        
                 }
             }
-
         }
 
 

--- a/src/scss/common/graph-sketcher-modal.scss
+++ b/src/scss/common/graph-sketcher-modal.scss
@@ -167,7 +167,7 @@
             }
         }
 
-        @media (min-height: 450px) {
+        @include respond-above(xs) {
             $button-size: 90px;
             $button-spacing: 10px;
 
@@ -239,7 +239,7 @@
             }
         }
 
-        @media (max-height: 451px) {
+        @include respond-below(xs) {
             $button-size: 61px;
             $button-spacing: 8px;
 
@@ -294,21 +294,25 @@
 
                 &#graph-sketcher-ui-bezier-button {
                     top: 2 * $button-spacing;
-                    right: 4 * $button-spacing + 1 * $button-size + 90px;
+                    left: 3 * $button-spacing + $button-size;
                 }
 
                 &#graph-sketcher-ui-linear-button {
                     top: 2 * $button-spacing;
-                    right: 5 * $button-spacing + 2 * $button-size + 90px;
+                    left: 2 * $button-spacing;
+                }    
+            }
+            div#graph-sketcher-ui-color-select-hexagons {
+                top: 2 * $button-spacing;
+                left: 4 * $button-spacing + 2 * $button-size;
+                width: $button-size;
+                height: $button-size;
+                svg {
+                    width: $button-size;
+                    height: $button-size;                        
                 }
             }
 
-            div#graph-sketcher-ui-color-select-hexagons {
-                top: 2 * $button-spacing;
-                right: 3 * $button-spacing + $button-size;
-                width: 90px;
-                height: 90px;
-            }
         }
 
 


### PR DESCRIPTION
This alters the Graph Sketcher modal to behave like the Equation Editor modal - it fills the viewport and stops the touch-action from scrolling the page in any direction. It also records the scroll y position on modal open so that it can return to it on modal close.
This has been tested on a Android Pixel and iPhone where graphs were sketchable, hopefully it works for other smaller devices too. I suggest we release and ask for further feedback from the content teams and their devices.