### PR TITLE
Prevent symbolic question response resetting on reload

### DIFF
--- a/src/app/components/content/IsaacSymbolicQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicQuestion.tsx
@@ -106,7 +106,11 @@ const IsaacSymbolicQuestion = ({doc, questionId, readonly}: IsaacQuestionProps<I
     const updateState = (state: any) => {
         const newState = sanitiseInequalityState(state);
         const pythonExpression = newState?.result?.python || "";
-        dispatchSetCurrentAttempt({type: 'formula', value: JSON.stringify(newState), pythonExpression});
+        if (state.userInput !== "" || modalVisible) {
+            // Only call dispatch if the user has inputted text or is interacting with the modal
+            // Otherwise this causes the response to reset on reload removing the banner
+            dispatchSetCurrentAttempt({type: 'formula', value: JSON.stringify(newState), pythonExpression});
+        }
         initialEditorSymbols.current = state.symbols;
     };
 


### PR DESCRIPTION
When a user changes their input the response banner needs to be removed
to allow the user to reassess their attempt. This is done through
`dispatchSetCurrentAttempt` which sets `validationResponse` to
`undefined`.

The issue with symbolic questions is that there are two input types that
need to be kept in sync and both need to be able to set a current
attempt. Text input only does this when there is no input otherwise it
updates symbolic input's state. The symbolic input will always run the
dispatch when it's state changes.

However, the symbolic input's state is set on reload which triggered the
dispatch causing the brief flash of the banner. Adding conditions to
make sure that there has been a meaningful change prevents this.
