### PR TITLE
Allow users to set start dates for tests

### DIFF
--- a/src/app/components/elements/modals/QuizSettingModal.tsx
+++ b/src/app/components/elements/modals/QuizSettingModal.tsx
@@ -46,7 +46,7 @@ interface QuizSettingModalProps {
     feedbackMode?: QuizFeedbackMode | null;
 }
 
-export function QuizSettingModal({allowedToSchedule, quiz, dueDate: initialDueDate, scheduledStartDate: initialScheduledStartDate, feedbackMode: initialFeedbackMode}: QuizSettingModalProps) {
+export function QuizSettingModal({quiz, dueDate: initialDueDate, scheduledStartDate: initialScheduledStartDate, feedbackMode: initialFeedbackMode}: QuizSettingModalProps) {
     const dispatch: AppDispatch = useAppDispatch();
     const groupsQuery = useGetGroupsQuery(false);
     const user = useAppSelector(selectors.user.loggedInOrNull);
@@ -88,7 +88,7 @@ export function QuizSettingModal({allowedToSchedule, quiz, dueDate: initialDueDa
 
     const groupInvalid = validated.has('group') && selectedGroups.length === 0;
     const dueDateInvalid = isDefined(dueDate) && ((scheduledStartDate ? scheduledStartDate.valueOf() > dueDate.valueOf() : false) || dueDate.valueOf() < Date.now());
-    const scheduledStartDateInvalid = isDefined(scheduledStartDate) && scheduledStartDate.valueOf() <= TODAY().valueOf();
+    const scheduledStartDateInvalid = isDefined(scheduledStartDate) && scheduledStartDate.valueOf() < TODAY().valueOf();
     const feedbackModeInvalid = validated.has('feedbackMode') && feedbackMode === null;
 
     const scheduledQuizHelpTooltipId = "scheduled-quiz-help-tooltip";
@@ -139,7 +139,7 @@ export function QuizSettingModal({allowedToSchedule, quiz, dueDate: initialDueDa
             />
             {feedbackModeInvalid && <FormFeedback className="d-block" valid={false}>You must select a feedback mode</FormFeedback>}
         </Label>
-        {allowedToSchedule && <Label className="w-100 mb-4">Set an optional start date:<span id={scheduledQuizHelpTooltipId} className="icon-help"/><br/>
+        <Label className="w-100 mb-4">Set an optional start date:<span id={scheduledQuizHelpTooltipId} className="icon-help"/><br/>
             <DateInput value={scheduledStartDate ?? undefined} invalid={scheduledStartDateInvalid || undefined}
                        yearRange={yearRange}
                        onChange={(e: ChangeEvent<HTMLInputElement>) => setScheduledStartDate(e.target.valueAsDate)}
@@ -149,12 +149,12 @@ export function QuizSettingModal({allowedToSchedule, quiz, dueDate: initialDueDa
                 The test will be visible to students from this date onwards.<br/>
                 If you do not set a start date, the test will be visible immediately.
             </UncontrolledTooltip>
-            {scheduledStartDateInvalid && <small className={"pt-2 text-danger"}>Start date must be today, or in the future.</small>}
-        </Label>}
+            {scheduledStartDateInvalid && <small className={"pt-2 text-danger"}>Start date must be today or in the future.</small>}
+        </Label>
         <Label className="w-100 mb-4">Set an optional due date:<br/>
             <DateInput invalid={dueDateInvalid || undefined} value={dueDate ?? undefined} yearRange={yearRange}
                        onChange={(e) => setDueDate(e.target.valueAsDate)}/>
-            {dueDateInvalid && <small className={"pt-2 text-danger"}>{allowedToSchedule ? "Due date must be on, or after the start date." : "Due date must be after today."}</small>}
+            {dueDateInvalid && <small className={"pt-2 text-danger"}>{dueDate.valueOf() > TODAY().valueOf() ? "Due date must be on or after the start date." : `Due date must be after today.`}</small>}
         </Label>
 
         <div className="w-100">

--- a/src/app/components/pages/quizzes/SetQuizzes.tsx
+++ b/src/app/components/pages/quizzes/SetQuizzes.tsx
@@ -19,7 +19,7 @@ import {
     below, confirmThen,
     isAda,
     isEventLeaderOrStaff,
-    isPhy, isStaff, KEY,
+    isPhy, KEY,
     MANAGE_QUIZ_TAB,
     nthHourOf, persistence,
     siteSpecific,
@@ -108,6 +108,7 @@ const SetQuizzesPageComponent = ({user}: SetQuizzesPageProps) => {
             (hashAnchor && MANAGE_QUIZ_TAB[hashAnchor as any]) ||
             MANAGE_QUIZ_TAB.set;
         setActiveTab(tab);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [hashAnchor]);
 
     const {titleFilter, setTitleFilter, filteredQuizzes} = useFilteredQuizzes(user);
@@ -234,7 +235,7 @@ const SetQuizzesPageComponent = ({user}: SetQuizzesPageProps) => {
                                     </div>
                                     {quiz.summary && <div className="small text-muted d-none d-md-block">{quiz.summary}</div>}
                                     <Spacer />
-                                    <RS.Button className={`d-none d-md-block h-4 ${below["md"](deviceSize) ? "btn-sm" : ""}`} style={{minWidth: `${below["md"](deviceSize) ? "90px" : "140px"}`}} onClick={() => dispatch(showQuizSettingModal(quiz, isStaff(user)))}>
+                                    <RS.Button className={`d-none d-md-block h-4 ${below["md"](deviceSize) ? "btn-sm" : ""}`} style={{minWidth: `${below["md"](deviceSize) ? "90px" : "140px"}`}} onClick={() => dispatch(showQuizSettingModal(quiz))}>
                                         {siteSpecific("Set Test", "Set test")}
                                     </RS.Button>
                                 </div>
@@ -243,7 +244,7 @@ const SetQuizzesPageComponent = ({user}: SetQuizzesPageProps) => {
                                         Actions
                                     </RS.DropdownToggle>
                                     <RS.DropdownMenu>
-                                            <RS.DropdownItem onClick={() => dispatch(showQuizSettingModal(quiz, isStaff(user)))} style={{zIndex: '1'}}>
+                                            <RS.DropdownItem onClick={() => dispatch(showQuizSettingModal(quiz))} style={{zIndex: '1'}}>
                                                 {siteSpecific("Set Test", "Set test")}
                                             </RS.DropdownItem>
                                             <RS.DropdownItem divider />

--- a/src/app/state/actions/quizzes.tsx
+++ b/src/app/state/actions/quizzes.tsx
@@ -13,15 +13,15 @@ import {
 import {ContentSummaryDTO, IsaacQuizDTO, QuizFeedbackMode} from "../../../IsaacApiTypes";
 import {QuizSettingModal} from "../../components/elements/modals/QuizSettingModal";
 
-export const showQuizSettingModal = (quiz: ContentSummaryDTO | IsaacQuizDTO, allowedToSchedule?: boolean, dueDate?: Date | null, scheduledStartDate?: Date | null, feedbackMode?: QuizFeedbackMode | null) => (dispatch: AppDispatch) => {
+export const showQuizSettingModal = (quiz: ContentSummaryDTO | IsaacQuizDTO, dueDate?: Date | null, scheduledStartDate?: Date | null, feedbackMode?: QuizFeedbackMode | null) => (dispatch: AppDispatch) => {
     dispatch(openActiveModal({
         closeAction: () => {
-            dispatch(closeActiveModal())
+            dispatch(closeActiveModal());
         },
         title: `Setting test '${quiz.title ?? quiz.id}'`,
-        body: <QuizSettingModal quiz={quiz} dueDate={dueDate} scheduledStartDate={scheduledStartDate} feedbackMode={feedbackMode} allowedToSchedule={allowedToSchedule}/>
+        body: <QuizSettingModal quiz={quiz} dueDate={dueDate} scheduledStartDate={scheduledStartDate} feedbackMode={feedbackMode}/>
     }));
-}
+};
 
 export const loadQuizAssignmentAttempt = (quizAssignmentId: number) => async (dispatch: Dispatch<Action>) => {
     dispatch({type: ACTION_TYPE.QUIZ_LOAD_ASSIGNMENT_ATTEMPT_REQUEST, quizAssignmentId});


### PR DESCRIPTION
Previously only staff members could set start dates for tests. This
functionality has been extended to user accounts, this only applies to
accounts that can set tests.
