### PR TITLE
Hotfix/stop rendering error objects which lead to exceptions

### DIFF
--- a/src/app/components/handlers/PasswordResetHandler.tsx
+++ b/src/app/components/handlers/PasswordResetHandler.tsx
@@ -4,11 +4,12 @@ import {Button, Card, CardBody, CardFooter, Container, Form, FormFeedback, FormG
 import {PasswordFeedback} from "../../../IsaacAppTypes";
 import {loadZxcvbnIfNotPresent, passwordDebounce} from "../../services";
 import {RouteComponentProps} from "react-router";
+import { extractErrorMessage } from '../../services/errors';
 
 
 export const ResetPasswordHandler = ({match}: RouteComponentProps<{token?: string}>) => {
     const dispatch = useAppDispatch();
-    const errorMessage = useAppSelector((state: AppState) => state?.error || null);
+    const error = useAppSelector((state: AppState) => state?.error || null);
     const urlToken = match.params.token || null;
 
     const [isValidPassword, setValidPassword] = useState(true);
@@ -66,11 +67,11 @@ export const ResetPasswordHandler = ({match}: RouteComponentProps<{token?: strin
                 </CardBody>
                 <CardFooter>
                     <h4 role="alert" className="text-danger text-center mb-0">
-                        {errorMessage && errorMessage.type === "generalError" && errorMessage.generalError}
+                        {extractErrorMessage(error)}
                     </h4>
                     <Button color="secondary" className="mb-2" block
                         onClick={() => {
-                            if (isValidPassword && !errorMessage && urlToken) {
+                            if (isValidPassword && !error && urlToken) {
                                 dispatch(handlePasswordReset({token: urlToken, password: currentPassword}));
                             }
                         }}

--- a/src/app/components/pages/Contact.tsx
+++ b/src/app/components/pages/Contact.tsx
@@ -29,6 +29,7 @@ import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
 import {PageFragment} from "../elements/PageFragment";
 import {MetaDescription} from "../elements/MetaDescription";
 import {Immutable} from "immer";
+import { extractErrorMessage } from '../../services/errors';
 
 const determineUrlQueryPresets = (user?: Immutable<PotentialUser> | null) => {
     const urlQuery = queryString.parse(location.search);
@@ -64,7 +65,8 @@ const determineUrlQueryPresets = (user?: Immutable<PotentialUser> | null) => {
 
 export const Contact = () => {
     const user = useAppSelector(selectors.user.orNull);
-    const errorMessage = useAppSelector((state: AppState) => state?.error || null);
+    const error = useAppSelector((state: AppState) => state?.error);
+    const errorMessage = extractErrorMessage(error);
     const [presetSubject, presetMessage, presetPlaceholder] = determineUrlQueryPresets(user);
     const [firstName, setFirstName] = useState(user && user.loggedIn && user.givenName || "");
     const [lastName, setLastName] = useState(user && user.loggedIn && user.familyName || "");

--- a/src/app/components/pages/LogIn.tsx
+++ b/src/app/components/pages/LogIn.tsx
@@ -30,6 +30,7 @@ import {Loading} from "../handlers/IsaacSpinner";
 import classNames from "classnames";
 import {RaspberryPiSignInButton} from "../elements/RaspberryPiSignInButton";
 import {GoogleSignInButton} from "../elements/GoogleSignInButton";
+import { extractErrorMessage } from '../../services/errors';
 
 /* Interconnected state and functions providing a "logging in" API - intended to be used within a component that displays
  * email and password inputs, and a button to login, all inside a Form component. You will also need a TFAInput component,
@@ -41,7 +42,8 @@ export const useLoginLogic = () => {
     const dispatch = useAppDispatch();
 
     const totpChallengePending = useAppSelector((state: AppState) => state?.totpChallengePending);
-    const errorMessage = useAppSelector(selectors.error.general);
+    const error = useAppSelector((state: AppState) => state?.error);
+    const errorMessage = extractErrorMessage(error);
     const [email, setEmail] = useState("");
     const [password, setPassword] = useState("");
     const [rememberMe, setRememberMe] = useState<boolean>(false);

--- a/src/app/components/pages/MyAccount.tsx
+++ b/src/app/components/pages/MyAccount.tsx
@@ -68,7 +68,7 @@ const stateToProps = (state: AppState, props: any) => {
     const {location: {search, hash}} = props;
     const searchParams = queryString.parse(search);
     return {
-        errorMessage: state?.error ?? null,
+        error: state?.error ?? null,
         userAuthSettings: state?.userAuthSettings ?? null,
         userPreferences: state?.userPreferences ?? null,
         firstLogin: (history?.location?.state as { firstLogin: any } | undefined)?.firstLogin,
@@ -85,7 +85,7 @@ const dispatchToProps = {
 
 interface AccountPageProps {
     user: PotentialUser;
-    errorMessage: ErrorState;
+    error: ErrorState;
     userAuthSettings: UserAuthenticationSettingsDTO | null;
     getChosenUserAuthSettings: (userid: number) => void;
     userPreferences: UserPreferencesDTO | null;
@@ -107,7 +107,7 @@ function hashEqual<T>(current: NonNullable<T>, prev: NonNullable<T>, options?: N
     return equal;
 }
 
-const AccountPageComponent = ({user, getChosenUserAuthSettings, errorMessage, userAuthSettings, userPreferences, hashAnchor, authToken, userOfInterest}: AccountPageProps) => {
+const AccountPageComponent = ({user, getChosenUserAuthSettings, error, userAuthSettings, userPreferences, hashAnchor, authToken, userOfInterest}: AccountPageProps) => {
     const dispatch = useAppDispatch();
 
     const {data: adminUserToEdit} = useAdminGetUserQuery(userOfInterest ? Number(userOfInterest) : skipToken);
@@ -371,8 +371,8 @@ const AccountPageComponent = ({user, getChosenUserAuthSettings, errorMessage, us
                         <CardFooter className="py-4">
                             <Row>
                                 <Col size={12} md={{size: 6, offset: 3}}>
-                                    {errorMessage?.type === "generalError" && <h3 role="alert" className="text-danger text-center">
-                                        {errorMessage.generalError}
+                                    {error?.type === "generalError" && <h3 role="alert" className="text-danger text-center">
+                                        {error.generalError}
                                     </h3>}
                                     {/* Teacher connections does not have a save */}
                                     <Input

--- a/src/app/components/pages/Registration.tsx
+++ b/src/app/components/pages/Registration.tsx
@@ -40,11 +40,13 @@ import {Redirect, RouteComponentProps, withRouter} from "react-router";
 import {MetaDescription} from "../elements/MetaDescription";
 import {RaspberryPiSignInButton} from "../elements/RaspberryPiSignInButton";
 import {GoogleSignInButton} from "../elements/GoogleSignInButton";
+import { extractErrorMessage } from '../../services/errors';
 
 export const Registration = withRouter(({location}:  RouteComponentProps<{}, {}, {email?: string; password?: string}>) => {
     const dispatch = useAppDispatch();
     const user = useAppSelector(selectors.user.orNull);
-    const errorMessage = useAppSelector(selectors.error.general);
+    const error = useAppSelector((state) => state?.error);
+    const errorMessage = extractErrorMessage(error);
     const userEmail = location.state?.email || undefined;
     const userPassword = location.state?.password || undefined;
 

--- a/src/app/components/pages/TeacherRequest.tsx
+++ b/src/app/components/pages/TeacherRequest.tsx
@@ -34,13 +34,15 @@ import {
 import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
 import {Link} from "react-router-dom";
 import {IsaacContent} from "../content/IsaacContent";
+import { extractErrorMessage } from '../../services/errors';
 
 const warningFragmentId = "teacher_registration_warning_message";
 const nonSchoolDomains = ["@gmail", "@yahoo", "@hotmail", "@sharklasers", "@guerrillamail"];
 
 export const TeacherRequest = () => {
     const user = useAppSelector(selectors.user.orNull);
-    const errorMessage = useAppSelector((state: AppState) => (state && state.error) || null);
+    const error = useAppSelector((state: AppState) => state?.error);
+    const errorMessage = extractErrorMessage(error);
     const {data: warningFragment} = useGetPageFragmentQuery(warningFragmentId);
     const [submitContactForm] = useSubmitContactFormMutation();
 

--- a/src/app/components/pages/TutorRequest.tsx
+++ b/src/app/components/pages/TutorRequest.tsx
@@ -34,12 +34,14 @@ import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
 import {Link} from "react-router-dom";
 import {IsaacContent} from "../content/IsaacContent";
 import {StyledSelect} from "../elements/inputs/StyledSelect";
+import { extractErrorMessage } from '../../services/errors';
 
 const warningFragmentId = "teacher_registration_warning_message"; // TUTOR have decided to keep this message
 
 export const TutorRequest = () => {
     const user = useAppSelector(selectors.user.orNull);
-    const errorMessage = useAppSelector((state: AppState) => (state && state.error) || null);
+    const error = useAppSelector((state: AppState) => state?.error);
+    const errorMessage = extractErrorMessage(error);
     const {data: warningFragment} = useGetPageFragmentQuery(warningFragmentId);
     const [submitContactForm] = useSubmitContactFormMutation();
 

--- a/src/app/services/errors.ts
+++ b/src/app/services/errors.ts
@@ -1,0 +1,9 @@
+import { ErrorState } from "../state";
+
+export function extractErrorMessage(error?: ErrorState | null): string | null {
+    if (error?.type === "generalError") {
+        return error.generalError;
+    } else {
+        return null;
+    }
+}

--- a/src/app/state/selectors.tsx
+++ b/src/app/state/selectors.tsx
@@ -30,10 +30,6 @@ export const selectors = {
         }
     },
 
-    error: {
-        general: (state: AppState) => state?.error && state.error.type == "generalError" && state.error.generalError || null,
-    },
-
     user:  {
         orNull: (state: AppState) => state?.user || null,
         loggedInOrNull: (state: AppState) => state?.user?.loggedIn && state.user || null,


### PR DESCRIPTION
Poor naming of the variable returned from redux's `state.error` as `errorMessage` caused us to try and render it as a string while really it was an object which sometimes included a message that could be rendered. React doesn't render non-react component objects and so raised an error in these cases which got caught by the application error boundary.

Using redux global error state is a bad idea generally (we don't make much use of it but we did employ it when we first started) as it has caused problems such as page specific errors being displayed across page changes. Eventually we should get rid of it. This might happen with the signup flow redesign because that is the main area that still makes use of the state.