### PR TITLE
Add scroll-to-top button

### DIFF
--- a/src/app/components/navigation/IsaacApp.tsx
+++ b/src/app/components/navigation/IsaacApp.tsx
@@ -39,7 +39,7 @@ import {
     KEY,
     showNotification,
     isTutorOrAbove,
-    PATHS, isAda
+    PATHS
 } from "../../services"
 import {Generic} from "../pages/Generic";
 import {ServerError} from "../pages/ServerError";

--- a/src/app/components/navigation/IsaacApp.tsx
+++ b/src/app/components/navigation/IsaacApp.tsx
@@ -1,4 +1,4 @@
-import React, {lazy, Suspense, useEffect} from 'react';
+import React, {lazy, Suspense, useEffect, useRef} from 'react';
 import {
     AppState,
     fetchGlossaryTerms,
@@ -39,7 +39,7 @@ import {
     KEY,
     showNotification,
     isTutorOrAbove,
-    PATHS
+    PATHS, isAda
 } from "../../services"
 import {Generic} from "../pages/Generic";
 import {ServerError} from "../pages/ServerError";
@@ -77,6 +77,7 @@ import {TutorRequest} from "../pages/TutorRequest";
 import {AssignmentProgress} from "../pages/AssignmentProgress";
 import {MyGameboards} from "../pages/MyGameboards";
 import {GameboardFilter} from "../pages/GameboardFilter";
+import {ScrollToTop} from "../site/ScrollToTop";
 
 const ContentEmails = lazy(() => import('../pages/ContentEmails'));
 const MyProgress = lazy(() => import('../pages/MyProgress'));
@@ -90,6 +91,7 @@ export const IsaacApp = () => {
     const {data: segueEnvironment} = useGetSegueEnvironmentQuery();
     const notifications = useAppSelector((state: AppState) => state && state.notifications && state.notifications.notifications || []);
     const user = useAppSelector(selectors.user.orNull);
+    const mainContentRef = useRef(null);
 
     // Run once on component mount
     useEffect(() => {
@@ -132,7 +134,7 @@ export const IsaacApp = () => {
         <UnsupportedBrowserBanner />
         <DowntimeWarningBanner />
         <EmailVerificationBanner />
-        <main id="main" data-testid="main" role="main" className="flex-fill content-body">
+        <main ref={mainContentRef} id="main" data-testid="main" role="main" className="flex-fill content-body">
             <ErrorBoundary FallbackComponent={ChunkOrClientError}>
                 <Suspense fallback={<Loading/>}>
                     <Switch>
@@ -220,6 +222,7 @@ export const IsaacApp = () => {
                 </Suspense>
             </ErrorBoundary>
         </main>
+        {isAda && <ScrollToTop mainContent={mainContentRef}/>}
         <SiteSpecific.Footer />
     </Router>;
 };

--- a/src/app/components/navigation/IsaacApp.tsx
+++ b/src/app/components/navigation/IsaacApp.tsx
@@ -222,7 +222,7 @@ export const IsaacApp = () => {
                 </Suspense>
             </ErrorBoundary>
         </main>
-        {isAda && <ScrollToTop mainContent={mainContentRef}/>}
+        <ScrollToTop mainContent={mainContentRef}/>
         <SiteSpecific.Footer />
     </Router>;
 };

--- a/src/app/components/site/ScrollToTop.tsx
+++ b/src/app/components/site/ScrollToTop.tsx
@@ -1,0 +1,28 @@
+import React, {useEffect, useRef} from "react";
+
+export const ScrollToTop = ({mainContent}: {mainContent: React.RefObject<any>}) => {
+    const scrollButton = useRef(null);
+
+    const isSticky = () => {
+        const scrollTop = window.scrollY;
+        // @ts-ignore
+        scrollTop >= mainContent.current.offsetTop + 1 ? scrollButton.current.classList.add('is-sticky') : scrollButton.current.classList.remove('is-sticky');
+    }
+
+    const scroll = () => {
+        mainContent.current.scrollIntoView({behavior: 'smooth'});
+    }
+
+    useEffect(() => {
+        window.addEventListener('scroll', isSticky);
+        return () => {
+            window.removeEventListener('scroll', isSticky);
+        };
+    });
+
+    return <div ref={scrollButton} onClick={scroll} className="scroll-btn">
+        <button>
+            <img src="/assets/chevron-up.svg" alt="Scroll to top of page"/>
+        </button>
+    </div>
+}

--- a/src/scss/common/scroll-button.scss
+++ b/src/scss/common/scroll-button.scss
@@ -3,12 +3,11 @@ $height: 50px;
 $color: #ffffff;
 
 .scroll-btn {
+  visibility: hidden; // If not in use hide
+  height: 0;
   display: grid;
   box-shadow: 0 2px 24px 0 rgb(0 0 0 / 15%);
   background-color: $color !important;
-  border-radius: 50%;
-  height: $height;
-  width: $width;
   justify-content: center;
   align-content: center;
 }
@@ -25,12 +24,16 @@ $color: #ffffff;
 }
 
 .is-sticky {
+  visibility: visible;
   position: fixed;
   bottom: 10px;
   right: 10px;
   z-index: 999;
   box-shadow: 0 2px 24px 0 rgb(0 0 0 / 15%);
   background-color: $color !important;
+  border-radius: 50%;
+  height: $height;
+  width: $width;
   animation: 500ms ease-in-out 0s normal none 1 running fadeInDown;
   padding-top: 0;
   padding-bottom: 0;

--- a/src/scss/common/scroll-button.scss
+++ b/src/scss/common/scroll-button.scss
@@ -1,0 +1,37 @@
+$width: 50px;
+$height: 50px;
+$color: #ffffff;
+
+.scroll-btn {
+  display: grid;
+  box-shadow: 0 2px 24px 0 rgb(0 0 0 / 15%);
+  background-color: $color !important;
+  border-radius: 50%;
+  height: $height;
+  width: $width;
+  justify-content: center;
+  align-content: center;
+}
+
+.scroll-btn img {
+  height: 0.75 * $height;
+  width: 0.75 * $width;
+  align-self: center;
+}
+
+.scroll-btn button {
+  // Alpha channel 0 to make transparent
+  background: #00000000;
+}
+
+.is-sticky {
+  position: fixed;
+  bottom: 10px;
+  right: 10px;
+  z-index: 999;
+  box-shadow: 0 2px 24px 0 rgb(0 0 0 / 15%);
+  background-color: $color !important;
+  animation: 500ms ease-in-out 0s normal none 1 running fadeInDown;
+  padding-top: 0;
+  padding-bottom: 0;
+}

--- a/src/scss/cs/isaac.scss
+++ b/src/scss/cs/isaac.scss
@@ -322,6 +322,7 @@ $shadow-black: rgb(0, 0, 0); // Used by buttons
 @import "search";
 @import "../common/navigation-bar";
 @import "footer";
+@import "../common/scroll-button";
 
 // Pages
 @import "pages";

--- a/src/scss/phy/isaac.scss
+++ b/src/scss/phy/isaac.scss
@@ -139,6 +139,7 @@ $question-font-weight: 600;
 @import "../common/navigation-bar";
 @import "footer";
 @import "header";
+@import "../common/scroll-button";
 
 // Pages
 @import "subjects";


### PR DESCRIPTION
ScrollToTop component added to the IsaacApp component. It remains at the bottom of the screen (out of site) until the user scrolls beyond the top of the main content at which point it sticks to the bottom right of the screen.

Currently only on the Ada site but removing the conditional will add it to the Physics site as well. The scroll-button.scss will also need to be imported in the relevant isaac.scss file.