### PR TITLE
Warn on duplicate group name

### DIFF
--- a/src/app/components/pages/Groups.tsx
+++ b/src/app/components/pages/Groups.tsx
@@ -228,8 +228,8 @@ const GroupEditor = ({group, allGroups, user, createNewGroup, groupNameInputRef}
                             <Input
                                 innerRef={groupNameInputRef} length={50} placeholder="Group name" value={newGroupName}
                                 onChange={e => setNewGroupName(e.target.value)} aria-label="Group Name" disabled={isDefined(group) && !(isUserGroupOwner || group.additionalManagerPrivileges)}
-                                invalid={newGroupName !== undefined && newGroupName.length > 0 && allGroups?.some(g => g.groupName == newGroupName && (group ? group.id != g.id : true))}
-                                valid={newGroupName !== undefined && newGroupName.length > 0 && !allGroups?.some(g => g.groupName == newGroupName && (group ? group.id != g.id : true))}
+                                invalid={newGroupName !== undefined && newGroupName.length > 0 && allGroups?.some(g => g.groupName == newGroupName && (isDefined(group) ? group.id != g.id : true))}
+                                valid={newGroupName !== undefined && newGroupName.length > 0 && !allGroups?.some(g => g.groupName == newGroupName) && (isDefined(group) ? newGroupName !== group.groupName : true)}
                             />
                             {(!isDefined(group) || isUserGroupOwner || group.additionalManagerPrivileges) && <InputGroupAddon addonType="append">
                                 <Button

--- a/src/app/components/pages/Groups.tsx
+++ b/src/app/components/pages/Groups.tsx
@@ -402,8 +402,9 @@ export const Groups = ({user}: {user: RegisteredUserDTO}) => {
     const [showArchived, setShowArchived] = useState(false);
     const groupQuery = useGetGroupsQuery(showArchived);
     const { currentData: groups, isLoading, isFetching } = groupQuery;
+    const otherGroups = useGetGroupsQuery(!showArchived);
 
-    const allGroups = [...(groups ?? []) , ...(useGetGroupsQuery(!showArchived).currentData ?? [])];
+    const allGroups = [...(groups ?? []) , ...(otherGroups.currentData ?? [])];
 
     const [createGroup] = useCreateGroupMutation();
     const [deleteGroup] = useDeleteGroupMutation();

--- a/src/app/components/pages/Groups.tsx
+++ b/src/app/components/pages/Groups.tsx
@@ -10,6 +10,7 @@ import {
     DropdownMenu,
     DropdownToggle,
     Form,
+    FormFeedback,
     Input,
     InputGroup,
     InputGroupAddon,
@@ -154,9 +155,10 @@ const MemberInfo = ({group, member, user}: MemberInfoProps) => {
 interface GroupEditorProps {
     user: RegisteredUserDTO;
     group?: AppGroup;
+    allGroups?: AppGroup[];
     groupNameInputRef?: MutableRefObject<HTMLInputElement | null>;
 }
-const GroupEditor = ({group, user, createNewGroup, groupNameInputRef}: GroupCreatorProps & GroupEditorProps) => {
+const GroupEditor = ({group, allGroups, user, createNewGroup, groupNameInputRef}: GroupCreatorProps & GroupEditorProps) => {
     const dispatch = useAppDispatch();
 
     const [updateGroup] = useUpdateGroupMutation();
@@ -226,6 +228,8 @@ const GroupEditor = ({group, user, createNewGroup, groupNameInputRef}: GroupCrea
                             <Input
                                 innerRef={groupNameInputRef} length={50} placeholder="Group name" value={newGroupName}
                                 onChange={e => setNewGroupName(e.target.value)} aria-label="Group Name" disabled={isDefined(group) && !(isUserGroupOwner || group.additionalManagerPrivileges)}
+                                invalid={newGroupName !== undefined && newGroupName.length > 0 && allGroups?.some(g => g.groupName == newGroupName && (group ? group.id != g.id : true))}
+                                valid={newGroupName !== undefined && newGroupName.length > 0 && !allGroups?.some(g => g.groupName == newGroupName && (group ? group.id != g.id : true))}
                             />
                             {(!isDefined(group) || isUserGroupOwner || group.additionalManagerPrivileges) && <InputGroupAddon addonType="append">
                                 <Button
@@ -237,6 +241,7 @@ const GroupEditor = ({group, user, createNewGroup, groupNameInputRef}: GroupCrea
                                     {group ? "Update" : "Create"}
                                 </Button>
                             </InputGroupAddon>}
+                            <FormFeedback>A group with that name already exists.</FormFeedback>
                         </InputGroup>
                     </Form>
                 </Col>
@@ -344,7 +349,7 @@ const GroupEditor = ({group, user, createNewGroup, groupNameInputRef}: GroupCrea
     </Card>;
 };
 
-const MobileGroupCreatorComponent = ({className, createNewGroup}: GroupCreatorProps & {className: string}) => {
+const MobileGroupCreatorComponent = ({className, createNewGroup, allGroups}: GroupCreatorProps & {className: string, allGroups: AppGroup[]}) => {
     const dispatch = useAppDispatch();
     const [newGroupName, setNewGroupName] = useState("");
 
@@ -364,8 +369,16 @@ const MobileGroupCreatorComponent = ({className, createNewGroup}: GroupCreatorPr
             <h6 className={siteSpecific("", "font-weight-semi-bold")}>Create New Group</h6>
         </Col>
         <Col size={12} className="mb-2">
-            <Input length={50} placeholder="Enter the name of your group here" value={newGroupName}
-                onChange={e => setNewGroupName(e.target.value)} aria-label="Group Name"/>
+            <Form>
+                <InputGroup>
+                    <Input length={50} placeholder="Enter the name of your group here" value={newGroupName}
+                        onChange={e => setNewGroupName(e.target.value)} aria-label="Group Name"
+                        invalid={newGroupName !== undefined && newGroupName.length > 0 && allGroups?.some(g => g.groupName == newGroupName)}
+                        valid={newGroupName !== undefined && newGroupName.length > 0 && !allGroups?.some(g => g.groupName == newGroupName)}
+                        />
+                    <FormFeedback>A group with that name already exists.</FormFeedback>
+                </InputGroup>
+            </Form>
         </Col>
         <Col size={12} className={siteSpecific("", "mt-2")}>
             <Button block color="primary" outline={isAda} onClick={saveUpdatedGroup} disabled={newGroupName == ""}>
@@ -380,6 +393,8 @@ export const Groups = ({user}: {user: RegisteredUserDTO}) => {
     const [showArchived, setShowArchived] = useState(false);
     const groupQuery = useGetGroupsQuery(showArchived);
     const { currentData: groups, isLoading, isFetching } = groupQuery;
+
+    const allGroups = [...(useGetGroupsQuery(false).currentData ?? []) , ...(useGetGroupsQuery(true).currentData ?? [])];
 
     const [createGroup] = useCreateGroupMutation();
     const [deleteGroup] = useDeleteGroupMutation();
@@ -474,7 +489,7 @@ export const Groups = ({user}: {user: RegisteredUserDTO}) => {
                 <Col lg={4}>
                     <Card>
                         <CardBody>
-                            <MobileGroupCreatorComponent className="d-block d-lg-none" createNewGroup={createNewGroup}/>
+                            <MobileGroupCreatorComponent className="d-block d-lg-none" createNewGroup={createNewGroup} allGroups={allGroups}/>
                             <div className="d-none d-lg-block mb-3">
                                 <Button block color="primary" outline onClick={() => {
                                     setSelectedGroupId(undefined);
@@ -526,7 +541,7 @@ export const Groups = ({user}: {user: RegisteredUserDTO}) => {
                                                 }
                                             </div>
                                             {selectedGroup && selectedGroup.id === g.id && <div className="d-lg-none py-2">
-                                                <GroupEditor user={user} group={selectedGroup} createNewGroup={createNewGroup}/>
+                                                <GroupEditor user={user} group={selectedGroup} allGroups={allGroups} createNewGroup={createNewGroup}/>
                                             </div>}
                                         </div>)
                                     : <div className={"group-item p-2"}>No {showArchived ? "archived" : "active"} groups</div>
@@ -536,7 +551,7 @@ export const Groups = ({user}: {user: RegisteredUserDTO}) => {
                     </Card>
                 </Col>
                 <Col lg={8} className="d-none d-lg-block" data-testid={"group-editor"}>
-                    <GroupEditor group={selectedGroup} groupNameInputRef={groupNameInputRef} user={user} createNewGroup={createNewGroup} />
+                    <GroupEditor group={selectedGroup} allGroups={allGroups} groupNameInputRef={groupNameInputRef} user={user} createNewGroup={createNewGroup} />
                 </Col>
             </Row>
         </ShowLoadingQuery>

--- a/src/app/components/pages/Groups.tsx
+++ b/src/app/components/pages/Groups.tsx
@@ -217,8 +217,8 @@ const GroupEditor = ({group, allGroups, user, createNewGroup, groupNameInputRef}
     const canArchive = group && (isUserGroupOwner || group.additionalManagerPrivileges);
     const canEmailUsers = isStaff(user) && usersInGroup.length > 0;
 
-    const getNameConflictingGroup = allGroups?.find(g => g.groupName == newGroupName && (isDefined(group) ? group.id != g.id : true));
-    const isGroupNameInvalid = isDefined(newGroupName) && isDefined(getNameConflictingGroup);
+    const existingGroupWithConflictingName = allGroups?.find(g => g.groupName == newGroupName && (isDefined(group) ? group.id != g.id : true));
+    const isGroupNameInvalid = isDefined(newGroupName) && isDefined(existingGroupWithConflictingName);
     const isGroupNameValid = isDefined(newGroupName) && newGroupName.length > 0 && !allGroups?.some(g => g.groupName == newGroupName) && (isDefined(group) ? newGroupName !== group.groupName : true);
     
     return <Card>
@@ -245,7 +245,7 @@ const GroupEditor = ({group, allGroups, user, createNewGroup, groupNameInputRef}
                                     {group ? "Update" : "Create"}
                                 </Button>
                             </InputGroupAddon>}
-                            <FormFeedback>A{isGroupNameInvalid && getNameConflictingGroup?.archived ? <>n archived</> : <></>} group with that name already exists.</FormFeedback>
+                            <FormFeedback>A{existingGroupWithConflictingName?.archived ? <>n archived</> : <></>} group with that name already exists.</FormFeedback>
                         </InputGroup>
                     </Form>
                 </Col>
@@ -369,8 +369,8 @@ const MobileGroupCreatorComponent = ({className, createNewGroup, allGroups}: Gro
         });
     }
 
-    const getNameConflictingGroup = allGroups?.find(g => g.groupName == newGroupName);
-    const isGroupNameInvalid = isDefined(newGroupName) && isDefined(getNameConflictingGroup);
+    const existingGroupWithConflictingName = allGroups?.find(g => g.groupName == newGroupName);
+    const isGroupNameInvalid = isDefined(newGroupName) && isDefined(existingGroupWithConflictingName);
     const isGroupNameValid = isDefined(newGroupName) && newGroupName.length > 0 && !allGroups?.some(g => g.groupName == newGroupName);
 
     return <Row className={className}>
@@ -385,7 +385,7 @@ const MobileGroupCreatorComponent = ({className, createNewGroup, allGroups}: Gro
                         invalid={isGroupNameInvalid}
                         valid={isGroupNameValid}
                         />
-                    <FormFeedback>A{isGroupNameInvalid && getNameConflictingGroup?.archived ? <>n archived</> : <></>} group with that name already exists.</FormFeedback>
+                    <FormFeedback>A{existingGroupWithConflictingName?.archived ? <>n archived</> : <></>} group with that name already exists.</FormFeedback>
                 </InputGroup>
             </Form>
         </Col>


### PR DESCRIPTION
Will warn the user if they enter a group name when creating a new group or editing an existing one that already exists; this does not block them from adding it should they insist.