### PR TITLE
Redirect to /verify on unverified teacher login

### DIFF
--- a/src/app/state/actions/index.tsx
+++ b/src/app/state/actions/index.tsx
@@ -349,7 +349,9 @@ export const logInUser = (provider: AuthenticationProvider, credentials: Credent
                 return;
             } else if (result.data.EMAIL_VERIFICATION_REQUIRED) {
                 // Email verification is required for this user
-                history.push("/register/verify")
+                history.push("/register/verify");
+                // A partial login is still "successful", though we are unable to request user preferences and auth settings
+                dispatch({type: ACTION_TYPE.USER_LOG_IN_RESPONSE_SUCCESS, user: result.data});
                 return;
             }
         }


### PR DESCRIPTION
The dispatch allows the rest of the site to load as if they were logged in, and we can later infer that we should redirect to the verify page if they try to do something that requires a ("full", i.e. verified) account as the session cookie notes that the verification is incomplete.