### PR TITLE
Remove text styling from terms in inline definition

### DIFF
--- a/src/app/components/elements/markup/index.tsx
+++ b/src/app/components/elements/markup/index.tsx
@@ -27,7 +27,7 @@ const TrustedHtml = ({html, className}: {html: string; className?: string}) => {
 // The job of this component is to render standard and Isaac-specific markdown (glossary terms, cloze question
 // drop zones) into HTML, which is then passed to `TrustedHTML`. The Isaac-specific markdown must be processed first,
 // so that it doesn't get incorrectly rendered with Remarkable (the markdown renderer we use).
-const TrustedMarkdown = ({markdown}: {markdown: string, renderParagraphs?: boolean}) => {
+const TrustedMarkdown = ({markdown, className}: {markdown: string, renderParagraphs?: boolean, className?: string}) => {
     const renderKatex = useRenderKatex();
 
     // This combines all of the above functions for markdown processing.
@@ -40,7 +40,7 @@ const TrustedMarkdown = ({markdown}: {markdown: string, renderParagraphs?: boole
         renderGlossaryBlocks       // |
     )(markdown);                   // control flow
 
-    return <TrustedHtml html={html}/>;
+    return <TrustedHtml html={html} className={className}/>;
 };
 
 // --- Types for the Markup component ---
@@ -82,7 +82,7 @@ export function Markup<T extends string>({encoding, "trusted-markup-encoding": t
         case "html":
             return <TrustedHtml html={renderKaTeX(children)}/>;
         case "markdown":
-            return <TrustedMarkdown markdown={children}/>;
+            return <TrustedMarkdown markdown={children} className={className}/>;
         case "latex":
             const escapedMarkup = utils.escapeHtml(children);
             return <span dangerouslySetInnerHTML={{__html: renderKaTeX(escapedMarkup)}} className={className} />;

--- a/src/app/components/elements/markup/portals/GlossaryTerms.tsx
+++ b/src/app/components/elements/markup/portals/GlossaryTerms.tsx
@@ -65,7 +65,7 @@ export const useGlossaryTermsInHtml: PortalInHtmlHook = (html) => {
                 termElements[i].setAttribute("id", uniqueId);
                 tooltips.push(
                     <UncontrolledTooltip key={uniqueId} placement="bottom" target={uniqueId}>
-                        <Markup trusted-markup-encoding={"markdown"}>
+                        <Markup trusted-markup-encoding={"markdown"} className={"inline-glossary-definition"}>
                             {titled ?
                                 "**" + term.value + "**: " + term.explanation?.value :
                                 term.explanation?.value

--- a/src/scss/common/glossary.scss
+++ b/src/scss/common/glossary.scss
@@ -7,6 +7,10 @@
   margin-top: -1em;
 }
 
+.inline-glossary-definition .inline-glossary-term {
+  text-decoration: none;
+}
+
 .glossary-page {
   #sentinel {
     max-height: 1px;

--- a/src/scss/common/glossary.scss
+++ b/src/scss/common/glossary.scss
@@ -11,6 +11,11 @@
   text-decoration: none;
 }
 
+.inline-glossary-definition .a-link {
+  color: white;
+  text-decoration: none;
+}
+
 .glossary-page {
   #sentinel {
     max-height: 1px;

--- a/src/scss/common/glossary.scss
+++ b/src/scss/common/glossary.scss
@@ -7,13 +7,15 @@
   margin-top: -1em;
 }
 
-.inline-glossary-definition .inline-glossary-term {
-  text-decoration: none;
-}
+.inline-glossary-definition {
+  .inline-glossary-term {
+    text-decoration: none;
+  }
 
-.inline-glossary-definition .a-link {
-  color: white;
-  text-decoration: none;
+  .a-link {
+    color: white;
+    text-decoration: none;
+  }
 }
 
 .glossary-page {


### PR DESCRIPTION
Removes all text styling from glossary terms when they are inside another inline glossary term's definition. Does **not** remove this styling if the parent glossary term is displayed as a block, e.g. in the bottom glossary.