### PR TITLE
Test setting to multiple groups

### DIFF
--- a/src/app/components/elements/modals/QuizSettingModal.tsx
+++ b/src/app/components/elements/modals/QuizSettingModal.tsx
@@ -46,7 +46,7 @@ interface QuizSettingModalProps {
     feedbackMode?: QuizFeedbackMode | null;
 }
 
-export function QuizSettingModal({allowedToSchedule, quiz, dueDate: initialDueDate, scheduledStartDate: initialScheduledStartDate, feedbackMode: _initialFeedbackMode}: QuizSettingModalProps) {
+export function QuizSettingModal({allowedToSchedule, quiz, dueDate: initialDueDate, scheduledStartDate: initialScheduledStartDate, feedbackMode: initialFeedbackMode}: QuizSettingModalProps) {
     const dispatch: AppDispatch = useAppDispatch();
     const groupsQuery = useGetGroupsQuery(false);
     const user = useAppSelector(selectors.user.loggedInOrNull);
@@ -57,7 +57,7 @@ export function QuizSettingModal({allowedToSchedule, quiz, dueDate: initialDueDa
     const [selectedGroups, setSelectedGroups] = useState<Item<number>[]>([]);
     const [dueDate, setDueDate] = useState<Date | null>(initialDueDate ?? null);
     const [scheduledStartDate, setScheduledStartDate] = useState<Date | null>(initialScheduledStartDate ?? null);
-    const [feedbackMode, setFeedbackMode] = useState<QuizFeedbackMode>();
+    const [feedbackMode, setFeedbackMode] = useState<QuizFeedbackMode | null>(initialFeedbackMode ?? null);
 
     const yearRange = range(currentYear, currentYear + 5);
 
@@ -73,7 +73,7 @@ export function QuizSettingModal({allowedToSchedule, quiz, dueDate: initialDueDa
             groups: selectedGroups,
             dueDate: dueDate ?? undefined,
             scheduledStartDate: scheduledStartDate ?? undefined,
-            quizFeedbackMode: feedbackMode,
+            quizFeedbackMode: feedbackMode ?? undefined,
             userId: user?.id
         })).then(success => {
             if (success) {
@@ -81,7 +81,7 @@ export function QuizSettingModal({allowedToSchedule, quiz, dueDate: initialDueDa
                 setSelectedGroups([]);
                 setDueDate(null);
                 setScheduledStartDate(null);
-                setFeedbackMode(undefined);
+                setFeedbackMode(null);
             }
         });
     }
@@ -100,7 +100,7 @@ export function QuizSettingModal({allowedToSchedule, quiz, dueDate: initialDueDa
                 defaultErrorTitle={"Error fetching groups"}
                 thenRender={groups => {
                     const groupOptions: Item<number>[] = groups.map(g => ({label: g.groupName as string, value: g.id as number}));
-                    return <StyledSelect isMulti placeholder="None"
+                    return <StyledSelect isMulti placeholder="Select groups"
                         options={groupOptions}
                         onChange={(s) => {
                             selectOnChange(setSelectedGroups, false)(s);

--- a/src/app/components/elements/modals/QuizSettingModal.tsx
+++ b/src/app/components/elements/modals/QuizSettingModal.tsx
@@ -94,7 +94,7 @@ export function QuizSettingModal({allowedToSchedule, quiz, dueDate: initialDueDa
     const scheduledQuizHelpTooltipId = "scheduled-quiz-help-tooltip";
 
     return <div className="mb-4">
-        <Label className="w-100 mb-4">Set test to the following group:<br/>
+        <Label className="w-100 mb-4">Set test to the following group(s):<br/>
             <ShowLoadingQuery
                 query={groupsQuery}
                 defaultErrorTitle={"Error fetching groups"}

--- a/src/app/components/elements/modals/QuizSettingModal.tsx
+++ b/src/app/components/elements/modals/QuizSettingModal.tsx
@@ -2,13 +2,14 @@ import React, {ChangeEvent, useState} from "react";
 import {ContentSummaryDTO, IsaacQuizDTO, QuizFeedbackMode} from "../../../../IsaacApiTypes";
 import {
     AppDispatch,
+    closeActiveModal,
+    selectors,
     useAppDispatch,
-    useGetGroupsQuery,
+    useAppSelector,
     useAssignQuizMutation,
-    showSuccessToast,
-    mutationSucceeded, closeActiveModal, useAppSelector, selectors
+    useGetGroupsQuery
 } from "../../../state";
-import {assignMultipleQuiz, isDefined, Item, nthHourOf, selectOnChange, TODAY} from "../../../services";
+import {assignMultipleQuiz, isDefined, Item, selectOnChange, TODAY} from "../../../services";
 import range from "lodash/range";
 import {currentYear, DateInput} from "../inputs/DateInput";
 import {IsaacSpinner} from "../../handlers/IsaacSpinner";
@@ -45,12 +46,12 @@ interface QuizSettingModalProps {
     feedbackMode?: QuizFeedbackMode | null;
 }
 
-export function QuizSettingModal({allowedToSchedule, quiz, dueDate: initialDueDate, scheduledStartDate: initialScheduledStartDate, feedbackMode: initialFeedbackMode}: QuizSettingModalProps) {
+export function QuizSettingModal({allowedToSchedule, quiz, dueDate: initialDueDate, scheduledStartDate: initialScheduledStartDate, feedbackMode: _initialFeedbackMode}: QuizSettingModalProps) {
     const dispatch: AppDispatch = useAppDispatch();
     const groupsQuery = useGetGroupsQuery(false);
     const user = useAppSelector(selectors.user.loggedInOrNull);
 
-    const [assignQuiz, {isLoading: isAssigning}] = useAssignQuizMutation();
+    const [_assignQuiz, {isLoading: isAssigning}] = useAssignQuizMutation();
 
     const [validated, setValidated] = useState<Set<ControlName>>(new Set());
     const [selectedGroups, setSelectedGroups] = useState<Item<number>[]>([]);
@@ -113,7 +114,7 @@ export function QuizSettingModal({allowedToSchedule, quiz, dueDate: initialDueDa
                             control: (styles) => ({...styles, ...(groupInvalid ? {borderColor: '#dc3545'} : {})}),
                             menuPortal: base => ({...base, zIndex: 9999}),
                         }}
-                    />
+                    />;
                 }}
             />
             {groupInvalid && <FormFeedback className="d-block" valid={false}>You must select a group</FormFeedback>}

--- a/src/app/services/quiz.ts
+++ b/src/app/services/quiz.ts
@@ -1,27 +1,36 @@
 import {useEffect, useMemo, useState} from "react";
 import {
+    AppDispatch,
+    assignmentsApi,
     deregisterQuestions,
     getRTKQueryErrorMessage,
+    mutationSucceeded,
+    quizApi,
     registerQuestions,
     selectors,
+    showErrorToast,
+    showRTKQueryErrorToastIfNeeded,
+    showSuccessToast,
+    showToast,
     useAppDispatch,
     useAppSelector,
-    useGetStudentQuizAttemptWithFeedbackQuery,
     useGetAvailableQuizzesQuery,
     useGetMyQuizAttemptWithFeedbackQuery,
-    AppDispatch,
-    quizApi,
-    mutationSucceeded,
-    showToast, showErrorToast, showSuccessToast, showRTKQueryErrorToastIfNeeded, assignmentsApi
+    useGetStudentQuizAttemptWithFeedbackQuery
 } from "../state";
 import {
-    API_PATH, getValue,
+    API_PATH,
+    getValue,
     isDefined,
     isEventLeaderOrStaff,
     isQuestion,
     Item,
-    matchesAllWordsInAnyOrder, nthHourOf, siteSpecific,
-    tags, TODAY, toTuple,
+    matchesAllWordsInAnyOrder,
+    nthHourOf,
+    siteSpecific,
+    tags,
+    TODAY,
+    toTuple,
     useQueryParams
 } from "./";
 import {
@@ -29,14 +38,14 @@ import {
     IsaacQuizSectionDTO,
     QuestionDTO,
     QuizAssignmentDTO,
-    QuizAttemptDTO, QuizFeedbackMode,
+    QuizAttemptDTO,
+    QuizFeedbackMode,
     QuizSummaryDTO,
     RegisteredUserDTO
 } from "../../IsaacApiTypes";
 import partition from "lodash/partition";
 import {skipToken} from "@reduxjs/toolkit/query";
 import {createAsyncThunk} from "@reduxjs/toolkit";
-import {QuizFeedbackModes} from "../../IsaacAppTypes";
 
 export interface QuizSpec {
     quizId: string;
@@ -96,7 +105,7 @@ export const assignMultipleQuiz = createAsyncThunk(
             dueDate: dueDate,
             scheduledStartDate: scheduledStartDate,
             quizFeedbackMode: quizFeedbackMode
-        }))
+        }));
 
         const response = await dispatch(quizApi.endpoints.assignQuiz.initiate(quizzes));
         if (mutationSucceeded(response)) {
@@ -320,5 +329,5 @@ export function isAttempt(a: QuizAttemptOrAssignment): a is QuizAttemptDTO {
 }
 
 export function partitionCompleteAndIncompleteQuizzes(assignmentsAndAttempts: QuizAttemptOrAssignment[]): [QuizAttemptOrAssignment[], QuizAttemptOrAssignment[]] {
-    return partition(assignmentsAndAttempts, a => isDefined(isAttempt(a) ? a.completedDate : a.attempt?.completedDate))
+    return partition(assignmentsAndAttempts, a => isDefined(isAttempt(a) ? a.completedDate : a.attempt?.completedDate));
 }

--- a/src/app/services/quiz.ts
+++ b/src/app/services/quiz.ts
@@ -7,20 +7,177 @@ import {
     useAppDispatch,
     useAppSelector,
     useGetStudentQuizAttemptWithFeedbackQuery,
-    useGetAvailableQuizzesQuery, useGetMyQuizAttemptWithFeedbackQuery
+    useGetAvailableQuizzesQuery,
+    useGetMyQuizAttemptWithFeedbackQuery,
+    AppDispatch,
+    quizApi,
+    mutationSucceeded,
+    showToast, showErrorToast, showSuccessToast, showRTKQueryErrorToastIfNeeded, assignmentsApi
 } from "../state";
-import {API_PATH, isDefined, isEventLeaderOrStaff, isQuestion, matchesAllWordsInAnyOrder, tags, useQueryParams} from "./";
+import {
+    API_PATH, getValue,
+    isDefined,
+    isEventLeaderOrStaff,
+    isQuestion,
+    Item,
+    matchesAllWordsInAnyOrder, nthHourOf, siteSpecific,
+    tags, TODAY, toTuple,
+    useQueryParams
+} from "./";
 import {
     ContentDTO,
     IsaacQuizSectionDTO,
     QuestionDTO,
     QuizAssignmentDTO,
-    QuizAttemptDTO,
+    QuizAttemptDTO, QuizFeedbackMode,
     QuizSummaryDTO,
     RegisteredUserDTO
 } from "../../IsaacApiTypes";
 import partition from "lodash/partition";
 import {skipToken} from "@reduxjs/toolkit/query";
+import {createAsyncThunk} from "@reduxjs/toolkit";
+import {QuizFeedbackModes} from "../../IsaacAppTypes";
+
+export interface QuizSpec {
+    quizId: string;
+    groups: Item<number>[];
+    dueDate?: Date;
+    scheduledStartDate?: Date;
+    quizFeedbackMode?: QuizFeedbackMode;
+    userId?: number;
+}
+
+export const assignMultipleQuiz = createAsyncThunk(
+    "quiz/assignQuiz",
+    async (
+        {quizId, groups, dueDate, scheduledStartDate, quizFeedbackMode, userId}: QuizSpec,
+        {dispatch, rejectWithValue}
+    ) => {
+        const appDispatch = dispatch as AppDispatch;
+        if (groups.length === 0) {
+            appDispatch(showErrorToast(
+                `${siteSpecific("Quiz", "Test")} assignment failed`,
+                "Error: Please choose one or more groups."
+            ));
+            return rejectWithValue(null);
+        }
+
+        const today =  TODAY();
+        const isDue = dueDate !== undefined;
+        const isScheduled = scheduledStartDate !== undefined;
+
+        if (isDue) {
+            dueDate?.setHours(0, 0, 0, 0);
+            if ((dueDate.valueOf() - today.valueOf()) < 0) {
+                appDispatch(showToast({color: "danger", title: `${siteSpecific("Quiz", "Test")} assignment${groups.length > 1 ? "(s)" : ""} failed`, body: "Error: Due date cannot be in the past.", timeout: 5000}));
+                return rejectWithValue(null);
+            }
+        }
+
+        if (isScheduled) {
+            // Start date can be today, in which case the assignment will be immediately set (if it is past 7am)
+            if (nthHourOf(0, scheduledStartDate).valueOf() < nthHourOf(0, new Date()).valueOf()) {
+                appDispatch(showToast({color: "danger", title: `${siteSpecific("Quiz", "Test")} assignment${groups.length > 1 ? "(s)" : ""} failed`, body: "Error: Scheduled start date cannot be in the past.", timeout: 5000}));
+                return rejectWithValue(null);
+            }
+        }
+
+        if (isDue && isScheduled) {
+            if (nthHourOf(0, scheduledStartDate).valueOf() > dueDate.valueOf()) {
+                appDispatch(showToast({color: "danger", title: `${siteSpecific("Quiz", "Test")} assignment${groups.length > 1 ? "(s)" : ""} failed`, body: "Error: Due date must be on or after scheduled start date.", timeout: 5000}));
+                return rejectWithValue(null);
+            }
+        }
+
+        const groupIds = groups.map(getValue);
+        const quizzes: QuizAssignmentDTO[] = groupIds.map(id => ({
+            quizId: quizId,
+            groupId: id,
+            dueDate: dueDate,
+            scheduledStartDate: scheduledStartDate,
+            quizFeedbackMode: quizFeedbackMode
+        }))
+
+        const response = await dispatch(quizApi.endpoints.assignQuiz.initiate(quizzes));
+        if (mutationSucceeded(response)) {
+            const groupLookUp = new Map(groups.map(toTuple));
+            const quizStatuses = response.data;
+            const newQuizAssignments: QuizAssignmentDTO[] = quizStatuses.filter(q => isDefined(q.assignmentId)).map(q => ({
+                id: q.assignmentId as number,
+                groupId: q.groupId,
+                quizId: quizId,
+                // FIXME see gameboard.ts [96:17] about timestamps
+                creationDate: (new Date()).valueOf() as unknown as Date,
+                dueDate: dueDate?.valueOf() as unknown as Date | undefined,
+                scheduledStartDate: scheduledStartDate?.valueOf() as unknown as Date | undefined,
+                ownerUserId: userId,
+            }));
+            const successfulIds = newQuizAssignments.map(q => q.groupId);
+            const failedIds = quizStatuses.filter(q => isDefined(q.errorMessage));
+            if (failedIds.length === 0) {
+                appDispatch(showSuccessToast(
+                    siteSpecific(
+                        `Quiz${successfulIds.length > 1 ? "zes" : ""} saved`,
+                        `Test${successfulIds.length > 1 ? "s" : ""} assigned`
+                    ),
+                    siteSpecific(
+                        `${successfulIds.length > 1 ? "All quizzes have" : "This quiz has"} been saved successfully.`,
+                        `${successfulIds.length > 1 ? "All tests have" : "This test has"} been saved successfully.`,
+                    )
+                ));
+            } else {
+                // Show each group assignment error in a separate toast
+                failedIds.forEach(({groupId, errorMessage}) => {
+                    appDispatch(showErrorToast(
+                        `${siteSpecific("Quiz", "Test")} assignment to ${groupLookUp.get(groupId) ?? "unknown group"} failed`,
+                        errorMessage as string
+                    ));
+                });
+                // Check whether some group assignments succeeded, if so show "partial success" toast
+                if (failedIds.length === quizStatuses.length) {
+                    return rejectWithValue(null);
+                } else {
+                    const partialSuccessMessage = siteSpecific(
+                        successfulIds.length > 1
+                            ? "Some quizzes were saved successfully."
+                            : `Quiz assigned to ${groupLookUp.get(successfulIds[0] as number)} was saved successfully.`,
+                        successfulIds.length > 1
+                            ? "Some tests were saved successfully."
+                            : `Test assigned to ${groupLookUp.get(successfulIds[0] as number)} was saved successfully.`,
+                    );
+                    appDispatch(showSuccessToast(
+                        siteSpecific(
+                            `Quiz${successfulIds.length > 1 ? "zes" : ""} saved`,
+                            `Test${successfulIds.length > 1 ? "s" : ""} saved`,
+                        ),
+                        partialSuccessMessage
+                    ));
+                }
+            }
+            appDispatch(quizApi.util.updateQueryData(
+                "getQuizAssignmentsSetByMe",
+                undefined,
+                (quizzesByMe) => quizzesByMe.concat(newQuizAssignments)
+            ));
+            successfulIds.forEach(groupId => {
+                appDispatch(assignmentsApi.util.updateQueryData(
+                   "getMySetAssignments",
+                    groupId,
+                    (quizzesByMe => quizzesByMe.concat(
+                        newQuizAssignments.filter(q => q.groupId === groupId)
+                    ))
+                ));
+            });
+            return newQuizAssignments;
+        } else {
+            appDispatch(showRTKQueryErrorToastIfNeeded(
+                `${siteSpecific("Quiz", "Test")} assignment${groups.length > 1 ? "(s)" : ""} failed`,
+                response
+            ));
+            return rejectWithValue(null);
+        }
+    }
+);
 
 export function extractQuestions(doc: ContentDTO | undefined): QuestionDTO[] {
     const qs: QuestionDTO[] = [];

--- a/src/app/state/slices/api/quizApi.ts
+++ b/src/app/state/slices/api/quizApi.ts
@@ -1,5 +1,6 @@
 import {isaacApi} from "./baseApi";
 import {
+    AssignmentFeedbackDTO,
     ChoiceDTO,
     IsaacQuizDTO,
     QuestionValidationResponseDTO,
@@ -165,9 +166,9 @@ export const quizApi = isaacApi.enhanceEndpoints({
             })
         }),
 
-        assignQuiz: build.mutation<QuizAssignmentDTO, QuizAssignmentDTO>({
+        assignQuiz: build.mutation<AssignmentFeedbackDTO[], QuizAssignmentDTO[]>({
             query: (assignment) => ({
-                url: "/quiz/assignment",
+                url: "/quiz/assign_bulk",
                 method: "POST",
                 body: assignment,
             }),


### PR DESCRIPTION
Relies on [Test setting to multiple groups #564](https://github.com/isaacphysics/isaac-api/pull/564) in the backend as it anticipates the new POST and return types.

Single quiz assignments are still possible by selecting only one group.