### PR TITLE
New Ada content headers

### DIFF
--- a/src/scss/cs/accordions.scss
+++ b/src/scss/cs/accordions.scss
@@ -31,7 +31,15 @@
   background: $cs-white;
   border-top: 1px solid $cs-cultured;
 
-  .content-value h3 {
-    border-bottom: 2px solid #00000010;
+  .content-value {
+    h3 {
+      border-bottom: 2px solid #00000010;
+    }
+
+    h3, h4 {
+      font-size: 1.25rem !important;
+      font-weight: inherit;
+      line-height: inherit;
+    }
   }
 }

--- a/src/scss/cs/accordions.scss
+++ b/src/scss/cs/accordions.scss
@@ -30,4 +30,8 @@
 .accordion {
   background: $cs-white;
   border-top: 1px solid $cs-cultured;
+
+  .content-value h3 {
+    border-bottom: 2px solid #00000010;
+  }
 }


### PR DESCRIPTION
With the updated headers in Ada content accordions H3 titles will be underlined (the largest title in a content accordion) and H4 titles (nested underneath H3) are not.

Note that the accordion title and internal headers all have the same style now (that is the old accordion title <span>).