### PR TITLE
Prevent screenreaders skipping gameboard completion column

### DIFF
--- a/src/app/components/elements/cards/BoardCard.tsx
+++ b/src/app/components/elements/cards/BoardCard.tsx
@@ -110,11 +110,14 @@ export const BoardCard = ({user, board, boardView, assignees, toggleAssignModal,
 
     const basicCellClasses = `align-middle ${siteSpecific("text-center", "text-left")}`;
 
-    const phyHexagon = <div tabIndex={0} className={classNames("board-subject-hexagon-container", {"table-view": boardView === BoardViews.table})}>
+    const phyHexagon = <div className={classNames("board-subject-hexagon-container", {"table-view": boardView === BoardViews.table})}>
         {isSetAssignments
             ? <HexagonGroupsButton toggleAssignModal={toggleAssignModal} boardSubjects={boardSubjects} assignees={assignees} id={hexagonId} />
             : ((board.percentageCompleted === 100)
-                ? <span className="board-subject-hexagon subject-complete"/>
+                ? <>
+                    <span className="board-subject-hexagon subject-complete"/>
+                    <span className="sr-only">Complete</span>
+                </>
                 : <>
                     {generateGameboardSubjectHexagons(boardSubjects)}
                     <div className="board-percent-completed">{board.percentageCompleted}</div>

--- a/src/app/components/elements/cards/BoardCard.tsx
+++ b/src/app/components/elements/cards/BoardCard.tsx
@@ -110,7 +110,7 @@ export const BoardCard = ({user, board, boardView, assignees, toggleAssignModal,
 
     const basicCellClasses = `align-middle ${siteSpecific("text-center", "text-left")}`;
 
-    const phyHexagon = <div className={classNames("board-subject-hexagon-container", {"table-view": boardView === BoardViews.table})}>
+    const phyHexagon = <div tabIndex={0} className={classNames("board-subject-hexagon-container", {"table-view": boardView === BoardViews.table})}>
         {isSetAssignments
             ? <HexagonGroupsButton toggleAssignModal={toggleAssignModal} boardSubjects={boardSubjects} assignees={assignees} id={hexagonId} />
             : ((board.percentageCompleted === 100)


### PR DESCRIPTION
In the My Gameboards table the completion div graphic is added to the screenreader tab sequence. This has not been added to assignments, tests, etc.