### PR TITLE
Prevent question select clipping on tiny devices

### DIFF
--- a/src/app/components/elements/svg/HierarchyFilter.tsx
+++ b/src/app/components/elements/svg/HierarchyFilter.tsx
@@ -69,7 +69,8 @@ function hexagonTranslation(deviceSize: DeviceSize, hexagon: HexagonProportions,
 
 export function HierarchyFilterHexagonal({tiers, choices, selections, setTierSelection}: HierarchyFilterProps) {
     const deviceSize = useDeviceSize();
-    const hexagon = calculateHexagonProportions(36, deviceSize === "xs" ? 10 : 8);
+    const leadingHexagon = calculateHexagonProportions(36, deviceSize === "xs" ? 2 : 8);
+    const hexagon = calculateHexagonProportions(36, deviceSize === "xs" ? 16 : 8);
     const focusPadding = 3;
 
     const maxOptions = choices.slice(1).map(c => c.length).reduce((a, b) => Math.max(a, b), 0);
@@ -88,7 +89,7 @@ export function HierarchyFilterHexagonal({tiers, choices, selections, setTierSel
                         sourceIndex={choices[i].map(c => c.value).indexOf(selections[i][0]?.value)}
                         optionIndices={[...choices[i+1].keys()]} // range from 0 to choices[i+1].length
                         targetIndices={selections[i+1]?.map(s => choices[i+1].map(c => c.value).indexOf(s.value)) || [-1]}
-                        hexagonProportions={hexagon} connectionProperties={connectionProperties}
+                        leadingHexagonProportions={leadingHexagon} hexagonProportions={hexagon} connectionProperties={connectionProperties}
                         rowIndex={i} mobile={deviceSize === "xs"} className={`connection ${subject}`}
                     />
                 </g>;
@@ -109,7 +110,7 @@ export function HierarchyFilterHexagonal({tiers, choices, selections, setTierSel
                         );
                     }
 
-                    return <g key={choice.value} transform={hexagonTranslation(deviceSize, hexagon, i, j)}>
+                    return <g key={choice.value} transform={hexagonTranslation(deviceSize, i === 0 ? leadingHexagon : hexagon, i, j)}>
                         <Hexagon {...hexagon} className={classNames("hex", subject, {"active": isSelected && !isComingSoon, "de-emph": isComingSoon})} />
                         <foreignObject width={hexagon.halfWidth * 2} height={hexagon.quarterHeight * 4}>
                             <div className={classNames("hexagon-tier-title", {"active": isSelected && !isComingSoon, "de-emph": isComingSoon, "small": longWordInLabel})}>

--- a/src/app/components/pages/GameboardFilter.tsx
+++ b/src/app/components/pages/GameboardFilter.tsx
@@ -64,6 +64,7 @@ import {
     CustomInput
 } from "reactstrap";
 import {StyledSelect} from "../elements/inputs/StyledSelect";
+import { Spacer } from '../elements/Spacer';
 
 function itemiseByValue<R extends {value: string}>(values: string[], options: R[]) {
     return options.filter(option => values.includes(option.value));
@@ -199,7 +200,7 @@ const PhysicsFilter = ({tiers, choices, showBookQuestions, setShowBookQuestions,
     const deviceSize = useDeviceSize();
     const [filterExpanded, setFilterExpanded] = useState(deviceSize != "xs");
 
-    return <Card id="filter-panel" className="mt-4 px-2 py-3 p-sm-4 pb-5">
+    return <Card id="filter-panel" className="mt-4 px-1 py-3 p-sm-4 pb-5 pb-sm-5">
         <Row>
             <Col sm={8} lg={9}>
                 <button className="bg-transparent w-100 p-0" onClick={() => setFilterExpanded(!filterExpanded)}>
@@ -281,18 +282,19 @@ const PhysicsFilter = ({tiers, choices, showBookQuestions, setShowBookQuestions,
             {/* Buttons */}
             <Row className="mt-4">
                 <Col>
-                    {previousBoard && <Button size="sm" color="primary" outline onClick={previousBoard}>
-                        <span className="d-md-inline d-none">Undo Shuffle</span> &#9100;
+                    {previousBoard && <Button className="w-100 w-sm-auto h-100 h-sm-auto" size="sm" color="primary" outline onClick={previousBoard}>
+                        <span>Undo Shuffle&nbsp;&#9100;</span> 
                     </Button>}
                 </Col>
+                <Spacer width={10}/>
                 <Col className="text-right">
-                    <Button size="sm" color="primary" outline onClick={refresh}>
-                        <span className="d-md-inline d-none">Shuffle Questions</span> ⟳
+                    <Button className="w-100 w-sm-auto h-100 h-sm-auto" size="sm" color="primary" outline onClick={refresh}>
+                        <span>Shuffle Questions&nbsp;⟳</span> 
                     </Button>
                 </Col>
             </Row>
         </>}
-        <Button color="link" className="filter-go-to-questions" onClick={scrollToQuestions}>
+        <Button color="link" className="filter-go-to-questions" style={{width: "max-content"}} onClick={scrollToQuestions}>
             Go to Questions...
         </Button>
         <Button


### PR DESCRIPTION
Stops hexagons from clipping off the edge of the screen for very small devices (min supported width now 343px). 