### PR TITLE
Improve existing styling, bring back phy notification table

### DIFF
--- a/src/app/components/elements/inputs/CheckboxInput.tsx
+++ b/src/app/components/elements/inputs/CheckboxInput.tsx
@@ -20,7 +20,7 @@ export const StyledCheckbox = ({initialValue, ...props} : StyledCheckboxProps) =
                 setChecked(c => !c);
             }}/>
         </div>
-        {props.label && <label htmlFor={id} className={isPhy ? "pt-1" : ""} {...props.label.props}/>}
+        {props.label && <label htmlFor={id} className="pt-1" {...props.label.props}/>}
         <Spacer/>
     </div>;
 };

--- a/src/app/components/elements/inputs/CheckboxInput.tsx
+++ b/src/app/components/elements/inputs/CheckboxInput.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { Input, InputProps } from "reactstrap";
 import { v4 } from "uuid";
 import { Spacer } from "../Spacer";
-
+import { isPhy } from "../../../services";
 
 export interface StyledCheckboxProps extends InputProps {
     initialValue: boolean;
@@ -20,7 +20,7 @@ export const StyledCheckbox = ({initialValue, ...props} : StyledCheckboxProps) =
                 setChecked(c => !c);
             }}/>
         </div>
-        {props.label && <label htmlFor={id} {...props.label.props}/>}
+        {props.label && <label htmlFor={id} className={isPhy ? "pt-1" : ""} {...props.label.props}/>}
         <Spacer/>
     </div>;
 };

