### PR TITLE
Print at scale without overflowing

### DIFF
--- a/src/app/components/site/ScrollToTop.tsx
+++ b/src/app/components/site/ScrollToTop.tsx
@@ -20,7 +20,7 @@ export const ScrollToTop = ({mainContent}: {mainContent: React.RefObject<any>}) 
         };
     });
 
-    return <div ref={scrollButton} onClick={scroll} className="scroll-btn">
+    return <div ref={scrollButton} onClick={scroll} className="scroll-btn d-print-none">
         <button>
             <img src="/assets/chevron-up.svg" alt="Scroll to top of page"/>
         </button>

--- a/src/scss/common/print.scss
+++ b/src/scss/common/print.scss
@@ -1,7 +1,12 @@
 @media print {
 
   @page {
-    size: A4;
+    // min-width of 992px, scaled to 1:sqrt(2), plus 1in default padding on each side
+    size: calc(992px + 1in) calc(992px * sqrt(2) + 1in);
+  }
+
+  body {
+    min-width: unset !important;
   }
 
   div#root {
@@ -45,6 +50,7 @@
 
   .container {
     max-width: none;
+    min-width: unset !important;
   }
 
   .question-panel {


### PR DESCRIPTION
- Unsets min-width when printing so the Scale parameter in print menus works as intended;
- Since the previous print layout was designed for 992px min-width, sets the page size to this plus the padding difference not added by @ page size (0.5in left/right/top/bottom).

This correction isn't perfect, and the scale of certain pages is very slightly different to before. Worth checking if this affects any pages in particular.