### PR TITLE
Add "coordinates" to tags for question finder

### DIFF
--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -611,6 +611,7 @@ export enum TAG_ID {
     shapes = "shapes",
     trigonometry = "trigonometry",
     planes = "planes",
+    coordinates = "coordinates",
     // Algebra
     manipulation = "manipulation",
     quadratics = "quadratics",

--- a/src/app/services/tagsPhy.ts
+++ b/src/app/services/tagsPhy.ts
@@ -100,6 +100,7 @@ export class PhysicsTagService extends AbstractBaseTagService {
         {id: TAG_ID.trigonometry, title: `Trigon${softHyphen}ometry`, parent: TAG_ID.geometry},
         {id: TAG_ID.vectors, title: "Vectors", parent: TAG_ID.geometry},
         {id: TAG_ID.planes, title: "Planes", parent: TAG_ID.geometry},
+        {id: TAG_ID.coordinates, title: "Coordinates", parent: TAG_ID.geometry},
         // Functions
         {id: TAG_ID.generalFunctions, title: "General Functions", parent: TAG_ID.functions},
         {id: TAG_ID.graphSketching, title: "Graph Sketching", parent: TAG_ID.functions},


### PR DESCRIPTION
Adding "coordinates" to the TAG_ID and tagsPhy under math > geometry > coordinates