### PR TITLE
Remove unnecessary redux checks

### DIFF
--- a/src/app/components/pages/SetAssignments.tsx
+++ b/src/app/components/pages/SetAssignments.tsx
@@ -59,7 +59,8 @@ import {
     siteSpecific,
     sortIcon,
     useDeviceSize,
-    useGameboards
+    useGameboards,
+    TODAY
 } from "../../services";
 import {IsaacSpinner, Loading} from "../handlers/IsaacSpinner";
 import {GameboardDTO, RegisteredUserDTO, UserGroupDTO} from "../../../IsaacApiTypes";
@@ -97,7 +98,8 @@ const AssignGroup = ({groups, board}: AssignGroupProps) => {
     }
 
     const yearRange = range(currentYear, currentYear + 5);
-    const dueDateInvalid = dueDate && scheduledStartDate ? nthHourOf(0, scheduledStartDate).valueOf() > dueDate.valueOf() : false;
+    const dueDateInvalid = dueDate && scheduledStartDate ? (nthHourOf(0, scheduledStartDate).valueOf() > dueDate.valueOf() || TODAY().valueOf() > dueDate.valueOf()) : false;
+    const startDateInvalid = scheduledStartDate ? TODAY().valueOf() > scheduledStartDate.valueOf() : false;
 
     function setScheduledStartDateAtSevenAM(e: ChangeEvent<HTMLInputElement>) {
         const utcDate = e.target.valueAsDate;
@@ -126,7 +128,9 @@ const AssignGroup = ({groups, board}: AssignGroupProps) => {
         <Label className="w-100 pb-2">Due date reminder <span className="text-muted"> (optional)</span>
             <DateInput value={dueDate} placeholder="Select your due date..." yearRange={yearRange}
                 onChange={(e: ChangeEvent<HTMLInputElement>) => setDueDate(e.target.valueAsDate as Date)} /> {/* DANGER here with force-casting Date|null to Date */}
-            {dueDateInvalid && <small className={"pt-2 text-danger"}>Due date must be on or after start date.</small>}
+            {dueDateInvalid && <small className={"pt-2 text-danger"}>Due date must be on or after start date and in the future.</small>}
+            {dueDateInvalid && startDateInvalid && <br/>}
+            {startDateInvalid && <small className={"pt-2 text-danger"}>Start date must be in the future.</small>}
         </Label>
         {isStaff(user) && <Label className="w-100 pb-2">Notes (optional):
             <Input type="textarea"
@@ -145,7 +149,7 @@ const AssignGroup = ({groups, board}: AssignGroupProps) => {
             block color={siteSpecific("secondary", "primary")}
             onClick={assign}
             role={"button"}
-            disabled={selectedGroups.length === 0 || (isDefined(assignmentNotes) && assignmentNotes.length > 500)}
+            disabled={selectedGroups.length === 0 || (isDefined(assignmentNotes) && assignmentNotes.length > 500) || dueDateInvalid || startDateInvalid}
         >Assign to group{selectedGroups.length > 1 ? "s" : ""}</Button>
     </Container>;
 };

--- a/src/app/services/quiz.ts
+++ b/src/app/services/quiz.ts
@@ -11,7 +11,6 @@ import {
     showErrorToast,
     showRTKQueryErrorToastIfNeeded,
     showSuccessToast,
-    showToast,
     useAppDispatch,
     useAppSelector,
     useGetAvailableQuizzesQuery,
@@ -26,10 +25,8 @@ import {
     isQuestion,
     Item,
     matchesAllWordsInAnyOrder,
-    nthHourOf,
     siteSpecific,
     tags,
-    TODAY,
     toTuple,
     useQueryParams
 } from "./";
@@ -63,40 +60,6 @@ export const assignMultipleQuiz = createAsyncThunk(
         {dispatch, rejectWithValue}
     ) => {
         const appDispatch = dispatch as AppDispatch;
-        if (groups.length === 0) {
-            appDispatch(showErrorToast(
-                `${siteSpecific("Quiz", "Test")} assignment failed`,
-                "Error: Please choose one or more groups."
-            ));
-            return rejectWithValue(null);
-        }
-
-        const today =  TODAY();
-        const isDue = dueDate !== undefined;
-        const isScheduled = scheduledStartDate !== undefined;
-
-        if (isDue) {
-            dueDate?.setHours(0, 0, 0, 0);
-            if ((dueDate.valueOf() - today.valueOf()) < 0) {
-                appDispatch(showToast({color: "danger", title: `${siteSpecific("Quiz", "Test")} assignment${groups.length > 1 ? "(s)" : ""} failed`, body: "Error: Due date cannot be in the past.", timeout: 5000}));
-                return rejectWithValue(null);
-            }
-        }
-
-        if (isScheduled) {
-            // Start date can be today, in which case the assignment will be immediately set (if it is past 7am)
-            if (nthHourOf(0, scheduledStartDate).valueOf() < nthHourOf(0, new Date()).valueOf()) {
-                appDispatch(showToast({color: "danger", title: `${siteSpecific("Quiz", "Test")} assignment${groups.length > 1 ? "(s)" : ""} failed`, body: "Error: Scheduled start date cannot be in the past.", timeout: 5000}));
-                return rejectWithValue(null);
-            }
-        }
-
-        if (isDue && isScheduled) {
-            if (nthHourOf(0, scheduledStartDate).valueOf() > dueDate.valueOf()) {
-                appDispatch(showToast({color: "danger", title: `${siteSpecific("Quiz", "Test")} assignment${groups.length > 1 ? "(s)" : ""} failed`, body: "Error: Due date must be on or after scheduled start date.", timeout: 5000}));
-                return rejectWithValue(null);
-            }
-        }
 
         const groupIds = groups.map(getValue);
         const quizzes: QuizAssignmentDTO[] = groupIds.map(id => ({

--- a/src/app/state/slices/api/gameboards.ts
+++ b/src/app/state/slices/api/gameboards.ts
@@ -6,9 +6,8 @@ import {
     isTutorOrAbove,
     Item,
     KEY,
-    nthHourOf, PATHS,
+    PATHS,
     persistence, siteSpecific,
-    TODAY,
     toTuple
 } from "../../../services";
 import {createAsyncThunk} from "@reduxjs/toolkit";
@@ -23,7 +22,6 @@ import {
     showErrorToast,
     showRTKQueryErrorToastIfNeeded,
     showSuccessToast,
-    showToast
 } from "../../index";
 import {PotentialUser} from "../../../../IsaacAppTypes";
 import {Immutable} from "immer";
@@ -47,32 +45,6 @@ export const assignGameboard = createAsyncThunk(
                 "Error: Please choose one or more groups."
             ));
             return rejectWithValue(null);
-        }
-
-        const today = TODAY();
-
-        // TODO think about whether this can be done in the back-end too?
-        if (dueDate !== undefined) {
-            dueDate?.setHours(0, 0, 0, 0);
-            if ((dueDate.valueOf() - today.valueOf()) < 0) {
-                appDispatch(showToast({color: "danger", title: `${siteSpecific("Gameboard", "Quiz")} assignment${groups.length > 1 ? "(s)" : ""} failed`, body: "Error: Due date cannot be in the past.", timeout: 5000}));
-                return rejectWithValue(null);
-            }
-        }
-
-        if (scheduledStartDate !== undefined) {
-            // Start date can be today, in which case the assignment will be immediately set (if it is past 7am)
-            if (nthHourOf(0, scheduledStartDate).valueOf() < nthHourOf(0, new Date()).valueOf()) {
-                appDispatch(showToast({color: "danger", title: `${siteSpecific("Gameboard", "Quiz")} assignment${groups.length > 1 ? "(s)" : ""} failed`, body: "Error: Scheduled start date cannot be in the past.", timeout: 5000}));
-                return rejectWithValue(null);
-            }
-        }
-
-        if (dueDate !== undefined && scheduledStartDate !== undefined) {
-            if (nthHourOf(0, scheduledStartDate).valueOf() > dueDate.valueOf()) {
-                appDispatch(showToast({color: "danger", title: `${siteSpecific("Gameboard", "Quiz")} assignment${groups.length > 1 ? "(s)" : ""} failed`, body: "Error: Due date must be on or after scheduled start date.", timeout: 5000}));
-                return rejectWithValue(null);
-            }
         }
 
         const groupIds = groups.map(getValue);


### PR DESCRIPTION
When setting an assignment or quiz checks on whether the due date is valid is done in the modal, the redux thunk, and
the backend. This is inefficient, so the redux thunk checks have been removed.

- Add front end date checks to set assignment
- Remove unnecessary redux date checks
