### PR TITLE
Add screenreader only tables for "My progress" charts

### DIFF
--- a/src/app/components/elements/views/QuestionProgressCharts.tsx
+++ b/src/app/components/elements/views/QuestionProgressCharts.tsx
@@ -155,12 +155,13 @@ export const QuestionProgressCharts = (props: QuestionProgressChartsProps) => {
                         No data
                     </span> :
                     <table className={"sr-only"}>
-                    <tbody>
+                    <thead>
                     <tr>
                         <th>Subject</th>
                         <th>{subId}</th>
                     </tr>
-                    </tbody>
+                    </thead>
+					<tbody>
                     {categoryColumns.map((val, key) => {
                         return (
                             <tr key={key}>
@@ -169,6 +170,7 @@ export const QuestionProgressCharts = (props: QuestionProgressChartsProps) => {
                             </tr>
                         );
                     })}
+					</tbody>
                 </table>}
             </div>
         </RS.Col>}
@@ -195,12 +197,13 @@ export const QuestionProgressCharts = (props: QuestionProgressChartsProps) => {
                         No data
                     </span> :
                     <table className={"sr-only"}>
-                        <tbody>
+                        <thead>
                         <tr>
                             <th>Topic</th>
                             <th>{subId}</th>
                         </tr>
-                        </tbody>
+                        </thead>
+						<tbody>
                         {topicColumns.map((val, key) => {
                             return (
                                 <tr key={key}>
@@ -209,6 +212,7 @@ export const QuestionProgressCharts = (props: QuestionProgressChartsProps) => {
                                 </tr>
                             );
                         })}
+						</tbody>
                     </table>}
             </div>
         </RS.Col>
@@ -235,12 +239,13 @@ export const QuestionProgressCharts = (props: QuestionProgressChartsProps) => {
                         No data
                     </span> :
                     <table className={"sr-only"}>
-                        <tbody>
+                        <thead>
                         <tr>
                             <th>Stage</th>
                             <th>{subId}</th>
                         </tr>
-                        </tbody>
+                        </thead>
+						<tbody>
                         {difficultyColumns.map((val, key) => {
                             return (
                                 <tr key={key}>
@@ -249,6 +254,7 @@ export const QuestionProgressCharts = (props: QuestionProgressChartsProps) => {
                                 </tr>
                             );
                         })}
+						</tbody>
                     </table>}
             </div>
         </RS.Col>}

--- a/src/app/components/elements/views/QuestionProgressCharts.tsx
+++ b/src/app/components/elements/views/QuestionProgressCharts.tsx
@@ -50,7 +50,7 @@ const colourPicker = (names: string[]): { [key: string]: string } => {
         }
     }
     return selected;
