### PR TITLE
Instructional text for graph sketcher

### DIFF
--- a/src/app/components/content/IsaacGraphSketcherQuestion.tsx
+++ b/src/app/components/content/IsaacGraphSketcherQuestion.tsx
@@ -2,7 +2,7 @@ import React, {useState, useEffect, useRef} from "react";
 import {GraphChoiceDTO, IsaacGraphSketcherQuestionDTO} from "../../../IsaacApiTypes";
 import GraphSketcherModal from "../elements/modals/GraphSketcherModal";
 import {GraphSketcher, makeGraphSketcher, LineType, GraphSketcherState} from "isaac-graph-sketcher";
-import {useCurrentQuestionAttempt} from "../../services";
+import {isDefined, useCurrentQuestionAttempt} from "../../services";
 import {IsaacQuestionProps} from "../../../IsaacAppTypes";
 import {IsaacContentValueOrChildren} from "./IsaacContentValueOrChildren";
 import {selectors, useAppSelector} from "../../state";
@@ -86,6 +86,9 @@ const IsaacGraphSketcherQuestion = ({doc, questionId, readonly}: IsaacQuestionPr
         <div className="sketch-preview text-center" onClick={openModal} onKeyUp={openModal} role={readonly ? undefined : "button"}
              tabIndex={readonly ? undefined : 0}>
             <div ref={previewRef} className={`${questionId}-graph-sketcher-preview`} />
+            {!isDefined(currentAttempt?.value) && <div className="graph-sketcher-preview-overlay">
+                <div className="graph-sketcher-preview-overlay-text">Click here to sketch</div>
+            </div>}
         </div>
         {modalVisible && <GraphSketcherModal
             user={user}

--- a/src/app/components/content/IsaacGraphSketcherQuestion.tsx
+++ b/src/app/components/content/IsaacGraphSketcherQuestion.tsx
@@ -45,7 +45,7 @@ const IsaacGraphSketcherQuestion = ({doc, questionId, readonly}: IsaacQuestionPr
 
         return () => {
             window.removeEventListener('keyup', handleKeyPress);
-        }
+        };
     }, []);
 
     useEffect(() => {
@@ -63,7 +63,7 @@ const IsaacGraphSketcherQuestion = ({doc, questionId, readonly}: IsaacQuestionPr
                 }
             }
             p.remove();
-        }
+        };
     }, []);
 
     useEffect(() => {
@@ -86,9 +86,6 @@ const IsaacGraphSketcherQuestion = ({doc, questionId, readonly}: IsaacQuestionPr
         <div className="sketch-preview text-center" onClick={openModal} onKeyUp={openModal} role={readonly ? undefined : "button"}
              tabIndex={readonly ? undefined : 0}>
             <div ref={previewRef} className={`${questionId}-graph-sketcher-preview`} />
-            {!isDefined(currentAttempt?.value) && <div className="graph-sketcher-preview-overlay">
-                <div className="graph-sketcher-preview-overlay-text">Click here to sketch</div>
-            </div>}
         </div>
         {modalVisible && <GraphSketcherModal
             user={user}
@@ -97,6 +94,9 @@ const IsaacGraphSketcherQuestion = ({doc, questionId, readonly}: IsaacQuestionPr
             initialState={initialState}
             question={doc}
         />}
-    </div>
+        <div className="question-content d-flex justify-content-center d-print-none">
+            <div><i>{isDefined(currentAttempt?.value) ? "Click on the grid to edit your sketch." : "Click on the grid to start your sketch."}</i></div>
+        </div>
+    </div>;
 };
 export default IsaacGraphSketcherQuestion;

--- a/src/app/components/pages/GraphSketcher.tsx
+++ b/src/app/components/pages/GraphSketcher.tsx
@@ -89,9 +89,6 @@ const GraphSketcherPage = () => {
                     <div className="graph-sketcher-question">
                         <div className="sketch-preview" onClick={openModal} onKeyUp={openModal} role="button" tabIndex={0}>
                             <div ref={previewRef} className={`graph-sketcher-preview`} />
-                            {!isDefined(currentAttempt?.value) && <div className="graph-sketcher-preview-overlay">
-                                <div className="graph-sketcher-preview-overlay-text">Click here to sketch</div>
-                            </div>}
                         </div>
                         {modalVisible && <GraphSketcherModal
                             user={user}
@@ -103,6 +100,9 @@ const GraphSketcherPage = () => {
                     {graphSpec && graphSpec.map((spec, i) => <pre key={i}>{spec}</pre>)}
                 </Col>
             </Row>
+            <div className="question-content d-flex justify-content-center d-print-none">
+                <div><i>{isDefined(currentAttempt?.value) ? "Click on the grid to edit your sketch." : "Click on the grid to start your sketch."}</i></div>
+            </div>
         </Container>
     </div>;
 };

--- a/src/app/components/pages/GraphSketcher.tsx
+++ b/src/app/components/pages/GraphSketcher.tsx
@@ -10,7 +10,7 @@ import {
     makeGraphSketcher
 } from "isaac-graph-sketcher";
 import GraphSketcherModal from '../elements/modals/GraphSketcherModal';
-import {isStaff} from "../../services";
+import {isDefined, isStaff} from "../../services";
 
 const GraphSketcherPage = () => {
     const user = useAppSelector(selectors.user.orNull);
@@ -89,6 +89,9 @@ const GraphSketcherPage = () => {
                     <div className="graph-sketcher-question">
                         <div className="sketch-preview" onClick={openModal} onKeyUp={openModal} role="button" tabIndex={0}>
                             <div ref={previewRef} className={`graph-sketcher-preview`} />
+                            {!isDefined(currentAttempt?.value) && <div className="graph-sketcher-preview-overlay">
+                                <div className="graph-sketcher-preview-overlay-text">Click here to sketch</div>
+                            </div>}
                         </div>
                         {modalVisible && <GraphSketcherModal
                             user={user}

--- a/src/scss/common/graph-sketcher-modal.scss
+++ b/src/scss/common/graph-sketcher-modal.scss
@@ -319,10 +319,3 @@
     padding: 1em 0;
     text-align: center;
 }
-
-.sketch-preview {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-}

--- a/src/scss/common/graph-sketcher-modal.scss
+++ b/src/scss/common/graph-sketcher-modal.scss
@@ -319,3 +319,17 @@
     padding: 1em 0;
     text-align: center;
 }
+
+.sketch-preview {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+}
+
+.graph-sketcher-preview-overlay {
+    width: 400px;
+    font-size: 4.5em;
+    position: absolute;
+    color: lightgray;
+}

--- a/src/scss/common/graph-sketcher-modal.scss
+++ b/src/scss/common/graph-sketcher-modal.scss
@@ -326,10 +326,3 @@
     align-items: center;
     justify-content: center;
 }
-
-.graph-sketcher-preview-overlay {
-    width: 400px;
-    font-size: 4.5em;
-    position: absolute;
-    color: lightgray;
-}


### PR DESCRIPTION
Adds instructional text beneath the graph sketcher, as requested by the content team, for ease of use. The text does not display when printing.