### PR TITLE
Prevent button overlaps in sketcher UI

### DIFF
--- a/src/app/components/elements/modals/GraphSketcherModal.tsx
+++ b/src/app/components/elements/modals/GraphSketcherModal.tsx
@@ -131,7 +131,6 @@ const GraphSketcherModal = (props: GraphSketcherModalProps) => {
     const deviceSize = useDeviceSize();
     const deviceHeight = useDeviceHeight();
     const hexagonSize = above['sm'](deviceSize) && above['sm'](deviceHeight) ? 74 : 48;
-    console.log(hexagonSize);
     const colourHexagon = calculateHexagonProportions(hexagonSize/4, 3);
 
     const copySpecificationToClipboard = useCallback(() => {

--- a/src/app/components/elements/modals/GraphSketcherModal.tsx
+++ b/src/app/components/elements/modals/GraphSketcherModal.tsx
@@ -7,7 +7,6 @@ import {
 } from "isaac-graph-sketcher";
 import debounce from "lodash/debounce";
 import {IsaacGraphSketcherQuestionDTO} from "../../../../IsaacApiTypes";
-import {Markup} from "../markup";
 import {calculateHexagonProportions, Hexagon} from "../svg/Hexagon";
 import classNames from "classnames";
 import {
@@ -18,7 +17,7 @@ import {
     useGenerateAnswerSpecificationMutation
 } from "../../../state";
 import {PageFragment} from "../PageFragment";
-import {above, isStaff, useDeviceSize} from "../../../services";
+import {above, isStaff, useDeviceSize, useDeviceHeight} from "../../../services";
 import {Immutable} from "immer";
 import {PotentialUser} from "../../../../IsaacAppTypes";
 import {IsaacContentValueOrChildren} from "../../content/IsaacContentValueOrChildren";
@@ -130,7 +129,9 @@ const GraphSketcherModal = (props: GraphSketcherModalProps) => {
     const redo = () => modalSketch?.redo();
 
     const deviceSize = useDeviceSize();
-    const hexagonSize = above['sm'](deviceSize) ? 74 : 48;
+    const deviceHeight = useDeviceHeight();
+    const hexagonSize = above['sm'](deviceSize) && above['sm'](deviceHeight) ? 74 : 48;
+    console.log(hexagonSize);
     const colourHexagon = calculateHexagonProportions(hexagonSize/4, 3);
 
     const copySpecificationToClipboard = useCallback(() => {

--- a/src/app/services/device.ts
+++ b/src/app/services/device.ts
@@ -9,7 +9,8 @@ export const isNotMobile = !isMobile();
 
 export const isTouchDevice = () => {
     return ('ontouchstart' in window) || (navigator.maxTouchPoints > 0);
-}
+};
+
 export const isNotTouchDevice = () => !isTouchDevice();
 
 export enum DeviceSize {
@@ -18,6 +19,11 @@ export enum DeviceSize {
     MD = "md",
     SM = "sm",
     XS = "xs",
+}
+
+export enum DeviceOrientation {
+    PORTRAIT = "portrait",
+    LANDSCAPE = "landscape",
 }
 
 const descDeviceSizes = [DeviceSize.XL, DeviceSize.LG, DeviceSize.MD, DeviceSize.SM, DeviceSize.XS];
@@ -35,12 +41,33 @@ export const useDeviceSize = () => {
     const [windowSize, setWindowSize] = useState(getSize);
 
     useEffect(() => {
-        const handleResize = () => {setWindowSize(getSize())};
+        const handleResize = () => {setWindowSize(getSize());};
         window.addEventListener('resize', handleResize);
         return () => window.removeEventListener('resize', handleResize);
     }, []);
 
     return windowSize;
+};
+
+export const useDeviceHeight = () => {
+    const getHeight = (): DeviceSize => {
+        const height = window.innerHeight;
+        if (height >= 1200) return DeviceSize.XL;
+        else if (height >= 992) return DeviceSize.LG;
+        else if (height >= 768) return DeviceSize.MD;
+        else if (height >= 576) return DeviceSize.SM;
+        else return DeviceSize.XS;
+    };
+
+    const [windowHeight, setWindowHeight] = useState(getHeight);
+
+    useEffect(() => {
+        const handleResize = () => {setWindowHeight(getHeight());};
+        window.addEventListener('resize', handleResize);
+        return () => window.removeEventListener('resize', handleResize);
+    }, []);
+
+    return windowHeight;
 };
 
 // above(ds) and below(ds) return true if device size === ds to match the scss functions respond-above(ds) and respond-below(ds)

--- a/src/scss/common/graph-sketcher-modal.scss
+++ b/src/scss/common/graph-sketcher-modal.scss
@@ -10,6 +10,8 @@
 }
 
 #graph-sketcher-modal {
+    min-height: 375px;
+    min-width: 310px;
     .graph-sketcher-ui {
         position: absolute;
         width: 100%;
@@ -172,7 +174,7 @@
             }
         }
 
-        @include respond-above(xs) {
+        @include respond-above(lg) {
             $button-size: 90px;
             $button-spacing: 10px;
 
@@ -244,7 +246,162 @@
             }
         }
 
-        @include respond-below(xs) {
+        @media (orientation:portrait) {
+            @include respond-below(xs) {
+                $button-size: 61px;
+                $button-spacing: 8px;
+
+                #graph-sketcher-ui-debug-window {
+                    top: 3 * $button-spacing + $button-size;
+                    left: 2 * $button-spacing;
+                }
+
+                .button {
+                    width: $button-size;
+                    height: $button-size;
+
+                    &#graph-sketcher-ui-trash-button {
+                        top: 2 * $button-spacing;
+                        right: 2 * $button-spacing;
+                    }
+
+                    &#graph-sketcher-ui-reset-button {
+                        top: 3 * $button-spacing + $button-size;
+                        right: 2 * $button-spacing;
+                    }
+
+                    &#graph-sketcher-ui-question-button {
+                        bottom: 3 * $button-spacing + $button-size;
+                        left: 2 * $button-spacing;
+                    }
+
+                    &#graph-sketcher-ui-undo-button {
+                        bottom: 2 * $button-spacing;
+                        left: 2 * $button-spacing;
+                    }
+
+                    &#graph-sketcher-ui-redo-button {
+                        bottom: 2 * $button-spacing;
+                        left: 3 * $button-spacing + $button-size;
+                    }
+
+                    &#graph-sketcher-ui-submit-button {
+                        bottom: 2 * $button-spacing;
+                        right: 2 * $button-spacing;
+                    }
+
+                    &#graph-sketcher-ui-help-button {
+                        bottom: 3 * $button-spacing + $button-size;
+                        right: 2 * $button-spacing;
+                    }
+
+                    &#graph-sketcher-ui-debug-button {
+                        top: 3 * $button-spacing + $button-size;
+                        left: 2 * $button-spacing;
+                    }
+
+                    &#graph-sketcher-ui-bezier-button {
+                        top: 2 * $button-spacing;
+                        left: 3 * $button-spacing + $button-size;
+                    }
+
+                    &#graph-sketcher-ui-linear-button {
+                        top: 2 * $button-spacing;
+                        left: 2 * $button-spacing;
+                    }
+                }
+
+                div#graph-sketcher-ui-color-select-hexagons {
+                    top: 2 * $button-spacing;
+                    left: 4 * $button-spacing + 2 * $button-size;
+                    width: $button-size;
+                    height: $button-size;
+                    svg {
+                        width: $button-size;
+                        height: $button-size;                        
+                    }
+                }
+            }
+        }
+
+        @include respond-above(xs) {
+            $button-size: 90px;
+            $button-spacing: 10px;
+
+            #graph-sketcher-ui-debug-window {
+                top: 3 * $button-spacing + $button-size;
+                left: 2 * $button-spacing;
+            }
+
+            .button {
+                width: $button-size;
+                height: $button-size;
+
+                &#graph-sketcher-ui-trash-button {
+                    top: 2 * $button-spacing;
+                    right: 2 * $button-spacing;
+                }
+
+                &#graph-sketcher-ui-reset-button {
+                    top: 3 * $button-spacing + $button-size;
+                    right: 2 * $button-spacing;
+                }
+
+                &#graph-sketcher-ui-question-button {
+                    bottom: 3 * $button-spacing + $button-size;
+                    left: 2 * $button-spacing;
+                }
+
+                &#graph-sketcher-ui-undo-button {
+                    bottom: 2 * $button-spacing;
+                    left: 2 * $button-spacing;
+                }
+
+                &#graph-sketcher-ui-redo-button {
+                    bottom: 2 * $button-spacing;
+                    left: 3 * $button-spacing + $button-size;
+                }
+
+                &#graph-sketcher-ui-submit-button {
+                    bottom: 2 * $button-spacing;
+                    right: 2 * $button-spacing;
+                }
+
+                &#graph-sketcher-ui-help-button {
+                    bottom: 3 * $button-spacing + $button-size;
+                    right: 2 * $button-spacing;
+                }
+
+                &#graph-sketcher-ui-debug-button {
+                    top: unset;
+                    bottom: 3 * $button-spacing + $button-size;
+                    left: 2 * $button-spacing;
+                }
+
+                &#graph-sketcher-ui-bezier-button {
+                    top: 3 * $button-spacing + $button-size;
+                    left: 2 * $button-spacing;
+                }
+
+                &#graph-sketcher-ui-linear-button {
+                    top: 2 * $button-spacing;
+                    left: 2 * $button-spacing;
+                }
+            }
+
+            div#graph-sketcher-ui-color-select-hexagons {
+                top: 4 * $button-spacing + 2 * $button-size;
+                left: 2 * $button-spacing;
+                width: $button-size;
+                height: $button-size;
+                svg {
+                    width: $button-size;
+                    height: $button-size;                        
+                }
+            }
+        }
+
+        @media screen and (orientation:landscape) and (max-height: 576px) {
             $button-size: 61px;
             $button-spacing: 8px;
 
@@ -293,13 +450,14 @@
                 }
 
                 &#graph-sketcher-ui-debug-button {
-                    top: 3 * $button-spacing + $button-size;
+                    top: unset;
+                    bottom: 3 * $button-spacing + $button-size;
                     left: 2 * $button-spacing;
                 }
 
                 &#graph-sketcher-ui-bezier-button {
-                    top: 2 * $button-spacing;
-                    left: 3 * $button-spacing + $button-size;
+                    top: 3 * $button-spacing + $button-size;
+                    left: 2 * $button-spacing;
                 }
 
                 &#graph-sketcher-ui-linear-button {
@@ -309,8 +467,8 @@
             }
 
             div#graph-sketcher-ui-color-select-hexagons {
-                top: 2 * $button-spacing;
-                left: 4 * $button-spacing + 2 * $button-size;
+                top: 4 * $button-spacing + 2 * $button-size;
+                left: 2 * $button-spacing;
                 width: $button-size;
                 height: $button-size;
                 svg {
@@ -319,7 +477,6 @@
                 }
             }
         }
-
 
     }
 }


### PR DESCRIPTION
Adds a new useDeviceHeight hook to permit proper layout in the sketcher when in landscape mode.