--- a/src/app/components/elements/inputs/UserEmailPreferencesInput.tsx
+++ b/src/app/components/elements/inputs/UserEmailPreferencesInput.tsx
@@ -108,13 +108,12 @@ export const UserEmailPreferencesInput = ({emailPreferences, setEmailPreferences
 export const useEmailPreferenceState = (initialEmailPreferences?: Nullable<UserEmailPreferences>): [Nullable<UserEmailPreferences>, Dispatch<SetStateAction<Nullable<UserEmailPreferences>>>] => {
     const defaults: UserEmailPreferences = {
         ASSIGNMENTS: true,
-        NEWS_AND_UPDATES: false,
-        EVENTS: false
+        NEWS_AND_UPDATES: undefined,
+        EVENTS: undefined
     };
 
     const [emailPreferences, _setEmailPreferences] = useState<Nullable<UserEmailPreferences>>({...defaults, ...initialEmailPreferences});
     const setEmailPreferences = (newEmailPreferences: Nullable<UserEmailPreferences> | ((ep: Nullable<UserEmailPreferences>) => Nullable<UserEmailPreferences>)) => {
-        console.log(newEmailPreferences);
         if (typeof newEmailPreferences === "function") {
             return _setEmailPreferences((old) => ({...defaults, ...(newEmailPreferences(old))}));
         }

--- a/src/app/components/elements/inputs/UserEmailPreferencesInput.tsx
+++ b/src/app/components/elements/inputs/UserEmailPreferencesInput.tsx
@@ -1,17 +1,19 @@
 import {StyledCheckbox} from "./CheckboxInput";
-import {FormGroup} from "reactstrap";
+import {FormGroup, Table} from "reactstrap";
 import React, {SetStateAction, useState} from "react";
 import {UserEmailPreferences} from "../../../../IsaacAppTypes";
-import {siteSpecific} from "../../../services";
+import {isPhy, siteSpecific} from "../../../services";
 import {Dispatch} from "react";
+import { TrueFalseRadioInput } from "./TrueFalseRadioInput";
 
 interface UserEmailPreferencesProps {
     emailPreferences: UserEmailPreferences | null | undefined;
     setEmailPreferences: (e: UserEmailPreferences) => void;
+    submissionAttempted?: boolean;
     idPrefix?: string;
 }
 
-export const UserEmailPreferencesInput = ({emailPreferences, setEmailPreferences, idPrefix="my-account-"}: UserEmailPreferencesProps) => {
+export const UserEmailPreferencesInput = ({emailPreferences, setEmailPreferences, submissionAttempted, idPrefix="my-account-"}: UserEmailPreferencesProps) => {
 
     const isaacEmailPreferenceDescriptions = {
         assignments: siteSpecific(
@@ -29,25 +31,78 @@ export const UserEmailPreferencesInput = ({emailPreferences, setEmailPreferences
     };
 
     return <FormGroup className="overflow-auto">
-        <StyledCheckbox initialValue={emailPreferences?.ASSIGNMENTS ?? false} id={`${idPrefix}assignments`}
-                        changeFunction={(checked) => setEmailPreferences({...emailPreferences, ASSIGNMENTS: checked})}
-                        label={<span><b>Assignments</b></span>}
-        />
-        <span className="d-block mb-4">{isaacEmailPreferenceDescriptions.assignments}</span>
+        {isPhy && submissionAttempted !== undefined ? <> {/* submissionAttempted should always exist on phy, just here for typing */}
+            <Table className="mb-0">
+                <thead>
+                    <tr>
+                        <th>Email type</th>
+                        <th className="d-none d-sm-table-cell">Description</th>
+                        <th className="text-center">Preference</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td className="form-required">Assignments</td>
+                        <td className="d-none d-sm-table-cell">
+                            {isaacEmailPreferenceDescriptions.assignments}
+                        </td>
+                        <td className="text-center">
+                            <TrueFalseRadioInput
+                                id={`${idPrefix}assignments`} stateObject={emailPreferences}
+                                propertyName="ASSIGNMENTS" setStateFunction={setEmailPreferences}
+                                submissionAttempted={submissionAttempted}
+                            />
+                        </td>
+                    </tr>
+                    <tr>
+                        <td className="form-required">News</td>
+                        <td className="d-none d-sm-table-cell">
+                            {isaacEmailPreferenceDescriptions.news}
+                        </td>
+                        <td className="text-center">
+                            <TrueFalseRadioInput
+                                id={`${idPrefix}news`} stateObject={emailPreferences}
+                                propertyName="NEWS_AND_UPDATES" setStateFunction={setEmailPreferences}
+                                submissionAttempted={submissionAttempted}
+                            />
+                        </td>
+                    </tr>
+                    {isPhy && <tr>
+                        <td className="form-required">Events</td>
+                        <td className="d-none d-sm-table-cell">
+                            {isaacEmailPreferenceDescriptions.events}
+                        </td>
+                        <td className="text-center">
+                            <TrueFalseRadioInput
+                                id={`${idPrefix}events`} stateObject={emailPreferences}
+                                propertyName="EVENTS" setStateFunction={setEmailPreferences}
+                                submissionAttempted={submissionAttempted}
+                            />
+                        </td>
+                    </tr>}
+                </tbody>
+            </Table>
+        </> : <>
+            <StyledCheckbox initialValue={emailPreferences?.ASSIGNMENTS ?? false} id={`${idPrefix}assignments`}
+                changeFunction={(checked) => setEmailPreferences({...emailPreferences, ASSIGNMENTS: checked})}
+                label={<span><b>Assignments</b></span>}
+            />
+            <span className="d-block mb-4">{isaacEmailPreferenceDescriptions.assignments}</span>
 
-        <StyledCheckbox initialValue={emailPreferences?.NEWS_AND_UPDATES ?? false} id={`${idPrefix}news`}
-                        changeFunction={(checked) => setEmailPreferences({...emailPreferences, NEWS_AND_UPDATES: checked})}
-                        label={<span><b>News</b></span>}
-        />
-        <span className="d-block mb-4">{isaacEmailPreferenceDescriptions.news}</span>
+            <StyledCheckbox initialValue={emailPreferences?.NEWS_AND_UPDATES ?? false} id={`${idPrefix}news`}
+                changeFunction={(checked) => setEmailPreferences({...emailPreferences, NEWS_AND_UPDATES: checked})}
+                label={<span><b>News</b></span>}
+            />
+            <span className="d-block mb-4">{isaacEmailPreferenceDescriptions.news}</span>
 
-        <StyledCheckbox initialValue={emailPreferences?.EVENTS ?? false} id={`${idPrefix}events`}
-                        changeFunction={(checked) => setEmailPreferences({...emailPreferences, EVENTS: checked})}
-                        label={<span><b>Events</b></span>}
-        />
-        <span className="d-block mb-4">{isaacEmailPreferenceDescriptions.events}</span>
-    </FormGroup>
-}
+            <StyledCheckbox initialValue={emailPreferences?.EVENTS ?? false} id={`${idPrefix}events`}
+                changeFunction={(checked) => setEmailPreferences({...emailPreferences, EVENTS: checked})}
+                label={<span><b>Events</b></span>}
+            />
+            <span className="d-block mb-4">{isaacEmailPreferenceDescriptions.events}</span>
+        </>}
+    </FormGroup>;
+};
 
 // Extended useState hook for email preferences, setting defaults
 export const useEmailPreferenceState = (initialEmailPreferences?: Nullable<UserEmailPreferences>): [Nullable<UserEmailPreferences>, Dispatch<SetStateAction<Nullable<UserEmailPreferences>>>] => {
@@ -55,7 +110,7 @@ export const useEmailPreferenceState = (initialEmailPreferences?: Nullable<UserE
         ASSIGNMENTS: true,
         NEWS_AND_UPDATES: false,
         EVENTS: false
-    }
+    };
 
     const [emailPreferences, _setEmailPreferences] = useState<Nullable<UserEmailPreferences>>({...defaults, ...initialEmailPreferences});
     const setEmailPreferences = (newEmailPreferences: Nullable<UserEmailPreferences> | ((ep: Nullable<UserEmailPreferences>) => Nullable<UserEmailPreferences>)) => {

--- a/src/app/components/elements/panels/MyAccountTab.tsx
+++ b/src/app/components/elements/panels/MyAccountTab.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { CardBody, Col, Container, Row } from "reactstrap";
-import { isPhy } from "../../../services";
+import { isAda, isPhy } from "../../../services";
+import classNames from "classnames";
 
 export interface MyAccountTabProps {
     leftColumn: React.ReactNode;
@@ -8,18 +9,18 @@ export interface MyAccountTabProps {
 }
 
 export const MyAccountTab = ({leftColumn, rightColumn} : MyAccountTabProps) => {
-    return <CardBody>
-        <Container className="px-0 px-lg-2">
+    return <CardBody className={classNames("px-4", {"px-sm-5": isAda})}>
+        <Container>
             {isPhy ? <Col className="px-0 px-lg-2">
                 {leftColumn}
                 <Row className="pt-4"/>
                 {rightColumn}
             </Col> :
             <Row>
-                <Col lg={6} className="pr-lg-4 px-0 px-lg-2">
+                <Col lg={6} className="pr-lg-4 px-0 pl-lg-2">
                     {leftColumn}
                 </Col>
-                <Col lg={6} className="pl-lg-4 px-0 px-lg-2 pt-4 pt-lg-0">
+                <Col lg={6} className="pl-lg-4 px-0 pl-lg-2 pt-4 pt-lg-0">
                     {rightColumn}
                 </Col>
             </Row>}

--- a/src/app/components/elements/panels/MyAccountTab.tsx
+++ b/src/app/components/elements/panels/MyAccountTab.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { CardBody, Col, Container, Row } from "reactstrap";
+import { isPhy } from "../../../services";
+
+export interface MyAccountTabProps {
+    leftColumn: React.ReactNode;
+    rightColumn: React.ReactNode;
+}
+
+export const MyAccountTab = ({leftColumn, rightColumn} : MyAccountTabProps) => {
+    return <CardBody>
+        <Container className="px-0 px-lg-2">
+            {isPhy ? <Col className="px-0 px-lg-2">
+                {leftColumn}
+                <Row className="pt-4"/>
+                {rightColumn}
+            </Col> :
+            <Row>
+                <Col lg={6} className="pr-lg-4 px-0 px-lg-2">
+                    {leftColumn}
+                </Col>
+                <Col lg={6} className="pl-lg-4 px-0 px-lg-2 pt-4 pt-lg-0">
+                    {rightColumn}
+                </Col>
+            </Row>}
+        </Container>
+    </CardBody>;
+};

--- a/src/app/components/elements/panels/TeacherConnections.tsx
+++ b/src/app/components/elements/panels/TeacherConnections.tsx
@@ -36,6 +36,7 @@ import {
 } from "../modals/TeacherConnectionModalCreators";
 import { FixedSizeList } from "react-window";
 import { Spacer } from "../Spacer";
+import { MyAccountTab } from "./MyAccountTab";
 
 const CONNECTIONS_ROW_HEIGHT = 40;
 const CONNECTIONS_MAX_VISIBLE_ROWS = 10;
@@ -154,215 +155,211 @@ export const TeacherConnections = ({user, authToken, editingOtherUser, userToEdi
         }
     }
 
-    return <RS.CardBody>
-        <RS.Container>
-            <RS.Row>
-                <RS.Col lg={isAda ? 6 : 12}>
-                    <h3>Connect to your teacher</h3>
-                    <PageFragment fragmentId={`teacher_connections_help_${isTutorOrAbove(user) ? "teacher" : "student"}`} ifNotFound={RenderNothing} />
-                </RS.Col>
-                <RS.Col lg={isAda ? 6 : 12} className="mt-4 mt-lg-0">
-                    <h3>
-                        <span>Teacher connections<span id="teacher-connections-title" className="icon-help" /></span>
-                        <RS.UncontrolledTooltip placement="bottom" target="teacher-connections-title">
-                            The teachers that you are connected to can view your {siteSpecific("Isaac", "Ada")} assignment progress.
-                        </RS.UncontrolledTooltip>
-                    </h3>
-                    <p>Enter the code given by your teacher to create a teacher connection and join a group.</p>
-                    {/* TODO Need to handle nested form complaint */}
-                    <RS.Form onSubmit={processToken}>
-                        <RS.InputGroup className={"separate-input-group mb-4 d-flex flex-row justify-content-center"}>
-                            <RS.Input
-                                type="text" placeholder="Enter your code in here" value={authToken || undefined} className="py-4"
-                                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setAuthenticationToken(e.target.value)}
-                            />
-                            <RS.InputGroupAddon addonType="append">
-                                <RS.Button onClick={processToken} className={classNames("py-2", {"px-0 border-dark": isPhy})} color="secondary" outline disabled={editingOtherUser}>
-                                    Connect
-                                </RS.Button>
-                            </RS.InputGroupAddon>
-                        </RS.InputGroup>
-                    </RS.Form>
+    return <MyAccountTab 
+        leftColumn={<>
+            <h3>Connect to your teacher</h3>
+            <PageFragment fragmentId={`teacher_connections_help_${isTutorOrAbove(user) ? "teacher" : "student"}`} ifNotFound={RenderNothing} />
+        </>}
+        rightColumn={<>
+            <h3>
+                <span>Teacher connections<span id="teacher-connections-title" className="icon-help" /></span>
+                <RS.UncontrolledTooltip placement="bottom" target="teacher-connections-title">
+                    The teachers that you are connected to can view your {siteSpecific("Isaac", "Ada")} assignment progress.
+                </RS.UncontrolledTooltip>
+            </h3>
+            <p>Enter the code given by your teacher to create a teacher connection and join a group.</p>
+            {/* TODO Need to handle nested form complaint */}
+            <RS.Form onSubmit={processToken}>
+                <RS.InputGroup className={"separate-input-group mb-4 d-flex flex-row justify-content-center"}>
+                    <RS.Input
+                        type="text" placeholder="Enter your code in here" value={authToken || undefined} className="py-4"
+                        onChange={(e: React.ChangeEvent<HTMLInputElement>) => setAuthenticationToken(e.target.value)}
+                    />
+                    <RS.InputGroupAddon addonType="append">
+                        <RS.Button onClick={processToken} className={classNames("py-2", {"px-0 border-dark": isPhy})} color="secondary" outline disabled={editingOtherUser}>
+                            Connect
+                        </RS.Button>
+                    </RS.InputGroupAddon>
+                </RS.InputGroup>
+            </RS.Form>
 
-                    <div className="connect-list">
-                        <ConnectionsHeader title="Teacher connections" enableSearch={enableTeacherSearch} setEnableSearch={setEnableTeacherSearch} setSearchText={setTeacherSearchText}/>
-                        <div className="connect-list-inner">
-                            <ul className={classNames("teachers-connected list-unstyled my-0", {"ml-3 mr-2": isPhy}, {"ml-1 mr-2": isAda})}>
-                                <FixedSizeList height={CONNECTIONS_ROW_HEIGHT * (Math.min(CONNECTIONS_MAX_VISIBLE_ROWS, filteredActiveAuthorisations?.length ?? 0))} itemCount={filteredActiveAuthorisations?.length ?? 0} itemSize={CONNECTIONS_ROW_HEIGHT} width="100%" style={{scrollbarGutter: "stable"}}>
-                                    {({index, style}) => {
-                                        const teacherAuthorisation = filteredActiveAuthorisations?.[index];
-                                        if (!teacherAuthorisation) {
-                                            return null;
-                                        }
-                                        return <React.Fragment key={teacherAuthorisation.id}>
-                                        <li style={style} className="py-2">
-                                            <span className="icon-person-active" />
-                                            <span id={`teacher-authorisation-${teacherAuthorisation.id}`}>
-                                                {extractTeacherName(teacherAuthorisation)}
-                                            </span>
-                                            <RS.UncontrolledTooltip
-                                                placement="bottom" target={`teacher-authorisation-${teacherAuthorisation.id}`}
-                                                >
-                                                This user ({teacherAuthorisation.email}) has access to your data.
-                                                To remove this access, click &apos;Revoke&apos;.
-                                            </RS.UncontrolledTooltip>
-                                            <RS.Button
-                                                color="link" className="revoke-teacher pr-1"
-                                                disabled={editingOtherUser}
-                                                onClick={() => user.loggedIn && user.id && dispatch(openActiveModal(revocationConfirmationModal(user.id, teacherAuthorisation)))}
-                                                >
-                                                Revoke
-                                            </RS.Button>
-                                        </li>
-                                    </React.Fragment>;
-                                    }}
-                                </FixedSizeList>
-                            </ul>
-                            {activeAuthorisations && activeAuthorisations.length === 0 && <p className="teachers-connected">
-                                You have no active teacher connections.
-                            </p>}
-                        </div>
-                    </div>
-
-                    {isLoggedIn(user) && !isStudent(user) && <React.Fragment>
-                        <hr className={siteSpecific("my-5", "my-4")} />
-                        <h3>
-                            <span>Your student connections<span id="student-connections-title" className="icon-help" /></span>
-                            <RS.UncontrolledTooltip placement="bottom" target="student-connections-title">
-                                These are the students who have shared their {siteSpecific("Isaac", "Ada")} data with you.
-                                These students are also able to view your name and email address on their Teacher connections page.
-                            </RS.UncontrolledTooltip>
-                        </h3>
-                        <p>
-                            You can invite students to share their {siteSpecific("Isaac", "Ada")} data with you through the {" "}
-                            <Link to="/groups">{siteSpecific("group management page", "Manage groups")}</Link>{siteSpecific(".", " page.")}
-                        </p>
-                        <div className="connect-list">
-                            <ConnectionsHeader title="Student connections" enableSearch={enableStudentSearch} setEnableSearch={setEnableStudentSearch} setSearchText={setStudentSearchText}/>
-                            <div className="connect-list-inner">
-                                <ul className={classNames("teachers-connected list-unstyled my-0", {"ml-3 mr-2": isPhy}, {"ml-1 mr-2": isAda})}>
-                                    <FixedSizeList height={CONNECTIONS_ROW_HEIGHT * (Math.min(CONNECTIONS_MAX_VISIBLE_ROWS, filteredStudentAuthorisations?.length ?? 0))} itemCount={filteredStudentAuthorisations?.length ?? 0} itemSize={CONNECTIONS_ROW_HEIGHT} width="100%" style={{scrollbarGutter: "stable"}}>
-                                        {({index, style}) => {
-                                            const student = filteredStudentAuthorisations?.[index];
-                                            if (!student) {
-                                                return null;
-                                            }
-                                            return <li key={student.id} style={style} className="py-2">
-                                                <span className="icon-person-active" />
-                                                <span id={`student-authorisation-${student.id}`}>
-                                                    {student.givenName} {student.familyName}
-                                                </span>
-                                                <RS.UncontrolledTooltip
-                                                    placement="bottom" target={`student-authorisation-${student.id}`}
-                                                >
-                                                    You have access to this user&apos;s data and they can see your name and email address.
-                                                    To remove this access, click &apos;Remove&apos;.
-                                                </RS.UncontrolledTooltip>
-                                                <RS.Button
-                                                    color="link" className="revoke-teacher pr-1" disabled={editingOtherUser}
-                                                    onClick={() => user.loggedIn && user.id && dispatch(openActiveModal(releaseConfirmationModal(user.id, student)))}
-                                                >
-                                                    Remove
-                                                </RS.Button>
-                                            </li>;
-                                        }}
-                                    </FixedSizeList>
-                                </ul>
-
-                                {studentAuthorisations && studentAuthorisations.length === 0 && <p className="teachers-connected">
-                                    You have no active student connections.
-                                </p>}
-                            </div>
-                            {studentAuthorisations && studentAuthorisations.length > 0 && <p className="remove-link">
-                                <RS.Button color="link" onClick={() => dispatch(openActiveModal(releaseAllConfirmationModal()))} disabled={editingOtherUser}>
-                                    Remove all
-                                </RS.Button>
-                            </p>}
-                        </div>
-                    </React.Fragment>}
-
-                    <hr className={siteSpecific("my-5", "my-4")} />
-                    <h3>
-                        <span>
-                            Your group memberships
-                            <span id="group-memberships-title" className="icon-help" />
-                        </span>
-                        <RS.UncontrolledTooltip placement="bottom" target="group-memberships-title">
-                            These are the groups you are currently a member of.
-                            Groups on {siteSpecific("Isaac", "Ada")} let teachers set assignments to multiple students in one go.
-                        </RS.UncontrolledTooltip>
-                    </h3>
-                    <p>
-                        You can manage who is able to set you assignments by temporarily leaving a group. While you are
-                        inactive in a group you won&apos;t receive any assignments from that group.<br/>
-                        If you want to permanently leave a group, ask your teacher to remove you.
-                    </p>
-                    <div className="my-groups-table-section overflow-auto">
-                        <div className="connect-list">
-                            <ConnectionsHeader title="Group memberships" enableSearch={enableGroupSearch} setEnableSearch={setEnableGroupSearch} setSearchText={setGroupSearchText}/>
-                            <div className="connect-list-inner">
-                                <ul className={classNames("teachers-connected list-unstyled m-0")}>
-                                    {sortedGroupMemberships && <FixedSizeList height={MEMBERSHIPS_ROW_HEIGHT * (Math.min(MEMBERSHIPS_MAX_VISIBLE_ROWS, sortedGroupMemberships.length ?? 0))} itemCount={sortedGroupMemberships.length ?? 0} itemSize={MEMBERSHIPS_ROW_HEIGHT} width="100%" style={{scrollbarGutter: "stable"}}>
-                                        {({index, style}) => {
-                                            const membership = sortedGroupMemberships[index];
-                                            return <li key={index} style={style} className={classNames("py-2", {"inactive-group" : isAda && membership.membershipStatus === MEMBERSHIP_STATUS.INACTIVE})}>
-                                                <div className="d-flex">
-                                                    <RS.Col>
-                                                        {membership.membershipStatus === MEMBERSHIP_STATUS.INACTIVE ?
-                                                            <span className="text-muted"><b>{(membership.group.groupName ?? "Group " + membership.group.id)}</b>{" ("}<i>inactive</i>{")"}</span>
-                                                            :
-                                                            <span><b>{(membership.group.groupName ?? "Group " + membership.group.id)}</b></span>
-                                                        }
-                                                        <br/>
-                                                        {membership.group.ownerSummary && 
-                                                            <span className="text-muted">Teacher{membership.group.additionalManagers && membership.group.additionalManagers.length > 0 ? "s" : ""}: {
-                                                            [membership.group.ownerSummary, ...membership.group.additionalManagers ?? []].map(extractTeacherName).join(", ")
-                                                        }</span>}
-                                                    </RS.Col>
-                                                    <RS.Col className="d-flex flex-col justify-content-end flex-grow-0 pr-1">
-                                                        {membership.membershipStatus === MEMBERSHIP_STATUS.ACTIVE && <React.Fragment>
-                                                            <RS.Button color="link" disabled={editingOtherUser} onClick={() =>
-                                                                changeMyMembershipStatus({groupId: membership.group.id as number, newStatus: MEMBERSHIP_STATUS.INACTIVE})
-                                                            }>
-                                                                Leave
-                                                            </RS.Button>
-                                                            {isPhy && <>
-                                                                <span id={`leave-group-action-${membership.group.id}`} className="icon-help membership-status-help-button" />
-                                                                <RS.UncontrolledTooltip placement="bottom" target={`leave-group-action-${membership.group.id}`}
-                                                                                        modifiers={{preventOverflow: {boundariesElement: "viewport"}}}>
-                                                                    If you leave a group you will no longer receive notifications of new assignments.
-                                                                </RS.UncontrolledTooltip>
-                                                            </>}
-                                                        </React.Fragment>}
-
-                                                        {membership.membershipStatus === MEMBERSHIP_STATUS.INACTIVE && <React.Fragment>
-                                                            <RS.Button color="link" disabled={editingOtherUser} onClick={() =>
-                                                                changeMyMembershipStatus({groupId: membership.group.id as number, newStatus: MEMBERSHIP_STATUS.ACTIVE})
-                                                            }>
-                                                                Rejoin
-                                                            </RS.Button>
-                                                            {isPhy && <>
-                                                                <span id={`rejoin-group-action-${membership.group.id}`} className="icon-help membership-status-help-button" />
-                                                                <RS.UncontrolledTooltip placement="bottom" target={`rejoin-group-action-${membership.group.id}`}
-                                                                                        modifiers={{preventOverflow: {boundariesElement: "viewport"}}}>
-                                                                    If you rejoin a group you will see all the assignments set since the group was created.
-                                                                </RS.UncontrolledTooltip>
-                                                            </>}
-                                                        </React.Fragment>}
-                                                    </RS.Col>
-                                                </div>
-                                            </li>;
-                                        }}
-                                    </FixedSizeList>}
-                                </ul>
-                            </div>
-                        </div>
-                    </div>
-                    {groupMemberships && groupMemberships.length === 0 && <p className="teachers-connected text-center">
-                        You are not a member of any groups.
+            <div className="connect-list">
+                <ConnectionsHeader title="Teacher connections" enableSearch={enableTeacherSearch} setEnableSearch={setEnableTeacherSearch} setSearchText={setTeacherSearchText}/>
+                <div className="connect-list-inner">
+                    <ul className={classNames("teachers-connected list-unstyled my-0", {"ml-3 mr-2": isPhy}, {"ml-1 mr-2": isAda})}>
+                        <FixedSizeList height={CONNECTIONS_ROW_HEIGHT * (Math.min(CONNECTIONS_MAX_VISIBLE_ROWS, filteredActiveAuthorisations?.length ?? 0))} itemCount={filteredActiveAuthorisations?.length ?? 0} itemSize={CONNECTIONS_ROW_HEIGHT} width="100%" style={{scrollbarGutter: "stable"}}>
+                            {({index, style}) => {
+                                const teacherAuthorisation = filteredActiveAuthorisations?.[index];
+                                if (!teacherAuthorisation) {
+                                    return null;
+                                }
+                                return <React.Fragment key={teacherAuthorisation.id}>
+                                <li style={style} className="py-2">
+                                    <span className="icon-person-active" />
+                                    <span id={`teacher-authorisation-${teacherAuthorisation.id}`}>
+                                        {extractTeacherName(teacherAuthorisation)}
+                                    </span>
+                                    <RS.UncontrolledTooltip
+                                        placement="bottom" target={`teacher-authorisation-${teacherAuthorisation.id}`}
+                                        >
+                                        This user ({teacherAuthorisation.email}) has access to your data.
+                                        To remove this access, click &apos;Revoke&apos;.
+                                    </RS.UncontrolledTooltip>
+                                    <RS.Button
+                                        color="link" className="revoke-teacher pr-1"
+                                        disabled={editingOtherUser}
+                                        onClick={() => user.loggedIn && user.id && dispatch(openActiveModal(revocationConfirmationModal(user.id, teacherAuthorisation)))}
+                                        >
+                                        Revoke
+                                    </RS.Button>
+                                </li>
+                            </React.Fragment>;
+                            }}
+                        </FixedSizeList>
+                    </ul>
+                    {activeAuthorisations && activeAuthorisations.length === 0 && <p className="teachers-connected">
+                        You have no active teacher connections.
                     </p>}
-                </RS.Col>
-            </RS.Row>
-        </RS.Container>
-    </RS.CardBody>;
+                </div>
+            </div>
+
+            {isLoggedIn(user) && !isStudent(user) && <React.Fragment>
+                <hr className={siteSpecific("my-5", "my-4")} />
+                <h3>
+                    <span>Your student connections<span id="student-connections-title" className="icon-help" /></span>
+                    <RS.UncontrolledTooltip placement="bottom" target="student-connections-title">
+                        These are the students who have shared their {siteSpecific("Isaac", "Ada")} data with you.
+                        These students are also able to view your name and email address on their Teacher connections page.
+                    </RS.UncontrolledTooltip>
+                </h3>
+                <p>
+                    You can invite students to share their {siteSpecific("Isaac", "Ada")} data with you through the {" "}
+                    <Link to="/groups">{siteSpecific("group management page", "Manage groups")}</Link>{siteSpecific(".", " page.")}
+                </p>
+                <div className="connect-list">
+                    <ConnectionsHeader title="Student connections" enableSearch={enableStudentSearch} setEnableSearch={setEnableStudentSearch} setSearchText={setStudentSearchText}/>
+                    <div className="connect-list-inner">
+                        <ul className={classNames("teachers-connected list-unstyled my-0", {"ml-3 mr-2": isPhy}, {"ml-1 mr-2": isAda})}>
+                            <FixedSizeList height={CONNECTIONS_ROW_HEIGHT * (Math.min(CONNECTIONS_MAX_VISIBLE_ROWS, filteredStudentAuthorisations?.length ?? 0))} itemCount={filteredStudentAuthorisations?.length ?? 0} itemSize={CONNECTIONS_ROW_HEIGHT} width="100%" style={{scrollbarGutter: "stable"}}>
+                                {({index, style}) => {
+                                    const student = filteredStudentAuthorisations?.[index];
+                                    if (!student) {
+                                        return null;
+                                    }
+                                    return <li key={student.id} style={style} className="py-2">
+                                        <span className="icon-person-active" />
+                                        <span id={`student-authorisation-${student.id}`}>
+                                            {student.givenName} {student.familyName}
+                                        </span>
+                                        <RS.UncontrolledTooltip
+                                            placement="bottom" target={`student-authorisation-${student.id}`}
+                                        >
+                                            You have access to this user&apos;s data and they can see your name and email address.
+                                            To remove this access, click &apos;Remove&apos;.
+                                        </RS.UncontrolledTooltip>
+                                        <RS.Button
+                                            color="link" className="revoke-teacher pr-1" disabled={editingOtherUser}
+                                            onClick={() => user.loggedIn && user.id && dispatch(openActiveModal(releaseConfirmationModal(user.id, student)))}
+                                        >
+                                            Remove
+                                        </RS.Button>
+                                    </li>;
+                                }}
+                            </FixedSizeList>
+                        </ul>
+
+                        {studentAuthorisations && studentAuthorisations.length === 0 && <p className="teachers-connected">
+                            You have no active student connections.
+                        </p>}
+                    </div>
+                    {studentAuthorisations && studentAuthorisations.length > 0 && <p className="remove-link">
+                        <RS.Button color="link" onClick={() => dispatch(openActiveModal(releaseAllConfirmationModal()))} disabled={editingOtherUser}>
+                            Remove all
+                        </RS.Button>
+                    </p>}
+                </div>
+            </React.Fragment>}
+
+            <hr className={siteSpecific("my-5", "my-4")} />
+            <h3>
+                <span>
+                    Your group memberships
+                    <span id="group-memberships-title" className="icon-help" />
+                </span>
+                <RS.UncontrolledTooltip placement="bottom" target="group-memberships-title">
+                    These are the groups you are currently a member of.
+                    Groups on {siteSpecific("Isaac", "Ada")} let teachers set assignments to multiple students in one go.
+                </RS.UncontrolledTooltip>
+            </h3>
+            <p>
+                You can manage who is able to set you assignments by temporarily leaving a group. While you are
+                inactive in a group you won&apos;t receive any assignments from that group.<br/>
+                If you want to permanently leave a group, ask your teacher to remove you.
+            </p>
+            <div className="my-groups-table-section overflow-auto">
+                <div className="connect-list">
+                    <ConnectionsHeader title="Group memberships" enableSearch={enableGroupSearch} setEnableSearch={setEnableGroupSearch} setSearchText={setGroupSearchText}/>
+                    <div className="connect-list-inner">
+                        <ul className={classNames("teachers-connected list-unstyled m-0")}>
+                            {sortedGroupMemberships && <FixedSizeList height={MEMBERSHIPS_ROW_HEIGHT * (Math.min(MEMBERSHIPS_MAX_VISIBLE_ROWS, sortedGroupMemberships.length ?? 0))} itemCount={sortedGroupMemberships.length ?? 0} itemSize={MEMBERSHIPS_ROW_HEIGHT} width="100%" style={{scrollbarGutter: "stable"}}>
+                                {({index, style}) => {
+                                    const membership = sortedGroupMemberships[index];
+                                    return <li key={index} style={style} className={classNames("py-2", {"inactive-group" : isAda && membership.membershipStatus === MEMBERSHIP_STATUS.INACTIVE})}>
+                                        <div className="d-flex">
+                                            <RS.Col>
+                                                {membership.membershipStatus === MEMBERSHIP_STATUS.INACTIVE ?
+                                                    <span className="text-muted"><b>{(membership.group.groupName ?? "Group " + membership.group.id)}</b>{" ("}<i>inactive</i>{")"}</span>
+                                                    :
+                                                    <span><b>{(membership.group.groupName ?? "Group " + membership.group.id)}</b></span>
+                                                }
+                                                <br/>
+                                                {membership.group.ownerSummary && 
+                                                    <span className="text-muted">Teacher{membership.group.additionalManagers && membership.group.additionalManagers.length > 0 ? "s" : ""}: {
+                                                    [membership.group.ownerSummary, ...membership.group.additionalManagers ?? []].map(extractTeacherName).join(", ")
+                                                }</span>}
+                                            </RS.Col>
+                                            <RS.Col className="d-flex flex-col justify-content-end flex-grow-0 pr-1">
+                                                {membership.membershipStatus === MEMBERSHIP_STATUS.ACTIVE && <React.Fragment>
+                                                    <RS.Button color="link" disabled={editingOtherUser} onClick={() =>
+                                                        changeMyMembershipStatus({groupId: membership.group.id as number, newStatus: MEMBERSHIP_STATUS.INACTIVE})
+                                                    }>
+                                                        Leave
+                                                    </RS.Button>
+                                                    {isPhy && <>
+                                                        <span id={`leave-group-action-${membership.group.id}`} className="icon-help membership-status-help-button" />
+                                                        <RS.UncontrolledTooltip placement="bottom" target={`leave-group-action-${membership.group.id}`}
+                                                                                modifiers={{preventOverflow: {boundariesElement: "viewport"}}}>
+                                                            If you leave a group you will no longer receive notifications of new assignments.
+                                                        </RS.UncontrolledTooltip>
+                                                    </>}
+                                                </React.Fragment>}
+
+                                                {membership.membershipStatus === MEMBERSHIP_STATUS.INACTIVE && <React.Fragment>
+                                                    <RS.Button color="link" disabled={editingOtherUser} onClick={() =>
+                                                        changeMyMembershipStatus({groupId: membership.group.id as number, newStatus: MEMBERSHIP_STATUS.ACTIVE})
+                                                    }>
+                                                        Rejoin
+                                                    </RS.Button>
+                                                    {isPhy && <>
+                                                        <span id={`rejoin-group-action-${membership.group.id}`} className="icon-help membership-status-help-button" />
+                                                        <RS.UncontrolledTooltip placement="bottom" target={`rejoin-group-action-${membership.group.id}`}
+                                                                                modifiers={{preventOverflow: {boundariesElement: "viewport"}}}>
+                                                            If you rejoin a group you will see all the assignments set since the group was created.
+                                                        </RS.UncontrolledTooltip>
+                                                    </>}
+                                                </React.Fragment>}
+                                            </RS.Col>
+                                        </div>
+                                    </li>;
+                                }}
+                            </FixedSizeList>}
+                        </ul>
+                    </div>
+                </div>
+            </div>
+            {groupMemberships && groupMemberships.length === 0 && <p className="teachers-connected text-center">
+                You are not a member of any groups.
+            </p>}
+        </>}
+    />;
 };

--- a/src/app/components/elements/panels/UserBetaFeatures.tsx
+++ b/src/app/components/elements/panels/UserBetaFeatures.tsx
@@ -1,31 +1,28 @@
 import React from "react";
 import { DisplaySettings } from "../../../../IsaacAppTypes";
-import { Button, CardBody, UncontrolledTooltip } from "reactstrap";
-import { SITE_TITLE, isAda } from "../../../services";
+import { SITE_TITLE } from "../../../services";
 import { StyledCheckbox } from "../inputs/CheckboxInput";
+import { MyAccountTab } from "./MyAccountTab";
 interface UserBetaFeaturesProps {
     displaySettings: DisplaySettings;
     setDisplaySettings: (ds: DisplaySettings | ((oldDs?: DisplaySettings) => DisplaySettings)) => void;
 }
 
 export const UserBetaFeatures = ({displaySettings, setDisplaySettings}: UserBetaFeaturesProps) => {
-    return <CardBody>
-        <p>
-            Here you can opt-in to beta features of the {SITE_TITLE} platform.
-        </p>
-        <StyledCheckbox type={"checkbox"} initialValue={displaySettings.HIDE_QUESTION_ATTEMPTS ?? false}
-            changeFunction={e => setDisplaySettings(
-                (oldDs) => ({...oldDs, HIDE_QUESTION_ATTEMPTS: e})
-            )} 
-            label={<>
-                Hide previous question attempts
-                <span id={`hide-previous-q-info`} className="icon-help mx-2" />
-                <UncontrolledTooltip placement="right-start" target={`hide-previous-q-info`}>
-                    This feature is helpful for revision, for example - you can attempt all of the questions
-                    on the website again, without seeing your previous answers.
-                </UncontrolledTooltip>
-            </>}
-            id={"hide-previous-q-attempts"}
-        />
-    </CardBody>;
+    return <MyAccountTab
+        leftColumn={<>
+            <h3>Beta Features</h3>
+            <p>Here you can opt-in to beta features of the {SITE_TITLE} platform.</p>
+        </>}
+        rightColumn={<>
+            <StyledCheckbox type={"checkbox"} initialValue={displaySettings.HIDE_QUESTION_ATTEMPTS ?? false}
+                changeFunction={e => setDisplaySettings(
+                    (oldDs) => ({...oldDs, HIDE_QUESTION_ATTEMPTS: e})
+                )} 
+                label={<p><b>Hide previous question attempts</b></p>}
+                id={"hide-previous-q-attempts"}
+            />
+            This feature is helpful for revision, for example - you can attempt all of the questions on the website again, without seeing your previous answers.
+        </>}
+    />;
 };

--- a/src/app/components/elements/panels/UserDetails.tsx
+++ b/src/app/components/elements/panels/UserDetails.tsx
@@ -137,5 +137,5 @@ export const UserDetails = (props: UserDetailsProps) => {
                 <BooleanNotationInput booleanNotation={booleanNotation} setBooleanNotation={setBooleanNotation} />
             </Col>
         </Row>}
-    </CardBody>
+    </CardBody>;
 };

--- a/src/app/components/elements/panels/UserEmailPreferencesPanel.tsx
+++ b/src/app/components/elements/panels/UserEmailPreferencesPanel.tsx
@@ -1,10 +1,10 @@
-import {CardBody, Col, Row} from "reactstrap";
 import React from "react";
 import {UserEmailPreferences} from "../../../../IsaacAppTypes";
 import {AppState, useAppSelector} from "../../../state";
 import {SITE_TITLE, siteSpecific, validateEmailPreferences} from "../../../services";
 import {UserEmailPreferencesInput} from "../inputs/UserEmailPreferencesInput";
 import {Alert} from "../Alert";
+import { MyAccountTab } from "./MyAccountTab";
 
 interface UserEmailPreferencesProps {
     emailPreferences: UserEmailPreferences | null | undefined;
@@ -22,18 +22,17 @@ export const UserEmailPreferencesPanel = ({emailPreferences, setEmailPreferences
         errorMessage = "Please specify all email preferences";
     }
 
-    return <CardBody className="pb-0">
+    return <>
         {error?.type == "generalError" && <Alert title="Unable to update your account" body={error.generalError} />}
-        <Row>
-            <Col xs={12} lg={6} className="mb-4">
+        <MyAccountTab
+            leftColumn={<>
                 <h3>Set your email notification preferences</h3>
                 <p>Get important information about the {SITE_TITLE} programme delivered to your inbox. These settings can be changed at any time.</p>
                 <b>Frequency</b>: expect one email per term for News{siteSpecific(" and a monthly bulletin for Events", "")}. Assignment notifications will be sent as needed by your teacher.
-            </Col>
-            <Col xs={12} lg={6}>
-                <UserEmailPreferencesInput emailPreferences={emailPreferences} setEmailPreferences={setEmailPreferences} idPrefix={idPrefix}/>
-            </Col>
-        </Row>
-
-    </CardBody>;
+            </>}
+            rightColumn={
+                <UserEmailPreferencesInput emailPreferences={emailPreferences} setEmailPreferences={setEmailPreferences} submissionAttempted={submissionAttempted} idPrefix={idPrefix}
+            />}
+        />
+    </>;
 };

--- a/src/app/components/elements/panels/UserMFA.tsx
+++ b/src/app/components/elements/panels/UserMFA.tsx
@@ -67,14 +67,14 @@ const UserMFA = ({userToUpdate, userAuthSettings, editingOtherUser}: UserMFAProp
 
     return <CardBody className="pt-0 px-0">
         <Row>
-            <Col xs={{size: 6, offset: 3}} className="px-4">
+            <Col xs={{size: 8, offset: 2}} lg={{size: 6, offset: 3}} className="px-4">
                 <hr className="text-center" />
                 <h4>Two-factor Authentication (2FA)</h4>
             </Col>
         </Row>
         {!editingOtherUser && userAuthSettings && userAuthSettings.hasSegueAccount ?
             <Row>
-                <Col xs={{size: 6, offset: 3}} className="px-4">
+                <Col xs={{size: 8, offset: 2}} lg={{size: 6, offset: 3}} className="px-4">
                     <Row>
                         <Col>
                             <p><strong>2FA Status: </strong>{userAuthSettings.mfaStatus || successfulMFASetup ? "Enabled" : "Disabled"}</p>

--- a/src/app/components/elements/panels/UserPassword.tsx
+++ b/src/app/components/elements/panels/UserPassword.tsx
@@ -1,21 +1,23 @@
-import {Button, CardBody, Col, FormFeedback, FormGroup, Input, InputProps, Label, Row} from "reactstrap";
+import {Button, Col, FormGroup, Label, Row} from "reactstrap";
 import React, {useState} from "react";
 import {PasswordFeedback, ValidationUser} from "../../../../IsaacAppTypes";
 import {AuthenticationProvider, UserAuthenticationSettingsDTO} from "../../../../IsaacApiTypes";
 import {
     AUTHENTICATOR_FRIENDLY_NAMES_MAP,
     AUTHENTICATOR_PROVIDERS,
+    above,
     isAda,
     isPhy,
     loadZxcvbnIfNotPresent,
-    MINIMUM_PASSWORD_LENGTH,
     passwordDebounce,
     siteSpecific,
+    useDeviceSize,
     validateEmail
 } from "../../../services";
 import classNames from "classnames";
 import {linkAccount, logOutUserEverywhere, resetPassword, unlinkAccount, useAppDispatch} from "../../../state";
 import {TogglablePasswordInput} from "../inputs/TogglablePasswordInput";
+import { MyAccountTab } from "./MyAccountTab";
 
 interface UserPasswordProps {
     currentPassword?: string;
@@ -33,7 +35,8 @@ interface UserPasswordProps {
 
 const ThirdPartyAccount = ({provider, isLinked, imgCss} : {provider: AuthenticationProvider, isLinked: boolean, imgCss: string}) => {
     const dispatch = useAppDispatch();
-    return <Row className="align-items-center linked-account-button-outer ml-2 mb-1">
+    const deviceSize = useDeviceSize();
+    return <Row className={classNames("align-items-center linked-account-button-outer mb-1", {"mx-2" : above['sm'](deviceSize)})}>
         <input
             type="button"
             id="linked-accounts-no-password"
@@ -53,6 +56,7 @@ export const UserPassword = (
     {currentPassword, currentUserEmail, setCurrentPassword, myUser, setMyUser, isNewPasswordValid, userAuthSettings, setNewPassword, newPassword, editingOtherUser, submissionAttempted}: UserPasswordProps) => {
 
     const dispatch = useAppDispatch();
+    const deviceSize = useDeviceSize();
     const authenticationProvidersUsed = (provider: AuthenticationProvider) => userAuthSettings && userAuthSettings.linkedAccounts && userAuthSettings.linkedAccounts.includes(provider);
 
     const [showPasswordFields, setShowPasswordFields] = useState(false);
@@ -81,131 +85,121 @@ export const UserPassword = (
         }
     });
 
-    return <CardBody className={"pb-0"}>
-        <Row>
-            {isAda && 
-            <Col xs={{size: 12}} lg={{size: 6}} className={classNames({"px-5 mb-4 mb-lg-0" : isAda})}>
-                <h3>Account security</h3>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Mi sit amet mauris commodo quis imperdiet massa tincidunt.
-            </Col>}
-            <Col xs = {isPhy ? {size: 6, offset: 3} : {size: 12}} lg={isPhy ? {size: 6, offset: 3} : {size: 6}} className={classNames({"px-5" : isAda})}>
-                <h4>Password</h4>
-                {userAuthSettings && userAuthSettings.hasSegueAccount ? 
-                    <>  
-                        {(isPhy || (isAda && showPasswordFields)) && 
-                        <>
-                            {!editingOtherUser && 
-                            <FormGroup>
-                                <Label htmlFor="password-current">Current password</Label>
-                                <TogglablePasswordInput
-                                    id="password-current" type="password" name="current-password"
-                                    onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                                        setCurrentPassword(e.target.value)
-                                    }
-                                />
-                            </FormGroup>}
-                            <FormGroup>
-                                <Label htmlFor="new-password">New password</Label>
-                                <TogglablePasswordInput
-                                    invalid={submissionAttempted && !isNewPasswordValid}
-                                    id="new-password" type="password" name="new-password"
-                                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                                        setNewPassword(e.target.value);
-                                        setMyUser(Object.assign({}, myUser, {password: e.target.value}));
-                                        passwordDebounce(e.target.value, setPasswordFeedback);
-                                    }}
-                                    onBlur={(e: React.ChangeEvent<HTMLInputElement>) => {
-                                        passwordDebounce(e.target.value, setPasswordFeedback);
-                                    }}
-                                    onFocus={loadZxcvbnIfNotPresent}
-                                    aria-describedby="passwordValidationMessage"
-                                    disabled={!editingOtherUser && currentPassword == ""}
-                                />
-                                {passwordFeedback &&
-                                <span className='float-right small mt-1'>
-                                    <strong>Password strength: </strong>
-                                    <span id="password-strength-feedback">
-                                        {passwordFeedback.feedbackText}
-                                    </span>
-                                </span>
+    return <MyAccountTab
+        leftColumn={<>
+            <h3>Account security</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Mi sit amet mauris commodo quis imperdiet massa tincidunt.</p>
+        </>}
+        rightColumn={<>
+            <h4>Password</h4>
+            {userAuthSettings && userAuthSettings.hasSegueAccount ? 
+                <>  
+                    {(isPhy || (isAda && showPasswordFields)) && 
+                    <>
+                        {!editingOtherUser && 
+                        <FormGroup>
+                            <Label htmlFor="password-current">Current password</Label>
+                            <TogglablePasswordInput
+                                id="password-current" type="password" name="current-password"
+                                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                                    setCurrentPassword(e.target.value)
                                 }
-                            </FormGroup>
-                        </>}
-                        {isAda && !showPasswordFields && <Button className="w-100 py-2 mt-3 mb-2" outline onClick={() => setShowPasswordFields(true)}>Change password</Button>}
-                    </>
-                : !passwordResetRequested ?
-                    <React.Fragment>
-                        <Row className="pt-4">
-                            <Col className="text-center">
-                                {userAuthSettings && userAuthSettings.linkedAccounts && <p>
-                                    You do not currently have a password set for this account; you
-                                    sign in using {" "}
-                                    {(userAuthSettings.linkedAccounts).map((linked, index) => {
-                                        return <span key={index} className="text-capitalize">
-                                            {AUTHENTICATOR_FRIENDLY_NAMES_MAP[linked]}
-                                        </span>;
-                                    })}.
-                                </p>}
-                            </Col>
-                        </Row>
-                        <Row className="pb-4">
-                            <Col className="text-center">
-                                <Button className="btn-secondary" onClick={resetPasswordIfValidEmail}>
-                                    Click here to add a password
-                                </Button>
-                            </Col>
-                        </Row>
-                    </React.Fragment>
-                    :
-                    <React.Fragment>
-                        <p>
-                            <strong className="d-block">Your password reset request is being processed.</strong>
-                            <strong className="d-block">Please check your inbox.</strong>
-                        </p>
-                    </React.Fragment>
-                }
+                            />
+                        </FormGroup>}
+                        <FormGroup>
+                            <Label htmlFor="new-password">New password</Label>
+                            <TogglablePasswordInput
+                                invalid={submissionAttempted && !isNewPasswordValid}
+                                id="new-password" type="password" name="new-password"
+                                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                                    setNewPassword(e.target.value);
+                                    setMyUser(Object.assign({}, myUser, {password: e.target.value}));
+                                    passwordDebounce(e.target.value, setPasswordFeedback);
+                                }}
+                                onBlur={(e: React.ChangeEvent<HTMLInputElement>) => {
+                                    passwordDebounce(e.target.value, setPasswordFeedback);
+                                }}
+                                onFocus={loadZxcvbnIfNotPresent}
+                                aria-describedby="passwordValidationMessage"
+                                disabled={!editingOtherUser && currentPassword == ""}
+                            />
+                            {passwordFeedback &&
+                            <span className='float-right small mt-1'>
+                                <strong>Password strength: </strong>
+                                <span id="password-strength-feedback">
+                                    {passwordFeedback.feedbackText}
+                                </span>
+                            </span>
+                            }
+                        </FormGroup>
+                    </>}
+                    {isAda && !showPasswordFields && <Button className="w-100 py-2 mt-3 mb-2" outline onClick={() => setShowPasswordFields(true)}>Change password</Button>}
+                </>
+            : !passwordResetRequested ?
                 <React.Fragment>
-                    <hr className="text-center" />
-                    {connectedAccounts.length > 0 && <FormGroup>
-                        <h4>Linked {siteSpecific("Accounts", "accounts")}</h4>
-                        <Col>
-                            {connectedAccounts.map((provider) => {
-                                return authButtonsMap[provider](true);
-                            })}
+                    <Row className="pt-4">
+                        <Col className="text-center">
+                            {userAuthSettings && userAuthSettings.linkedAccounts && <p>
+                                You do not currently have a password set for this account; you
+                                sign in using {" "}
+                                {(userAuthSettings.linkedAccounts).map((linked, index) => {
+                                    return <span key={index} className="text-capitalize">
+                                        {AUTHENTICATOR_FRIENDLY_NAMES_MAP[linked]}
+                                    </span>;
+                                })}.
+                            </p>}
                         </Col>
-                    </FormGroup>}
-                    {unconnectedAccounts.length > 0 && <FormGroup>
-                        <h4>Link other accounts</h4>
-                        <Col>
-                            {unconnectedAccounts.map((provider) => {
-                                return authButtonsMap[provider](false);
-                            })}
+                    </Row>
+                    <Row className="pb-4">
+                        <Col className="text-center">
+                            <Button className="btn-secondary" onClick={resetPasswordIfValidEmail}>
+                                Click here to add a password
+                            </Button>
                         </Col>
-                    </FormGroup>}
+                    </Row>
                 </React.Fragment>
+                :
                 <React.Fragment>
-                    <hr className="text-center"/>
-                    <FormGroup>
-                        <h4>Log Out</h4>
-                        <p>
-                            {"If you forgot to log out on a device you no longer have access to, you can " +
-                            "log your account out on all devices, including this one."}
-                        </p>
-                        <Col className="text-center mt-2 px-0">
-                            {isPhy && 
-                            <div className="vertical-center ml-2">
-                                <Button onClick={() => dispatch(logOutUserEverywhere())}>
-                                    Log me out everywhere
-                                </Button>
-                            </div>}
-                            {isAda &&
-                            <Button className="w-100 py-2 mt-3 mb-2" outline onClick={() => dispatch(logOutUserEverywhere())}>
-                                Log me out everywhere
-                            </Button>}
-                        </Col>
-                    </FormGroup>
+                    <p>
+                        <strong className="d-block">Your password reset request is being processed.</strong>
+                        <strong className="d-block">Please check your inbox.</strong>
+                    </p>
                 </React.Fragment>
-            </Col>
-        </Row>
-    </CardBody>;
+            }
+            <React.Fragment>
+                <hr className="text-center" />
+                {connectedAccounts.length > 0 && <FormGroup>
+                    <h4>Linked {siteSpecific("Accounts", "accounts")}</h4>
+                    <Col>
+                        {connectedAccounts.map((provider) => {
+                            return authButtonsMap[provider](true);
+                        })}
+                    </Col>
+                </FormGroup>}
+                {unconnectedAccounts.length > 0 && <FormGroup>
+                    <h4>Link other accounts</h4>
+                    <Col>
+                        {unconnectedAccounts.map((provider) => {
+                            return authButtonsMap[provider](false);
+                        })}
+                    </Col>
+                </FormGroup>}
+            </React.Fragment>
+            <React.Fragment>
+                <hr className="text-center"/>
+                <FormGroup>
+                    <h4>Log Out</h4>
+                    <p>
+                        {"If you forgot to log out on a device you no longer have access to, you can " +
+                        "log your account out on all devices, including this one."}
+                    </p>
+                    <Col className="text-center mt-2 px-0">
+                        <Button className={classNames("w-100 py-2 mt-3 mb-2", isAda)} color="primary" outline onClick={() => dispatch(logOutUserEverywhere())}>
+                            Log {above['sm'](deviceSize) ? "me " : ""}out everywhere
+                        </Button>
+                    </Col>
+                </FormGroup>
+            </React.Fragment>
+        </>}
+    />;
 };


### PR DESCRIPTION
Various changes to the existing sign-up flow to improve the styling for both sites.

Ada:
- Adds the required changes to the Beta Features tab

Phy:
- Brought back the notifications table with radio buttons

Both:
- Improved tab styling on small devices
- Abstracted the tab container into a new component, MyAccountTab, which contains the styling for both sites
  - If (when) physics want the redesign changes, funnel through the Ada part of this component.