### PR TITLE
Fix reorder question overflow on Physics

### DIFF
--- a/src/app/components/content/IsaacReorderQuestion.tsx
+++ b/src/app/components/content/IsaacReorderQuestion.tsx
@@ -138,7 +138,7 @@ const IsaacReorderQuestion = ({doc, questionId, readonly} : IsaacQuestionProps<I
                             <div ref={provided.innerRef}
                                         className={classNames("parsons-items", {"empty": !(availableItems && availableItems.length > 0), "drag-over": snapshot.isDraggingOver})}>
                                 {availableItems && availableItems.map((item, index) =>
-                                    <ReorderDraggableItem key={index} item={item} index={index} inAvailableItems readonly={readonly}/>)}
+                                    <ReorderDraggableItem key={item.id} item={item} index={index} inAvailableItems readonly={readonly}/>)}
                                 {(!availableItems || availableItems.length === 0)
                                     ? <div>&nbsp;</div>
                                     : provided.placeholder}
@@ -153,7 +153,7 @@ const IsaacReorderQuestion = ({doc, questionId, readonly} : IsaacQuestionProps<I
                             <div id="parsons-choice-area" ref={provided.innerRef}
                                         className={classNames("parsons-items", {"empty": !(currentAttempt && currentAttempt.items && currentAttempt.items.length > 0), "drag-over": snapshot.isDraggingOver})}>
                                 {currentAttempt && currentAttempt.items && currentAttempt.items.map((item, index) =>
-                                    <ReorderDraggableItem key={index} item={item} index={index} readonly={readonly}/>)}
+                                    <ReorderDraggableItem key={item.id} item={item} index={index} readonly={readonly}/>)}
                                 {(!currentAttempt || currentAttempt?.items?.length === 0)
                                     ? <div className="text-muted text-center">
                                         {readonly ? "No answer entered" : "Drag items across to build your answer"}

--- a/src/app/components/content/IsaacReorderQuestion.tsx
+++ b/src/app/components/content/IsaacReorderQuestion.tsx
@@ -29,10 +29,10 @@ const ReorderDraggableItem = ({item, index, inAvailableItems, readonly}: {item: 
                 <Markup trusted-markup-encoding={"html"}>
                     {item?.value ?? ""}
                 </Markup>
-            </div>
+            </div>;
         }}
-    </Draggable>
-}
+    </Draggable>;
+};
 
 const IsaacReorderQuestion = ({doc, questionId, readonly} : IsaacQuestionProps<IsaacReorderQuestionDTO>) => {
 
@@ -44,7 +44,7 @@ const IsaacReorderQuestion = ({doc, questionId, readonly} : IsaacQuestionProps<I
         if (!src || !dst) return;
         const srcItem = src.splice(fromIndex, 1)[0];
         dst.splice(toIndex, 0, srcItem);
-    }
+    };
 
     const onDragEnd = (result: DropResult) => {
         if (!result.source || !result.destination) {
@@ -78,14 +78,14 @@ const IsaacReorderQuestion = ({doc, questionId, readonly} : IsaacQuestionProps<I
         } else {
             console.error("Not sure how we got here...");
         }
-    }
+    };
 
     const onCurrentAttemptUpdate = (newCurrentAttempt?: Immutable<ItemChoiceDTO>, newAvailableItems?: Immutable<ItemDTO>[]) => {
         if (!newCurrentAttempt) {
             const defaultAttempt: ItemChoiceDTO = {
                 type: "itemChoice",
                 items: [],
-            }
+            };
             dispatchSetCurrentAttempt(defaultAttempt);
         }
         if (newCurrentAttempt) {
@@ -116,10 +116,11 @@ const IsaacReorderQuestion = ({doc, questionId, readonly} : IsaacQuestionProps<I
                 setAvailableItems(fixedAvailableItems);
             }
         }
-    }
+    };
 
     useEffect(() => {
         onCurrentAttemptUpdate(currentAttempt, availableItems);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [currentAttempt, availableItems]);
 
     return <div className="parsons-question">
@@ -137,7 +138,7 @@ const IsaacReorderQuestion = ({doc, questionId, readonly} : IsaacQuestionProps<I
                             <div ref={provided.innerRef}
                                         className={classNames("parsons-items", {"empty": !(availableItems && availableItems.length > 0), "drag-over": snapshot.isDraggingOver})}>
                                 {availableItems && availableItems.map((item, index) =>
-                                    <ReorderDraggableItem item={item} index={index} inAvailableItems readonly={readonly}/>)}
+                                    <ReorderDraggableItem key={index} item={item} index={index} inAvailableItems readonly={readonly}/>)}
                                 {(!availableItems || availableItems.length === 0)
                                     ? <div>&nbsp;</div>
                                     : provided.placeholder}
@@ -152,7 +153,7 @@ const IsaacReorderQuestion = ({doc, questionId, readonly} : IsaacQuestionProps<I
                             <div id="parsons-choice-area" ref={provided.innerRef}
                                         className={classNames("parsons-items", {"empty": !(currentAttempt && currentAttempt.items && currentAttempt.items.length > 0), "drag-over": snapshot.isDraggingOver})}>
                                 {currentAttempt && currentAttempt.items && currentAttempt.items.map((item, index) =>
-                                    <ReorderDraggableItem item={item} index={index} readonly={readonly}/>)}
+                                    <ReorderDraggableItem key={index} item={item} index={index} readonly={readonly}/>)}
                                 {(!currentAttempt || currentAttempt?.items?.length === 0)
                                     ? <div className="text-muted text-center">
                                         {readonly ? "No answer entered" : "Drag items across to build your answer"}
@@ -164,6 +165,6 @@ const IsaacReorderQuestion = ({doc, questionId, readonly} : IsaacQuestionProps<I
                 </Col>
             </DragDropContext>
         </Row>
-    </div>
+    </div>;
 };
 export default IsaacReorderQuestion;

--- a/src/app/components/content/QuizQuestion.tsx
+++ b/src/app/components/content/QuizQuestion.tsx
@@ -33,7 +33,7 @@ export const QuizQuestion = ({doc}: { doc: ApiTypes.QuestionDTO }) => {
 
     return <React.Fragment>
         <div className={
-            classnames("question-component p-md-5", {"parsons-layout": ["isaacParsonsQuestion", "isaacReorderQuestion"].includes(doc.type as string)})
+            classnames("question-component p-md-5", {"parsons-layout": isAda && ["isaacParsonsQuestion", "isaacReorderQuestion"].includes(doc.type as string)})
         }>
             {isAda && doc.id && <h3 className={"mb-3"}>Question {questionNumbers[doc.id]}</h3>}
 


### PR DESCRIPTION
Reorder questions overflow their container to provide more space to do the question.
This works well on Ada where there is an obvious animation to show that this is deliberate,
but looks weird on Physics where that animation does not exist.
Thus, this feature is now only on Ada.