-}
+};
 
 export const QuestionProgressCharts = (props: QuestionProgressChartsProps) => {
     const {subId, questionsByTag, questionsByLevel, questionsByStageAndDifficulty, flushRef} = props;
@@ -70,6 +70,8 @@ export const QuestionProgressCharts = (props: QuestionProgressChartsProps) => {
         .sort(comparatorFromOrderedValues(difficultiesOrdered as string[]))
         .map((key) => [difficultyLabelMap[key as Difficulty], questionsByStageAndDifficulty[stageChoices[0].value][key]]) : [];
 
+    console.log(categoryColumns, topicColumns, difficultyColumns);
+
     useEffect(() => {
         const charts: Chart[] = [];
         if (isPhy && !isAllZero(categoryColumns)) {
@@ -81,7 +83,7 @@ export const QuestionProgressCharts = (props: QuestionProgressChartsProps) => {
                 },
                 donut: {
                     title: "By " + topTagLevel,
-                    label: {format: (value, ratio, id) => `${value}`}
+                    label: {format: (value) => `${value}`}
                 },
                 bindto: `#${subId}-categoryChart`,
                 ...OPTIONS
@@ -97,7 +99,7 @@ export const QuestionProgressCharts = (props: QuestionProgressChartsProps) => {
             },
             donut: {
                 title: isAllZero(topicColumns) ? "No Data" : "By Topic",
-                label: {format: (value, ratio, id) => `${value}`}
+                label: {format: (value) => `${value}`}
             },
             bindto: `#${subId}-topicChart`,
             ...OPTIONS
@@ -113,7 +115,7 @@ export const QuestionProgressCharts = (props: QuestionProgressChartsProps) => {
                 },
                 donut: {
                     title: isAllZero(difficultyColumns) ? "No data" : "By Difficulty",
-                    label: {format: (value, ratio, id) => `${value}`}
+                    label: {format: (value) => `${value}`}
                 },
                 bindto: `#${subId}-stageChart`,
                 ...OPTIONS
@@ -134,7 +136,7 @@ export const QuestionProgressCharts = (props: QuestionProgressChartsProps) => {
         };
         return () => {
             flushRef.current = undefined;
-        }
+        };
     }, [questionsByTag, questionsByLevel, categoryColumns, topicColumns, difficultyColumns]);
 
     const numberOfCharts = siteSpecific(3, 2);
@@ -145,9 +147,29 @@ export const QuestionProgressCharts = (props: QuestionProgressChartsProps) => {
                 Questions by {topTagLevel}
             </div>
             <div className="d-flex flex-grow-1">
-                <div id={`${subId}-categoryChart`} className="text-center-width doughnut-binding align-self-center">
+                <div aria-hidden={"true"} id={`${subId}-categoryChart`} className="text-center-width doughnut-binding align-self-center">
                     <strong>{isAllZero(categoryColumns) ? "No data" : ""}</strong>
                 </div>
+                {isAllZero(categoryColumns) ?
+                    <span className={"sr-only"}>
+                        No data
+                    </span> :
+                    <table className={"sr-only"}>
+                    <tbody>
+                    <tr>
+                        <th>Subject</th>
+                        <th>{subId}</th>
+                    </tr>
+                    </tbody>
+                    {categoryColumns.map((val, key) => {
+                        return (
+                            <tr key={key}>
+                                <td>{val[0]}</td>
+                                <td>{val[1]}</td>
+                            </tr>
+                        );
+                    })}
+                </table>}
             </div>
         </RS.Col>}
         {isAda && <RS.Col md={3}/>}
@@ -159,15 +181,35 @@ export const QuestionProgressCharts = (props: QuestionProgressChartsProps) => {
                     className="d-inline-block text-left pr-2 w-50"
                     classNamePrefix="select"
                     defaultValue={{value: defaultSearchChoiceTag.id, label: defaultSearchChoiceTag.title}}
-                    options={tags.getSpecifiedTags(searchTagLevel, tags.allTagIds).map((tag) => {return {value: tag.id, label: tag.title}})}
+                    options={tags.getSpecifiedTags(searchTagLevel, tags.allTagIds).map((tag) => {return {value: tag.id, label: tag.title};})}
                     onChange={(e: SingleValue<{ value: TAG_ID; label: string; }>) => setSearchChoice((e as {value: TAG_ID; label: string}).value)}
                 />
                 <span className={siteSpecific("", "d-inline-block ml-2")}>questions</span>
             </div>
             <div className="d-flex flex-grow-1">
-                <div id={`${subId}-topicChart`} className="text-center-width doughnut-binding  align-self-center">
+                <div aria-hidden={"true"} id={`${subId}-topicChart`} className="text-center-width doughnut-binding  align-self-center">
                     <strong>{isAllZero(topicColumns) ? "No data" : ""}</strong>
                 </div>
+                {isAllZero(topicColumns) ?
+                    <span className={"sr-only"}>
+                        No data
+                    </span> :
+                    <table className={"sr-only"}>
+                        <tbody>
+                        <tr>
+                            <th>Topic</th>
+                            <th>{subId}</th>
+                        </tr>
+                        </tbody>
+                        {topicColumns.map((val, key) => {
+                            return (
+                                <tr key={key}>
+                                    <td>{val[0]}</td>
+                                    <td>{val[1]}</td>
+                                </tr>
+                            );
+                        })}
+                    </table>}
             </div>
         </RS.Col>
         {isAda && <RS.Col md={3}/>}
@@ -185,9 +227,29 @@ export const QuestionProgressCharts = (props: QuestionProgressChartsProps) => {
                 questions
             </div>
             <div className="d-flex flex-grow-1">
-                <div id={`${subId}-stageChart`} className="text-center-width doughnut-binding  align-self-center">
+                <div aria-hidden={"true"} id={`${subId}-stageChart`} className="text-center-width doughnut-binding  align-self-center">
                     <strong>{isAllZero(difficultyColumns) ? "No data" : ""}</strong>
                 </div>
+                {isAllZero(difficultyColumns) ?
+                    <span className={"sr-only"}>
+                        No data
+                    </span> :
+                    <table className={"sr-only"}>
+                        <tbody>
+                        <tr>
+                            <th>Stage</th>
+                            <th>{subId}</th>
+                        </tr>
+                        </tbody>
+                        {difficultyColumns.map((val, key) => {
+                            return (
+                                <tr key={key}>
+                                    <td>{val[0]}</td>
+                                    <td>{val[1]}</td>
+                                </tr>
+                            );
+                        })}
+                    </table>}
             </div>
         </RS.Col>}
     </RS.Row>;


### PR DESCRIPTION
The charts are now hidden from screen readers with a visually hidden table for the screenreaders. This table can later be made visible if desired.

Additional changes to comply with ESLint.