### PR TITLE
Improve screenreader descriptions for resource cards

### DIFF
--- a/src/app/components/content/IsaacCard.tsx
+++ b/src/app/components/content/IsaacCard.tsx
@@ -15,8 +15,8 @@ const PhysicsCard = ({doc, imageClassName}: IsaacCardProps) => {
     const classes = classNames({"menu-card": true, "disabled": disabled, "isaac-card-vertical": verticalContent});
     const imgSrc = image?.src && apiHelper.determineImageUrl(image.src);
 
-    const link = (clickUrl && isAppLink(clickUrl)) ? <Link to={clickUrl} className={classes + " stretched-link"} aria-disabled={disabled}/> :
-        <a href={clickUrl} className={classes + " stretched-link"} aria-disabled={disabled}/>
+    const link = (clickUrl && isAppLink(clickUrl)) ? <Link to={clickUrl} className={classes + " stretched-link"} aria-label={title} aria-disabled={disabled}/> :
+        <a href={clickUrl} className={classes + " stretched-link"} aria-label={title} aria-disabled={disabled}/>
 
     return verticalContent ?
         <Card className={classes}>


### PR DESCRIPTION
Adding the title of the resource card as an aria-label for both the clickable links and Link components in the resource cards.