### PR TITLE
Fix hash links to accordions breaking browser stack

### DIFF
--- a/src/app/components/pages/Generic.tsx
+++ b/src/app/components/pages/Generic.tsx
@@ -41,10 +41,11 @@ export const Generic = withRouter(({pageIdOverride, match: {params}}: GenericPag
 
     useEffect(() => {
         if (hash) {
-            // location.hash is correct when we load the page, but since nothing is loaded yet it doesn't scroll anywhere.
+            // location.hash is correct when we load the page, but if nothing is loaded yet it doesn't scroll anywhere.
             // this waits until doc is loaded (see 'hash' definition) and then unsets/resets the hash to trigger the scroll again.
-            location.hash = '';
-            location.hash = hash;
+            // we use history.replaceState to avoid adding a browser history entry.
+            history.replaceState(undefined, '', '#');
+            history.replaceState(undefined, '', `#${hash}`);
         }
     }, [hash]);
 


### PR DESCRIPTION
When linking to a page with a hash anchor, if the content is loaded asynchronously the browser can attempt to jump to the hash location before it is loaded. The original solution to this was to trigger a rescroll to the hash once the content was loaded, but this inadvertantly added to the browser stack and thus occasionally broke the browser history stack buttons. 