### PR TITLE
Link to account if preferences do not match page

### DIFF
--- a/src/app/components/elements/inputs/UserContextAccountInput.tsx
+++ b/src/app/components/elements/inputs/UserContextAccountInput.tsx
@@ -133,6 +133,7 @@ export function UserContextAccountInput({
             <React.Fragment>
                 <span id={`show-me-content-${componentId}`} className="icon-help" />
                 <RS.UncontrolledTooltip placement={"left-start"} target={`show-me-content-${componentId}`}>
+                    {/* This tooltip is very hard to reach */}
                     {tutorOrAbove ?
                         <>Add a stage and examination board for each qualification you are teaching.<br />On content pages, this will allow you to quickly switch between your personalised views of the content, depending on which class you are currently teaching.</> :
                         <>Select a stage and examination board here to filter the content so that you will only see material that is relevant for the qualification you have chosen.</>

--- a/src/app/components/navigation/IntendedAudienceWarningBanner.tsx
+++ b/src/app/components/navigation/IntendedAudienceWarningBanner.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import * as RS from "reactstrap";
 import {ContentBaseDTO} from "../../../IsaacApiTypes";
-import {isIntendedAudience, notRelevantMessage, useUserContext} from "../../services";
+import {isAda, isPhy, isIntendedAudience, notRelevantMessage, useUserContext} from "../../services";
 import {selectors, useAppSelector} from "../../state";
 import {RenderNothing} from "../elements/RenderNothing";
 
@@ -16,6 +16,8 @@ export function IntendedAudienceWarningBanner({doc}: {doc: ContentBaseDTO}) {
 
     return <RS.Alert color="warning" className={"no-print"}>
         <strong>Note: </strong>
-        {`The content on this page has ${notRelevantMessage(userContext)}. You can change your viewing preferences by updating your profile.`}
-    </RS.Alert>
+        {`The content on this page has ${notRelevantMessage(userContext)}. You can change your viewing preferences `}
+        {isAda && <strong>by updating your profile <a href="\account">here</a>.</strong>}
+        {isPhy && `by updating your profile.`}
+    </RS.Alert>;
 }


### PR DESCRIPTION
The warning when a users preferences do not match the page's audience now includes a link to change account preferences. Only on Ada.