### PR TITLE
Redirect to /verify when account required in partial login

### DIFF
--- a/src/app/components/content/IsaacQuestion.tsx
+++ b/src/app/components/content/IsaacQuestion.tsx
@@ -19,6 +19,8 @@ import {
     isAda,
     isLoggedIn,
     isPhy,
+    isTeacherOrAbove,
+    isVerified,
     KEY,
     persistence,
     QUESTION_TYPES,
@@ -115,7 +117,8 @@ export const IsaacQuestion = withRouter(({doc, location}: {doc: ApiTypes.Questio
                 }
 
                 dispatch(attemptQuestion(doc.id as string, questionPart?.currentAttempt, currentGameboard?.id));
-                if (isLoggedIn(currentUser) && currentGameboard?.id && !currentGameboard.savedToCurrentUser) {
+                const requiresVerification = isAda ? isTeacherOrAbove(currentUser) && !isVerified(currentUser) : false;
+                if (isLoggedIn(currentUser) && !requiresVerification && currentGameboard?.id && !currentGameboard.savedToCurrentUser) {
                     dispatch(saveGameboard({
                         boardId: currentGameboard.id,
                         user: currentUser,

--- a/src/app/components/navigation/IsaacApp.tsx
+++ b/src/app/components/navigation/IsaacApp.tsx
@@ -40,7 +40,10 @@ import {
     KEY,
     showNotification,
     isTutorOrAbove,
-    PATHS
+    PATHS,
+    isAda,
+    isTeacherOrAbove,
+    isVerified
 } from "../../services"
 import {Generic} from "../pages/Generic";
 import {ServerError} from "../pages/ServerError";
@@ -110,7 +113,8 @@ export const IsaacApp = () => {
         dispatch(fetchGlossaryTerms());
     }, [dispatch]);
 
-    const loggedInUserId = isLoggedIn(user) ? user.id : undefined;
+    const requiresVerification = isAda ? isTeacherOrAbove(user) && !isVerified(user) : false;
+    const loggedInUserId = isLoggedIn(user) && !requiresVerification ? user.id : undefined;
     useEffect(() => {
         if (loggedInUserId) {
             dispatch(requestNotifications());

--- a/src/app/components/navigation/NavigationBar.tsx
+++ b/src/app/components/navigation/NavigationBar.tsx
@@ -26,7 +26,9 @@ import {
     partitionCompleteAndIncompleteQuizzes,
     isLoggedIn,
     isPhy,
-    siteSpecific
+    siteSpecific,
+    isTeacherOrAbove,
+    isVerified
 } from "../../services";
 import {RenderNothing} from "../elements/RenderNothing";
 import classNames from "classnames";
@@ -87,8 +89,9 @@ export function MenuBadge({count, message, ...rest}: {count: number, message: st
 export function useAssignmentsCount() {
     const user = useAppSelector(selectors.user.orNull);
 
-    // Only fetches assignments if the user is logged in, and refetch on login/logout, reconnect.
-    const queryArg = user?.loggedIn ? undefined : skipToken;
+    // Only fetches assignments if the user is logged in (not including Ada partial logins), and refetch on login/logout, reconnect.
+    const requiresVerification = isAda ? isTeacherOrAbove(user) && !isVerified(user) : false;
+    const queryArg = user?.loggedIn && !requiresVerification ? undefined : skipToken;
     // We should add refetchOnFocus: true if we want to refetch on browser focus - hard to say if this is a good idea or not.
     const queryOptions = {refetchOnMountOrArgChange: true, refetchOnReconnect: true};
     const {data: quizAssignments} = useGetQuizAssignmentsAssignedToMeQuery(queryArg, queryOptions);

--- a/src/app/components/navigation/TrackedRoute.tsx
+++ b/src/app/components/navigation/TrackedRoute.tsx
@@ -4,8 +4,10 @@ import {FigureNumberingContext, PotentialUser} from "../../../IsaacAppTypes";
 import {ShowLoading} from "../handlers/ShowLoading";
 import {selectors, useAppSelector} from "../../state";
 import {
+    isAda,
     isTeacherOrAbove,
     isTutorOrAbove,
+    isVerified,
     KEY,
     persistence,
     TEACHER_REQUEST_ROUTE,
@@ -41,18 +43,20 @@ export const TrackedRoute = function({component, componentProps, ...rest}: Track
                 const propsWithUser = {user, ...props};
                 const userNeedsToBeTutorOrTeacher = rest.ifUser && [isTutorOrAbove.name, isTeacherOrAbove.name].includes(rest.ifUser.name); // TODO we should try to find a more robust way than this
                 return <ShowLoading until={user}>
-                    {user && ifUser(user) ?
-                        <WrapperComponent component={component} {...propsWithUser} {...componentProps} /> :
-                        user && !user.loggedIn && !isTutorOrAbove(user) && userNeedsToBeTutorOrTeacher ?
-                            persistence.save(KEY.AFTER_AUTH_PATH, props.location.pathname + props.location.search) && <Redirect to="/login"/>
-                            :
-                            user && !isTutorOrAbove(user) && userNeedsToBeTutorOrTeacher ?
-                                <Redirect to={TEACHER_REQUEST_ROUTE}/>
+                    {isAda && user && isTeacherOrAbove(user) && !isVerified(user) && ifUser.name ? 
+                        <Redirect to="/register/verify"/> :
+                        user && ifUser(user) ?
+                            <WrapperComponent component={component} {...propsWithUser} {...componentProps} /> :
+                            user && !user.loggedIn && !isTutorOrAbove(user) && userNeedsToBeTutorOrTeacher ?
+                                persistence.save(KEY.AFTER_AUTH_PATH, props.location.pathname + props.location.search) && <Redirect to="/login"/>
                                 :
-                                user && user.loggedIn && !ifUser(user) ?
-                                    <Unauthorised/>
+                                user && !isTutorOrAbove(user) && userNeedsToBeTutorOrTeacher ?
+                                    <Redirect to={TEACHER_REQUEST_ROUTE}/>
                                     :
-                                    persistence.save(KEY.AFTER_AUTH_PATH, props.location.pathname + props.location.search + props.location.hash) && <Redirect to="/login"/>
+                                    user && user.loggedIn && !ifUser(user) ?
+                                        <Unauthorised/>
+                                        :
+                                        persistence.save(KEY.AFTER_AUTH_PATH, props.location.pathname + props.location.search + props.location.hash) && <Redirect to="/login"/>
                     }
                 </ShowLoading>;
             }}/>;

--- a/src/app/services/user.ts
+++ b/src/app/services/user.ts
@@ -47,6 +47,10 @@ export function isAdminOrEventManager(user?: {readonly role?: UserRole, readonly
     return isAdmin(user) || isEventManager(user);
 }
 
+export function isVerified(user?: {readonly role?: UserRole, readonly loggedIn?: boolean, readonly emailVerificationStatus?: string} | null): boolean {
+    return isDefined(user) && (user.emailVerificationStatus === "VERIFIED");
+}
+
 export const roleRequirements: Record<UserRole, (u: {readonly role?: UserRole, readonly loggedIn?: boolean} | null) => boolean> = {
     "STUDENT": isStudent,
     "TUTOR": isTutorOrAbove,

--- a/src/app/state/actions/index.tsx
+++ b/src/app/state/actions/index.tsx
@@ -5,7 +5,10 @@ import {
     API_REQUEST_FAILURE_MESSAGE,
     DOCUMENT_TYPE, FIRST_LOGIN_STATE,
     history,
+    isAda,
     isFirstLoginInPersistence,
+    isTeacherOrAbove,
+    isVerified,
     KEY,
     persistence,
     QUESTION_ATTEMPT_THROTTLED_MESSAGE,
@@ -183,10 +186,13 @@ export const requestCurrentUser = () => async (dispatch: Dispatch<Action>) => {
         // Request the user
         const currentUser = await api.users.getCurrent();
         // Now with that information request auth settings and preferences asynchronously
-        await Promise.all([
-            dispatch(getUserAuthSettings() as any),
-            dispatch(getUserPreferences() as any)
-        ]);
+        const requiresVerification = isAda ? isTeacherOrAbove(currentUser.data) && !isVerified(currentUser.data) : false;
+        if (!requiresVerification) {
+            await Promise.all([
+                dispatch(getUserAuthSettings() as any),
+                dispatch(getUserPreferences() as any)
+            ]);
+        }
         dispatch({type: ACTION_TYPE.CURRENT_USER_RESPONSE_SUCCESS, user: currentUser.data});
     } catch (e) {
         dispatch({type: ACTION_TYPE.CURRENT_USER_RESPONSE_FAILURE});


### PR DESCRIPTION
Modifies TrackedRoute such that, for Ada teachers only, if they are accessing a page that requires an account and are not verified, they are redirected to the verification page.

Also adds verification checks to question attempts, navigation bar requests (e.g. indicator of num. of tests set), and other user requests to prevent warning toasts.