### PR TITLE
Show subtitles in search, question pages, and gameboard viewer

### DIFF
--- a/src/IsaacApiTypes.tsx
+++ b/src/IsaacApiTypes.tsx
@@ -367,6 +367,7 @@ export interface ContentDTO extends ContentBaseDTO {
 export interface ContentSummaryDTO {
     id?: string;
     title?: string;
+    subtitle?: string;
     summary?: string;
     type?: string;
     level?: string;
@@ -613,6 +614,7 @@ export interface GameboardItem {
     id?: string;
     contentType?: string;
     title?: string;
+    subtitle?: string;
     description?: string;
     uri?: string;
     tags?: string[];

--- a/src/app/components/elements/GameboardBuilderRow.tsx
+++ b/src/app/components/elements/GameboardBuilderRow.tsx
@@ -104,6 +104,10 @@ const GameboardBuilderRow = (
                 type="image" src="/assets/new-tab.svg" alt="Preview question" title="Preview question in modal"
                 className="pointer-cursor align-middle new-tab" onClick={() => {question.id && openQuestionModal(question.id)}}
             />
+            {question.subtitle && <>
+                <br/>
+                <span className="small text-muted d-none d-sm-block">{question.subtitle}</span>
+            </>}
         </td>
         <td className={classNames(cellClasses, siteSpecific("w-25", "w-20"))}>
             {topicTag()}

--- a/src/app/components/elements/list-groups/ContentSummaryListGroupItem.tsx
+++ b/src/app/components/elements/list-groups/ContentSummaryListGroupItem.tsx
@@ -139,6 +139,9 @@ export const ContentSummaryListGroupItem = ({item, search, displayTopicTitle}: {
                     {item.summary && <div className="small text-muted d-none d-md-block">
                         {item.summary}
                     </div>}
+                    {!item.summary && item.subtitle && <div className="small text-muted d-none d-md-block">
+                        {item.subtitle}
+                    </div>}
                 </div>
 
                 {!isContentsIntendedAudience && <div className="ml-auto mr-3 d-flex align-items-center">

--- a/src/app/components/elements/list-groups/ContentSummaryListGroupItem.tsx
+++ b/src/app/components/elements/list-groups/ContentSummaryListGroupItem.tsx
@@ -15,6 +15,7 @@ import {
     TAG_ID,
     TAG_LEVEL,
     tags,
+    useDeviceSize,
     useUserContext
 } from "../../../services";
 import {Link} from "react-router-dom";
@@ -58,6 +59,8 @@ export const ContentSummaryListGroupItem = ({item, search, displayTopicTitle}: {
             <img src="/assets/cs/icons/question-correct.svg" alt={questionIconLabel}/> :
             <img src="/assets/cs/icons/question-not-started.svg" alt={questionIconLabel}/>
     );
+
+    const deviceSize = useDeviceSize();
 
     let typeLabel;
 
@@ -139,7 +142,7 @@ export const ContentSummaryListGroupItem = ({item, search, displayTopicTitle}: {
                     {item.summary && <div className="small text-muted d-none d-md-block">
                         {item.summary}
                     </div>}
-                    {!item.summary && item.subtitle && <div className="small text-muted d-none d-md-block">
+                    {(!item.summary || deviceSize === "sm") && item.subtitle && <div className="small text-muted d-none d-sm-block">
                         {item.subtitle}
                     </div>}
                 </div>

--- a/src/app/components/pages/Gameboard.tsx
+++ b/src/app/components/pages/Gameboard.tsx
@@ -50,7 +50,7 @@ const GameboardItemComponent = ({gameboard, question}: {gameboard: GameboardDTO,
     const iconClasses = `gameboard-item-icon ${itemSubject?.id}-fill`;
     let iconHref = siteSpecific("/assets/question-hex.svg#icon", "/assets/cs/icons/question-not-started.svg");
     let message = siteSpecific("", "Not started");
-    let messageClasses = "";
+    const messageClasses = "";
 
     switch (question.state) {
         case "PERFECT":
@@ -80,7 +80,7 @@ const GameboardItemComponent = ({gameboard, question}: {gameboard: GameboardDTO,
                 {siteSpecific(
                     <svg className={iconClasses}><use href={iconHref} xlinkHref={iconHref}/></svg>,
                     <div className={"inner-progress-icon"}>
-                        <img src={iconHref} /><br/>
+                        <img src={iconHref} alt="" /><br/>
                         <span className={"icon-title"}>{message}</span>
                     </div>
                 )}

--- a/src/app/components/pages/Gameboard.tsx
+++ b/src/app/components/pages/Gameboard.tsx
@@ -92,6 +92,9 @@ const GameboardItemComponent = ({gameboard, question}: {gameboard: GameboardDTO,
                         {generateQuestionTitle(question)}
                     </Markup>
                     {isPhy && message && <span className={"gameboard-item-message" + (isPhy ? "-phy " : " ") + messageClasses}>{message}</span>}
+                    {isPhy && question.subtitle && <div className="small text-muted d-none d-md-block mb-2">
+                        {question.subtitle}
+                    </div>}
                     {questionTags && <div className={classNames("hierarchy-tags", {"mt-2": isAda})}>
                         {questionTags.map(tag => (<span className="hierarchy-tag" key={tag.id}>{tag.title}</span>))}
                     </div>}

--- a/src/app/components/pages/Gameboard.tsx
+++ b/src/app/components/pages/Gameboard.tsx
@@ -92,11 +92,11 @@ const GameboardItemComponent = ({gameboard, question}: {gameboard: GameboardDTO,
                         {generateQuestionTitle(question)}
                     </Markup>
                     {isPhy && message && <span className={"gameboard-item-message" + (isPhy ? "-phy " : " ") + messageClasses}>{message}</span>}
-                    {isPhy && question.subtitle && <div className="small text-muted d-none d-md-block mb-2">
-                        {question.subtitle}
-                    </div>}
                     {questionTags && <div className={classNames("hierarchy-tags", {"mt-2": isAda})}>
                         {questionTags.map(tag => (<span className="hierarchy-tag" key={tag.id}>{tag.title}</span>))}
+                    </div>}
+                    {isPhy && question.subtitle && <div className="small text-muted d-none d-sm-block">
+                        {question.subtitle}
                     </div>}
                 </div>
 

--- a/src/app/components/pages/Question.tsx
+++ b/src/app/components/pages/Question.tsx
@@ -76,6 +76,7 @@ export const Question = withRouter(({questionIdOverride, match, location, previe
                 {/*High contrast option*/}
                 <TitleAndBreadcrumb
                       currentPageTitle={generateQuestionTitle(doc)}
+                      subTitle={doc.subtitle}
                       intermediateCrumbs={[...navigation.breadcrumbHistory, ...getTags(doc.tags)]}
                       collectionType={navigation.collectionType}
                       audienceViews={determineAudienceViews(doc.audience, navigation.creationContext)}


### PR DESCRIPTION
Displays a question's subtitle in various places. In search, hides when a summary is present.

(requires API change: https://github.com/isaacphysics/isaac-api/pull/561) 