### PR TITLE
Fix contrast issue with `text-muted` class

### DIFF
--- a/src/app/components/content/IsaacParsonsQuestion.tsx
+++ b/src/app/components/content/IsaacParsonsQuestion.tsx
@@ -339,7 +339,7 @@ const IsaacParsonsQuestion = ({doc, questionId, readonly} : IsaacQuestionProps<I
                                     </Draggable>
                                 })}
                                 {(!currentAttempt || currentAttempt?.items?.length === 0) &&
-                                    <div className="text-muted text-center">
+                                    <div className="text-center placeholder-text">
                                         {readonly ? "No answer entered" : "Drag items across to build your answer"}
                                     </div>
                                 }

--- a/src/scss/common/focus.scss
+++ b/src/scss/common/focus.scss
@@ -77,18 +77,6 @@
   outline: 0.2rem solid $focus-blue;
 }
 
-::placeholder { // Firefox, Chrome, Opera
-  color: $gray-160 !important;
-}
-
-:-ms-input-placeholder { // Internet Explorer 10-11
-  color: $gray-160 !important;
-}
-
-::-ms-input-placeholder { // Microsoft Edge
-  color: $gray-160 !important;
-}
-
 :focus {
   outline: 0.2rem solid $black;
 }

--- a/src/scss/common/forms.scss
+++ b/src/scss/common/forms.scss
@@ -65,7 +65,6 @@
 
 input {
   &.form-control {
-    @include placeholder($gray-500);
     border: solid 1px $black;
     padding: 0 1.2em;
   }

--- a/src/scss/common/questions.scss
+++ b/src/scss/common/questions.scss
@@ -71,7 +71,7 @@
     padding: 0.15em 0.6em;
     cursor: default;
     &.empty {
-      color: $gray-500;
+      color: $text-muted;
     }
   }
 

--- a/src/scss/common/questions.scss
+++ b/src/scss/common/questions.scss
@@ -71,7 +71,7 @@
     padding: 0.15em 0.6em;
     cursor: default;
     &.empty {
-      color: $text-muted;
+      color: $input-placeholder-color;
     }
   }
 
@@ -108,6 +108,10 @@
 }
 
 .parsons-question {
+  .placeholder-text {
+    color: $input-placeholder-color;
+  }
+
   .parsons-items {
     border: solid 1px #00000021;
     padding: 0 0.5em;

--- a/src/scss/cs/forms.scss
+++ b/src/scss/cs/forms.scss
@@ -42,7 +42,6 @@
 
 input, textarea {
   &.form-control {
-    @include placeholder($text-muted);
     border: solid 1px $cs-black;
   }
 }

--- a/src/scss/cs/isaac.scss
+++ b/src/scss/cs/isaac.scss
@@ -13,7 +13,7 @@
 // Greyscale
 $cs-black: #000000;
 $cs-jet: #333333;
-$cs-muted-grey: #595959; // minimum contrast ratio for grey WCAG AAA normal text
+$cs-muted: #595959; // minimum contrast ratio for grey WCAG AAA normal text
 $cs-dark-silver: #B9B9B9;
 $cs-silver: #C2C2C2;
 $cs-light-gray: #D6D6D6;
@@ -233,10 +233,10 @@ $question-padding: 3rem;
 $question-font-size: 1rem;
 $question-font-weight: 400;
 
-$text-muted: $cs-muted-grey;
-
-
 // Colour Overrides
+$text-muted: $cs-muted;
+$input-placeholder-color: $cs-dark-silver;
+
 // FIXME overriding base Bootstrap colour definitions is not the right way to go about this.
 //  These are shared with and redefined by Physics.
 $purple: $dark-pink-300; // Something to do with links

--- a/src/scss/cs/isaac.scss
+++ b/src/scss/cs/isaac.scss
@@ -13,6 +13,7 @@
 // Greyscale
 $cs-black: #000000;
 $cs-jet: #333333;
+$cs-muted-grey: #595959; // minimum contrast ratio for grey WCAG AAA normal text
 $cs-dark-silver: #B9B9B9;
 $cs-silver: #C2C2C2;
 $cs-light-gray: #D6D6D6;
@@ -232,7 +233,7 @@ $question-padding: 3rem;
 $question-font-size: 1rem;
 $question-font-weight: 400;
 
-$text-muted: $cs-dark-silver;
+$text-muted: $cs-muted-grey;
 
 
 // Colour Overrides

--- a/src/scss/phy/isaac.scss
+++ b/src/scss/phy/isaac.scss
@@ -87,6 +87,8 @@ $question-padding: 3rem;
 $question-font-size: 1.25rem;
 $question-font-weight: 600;
 
+$input-placeholder-color: $gray-136;
+
 // ISAAC
 // Node module imports
 @import "~bootstrap/scss/bootstrap";


### PR DESCRIPTION
This brings the contrast of `text-muted` up to WCAG requirements for Ada CS. 

It then became apparent that the placeholder text for certain question types used `text-muted`, so for consistency I changed that and made sure that all placeholder text is now `$input-placeholder-color` as defined by each site.