### PR TITLE
Convert accordion titles to H2 headers

### DIFF
--- a/src/app/components/elements/Accordion.tsx
+++ b/src/app/components/elements/Accordion.tsx
@@ -181,9 +181,6 @@ export const Accordion = withRouter(({id, trustedTitle, index, children, startOp
                                     {trustedTitle}
                                 </Markup>
                             </h2>
-                            <Markup encoding={"latex"}>
-                                {trustedTitle + " (old title)"}
-                            </Markup>
                         </div>}
                         {isAda && deEmphasised && <div className="ml-auto mr-3 d-flex align-items-center">
                             <span id={`audience-help-${componentId}`} className="icon-help mx-1" />

--- a/src/app/components/elements/Accordion.tsx
+++ b/src/app/components/elements/Accordion.tsx
@@ -181,6 +181,9 @@ export const Accordion = withRouter(({id, trustedTitle, index, children, startOp
                                     {trustedTitle}
                                 </Markup>
                             </h2>
+                            <Markup encoding={"latex"}>
+                                {trustedTitle + " (old title)"}
+                            </Markup>
                         </div>}
                         {isAda && deEmphasised && <div className="ml-auto mr-3 d-flex align-items-center">
                             <span id={`audience-help-${componentId}`} className="icon-help mx-1" />

--- a/src/app/components/elements/Accordion.tsx
+++ b/src/app/components/elements/Accordion.tsx
@@ -176,9 +176,11 @@ export const Accordion = withRouter(({id, trustedTitle, index, children, startOp
                         {/* FIXME Revisit this maybe? https://github.com/isaacphysics/isaac-react-app/pull/473#discussion_r841556455 */}
                         <span className="accordion-part p-3 text-secondary">Part {ALPHABET[(index as number) % ALPHABET.length]}  {" "}</span>
                         {trustedTitle && <div className="p-3">
-                            <Markup encoding={"latex"}>
-                                {trustedTitle}
-                            </Markup>
+                            <h2>
+                                <Markup encoding={"latex"}>
+                                    {trustedTitle}
+                                </Markup>
+                            </h2>
                         </div>}
                         {isAda && deEmphasised && <div className="ml-auto mr-3 d-flex align-items-center">
                             <span id={`audience-help-${componentId}`} className="icon-help mx-1" />

--- a/src/scss/common/accordions.scss
+++ b/src/scss/common/accordions.scss
@@ -72,6 +72,14 @@
 
       .accordion-title {
         flex-grow: 1;
+
+        h2 {
+          font-size: inherit;
+          font-family: inherit;
+          font-weight: inherit;
+          line-height: inherit;
+          margin-bottom: inherit;
+        }
       }
 
       &:after {

--- a/src/scss/cs/accordions.scss
+++ b/src/scss/cs/accordions.scss
@@ -1,3 +1,4 @@
+@import "../common/accordions";
 
 .stage-label-gcse, .stage-label-alevel, .stage-label-all {
   color: black;
@@ -24,6 +25,10 @@
 .accordion .accordion-header {
   span, button, button:hover {
     color: black !important;
+  }
+
+  h2 {
+    font-size: inherit !important;
   }
 }
 

--- a/src/scss/cs/isaac.scss
+++ b/src/scss/cs/isaac.scss
@@ -298,7 +298,7 @@ $shadow-black: rgb(0, 0, 0); // Used by buttons
 @import "../common/media";
 @import "table";
 @import "tabs";
-@import "../common/accordions";
+@import "accordions";
 @import "cards";
 @import "list-groups";
 @import "inequality-modal";
@@ -339,7 +339,6 @@ $shadow-black: rgb(0, 0, 0); // Used by buttons
 @import "../common/events";
 @import "../common/glossary";
 @import "../common/quiz";
-@import "accordions";
 @import "../common/callout";
 
 @import "parsons-layout";


### PR DESCRIPTION
Wrap the accordion title spans in H2 headers. 

Additional styling to revert to the previous style still required if desired.