### PR TITLE
Update button text for adding group managers

### DIFF
--- a/src/app/components/pages/Groups.tsx
+++ b/src/app/components/pages/Groups.tsx
@@ -260,7 +260,7 @@ const GroupEditor = ({group, user, createNewGroup, groupNameInputRef}: GroupCrea
                         {/* Only teachers and above can add group managers */}
                         <Button outline={isAda} className="w-100 w-sm-auto d-inline-block text-nowrap" size="sm" color={siteSpecific("tertiary", "secondary")} onClick={() => dispatch(showGroupManagersModal({group, user}))}>
                             {isUserGroupOwner
-                                ? <>Add / remove<span className="d-none d-xl-inline">{" "}group managers</span></>
+                                ? <>Add {additionalManagers.length > 1 ? <>/ remove</> : <></>}<span className="d-none d-xl-inline">{" "}group managers</span></>
                                 : <>More info<span className="d-none d-sm-inline">rmation</span></>
                             }
                         </Button>

--- a/src/test/pages/Groups.test.tsx
+++ b/src/test/pages/Groups.test.tsx
@@ -345,7 +345,7 @@ describe("Groups", () => {
             const selectGroupButton = within(groups.find(g => within(g).getByTestId("select-group").textContent === mockGroup.groupName) as HTMLElement).getByTestId("select-group");
             await userEvent.click(selectGroupButton);
             const groupEditor = await screen.findByTestId("group-editor");
-            const addManagersButton = within(groupEditor).getByRole("button", {name: "Add / remove group managers"});
+            const addManagersButton = within(groupEditor).getByRole("button", {name: "Add group managers"});
             await userEvent.click(addManagersButton);
             await testAddAdditionalManagerInModal(existingGroupManagerHandler, mockNewManager);
         });
@@ -368,7 +368,7 @@ describe("Groups", () => {
             await userEvent.click(selectGroupButton);
             const groupEditor = await screen.findByTestId("group-editor");
             // Neither variant of the button should show
-            const addManagersButton = within(groupEditor).queryByRole("button", {name: "Add / remove group managers"});
+            const addManagersButton = within(groupEditor).queryByRole("button", {name: "Add group managers"});
             const viewManagersButton = within(groupEditor).queryByRole("button", {name: "More information"});
             expect(addManagersButton).toBeNull();
             expect(viewManagersButton).toBeNull();


### PR DESCRIPTION
If there are no managers to remove, change 'Add / remove group managers' text to just 'Add group managers'.