### PR TITLE
Add aria-label to news pod read more link

### DIFF
--- a/src/app/components/elements/cards/NewsCard.tsx
+++ b/src/app/components/elements/cards/NewsCard.tsx
@@ -41,7 +41,7 @@ const PhysicsNewsCard = ({newsItem, showTitle}: NewsCardProps) => {
             </div>
             <CardText>
                 {!url?.startsWith("http") ?
-                    <Link className="focus-target" to={`${url}`}>
+                    <Link aria-label={`${title} read more`} className="focus-target" to={`${url}`}>
                         Read more
                     </Link> :
                     // eslint-disable-next-line react/jsx-no-target-blank
@@ -51,7 +51,7 @@ const PhysicsNewsCard = ({newsItem, showTitle}: NewsCardProps) => {
                 }
             </CardText>
         </CardBody>
-    </Card>
+    </Card>;
 };
 
 export const AdaNewsCard = ({newsItem, showTitle}: NewsCardProps) => {


### PR DESCRIPTION
The read more link now includes the title of the news pod when tab focused as the title is otherwise not read out.