### PR TITLE
Feature/ada-signup-details-tabs

### DIFF
--- a/src/app/components/elements/inputs/BooleanNotationInput.tsx
+++ b/src/app/components/elements/inputs/BooleanNotationInput.tsx
@@ -1,8 +1,9 @@
-import {FormGroup, Input, Label} from "reactstrap";
-import {BOOLEAN_NOTATION, EMPTY_BOOLEAN_NOTATION_RECORD} from "../../../services";
+import {DropdownItem, FormGroup, Input, Label} from "reactstrap";
+import {BOOLEAN_NOTATION, EMPTY_BOOLEAN_NOTATION_RECORD, booleanNotationMap} from "../../../services";
 import {BooleanNotation} from "../../../../IsaacAppTypes";
 import React, {ChangeEvent} from "react";
 import classNames from "classnames";
+import { StyledDropdown } from "./DropdownInput";
 
 interface BooleanNotationInputProps {
     booleanNotation: Nullable<BooleanNotation>;
@@ -11,28 +12,29 @@ interface BooleanNotationInputProps {
 }
 export const BooleanNotationInput = ({booleanNotation, setBooleanNotation, isRequired = false} : BooleanNotationInputProps) => {
 
-    return <FormGroup>
+    const onChange = (event: any) => {
+        // Makes a new object, with all the boolean notation flags being false apart
+        // from those that are set in the newBooleanNotation parameter
+        const newBooleanNotation: BooleanNotation = {...EMPTY_BOOLEAN_NOTATION_RECORD};
+        newBooleanNotation[event.target.value as keyof BooleanNotation] = true;
+        setBooleanNotation(newBooleanNotation);
+    };
+
+    return <FormGroup className="mr-lg-5">
         <Label className={classNames({"form-optional": !isRequired}, "font-weight-bold")}
                htmlFor="boolean-notation-preference">Preferred logic notation</Label>
-        <Input
-            type="select" name="select" id="boolean-notation-preference"
-            value={
-                // This chooses the last string in this list that (when used as a key)
-                // is mapped to true in the current value of booleanNotation
-                Object.keys(BOOLEAN_NOTATION).reduce((val: string, key) => booleanNotation?.[key as keyof BooleanNotation] ? key : val, BOOLEAN_NOTATION.MATH)
-            }
-            onChange={(event: ChangeEvent<HTMLInputElement>) => {
-                    // Makes a new object, with all the boolean notation flags being false apart
-                    // from those that are set in the newBooleanNotation parameter
-                    const newBooleanNotation: BooleanNotation = {...EMPTY_BOOLEAN_NOTATION_RECORD};
-                    newBooleanNotation[event.target.value as keyof BooleanNotation] = true;
-                    setBooleanNotation(newBooleanNotation);
-                }
-            }
+
+        <StyledDropdown
+            type="select"
+            name="select"
+            id="boolean-notation-preference"
             required={isRequired}
+            onChange={onChange}
+            value={Object.keys(BOOLEAN_NOTATION).reduce((val: string, key) => booleanNotation?.[key as keyof BooleanNotation] ? key : val, BOOLEAN_NOTATION.MATH)}
         >
-            <option value={BOOLEAN_NOTATION.MATH}>And (&and;) Or (&or;) Not (&not;)</option>
-            <option value={BOOLEAN_NOTATION.ENG}>And (&middot;) Or (+) Not (bar)</option>
-        </Input>
-    </FormGroup>
-}
+            {[BOOLEAN_NOTATION.MATH, BOOLEAN_NOTATION.ENG].map((notation) => (
+                <option key={notation} value={notation}>{booleanNotationMap[notation]}</option>
+            ))}
+        </StyledDropdown>
+    </FormGroup>;
+};

--- a/src/app/components/elements/inputs/CheckboxInput.tsx
+++ b/src/app/components/elements/inputs/CheckboxInput.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { Input, InputProps } from "reactstrap";
 import { v4 } from "uuid";
 import { Spacer } from "../Spacer";
-
+import { isPhy } from "../../../services";
 
 export interface StyledCheckboxProps extends InputProps {
     initialValue: boolean;
@@ -20,7 +20,7 @@ export const StyledCheckbox = ({initialValue, ...props} : StyledCheckboxProps) =
                 setChecked(c => !c);
             }}/>
         </div>
-        {props.label && <label htmlFor={id} {...props.label.props}/>}
+        {props.label && <label htmlFor={id} className={isPhy ? "pt-1" : ""} {...props.label.props}/>}
         <Spacer/>
     </div>;
 };

--- a/src/app/components/elements/inputs/CountryInput.tsx
+++ b/src/app/components/elements/inputs/CountryInput.tsx
@@ -8,7 +8,7 @@ import {
     useGetCountriesQuery,
     useGetPriorityCountriesQuery,
 } from "../../../state";
-import {isNull} from "lodash";
+import { isAda } from "../../../services";
 
 interface CountryInputProps {
     userToUpdate: Immutable<ValidationUser>;
@@ -24,7 +24,7 @@ export const CountryInput = ({userToUpdate, setUserToUpdate, submissionAttempted
 
     return <RS.FormGroup className="my-1">
         <Label className={classNames({"form-optional": !required}, "font-weight-bold")}>Country</Label>
-        <p className="d-block">This helps us personalise the platform for you.</p>
+        <p className={classNames("d-block", {"text-gray mb-2" : isAda})}>This helps us personalise the platform for you.</p>
         <Input
             type="select" name="select" id={`${idPrefix}-country-select`}
             value={userToUpdate && userToUpdate.countryCode}
@@ -35,18 +35,18 @@ export const CountryInput = ({userToUpdate, setUserToUpdate, submissionAttempted
         >
             {priorityCountryOptions && Object.entries(priorityCountryOptions).map(
                 ([countryCode, countryDisplayName]) => {
-                    return <option key={countryCode} value={countryCode}>{countryDisplayName}</option>
+                    return <option key={countryCode} value={countryCode}>{countryDisplayName}</option>;
                 }
             )}
             <option /> {/* Empty option for spacing */}
             {allCountryOptions && Object.entries(allCountryOptions).map(
                 ([countryCode, countryDisplayName]) => {
-                    return <option key={countryCode} value={countryCode}>{countryDisplayName}</option>
+                    return <option key={countryCode} value={countryCode}>{countryDisplayName}</option>;
                 }
             )}
         </Input>
         <FormFeedback>
             Please select a country.
         </FormFeedback>
-    </RS.FormGroup>
+    </RS.FormGroup>;
 };

--- a/src/app/components/elements/inputs/CountryInput.tsx
+++ b/src/app/components/elements/inputs/CountryInput.tsx
@@ -9,6 +9,7 @@ import {
     useGetPriorityCountriesQuery,
 } from "../../../state";
 import { isAda } from "../../../services";
+import { StyledDropdown } from "./DropdownInput";
 
 interface CountryInputProps {
     userToUpdate: Immutable<ValidationUser>;
@@ -24,9 +25,9 @@ export const CountryInput = ({userToUpdate, setUserToUpdate, submissionAttempted
 
     return <RS.FormGroup className="my-1">
         <Label className={classNames({"form-optional": !required}, "font-weight-bold")}>Country</Label>
-        <p className={classNames("d-block", {"text-gray mb-2" : isAda})}>This helps us personalise the platform for you.</p>
-        <Input
-            type="select" name="select" id={`${idPrefix}-country-select`}
+        {isAda && <p className="d-block input-description mb-2">This helps us personalise the platform for you.</p>}
+        <StyledDropdown
+            id={`${idPrefix}-country-select`}
             value={userToUpdate && userToUpdate.countryCode}
             invalid={submissionAttempted && required && userToUpdate.countryCode == null}
             onChange={(e: ChangeEvent<HTMLInputElement>) =>
@@ -44,7 +45,7 @@ export const CountryInput = ({userToUpdate, setUserToUpdate, submissionAttempted
                     return <option key={countryCode} value={countryCode}>{countryDisplayName}</option>;
                 }
             )}
-        </Input>
+        </StyledDropdown>
         <FormFeedback>
             Please select a country.
         </FormFeedback>

--- a/src/app/components/elements/inputs/DateInput.tsx
+++ b/src/app/components/elements/inputs/DateInput.tsx
@@ -232,18 +232,25 @@ export const DateInput = (props: DateInputProps) => {
 
     return <React.Fragment>
         <InputGroup id={props.id} {...controlPropsWithValidationStripped} className={inputGroupClasses}>
-            <Input className="date-input-day mr-1" type="select" {...controlProps} aria-label={`Day${props.labelSuffix ? props.labelSuffix : ""}`} onChange={change("day")} value={values.day.get() || ""}>
-                {values.day.get() === undefined && <option />}
-                {range(1, Math.max(lastInMonth(), values.day.get() || 0) + 1).map(day => <option key={day}>{day}</option>)}
-            </Input>
-            <Input className="date-input-month mr-1" type="select" {...controlProps} aria-label={`Month${props.labelSuffix ? props.labelSuffix : ""}`} onChange={change("month")} value={values.month.get() || ""}>
-                {values.month.get() === undefined && <option />}
-                {MONTHS.map((month, index)=> <option value={index + 1} key={index + 1}>{month}</option>)}
-            </Input>
-            <Input className="date-input-year mr-1" type="select" {...controlProps} aria-label={`Year${props.labelSuffix ? props.labelSuffix : ""}`} onChange={change("year")} value={values.year.get() || ""}>
-                {values.year.get() === undefined && <option />}
-                {yearRange.map(year => <option key={year}>{year}</option>)}
-            </Input>
+            {/* these wrappers exist as ::after pseudo-elements don't work with .select */}
+            <div className="date-input-wrapper date-input-day position-relative mr-1">
+                <Input type="select" {...controlProps} aria-label={`Day${props.labelSuffix ? props.labelSuffix : ""}`} onChange={change("day")} value={values.day.get() || ""}>
+                    {values.day.get() === undefined && <option />}
+                    {range(1, Math.max(lastInMonth(), values.day.get() || 0) + 1).map(day => <option key={day}>{day}</option>)}
+                </Input>
+            </div>
+            <div className="date-input-wrapper date-input-month position-relative mr-1">
+                <Input type="select" {...controlProps} aria-label={`Month${props.labelSuffix ? props.labelSuffix : ""}`} onChange={change("month")} value={values.month.get() || ""}>
+                    {values.month.get() === undefined && <option />}
+                    {MONTHS.map((month, index)=> <option value={index + 1} key={index + 1}>{month}</option>)}
+                </Input>
+            </div>
+            <div className="date-input-wrapper date-input-year position-relative mr-1">
+                <Input type="select" {...controlProps} aria-label={`Year${props.labelSuffix ? props.labelSuffix : ""}`} onChange={change("year")} value={values.year.get() || ""}>
+                    {values.year.get() === undefined && <option />}
+                    {yearRange.map(year => <option key={year}>{year}</option>)}
+                </Input>
+            </div>
             {(props.noClear === undefined || !props.noClear) && <Button close {...controlPropsWithValidationStripped} className="mx-1" aria-label={`Clear date${props.labelSuffix ? props.labelSuffix : ""}`} onClick={clear} />}
         </InputGroup>
         <Input innerRef={hiddenRef} type="hidden" name={props.name} value={calculateHiddenValue()} {...controlProps} />

--- a/src/app/components/elements/inputs/DobInput.tsx
+++ b/src/app/components/elements/inputs/DobInput.tsx
@@ -19,7 +19,7 @@ export const DobInput = ({userToUpdate, setUserToUpdate, submissionAttempted, ed
             name="date-of-birth"
             defaultValue={userToUpdate.dateOfBirth as unknown as string}
             onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                setUserToUpdate(Object.assign({}, userToUpdate, {dateOfBirth: event.target.valueAsDate}))
+                setUserToUpdate(Object.assign({}, userToUpdate, {dateOfBirth: event.target.valueAsDate}));
             }}
             disableDefaults
             aria-describedby="age-validation-message"
@@ -28,5 +28,5 @@ export const DobInput = ({userToUpdate, setUserToUpdate, submissionAttempted, ed
         <RS.FormFeedback id="age-validation-message">
             {`${editingOtherUser ? "The user" : "You"} must be over ${siteSpecific("10", "13")} years old to create an account.`}
         </RS.FormFeedback>
-    </RS.FormGroup>
+    </RS.FormGroup>;
 };

--- a/src/app/components/elements/inputs/DropdownInput.tsx
+++ b/src/app/components/elements/inputs/DropdownInput.tsx
@@ -1,0 +1,16 @@
+import classNames from "classnames";
+import React from "react";
+import { Input, InputProps } from "reactstrap";
+import { isPhy } from "../../../services";
+
+export interface StyledDropdownProps extends InputProps {
+    value: string | number | undefined;
+}
+
+export const StyledDropdown = (props: StyledDropdownProps) => {
+    return <div className="position-relative w-100 styled-dropdown-caret">
+        <Input type="select" {...props} className={classNames("form-control d-inline-block pl-3 pr-4 mt-1 mt-sm-0 " + props.className, {"w-auto" : isPhy})}>
+            {props.children}
+        </Input>
+    </div>;
+};

--- a/src/app/components/elements/inputs/EmailInput.tsx
+++ b/src/app/components/elements/inputs/EmailInput.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import {Immutable} from "immer";
 import {ValidationUser} from "../../../../IsaacAppTypes";
 import classNames from "classnames";
+import { isAda } from "../../../services";
 
 interface EmailInputProps {
     userToUpdate: Immutable<ValidationUser>;
@@ -16,7 +17,7 @@ export const EmailInput = ({userToUpdate, setUserToUpdate, emailIsValid, submiss
     return <FormGroup>
         <Label className={classNames({"form-optional": !required}, "font-weight-bold")}
                htmlFor="email-input">Email address</Label>
-        <p className="d-block">This will be visible to your students. We recommend using your school email address.</p>
+        <p className={classNames("d-block", {"text-gray" : isAda})}>This will be visible to your students. We recommend using your school email address.</p>
         <Input
             id="email-input"
             type="email"
@@ -31,5 +32,5 @@ export const EmailInput = ({userToUpdate, setUserToUpdate, emailIsValid, submiss
         <FormFeedback id="emailValidationMessage">
             Please enter a valid email address.
         </FormFeedback>
-    </FormGroup>
-}
+    </FormGroup>;
+};

--- a/src/app/components/elements/inputs/EmailInput.tsx
+++ b/src/app/components/elements/inputs/EmailInput.tsx
@@ -17,7 +17,7 @@ export const EmailInput = ({userToUpdate, setUserToUpdate, emailIsValid, submiss
     return <FormGroup>
         <Label className={classNames({"form-optional": !required}, "font-weight-bold")}
                htmlFor="email-input">Email address</Label>
-        <p className={classNames("d-block", {"text-gray" : isAda})}>This will be visible to your students. We recommend using your school email address.</p>
+        {isAda && <p className="d-block input-description">This will be visible to your students. We recommend using your school email address.</p>}
         <Input
             id="email-input"
             type="email"

--- a/src/app/components/elements/inputs/GenderInput.tsx
+++ b/src/app/components/elements/inputs/GenderInput.tsx
@@ -5,6 +5,7 @@ import {Input} from "reactstrap";
 import {isAda, isPhy, validateUserGender} from "../../../services";
 import classNames from "classnames";
 import {Immutable} from "immer";
+import { StyledDropdown } from "./DropdownInput";
 
 interface GenderInputProps {
     userToUpdate: Immutable<ValidationUser>;
@@ -18,9 +19,9 @@ export const GenderInput = ({userToUpdate, setUserToUpdate, submissionAttempted,
         <RS.Label htmlFor={`${idPrefix}-gender-select`} className={classNames({"form-optional": !required}, "font-weight-bold")}>
             Gender
         </RS.Label>
-        <p className={classNames("d-block", {"text-gray mb-2" : isAda})}>We conduct academic research, including research like this on gender balance in computing. Answering this question helps inform our work.</p>
-        <Input
-            type="select" name="select" id={`${idPrefix}-gender-select`}
+        {isAda && <p className="d-block input-description mb-2">We conduct academic research, including research like this on gender balance in computing. Answering this question helps inform our work.</p>}
+        <StyledDropdown 
+            id={`${idPrefix}-gender-select`}
             value={userToUpdate && userToUpdate.gender}
             invalid={submissionAttempted && required && !validateUserGender(userToUpdate)}
             onChange={(e: ChangeEvent<HTMLInputElement>) =>
@@ -32,6 +33,6 @@ export const GenderInput = ({userToUpdate, setUserToUpdate, submissionAttempted,
             <option value="MALE">Male</option>
             <option value="OTHER">Other gender identity</option>
             <option value="PREFER_NOT_TO_SAY">Prefer not to say</option>
-        </Input>
+        </StyledDropdown>
     </RS.FormGroup>;
 };

--- a/src/app/components/elements/inputs/GenderInput.tsx
+++ b/src/app/components/elements/inputs/GenderInput.tsx
@@ -2,7 +2,7 @@ import React, {ChangeEvent} from "react";
 import {ValidationUser} from "../../../../IsaacAppTypes";
 import * as RS from "reactstrap";
 import {Input} from "reactstrap";
-import {validateUserGender} from "../../../services";
+import {isAda, isPhy, validateUserGender} from "../../../services";
 import classNames from "classnames";
 import {Immutable} from "immer";
 
@@ -14,11 +14,11 @@ interface GenderInputProps {
     required: boolean;
 }
 export const GenderInput = ({userToUpdate, setUserToUpdate, submissionAttempted, idPrefix="account", required}: GenderInputProps) => {
-    return <RS.FormGroup className="my-1">
+    return <RS.FormGroup className={classNames({"my-1": isPhy})}>
         <RS.Label htmlFor={`${idPrefix}-gender-select`} className={classNames({"form-optional": !required}, "font-weight-bold")}>
             Gender
         </RS.Label>
-        <p className="d-block">We conduct academic research, including research like this on gender balance in computing. Answering this question helps inform our work.</p>
+        <p className={classNames("d-block", {"text-gray mb-2" : isAda})}>We conduct academic research, including research like this on gender balance in computing. Answering this question helps inform our work.</p>
         <Input
             type="select" name="select" id={`${idPrefix}-gender-select`}
             value={userToUpdate && userToUpdate.gender}
@@ -33,5 +33,5 @@ export const GenderInput = ({userToUpdate, setUserToUpdate, submissionAttempted,
             <option value="OTHER">Other gender identity</option>
             <option value="PREFER_NOT_TO_SAY">Prefer not to say</option>
         </Input>
-    </RS.FormGroup>
+    </RS.FormGroup>;
 };

--- a/src/app/components/elements/inputs/ProgrammingLanguageInput.tsx
+++ b/src/app/components/elements/inputs/ProgrammingLanguageInput.tsx
@@ -1,7 +1,8 @@
-import {FormGroup, Input, Label} from "reactstrap";
+import {DropdownItem, FormGroup, Input, Label} from "reactstrap";
 import {PROGRAMMING_LANGUAGE, programmingLanguagesMap} from "../../../services";
 import {ProgrammingLanguage} from "../../../../IsaacAppTypes";
 import React, {ChangeEvent} from "react";
+import { StyledDropdown } from "./DropdownInput";
 
 
 interface ProgrammingLanguageInputProps {
@@ -10,25 +11,23 @@ interface ProgrammingLanguageInputProps {
 }
 
 export const ProgrammingLanguageInput = ({programmingLanguage, setProgrammingLanguage} : ProgrammingLanguageInputProps) => {
-    return <FormGroup>
+    const onChange = (event: any) => {
+        const newProgrammingLanguage = Object.entries(programmingLanguage ?? {}).reduce((acc, [k, v]) => ({...acc, [k]: false}), {});
+        setProgrammingLanguage(event.target.value ? {...newProgrammingLanguage, [event.target.value]: true} : newProgrammingLanguage);
+    };
+
+    return <FormGroup className="mr-lg-5">
         <Label className={"font-weight-bold"} htmlFor="programming-language-select">Preferred programming language</Label>
-        <Input
-            type="select"
-            name="select"
+        <StyledDropdown
             id="programming-language-select"
             value={Object.values(PROGRAMMING_LANGUAGE).reduce((val: string | undefined, key) =>
-                programmingLanguage?.[key as keyof ProgrammingLanguage] ? key : val, PROGRAMMING_LANGUAGE.NONE)}
-            onChange={(event: ChangeEvent<HTMLInputElement>) => {
-                let newProgrammingLanguage = Object.entries(programmingLanguage ?? {}).reduce((acc, [k, v]) => ({...acc, [k]: false}), {});
-                setProgrammingLanguage(event.target.value ? {...newProgrammingLanguage, [event.target.value]: true} : newProgrammingLanguage);
-            }}
+                programmingLanguage?.[key as keyof ProgrammingLanguage] ? key : val, "")}
+            onChange={onChange}
         >
-            <option />
-            <option value={PROGRAMMING_LANGUAGE.PSEUDOCODE}>{programmingLanguagesMap[PROGRAMMING_LANGUAGE.PSEUDOCODE]}</option>
-            <option value={PROGRAMMING_LANGUAGE.PYTHON}>{programmingLanguagesMap[PROGRAMMING_LANGUAGE.PYTHON]}</option>
-            <option value={PROGRAMMING_LANGUAGE.CSHARP}>{programmingLanguagesMap[PROGRAMMING_LANGUAGE.CSHARP]}</option>
-            <option value={PROGRAMMING_LANGUAGE.VBA}>{programmingLanguagesMap[PROGRAMMING_LANGUAGE.VBA]}</option>
-            <option value={PROGRAMMING_LANGUAGE.JAVA}>{programmingLanguagesMap[PROGRAMMING_LANGUAGE.JAVA]}</option>
-        </Input>
-    </FormGroup>
-}
+            <option value=""/>
+            {[PROGRAMMING_LANGUAGE.PSEUDOCODE, PROGRAMMING_LANGUAGE.PYTHON, PROGRAMMING_LANGUAGE.CSHARP, PROGRAMMING_LANGUAGE.VBA, PROGRAMMING_LANGUAGE.JAVA].map((language) => (
+                <option key={language} value={language}>{programmingLanguagesMap[language]}</option>
+            ))}
+        </StyledDropdown>
+    </FormGroup>;
+};

--- a/src/app/components/elements/inputs/SchoolInput.tsx
+++ b/src/app/components/elements/inputs/SchoolInput.tsx
@@ -2,7 +2,7 @@ import React, {useCallback, useEffect, useState} from "react";
 import AsyncCreatableSelect from "react-select/async-creatable";
 import * as RS from "reactstrap";
 import {School, ValidationUser} from "../../../../IsaacAppTypes";
-import {schoolNameWithPostcode, validateUserSchool} from "../../../services";
+import {isAda, schoolNameWithPostcode, validateUserSchool} from "../../../services";
 import throttle from "lodash/throttle";
 import classNames from "classnames";
 import {Immutable} from "immer";
@@ -99,7 +99,7 @@ export const SchoolInput = ({userToUpdate, setUserToUpdate, submissionAttempted,
     const isInvalid = submissionAttempted && required && !validateUserSchool(userToUpdate);
     return <RS.FormGroup className={`school ${className}`}>
         <Label className={"font-weight-bold"}>{"School (Optional)"}</Label>
-        <p className="d-block">This helps us personalise the platform for you.</p>
+        {isAda && <p className="d-block">This helps us personalise the platform for you.</p>}
         {userToUpdate.schoolOther !== NOT_APPLICABLE && <React.Fragment>
             <AsyncCreatableSelect
                 isClearable

--- a/src/app/components/elements/inputs/UserContextAccountInput.tsx
+++ b/src/app/components/elements/inputs/UserContextAccountInput.tsx
@@ -1,9 +1,10 @@
-import React, {useRef} from "react";
+import React, {ReactNode, useRef} from "react";
 import {BooleanNotation, DisplaySettings, ValidationUser} from "../../../../IsaacAppTypes";
 import {
     EMPTY_BOOLEAN_NOTATION_RECORD,
     EXAM_BOARD,
     examBoardBooleanNotationMap,
+    examBoardLabelMap,
     getFilteredExamBoardOptions,
     getFilteredStageOptions,
     isAda,
@@ -12,15 +13,16 @@ import {
     isTutorOrAbove,
     siteSpecific,
     STAGE,
+    stageLabelMap,
     TEACHER_REQUEST_ROUTE
 } from "../../../services";
-import * as RS from "reactstrap";
-import {CustomInput, Input, Label} from "reactstrap";
+import {Button, Col, CustomInput, DropdownItem, DropdownMenu, DropdownToggle, FormGroup, Input, Label, UncontrolledDropdown, UncontrolledDropdownProps, UncontrolledTooltip} from "reactstrap";
 import {UserContext} from "../../../../IsaacApiTypes";
 import {v4 as uuid_v4} from "uuid";
 import {Link} from "react-router-dom";
 import classNames from "classnames";
 import {Immutable} from "immer";
+import { StyledDropdown } from "./DropdownInput";
 
 interface UserContextRowProps {
     userContext: UserContext;
@@ -30,71 +32,101 @@ interface UserContextRowProps {
     existingUserContexts: UserContext[];
     setBooleanNotation: (bn: BooleanNotation) => void;
     setDisplaySettings: (ds: DisplaySettings | ((oldDs?: DisplaySettings) => DisplaySettings)) => void;
+    tutorOrAbove: boolean;
+    showPlusOption: boolean;
+    userContexts: UserContext[];
+    setUserContexts: (ucs: UserContext[]) => void;
+    index: number;
 }
 
 function UserContextRow({
-    userContext, setUserContext, showNullStageOption, submissionAttempted, existingUserContexts, setBooleanNotation, setDisplaySettings
+    userContext, setUserContext, showNullStageOption, submissionAttempted, existingUserContexts, setBooleanNotation, setDisplaySettings,
+    tutorOrAbove, showPlusOption, userContexts, setUserContexts, index
 }: UserContextRowProps) {
     const onlyUCWithThisStage = existingUserContexts.filter(uc => uc.stage === userContext.stage).length === 1;
+
+    const onStageUpdate = (e: any) => {
+        const stage = e.target.value as STAGE;
+        if (!isAda) {
+            setUserContext({...userContext, stage});
+            return;
+        }
+        // Set exam board to something sensible (for CS)
+        const onlyOneAtThisStage = existingUserContexts.filter(uc => uc.stage === e.target.value).length === 1;
+        const examBoard = getFilteredExamBoardOptions(
+            {byStages: [stage || STAGE.ALL], byUserContexts: existingUserContexts, includeNullOptions: onlyOneAtThisStage
+        })[0]?.value || EXAM_BOARD.ALL;
+        setBooleanNotation({...EMPTY_BOOLEAN_NOTATION_RECORD, [examBoardBooleanNotationMap[examBoard]]: true});
+
+        // Set display settings default values
+        setDisplaySettings(oldDs => ({...oldDs, HIDE_NON_AUDIENCE_CONTENT: true}));
+        setUserContext({...userContext, stage, examBoard});
+    };
+
+    const onExamBoardUpdate = (e: any) => {
+        setUserContext({...userContext, examBoard: e.target.value as EXAM_BOARD});
+        if (e.target.value) {
+            setBooleanNotation({...EMPTY_BOOLEAN_NOTATION_RECORD, [examBoardBooleanNotationMap[e.target.value as EXAM_BOARD]]: true});
+        }
+    };
+
     return <React.Fragment>
         {/* Stage Selector */}
-        <Input
-            className="form-control w-auto d-inline-block pl-1 pr-0 mt-1 mt-sm-0" type="select"
-            aria-label="Stage"
-            value={userContext.stage || ""}
-            invalid={submissionAttempted && !Object.values(STAGE).includes(userContext.stage as STAGE)}
-            onChange={e => {
-                const stage = e.target.value as STAGE;
-                if (!isAda) {
-                    setUserContext({...userContext, stage});
-                    return;
-                }
-                // Set exam board to something sensible (for CS)
-                const onlyOneAtThisStage = existingUserContexts.filter(uc => uc.stage === e.target.value).length === 1;
-                const examBoard = getFilteredExamBoardOptions(
-                    {byStages: [stage || STAGE.ALL], byUserContexts: existingUserContexts, includeNullOptions: onlyOneAtThisStage
-                })[0]?.value || EXAM_BOARD.ALL;
-                setBooleanNotation({...EMPTY_BOOLEAN_NOTATION_RECORD, [examBoardBooleanNotationMap[examBoard]]: true});
-
-                // Set display settings default values
-                setDisplaySettings(oldDs => ({...oldDs, HIDE_NON_AUDIENCE_CONTENT: true}));
-                setUserContext({...userContext, stage, examBoard});
-            }}
-        >
-            <option value=""></option>
-            {getFilteredStageOptions({
-                byUserContexts: existingUserContexts.filter(uc => !(uc.stage === userContext.stage && uc.examBoard === userContext.examBoard)),
-                includeNullOptions: showNullStageOption, hideFurtherA: true
-            }).map(item =>
-                <option key={item.value} value={item.value}>{item.label}</option>
-            )}
-        </Input>
-
-        {/* Exam Board Selector */}
-        {isAda && <Input
-            className="form-control w-auto d-inline-block pl-1 pr-0 ml-sm-2 mt-1 mt-sm-0" type="select"
-            aria-label="Exam Board"
-            value={userContext.examBoard || ""}
-            invalid={submissionAttempted && !Object.values(EXAM_BOARD).includes(userContext.examBoard as EXAM_BOARD)}
-            onChange={e => {
-                setUserContext({...userContext, examBoard: e.target.value as EXAM_BOARD});
-                if (e.target.value) {
-                    setBooleanNotation({...EMPTY_BOOLEAN_NOTATION_RECORD, [examBoardBooleanNotationMap[e.target.value as EXAM_BOARD]]: true});
-                }
-            }}
-        >
-            <option value=""></option>
-            {getFilteredExamBoardOptions({
-                byStages: [userContext.stage as STAGE || STAGE.ALL],
-                includeNullOptions: onlyUCWithThisStage,
-                byUserContexts: existingUserContexts.filter(uc => !(uc.stage === userContext.stage && uc.examBoard === userContext.examBoard))
-            })
-                .map(item =>
+        <div className="d-flex flex-row justify-content-between">
+            <StyledDropdown
+                className={classNames("account-dropdown", {"mr-1" : isAda})}
+                aria-label="Stage"
+                invalid={submissionAttempted && !Object.values(STAGE).includes(userContext.stage as STAGE)}
+                onChange={onStageUpdate}
+                value={userContext.stage}
+            >
+                <option value=""/>
+                {getFilteredStageOptions({
+                    byUserContexts: existingUserContexts.filter(uc => !(uc.stage === userContext.stage && uc.examBoard === userContext.examBoard)),
+                    includeNullOptions: showNullStageOption, hideFurtherA: true
+                }).map(item =>
                     <option key={item.value} value={item.value}>{item.label}</option>
-                )
-            }
-        </Input>}
-    </React.Fragment>
+                )}
+            </StyledDropdown>
+
+            {/* Exam Board Selector */}
+            {isAda && <StyledDropdown
+                className="account-dropdown ml-1"
+                aria-label="Exam Board"
+                invalid={submissionAttempted && !Object.values(EXAM_BOARD).includes(userContext.examBoard as EXAM_BOARD)}
+                onChange={onExamBoardUpdate}
+                value={userContext.examBoard}
+            >
+                <option value="" />
+                {getFilteredExamBoardOptions({
+                    byStages: [userContext.stage as STAGE || STAGE.ALL],
+                    includeNullOptions: onlyUCWithThisStage,
+                    byUserContexts: existingUserContexts.filter(uc => !(uc.stage === userContext.stage && uc.examBoard === userContext.examBoard))
+                }).map(item =>
+                    <option key={item.value} value={item.value}>{item.label}</option>
+                )}
+            </StyledDropdown>}
+
+            <div className="remove-stage-container">
+                {tutorOrAbove && userContexts.length > 1 && <button
+                    type="button" className="close float-none" aria-label="clear stage row"
+                    onClick={() => setUserContexts(userContexts.filter((uc, i) => i !== index))}
+                >
+                    ×
+                </button>}
+            </div>
+
+            {!isAda && showPlusOption && <Label className="m-0 mt-1">
+                <button
+                    type="button" aria-label="Add stage"
+                    className={`ml-3 align-middle close float-none pointer-cursor`}
+                    onClick={() => setUserContexts([...userContexts, {}])}
+                >
+                    +
+                </button>
+            </Label>}
+        </div>
+    </React.Fragment>;
 }
 
 interface UserContextAccountInputProps {
@@ -113,31 +145,31 @@ export function UserContextAccountInput({
     const componentId = useRef(uuid_v4().slice(0, 4)).current;
 
     return <div>
-        <RS.Label htmlFor="user-context-selector" className="font-weight-bold">
+        <Label htmlFor="user-context-selector" className="font-weight-bold">
             {siteSpecific(
                 <span>{tutorOrAbove ? "I am teaching..." : "I am interested in..."}</span>,
                 <span>Show me content for...</span>
             )}
-        </RS.Label>
+        </Label>
         {siteSpecific(
             // Physics
             <React.Fragment>
                 <span id={`show-me-content-${componentId}`} className="icon-help" />
-                <RS.UncontrolledTooltip placement={"left-start"} target={`show-me-content-${componentId}`}>
+                <UncontrolledTooltip placement={"left-start"} target={`show-me-content-${componentId}`}>
                     {"Choose a stage here to pre-select the material that is most relevant to your interests."}<br />
                     {"You will be able to change this preference on relevant pages."}<br />
                     {'If you prefer to see all content by default, select "All stages".'}
-                </RS.UncontrolledTooltip>
+                </UncontrolledTooltip>
             </React.Fragment>,
             // Computer science
             <React.Fragment>
                 <span id={`show-me-content-${componentId}`} className="icon-help" />
-                <RS.UncontrolledTooltip placement={"left-start"} target={`show-me-content-${componentId}`}>
+                <UncontrolledTooltip placement={"left-start"} target={`show-me-content-${componentId}`}>
                     {tutorOrAbove ?
                         <>Add a stage and examination board for each qualification you are teaching.<br />On content pages, this will allow you to quickly switch between your personalised views of the content, depending on which class you are currently teaching.</> :
                         <>Select a stage and examination board here to filter the content so that you will only see material that is relevant for the qualification you have chosen.</>
                     }
-                </RS.UncontrolledTooltip>
+                </UncontrolledTooltip>
             </React.Fragment>
         )}
         <div id="user-context-selector" className={classNames({"d-flex flex-wrap": isPhy})}>
@@ -147,53 +179,38 @@ export function UserContextAccountInput({
                     // at least one exam board for the potential stage
                     getFilteredStageOptions({byUserContexts: userContexts, hideFurtherA: true}).length > 0;
 
-                return <RS.FormGroup key={index}>
+                return <FormGroup key={index}>
                     <UserContextRow
                         userContext={userContext} showNullStageOption={userContexts.length <= 1} submissionAttempted={submissionAttempted}
                         setUserContext={newUc => setUserContexts(userContexts.map((uc, i) => i === index ? newUc : uc))}
                         existingUserContexts={userContexts} setBooleanNotation={setBooleanNotation} setDisplaySettings={setDisplaySettings}
+                        tutorOrAbove={tutorOrAbove} showPlusOption={showPlusOption} userContexts={userContexts} setUserContexts={setUserContexts}
+                        index={index}
                     />
 
-                    {tutorOrAbove && userContexts.length > 1 && <button
-                        type="button" className="mx-2 close float-none align-middle" aria-label="clear stage row"
-                        onClick={() => setUserContexts(userContexts.filter((uc, i) => i !== index))}
-                    >
-                        ×
-                    </button>}
-
-                    {showPlusOption && <RS.Label>
-                        <button
-                            type="button" aria-label="Add stage"
-                            className={`${userContexts.length <= 1 ? "ml-2" : ""} align-middle close float-none pointer-cursor`}
-                            onClick={() => setUserContexts([...userContexts, {}])}
-                        >
-                            +
-                        </button>
-                        {isAda && <span className="ml-1">add stage</span>}
-                    </RS.Label>}
-
-                    {isAda && index === userContexts.length - 1 && (userContexts.findIndex(p => p.stage === STAGE.ALL && p.examBoard === EXAM_BOARD.ALL) === -1) && <RS.Label className="mt-2">
-                        <CustomInput
-                            type="checkbox" id={`hide-content-check-${componentId}`} className="d-inline-block"
-                            checked={isDefined(displaySettings?.HIDE_NON_AUDIENCE_CONTENT) ? !displaySettings?.HIDE_NON_AUDIENCE_CONTENT : true}
-                            onChange={e => setDisplaySettings(oldDs => ({...oldDs, HIDE_NON_AUDIENCE_CONTENT: !e.target.checked}))}
-                        />{" "}
-                        <span>Show other content that is not for my selected qualification(s). <span id={`show-other-content-${componentId}`} className="icon-help ml-1" /></span>
-                        <RS.UncontrolledTooltip placement="bottom" target={`show-other-content-${componentId}`}>
-                            {tutorOrAbove ?
-                                "If you select this box, additional content that is not intended for your chosen stage and examination board will be shown (e.g. you will also see A level content in your GCSE view)." :
-                                "If you select this box, additional content that is not intended for your chosen stage and examination board will be shown (e.g. you will also see A level content if you are studying GCSE)."
-                            }
-                        </RS.UncontrolledTooltip>
-                    </RS.Label>}
+                    {isAda && index === userContexts.length - 1 && <>
+                        <Col lg={6} className="p-0 pr-4 pr-lg-0">
+                            <Button color="primary" outline className="mt-3 mb-2 px-2 w-100" onClick={() => setUserContexts([...userContexts, {}])}>
+                                Add more content
+                            </Button>
+                        </Col>
+                        {(userContexts.findIndex(p => p.stage === STAGE.ALL && p.examBoard === EXAM_BOARD.ALL) === -1) && <Label>
+                            <CustomInput
+                                type="checkbox" id={`hide-content-check-${componentId}`} className="d-inline-block mt-1"
+                                checked={isDefined(displaySettings?.HIDE_NON_AUDIENCE_CONTENT) ? !displaySettings?.HIDE_NON_AUDIENCE_CONTENT : true}
+                                onChange={e => setDisplaySettings(oldDs => ({...oldDs, HIDE_NON_AUDIENCE_CONTENT: !e.target.checked}))}
+                            />
+                            <span>Show content that is not for my selected qualification(s).</span>
+                        </Label>}
+                    </>}
 
                     {!tutorOrAbove && <><br/>
                         <small>
                             If you are a teacher or tutor, <Link to={TEACHER_REQUEST_ROUTE} target="_blank">upgrade your account</Link> to choose more than one {isAda && "exam board and "}stage.
                         </small>
                     </>}
-                </RS.FormGroup>
+                </FormGroup>;
             })}
         </div>
-    </div>
+    </div>;
 }

--- a/src/app/components/elements/inputs/UserEmailPreferencesInput.tsx
+++ b/src/app/components/elements/inputs/UserEmailPreferencesInput.tsx
@@ -1,17 +1,19 @@
 import {StyledCheckbox} from "./CheckboxInput";
-import {FormGroup} from "reactstrap";
+import {FormGroup, Table} from "reactstrap";
 import React, {SetStateAction, useState} from "react";
 import {UserEmailPreferences} from "../../../../IsaacAppTypes";
-import {siteSpecific} from "../../../services";
+import {isPhy, siteSpecific} from "../../../services";
 import {Dispatch} from "react";
+import { TrueFalseRadioInput } from "./TrueFalseRadioInput";
 
 interface UserEmailPreferencesProps {
     emailPreferences: UserEmailPreferences | null | undefined;
     setEmailPreferences: (e: UserEmailPreferences) => void;
+    submissionAttempted?: boolean;
     idPrefix?: string;
 }
 
-export const UserEmailPreferencesInput = ({emailPreferences, setEmailPreferences, idPrefix="my-account-"}: UserEmailPreferencesProps) => {
+export const UserEmailPreferencesInput = ({emailPreferences, setEmailPreferences, submissionAttempted, idPrefix="my-account-"}: UserEmailPreferencesProps) => {
 
     const isaacEmailPreferenceDescriptions = {
         assignments: siteSpecific(
@@ -29,25 +31,78 @@ export const UserEmailPreferencesInput = ({emailPreferences, setEmailPreferences
     };
 
     return <FormGroup className="overflow-auto">
-        <StyledCheckbox initialValue={emailPreferences?.ASSIGNMENTS ?? false} id={`${idPrefix}assignments`}
-                        changeFunction={(checked) => setEmailPreferences({...emailPreferences, ASSIGNMENTS: checked})}
-                        label={<span><b>Assignments</b></span>}
-        />
-        <span className="d-block mb-4">{isaacEmailPreferenceDescriptions.assignments}</span>
+        {isPhy && submissionAttempted !== undefined ? <> {/* submissionAttempted should always exist on phy, just here for typing */}
+            <Table className="mb-0">
+                <thead>
+                    <tr>
+                        <th>Email type</th>
+                        <th className="d-none d-sm-table-cell">Description</th>
+                        <th className="text-center">Preference</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td className="form-required">Assignments</td>
+                        <td className="d-none d-sm-table-cell">
+                            {isaacEmailPreferenceDescriptions.assignments}
+                        </td>
+                        <td className="text-center">
+                            <TrueFalseRadioInput
+                                id={`${idPrefix}assignments`} stateObject={emailPreferences}
+                                propertyName="ASSIGNMENTS" setStateFunction={setEmailPreferences}
+                                submissionAttempted={submissionAttempted}
+                            />
+                        </td>
+                    </tr>
+                    <tr>
+                        <td className="form-required">News</td>
+                        <td className="d-none d-sm-table-cell">
+                            {isaacEmailPreferenceDescriptions.news}
+                        </td>
+                        <td className="text-center">
+                            <TrueFalseRadioInput
+                                id={`${idPrefix}news`} stateObject={emailPreferences}
+                                propertyName="NEWS_AND_UPDATES" setStateFunction={setEmailPreferences}
+                                submissionAttempted={submissionAttempted}
+                            />
+                        </td>
+                    </tr>
+                    {isPhy && <tr>
+                        <td className="form-required">Events</td>
+                        <td className="d-none d-sm-table-cell">
+                            {isaacEmailPreferenceDescriptions.events}
+                        </td>
+                        <td className="text-center">
+                            <TrueFalseRadioInput
+                                id={`${idPrefix}events`} stateObject={emailPreferences}
+                                propertyName="EVENTS" setStateFunction={setEmailPreferences}
+                                submissionAttempted={submissionAttempted}
+                            />
+                        </td>
+                    </tr>}
+                </tbody>
+            </Table>
+        </> : <>
+            <StyledCheckbox initialValue={emailPreferences?.ASSIGNMENTS ?? false} id={`${idPrefix}assignments`}
+                changeFunction={(checked) => setEmailPreferences({...emailPreferences, ASSIGNMENTS: checked})}
+                label={<span><b>Assignments</b></span>}
+            />
+            <span className="d-block mb-4">{isaacEmailPreferenceDescriptions.assignments}</span>
 
-        <StyledCheckbox initialValue={emailPreferences?.NEWS_AND_UPDATES ?? false} id={`${idPrefix}news`}
-                        changeFunction={(checked) => setEmailPreferences({...emailPreferences, NEWS_AND_UPDATES: checked})}
-                        label={<span><b>News</b></span>}
-        />
-        <span className="d-block mb-4">{isaacEmailPreferenceDescriptions.news}</span>
+            <StyledCheckbox initialValue={emailPreferences?.NEWS_AND_UPDATES ?? false} id={`${idPrefix}news`}
+                changeFunction={(checked) => setEmailPreferences({...emailPreferences, NEWS_AND_UPDATES: checked})}
+                label={<span><b>News</b></span>}
+            />
+            <span className="d-block mb-4">{isaacEmailPreferenceDescriptions.news}</span>
 
-        <StyledCheckbox initialValue={emailPreferences?.EVENTS ?? false} id={`${idPrefix}events`}
-                        changeFunction={(checked) => setEmailPreferences({...emailPreferences, EVENTS: checked})}
-                        label={<span><b>Events</b></span>}
-        />
-        <span className="d-block mb-4">{isaacEmailPreferenceDescriptions.events}</span>
-    </FormGroup>
-}
+            <StyledCheckbox initialValue={emailPreferences?.EVENTS ?? false} id={`${idPrefix}events`}
+                changeFunction={(checked) => setEmailPreferences({...emailPreferences, EVENTS: checked})}
+                label={<span><b>Events</b></span>}
+            />
+            <span className="d-block mb-4">{isaacEmailPreferenceDescriptions.events}</span>
+        </>}
+    </FormGroup>;
+};
 
 // Extended useState hook for email preferences, setting defaults
 export const useEmailPreferenceState = (initialEmailPreferences?: Nullable<UserEmailPreferences>): [Nullable<UserEmailPreferences>, Dispatch<SetStateAction<Nullable<UserEmailPreferences>>>] => {
@@ -55,7 +110,7 @@ export const useEmailPreferenceState = (initialEmailPreferences?: Nullable<UserE
         ASSIGNMENTS: true,
         NEWS_AND_UPDATES: false,
         EVENTS: false
-    }
+    };
 
     const [emailPreferences, _setEmailPreferences] = useState<Nullable<UserEmailPreferences>>({...defaults, ...initialEmailPreferences});
     const setEmailPreferences = (newEmailPreferences: Nullable<UserEmailPreferences> | ((ep: Nullable<UserEmailPreferences>) => Nullable<UserEmailPreferences>)) => {

--- a/src/app/components/elements/panels/MyAccountTab.tsx
+++ b/src/app/components/elements/panels/MyAccountTab.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { CardBody, Col, Container, Row } from "reactstrap";
-import { isPhy } from "../../../services";
+import { isAda, isPhy } from "../../../services";
+import classNames from "classnames";
 
 export interface MyAccountTabProps {
     leftColumn: React.ReactNode;
@@ -8,18 +9,18 @@ export interface MyAccountTabProps {
 }
 
 export const MyAccountTab = ({leftColumn, rightColumn} : MyAccountTabProps) => {
-    return <CardBody>
-        <Container className="px-0 px-lg-2">
+    return <CardBody className={classNames("px-4", {"px-sm-5": isAda})}>
+        <Container>
             {isPhy ? <Col className="px-0 px-lg-2">
                 {leftColumn}
                 <Row className="pt-4"/>
                 {rightColumn}
             </Col> :
             <Row>
-                <Col lg={6} className="pr-lg-4 px-0 px-lg-2">
+                <Col lg={6} className="pr-lg-4 px-0 pl-lg-2">
                     {leftColumn}
                 </Col>
-                <Col lg={6} className="pl-lg-4 px-0 px-lg-2 pt-4 pt-lg-0">
+                <Col lg={6} className="pl-lg-4 px-0 pl-lg-2 pt-4 pt-lg-0">
                     {rightColumn}
                 </Col>
             </Row>}

--- a/src/app/components/elements/panels/MyAccountTab.tsx
+++ b/src/app/components/elements/panels/MyAccountTab.tsx
@@ -9,7 +9,7 @@ export interface MyAccountTabProps {
 }
 
 export const MyAccountTab = ({leftColumn, rightColumn} : MyAccountTabProps) => {
-    return <CardBody className={classNames("px-4", {"px-sm-5": isAda})}>
+    return <CardBody className={classNames("my-account-tab px-4", {"px-sm-5": isAda})}>
         <Container>
             {isPhy ? <Col className="px-0 px-lg-2">
                 {leftColumn}

--- a/src/app/components/elements/panels/MyAccountTab.tsx
+++ b/src/app/components/elements/panels/MyAccountTab.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { CardBody, Col, Container, Row } from "reactstrap";
+import { isPhy } from "../../../services";
+
+export interface MyAccountTabProps {
+    leftColumn: React.ReactNode;
+    rightColumn: React.ReactNode;
+}
+
+export const MyAccountTab = ({leftColumn, rightColumn} : MyAccountTabProps) => {
+    return <CardBody>
+        <Container className="px-0 px-lg-2">
+            {isPhy ? <Col className="px-0 px-lg-2">
+                {leftColumn}
+                <Row className="pt-4"/>
+                {rightColumn}
+            </Col> :
+            <Row>
+                <Col lg={6} className="pr-lg-4 px-0 px-lg-2">
+                    {leftColumn}
+                </Col>
+                <Col lg={6} className="pl-lg-4 px-0 px-lg-2 pt-4 pt-lg-0">
+                    {rightColumn}
+                </Col>
+            </Row>}
+        </Container>
+    </CardBody>;
+};

--- a/src/app/components/elements/panels/TeacherConnections.tsx
+++ b/src/app/components/elements/panels/TeacherConnections.tsx
@@ -36,6 +36,7 @@ import {
 } from "../modals/TeacherConnectionModalCreators";
 import { FixedSizeList } from "react-window";
 import { Spacer } from "../Spacer";
+import { MyAccountTab } from "./MyAccountTab";
 
 const CONNECTIONS_ROW_HEIGHT = 40;
 const CONNECTIONS_MAX_VISIBLE_ROWS = 10;
@@ -154,215 +155,211 @@ export const TeacherConnections = ({user, authToken, editingOtherUser, userToEdi
         }
     }
 
-    return <RS.CardBody>
-        <RS.Container>
-            <RS.Row>
-                <RS.Col lg={isAda ? 6 : 12}>
-                    <h3>Connect to your teacher</h3>
-                    <PageFragment fragmentId={`teacher_connections_help_${isTutorOrAbove(user) ? "teacher" : "student"}`} ifNotFound={RenderNothing} />
-                </RS.Col>
-                <RS.Col lg={isAda ? 6 : 12} className="mt-4 mt-lg-0">
-                    <h3>
-                        <span>Teacher connections<span id="teacher-connections-title" className="icon-help" /></span>
-                        <RS.UncontrolledTooltip placement="bottom" target="teacher-connections-title">
-                            The teachers that you are connected to can view your {siteSpecific("Isaac", "Ada")} assignment progress.
-                        </RS.UncontrolledTooltip>
-                    </h3>
-                    <p>Enter the code given by your teacher to create a teacher connection and join a group.</p>
-                    {/* TODO Need to handle nested form complaint */}
-                    <RS.Form onSubmit={processToken}>
-                        <RS.InputGroup className={"separate-input-group mb-4 d-flex flex-row justify-content-center"}>
-                            <RS.Input
-                                type="text" placeholder="Enter your code in here" value={authToken || undefined} className="py-4"
-                                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setAuthenticationToken(e.target.value)}
-                            />
-                            <RS.InputGroupAddon addonType="append">
-                                <RS.Button onClick={processToken} className={classNames("py-2", {"px-0 border-dark": isPhy})} color="secondary" outline disabled={editingOtherUser}>
-                                    Connect
-                                </RS.Button>
-                            </RS.InputGroupAddon>
-                        </RS.InputGroup>
-                    </RS.Form>
+    return <MyAccountTab 
+        leftColumn={<>
+            <h3>Connect to your teacher</h3>
+            <PageFragment fragmentId={`teacher_connections_help_${isTutorOrAbove(user) ? "teacher" : "student"}`} ifNotFound={RenderNothing} />
+        </>}
+        rightColumn={<>
+            <h3>
+                <span>Teacher connections<span id="teacher-connections-title" className="icon-help" /></span>
+                <RS.UncontrolledTooltip placement="bottom" target="teacher-connections-title">
+                    The teachers that you are connected to can view your {siteSpecific("Isaac", "Ada")} assignment progress.
+                </RS.UncontrolledTooltip>
+            </h3>
+            <p>Enter the code given by your teacher to create a teacher connection and join a group.</p>
+            {/* TODO Need to handle nested form complaint */}
+            <RS.Form onSubmit={processToken}>
+                <RS.InputGroup className={"separate-input-group mb-4 d-flex flex-row justify-content-center"}>
+                    <RS.Input
+                        type="text" placeholder="Enter your code in here" value={authToken || undefined} className="py-4"
+                        onChange={(e: React.ChangeEvent<HTMLInputElement>) => setAuthenticationToken(e.target.value)}
+                    />
+                    <RS.InputGroupAddon addonType="append">
+                        <RS.Button onClick={processToken} className={classNames("py-2", {"px-0 border-dark": isPhy})} color="secondary" outline disabled={editingOtherUser}>
+                            Connect
+                        </RS.Button>
+                    </RS.InputGroupAddon>
+                </RS.InputGroup>
+            </RS.Form>
 
-                    <div className="connect-list">
-                        <ConnectionsHeader title="Teacher connections" enableSearch={enableTeacherSearch} setEnableSearch={setEnableTeacherSearch} setSearchText={setTeacherSearchText}/>
-                        <div className="connect-list-inner">
-                            <ul className={classNames("teachers-connected list-unstyled my-0", {"ml-3 mr-2": isPhy}, {"ml-1 mr-2": isAda})}>
-                                <FixedSizeList height={CONNECTIONS_ROW_HEIGHT * (Math.min(CONNECTIONS_MAX_VISIBLE_ROWS, filteredActiveAuthorisations?.length ?? 0))} itemCount={filteredActiveAuthorisations?.length ?? 0} itemSize={CONNECTIONS_ROW_HEIGHT} width="100%" style={{scrollbarGutter: "stable"}}>
-                                    {({index, style}) => {
-                                        const teacherAuthorisation = filteredActiveAuthorisations?.[index];
-                                        if (!teacherAuthorisation) {
-                                            return null;
-                                        }
-                                        return <React.Fragment key={teacherAuthorisation.id}>
-                                        <li style={style} className="py-2">
-                                            <span className="icon-person-active" />
-                                            <span id={`teacher-authorisation-${teacherAuthorisation.id}`}>
-                                                {extractTeacherName(teacherAuthorisation)}
-                                            </span>
-                                            <RS.UncontrolledTooltip
-                                                placement="bottom" target={`teacher-authorisation-${teacherAuthorisation.id}`}
-                                                >
-                                                This user ({teacherAuthorisation.email}) has access to your data.
-                                                To remove this access, click &apos;Revoke&apos;.
-                                            </RS.UncontrolledTooltip>
-                                            <RS.Button
-                                                color="link" className="revoke-teacher pr-1"
-                                                disabled={editingOtherUser}
-                                                onClick={() => user.loggedIn && user.id && dispatch(openActiveModal(revocationConfirmationModal(user.id, teacherAuthorisation)))}
-                                                >
-                                                Revoke
-                                            </RS.Button>
-                                        </li>
-                                    </React.Fragment>;
-                                    }}
-                                </FixedSizeList>
-                            </ul>
-                            {activeAuthorisations && activeAuthorisations.length === 0 && <p className="teachers-connected">
-                                You have no active teacher connections.
-                            </p>}
-                        </div>
-                    </div>
-
-                    {isLoggedIn(user) && !isStudent(user) && <React.Fragment>
-                        <hr className={siteSpecific("my-5", "my-4")} />
-                        <h3>
-                            <span>Your student connections<span id="student-connections-title" className="icon-help" /></span>
-                            <RS.UncontrolledTooltip placement="bottom" target="student-connections-title">
-                                These are the students who have shared their {siteSpecific("Isaac", "Ada")} data with you.
-                                These students are also able to view your name and email address on their Teacher connections page.
-                            </RS.UncontrolledTooltip>
-                        </h3>
-                        <p>
-                            You can invite students to share their {siteSpecific("Isaac", "Ada")} data with you through the {" "}
-                            <Link to="/groups">{siteSpecific("group management page", "Manage groups")}</Link>{siteSpecific(".", " page.")}
-                        </p>
-                        <div className="connect-list">
-                            <ConnectionsHeader title="Student connections" enableSearch={enableStudentSearch} setEnableSearch={setEnableStudentSearch} setSearchText={setStudentSearchText}/>
-                            <div className="connect-list-inner">
-                                <ul className={classNames("teachers-connected list-unstyled my-0", {"ml-3 mr-2": isPhy}, {"ml-1 mr-2": isAda})}>
-                                    <FixedSizeList height={CONNECTIONS_ROW_HEIGHT * (Math.min(CONNECTIONS_MAX_VISIBLE_ROWS, filteredStudentAuthorisations?.length ?? 0))} itemCount={filteredStudentAuthorisations?.length ?? 0} itemSize={CONNECTIONS_ROW_HEIGHT} width="100%" style={{scrollbarGutter: "stable"}}>
-                                        {({index, style}) => {
-                                            const student = filteredStudentAuthorisations?.[index];
-                                            if (!student) {
-                                                return null;
-                                            }
-                                            return <li key={student.id} style={style} className="py-2">
-                                                <span className="icon-person-active" />
-                                                <span id={`student-authorisation-${student.id}`}>
-                                                    {student.givenName} {student.familyName}
-                                                </span>
-                                                <RS.UncontrolledTooltip
-                                                    placement="bottom" target={`student-authorisation-${student.id}`}
-                                                >
-                                                    You have access to this user&apos;s data and they can see your name and email address.
-                                                    To remove this access, click &apos;Remove&apos;.
-                                                </RS.UncontrolledTooltip>
-                                                <RS.Button
-                                                    color="link" className="revoke-teacher pr-1" disabled={editingOtherUser}
-                                                    onClick={() => user.loggedIn && user.id && dispatch(openActiveModal(releaseConfirmationModal(user.id, student)))}
-                                                >
-                                                    Remove
-                                                </RS.Button>
-                                            </li>;
-                                        }}
-                                    </FixedSizeList>
-                                </ul>
-
-                                {studentAuthorisations && studentAuthorisations.length === 0 && <p className="teachers-connected">
-                                    You have no active student connections.
-                                </p>}
-                            </div>
-                            {studentAuthorisations && studentAuthorisations.length > 0 && <p className="remove-link">
-                                <RS.Button color="link" onClick={() => dispatch(openActiveModal(releaseAllConfirmationModal()))} disabled={editingOtherUser}>
-                                    Remove all
-                                </RS.Button>
-                            </p>}
-                        </div>
-                    </React.Fragment>}
-
-                    <hr className={siteSpecific("my-5", "my-4")} />
-                    <h3>
-                        <span>
-                            Your group memberships
-                            <span id="group-memberships-title" className="icon-help" />
-                        </span>
-                        <RS.UncontrolledTooltip placement="bottom" target="group-memberships-title">
-                            These are the groups you are currently a member of.
-                            Groups on {siteSpecific("Isaac", "Ada")} let teachers set assignments to multiple students in one go.
-                        </RS.UncontrolledTooltip>
-                    </h3>
-                    <p>
-                        You can manage who is able to set you assignments by temporarily leaving a group. While you are
-                        inactive in a group you won&apos;t receive any assignments from that group.<br/>
-                        If you want to permanently leave a group, ask your teacher to remove you.
-                    </p>
-                    <div className="my-groups-table-section overflow-auto">
-                        <div className="connect-list">
-                            <ConnectionsHeader title="Group memberships" enableSearch={enableGroupSearch} setEnableSearch={setEnableGroupSearch} setSearchText={setGroupSearchText}/>
-                            <div className="connect-list-inner">
-                                <ul className={classNames("teachers-connected list-unstyled m-0")}>
-                                    {sortedGroupMemberships && <FixedSizeList height={MEMBERSHIPS_ROW_HEIGHT * (Math.min(MEMBERSHIPS_MAX_VISIBLE_ROWS, sortedGroupMemberships.length ?? 0))} itemCount={sortedGroupMemberships.length ?? 0} itemSize={MEMBERSHIPS_ROW_HEIGHT} width="100%" style={{scrollbarGutter: "stable"}}>
-                                        {({index, style}) => {
-                                            const membership = sortedGroupMemberships[index];
-                                            return <li key={index} style={style} className={classNames("py-2", {"inactive-group" : isAda && membership.membershipStatus === MEMBERSHIP_STATUS.INACTIVE})}>
-                                                <div className="d-flex">
-                                                    <RS.Col>
-                                                        {membership.membershipStatus === MEMBERSHIP_STATUS.INACTIVE ?
-                                                            <span className="text-muted"><b>{(membership.group.groupName ?? "Group " + membership.group.id)}</b>{" ("}<i>inactive</i>{")"}</span>
-                                                            :
-                                                            <span><b>{(membership.group.groupName ?? "Group " + membership.group.id)}</b></span>
-                                                        }
-                                                        <br/>
-                                                        {membership.group.ownerSummary && 
-                                                            <span className="text-muted">Teacher{membership.group.additionalManagers && membership.group.additionalManagers.length > 0 ? "s" : ""}: {
-                                                            [membership.group.ownerSummary, ...membership.group.additionalManagers ?? []].map(extractTeacherName).join(", ")
-                                                        }</span>}
-                                                    </RS.Col>
-                                                    <RS.Col className="d-flex flex-col justify-content-end flex-grow-0 pr-1">
-                                                        {membership.membershipStatus === MEMBERSHIP_STATUS.ACTIVE && <React.Fragment>
-                                                            <RS.Button color="link" disabled={editingOtherUser} onClick={() =>
-                                                                changeMyMembershipStatus({groupId: membership.group.id as number, newStatus: MEMBERSHIP_STATUS.INACTIVE})
-                                                            }>
-                                                                Leave
-                                                            </RS.Button>
-                                                            {isPhy && <>
-                                                                <span id={`leave-group-action-${membership.group.id}`} className="icon-help membership-status-help-button" />
-                                                                <RS.UncontrolledTooltip placement="bottom" target={`leave-group-action-${membership.group.id}`}
-                                                                                        modifiers={{preventOverflow: {boundariesElement: "viewport"}}}>
-                                                                    If you leave a group you will no longer receive notifications of new assignments.
-                                                                </RS.UncontrolledTooltip>
-                                                            </>}
-                                                        </React.Fragment>}
-
-                                                        {membership.membershipStatus === MEMBERSHIP_STATUS.INACTIVE && <React.Fragment>
-                                                            <RS.Button color="link" disabled={editingOtherUser} onClick={() =>
-                                                                changeMyMembershipStatus({groupId: membership.group.id as number, newStatus: MEMBERSHIP_STATUS.ACTIVE})
-                                                            }>
-                                                                Rejoin
-                                                            </RS.Button>
-                                                            {isPhy && <>
-                                                                <span id={`rejoin-group-action-${membership.group.id}`} className="icon-help membership-status-help-button" />
-                                                                <RS.UncontrolledTooltip placement="bottom" target={`rejoin-group-action-${membership.group.id}`}
-                                                                                        modifiers={{preventOverflow: {boundariesElement: "viewport"}}}>
-                                                                    If you rejoin a group you will see all the assignments set since the group was created.
-                                                                </RS.UncontrolledTooltip>
-                                                            </>}
-                                                        </React.Fragment>}
-                                                    </RS.Col>
-                                                </div>
-                                            </li>;
-                                        }}
-                                    </FixedSizeList>}
-                                </ul>
-                            </div>
-                        </div>
-                    </div>
-                    {groupMemberships && groupMemberships.length === 0 && <p className="teachers-connected text-center">
-                        You are not a member of any groups.
+            <div className="connect-list">
+                <ConnectionsHeader title="Teacher connections" enableSearch={enableTeacherSearch} setEnableSearch={setEnableTeacherSearch} setSearchText={setTeacherSearchText}/>
+                <div className="connect-list-inner">
+                    <ul className={classNames("teachers-connected list-unstyled my-0", {"ml-3 mr-2": isPhy}, {"ml-1 mr-2": isAda})}>
+                        <FixedSizeList height={CONNECTIONS_ROW_HEIGHT * (Math.min(CONNECTIONS_MAX_VISIBLE_ROWS, filteredActiveAuthorisations?.length ?? 0))} itemCount={filteredActiveAuthorisations?.length ?? 0} itemSize={CONNECTIONS_ROW_HEIGHT} width="100%" style={{scrollbarGutter: "stable"}}>
+                            {({index, style}) => {
+                                const teacherAuthorisation = filteredActiveAuthorisations?.[index];
+                                if (!teacherAuthorisation) {
+                                    return null;
+                                }
+                                return <React.Fragment key={teacherAuthorisation.id}>
+                                <li style={style} className="py-2">
+                                    <span className="icon-person-active" />
+                                    <span id={`teacher-authorisation-${teacherAuthorisation.id}`}>
+                                        {extractTeacherName(teacherAuthorisation)}
+                                    </span>
+                                    <RS.UncontrolledTooltip
+                                        placement="bottom" target={`teacher-authorisation-${teacherAuthorisation.id}`}
+                                        >
+                                        This user ({teacherAuthorisation.email}) has access to your data.
+                                        To remove this access, click &apos;Revoke&apos;.
+                                    </RS.UncontrolledTooltip>
+                                    <RS.Button
+                                        color="link" className="revoke-teacher pr-1"
+                                        disabled={editingOtherUser}
+                                        onClick={() => user.loggedIn && user.id && dispatch(openActiveModal(revocationConfirmationModal(user.id, teacherAuthorisation)))}
+                                        >
+                                        Revoke
+                                    </RS.Button>
+                                </li>
+                            </React.Fragment>;
+                            }}
+                        </FixedSizeList>
+                    </ul>
+                    {activeAuthorisations && activeAuthorisations.length === 0 && <p className="teachers-connected">
+                        You have no active teacher connections.
                     </p>}
-                </RS.Col>
-            </RS.Row>
-        </RS.Container>
-    </RS.CardBody>;
+                </div>
+            </div>
+
+            {isLoggedIn(user) && !isStudent(user) && <React.Fragment>
+                <hr className={siteSpecific("my-5", "my-4")} />
+                <h3>
+                    <span>Your student connections<span id="student-connections-title" className="icon-help" /></span>
+                    <RS.UncontrolledTooltip placement="bottom" target="student-connections-title">
+                        These are the students who have shared their {siteSpecific("Isaac", "Ada")} data with you.
+                        These students are also able to view your name and email address on their Teacher connections page.
+                    </RS.UncontrolledTooltip>
+                </h3>
+                <p>
+                    You can invite students to share their {siteSpecific("Isaac", "Ada")} data with you through the {" "}
+                    <Link to="/groups">{siteSpecific("group management page", "Manage groups")}</Link>{siteSpecific(".", " page.")}
+                </p>
+                <div className="connect-list">
+                    <ConnectionsHeader title="Student connections" enableSearch={enableStudentSearch} setEnableSearch={setEnableStudentSearch} setSearchText={setStudentSearchText}/>
+                    <div className="connect-list-inner">
+                        <ul className={classNames("teachers-connected list-unstyled my-0", {"ml-3 mr-2": isPhy}, {"ml-1 mr-2": isAda})}>
+                            <FixedSizeList height={CONNECTIONS_ROW_HEIGHT * (Math.min(CONNECTIONS_MAX_VISIBLE_ROWS, filteredStudentAuthorisations?.length ?? 0))} itemCount={filteredStudentAuthorisations?.length ?? 0} itemSize={CONNECTIONS_ROW_HEIGHT} width="100%" style={{scrollbarGutter: "stable"}}>
+                                {({index, style}) => {
+                                    const student = filteredStudentAuthorisations?.[index];
+                                    if (!student) {
+                                        return null;
+                                    }
+                                    return <li key={student.id} style={style} className="py-2">
+                                        <span className="icon-person-active" />
+                                        <span id={`student-authorisation-${student.id}`}>
+                                            {student.givenName} {student.familyName}
+                                        </span>
+                                        <RS.UncontrolledTooltip
+                                            placement="bottom" target={`student-authorisation-${student.id}`}
+                                        >
+                                            You have access to this user&apos;s data and they can see your name and email address.
+                                            To remove this access, click &apos;Remove&apos;.
+                                        </RS.UncontrolledTooltip>
+                                        <RS.Button
+                                            color="link" className="revoke-teacher pr-1" disabled={editingOtherUser}
+                                            onClick={() => user.loggedIn && user.id && dispatch(openActiveModal(releaseConfirmationModal(user.id, student)))}
+                                        >
+                                            Remove
+                                        </RS.Button>
+                                    </li>;
+                                }}
+                            </FixedSizeList>
+                        </ul>
+
+                        {studentAuthorisations && studentAuthorisations.length === 0 && <p className="teachers-connected">
+                            You have no active student connections.
+                        </p>}
+                    </div>
+                    {studentAuthorisations && studentAuthorisations.length > 0 && <p className="remove-link">
+                        <RS.Button color="link" onClick={() => dispatch(openActiveModal(releaseAllConfirmationModal()))} disabled={editingOtherUser}>
+                            Remove all
+                        </RS.Button>
+                    </p>}
+                </div>
+            </React.Fragment>}
+
+            <hr className={siteSpecific("my-5", "my-4")} />
+            <h3>
+                <span>
+                    Your group memberships
+                    <span id="group-memberships-title" className="icon-help" />
+                </span>
+                <RS.UncontrolledTooltip placement="bottom" target="group-memberships-title">
+                    These are the groups you are currently a member of.
+                    Groups on {siteSpecific("Isaac", "Ada")} let teachers set assignments to multiple students in one go.
+                </RS.UncontrolledTooltip>
+            </h3>
+            <p>
+                You can manage who is able to set you assignments by temporarily leaving a group. While you are
+                inactive in a group you won&apos;t receive any assignments from that group.<br/>
+                If you want to permanently leave a group, ask your teacher to remove you.
+            </p>
+            <div className="my-groups-table-section overflow-auto">
+                <div className="connect-list">
+                    <ConnectionsHeader title="Group memberships" enableSearch={enableGroupSearch} setEnableSearch={setEnableGroupSearch} setSearchText={setGroupSearchText}/>
+                    <div className="connect-list-inner">
+                        <ul className={classNames("teachers-connected list-unstyled m-0")}>
+                            {sortedGroupMemberships && <FixedSizeList height={MEMBERSHIPS_ROW_HEIGHT * (Math.min(MEMBERSHIPS_MAX_VISIBLE_ROWS, sortedGroupMemberships.length ?? 0))} itemCount={sortedGroupMemberships.length ?? 0} itemSize={MEMBERSHIPS_ROW_HEIGHT} width="100%" style={{scrollbarGutter: "stable"}}>
+                                {({index, style}) => {
+                                    const membership = sortedGroupMemberships[index];
+                                    return <li key={index} style={style} className={classNames("py-2", {"inactive-group" : isAda && membership.membershipStatus === MEMBERSHIP_STATUS.INACTIVE})}>
+                                        <div className="d-flex">
+                                            <RS.Col>
+                                                {membership.membershipStatus === MEMBERSHIP_STATUS.INACTIVE ?
+                                                    <span className="text-muted"><b>{(membership.group.groupName ?? "Group " + membership.group.id)}</b>{" ("}<i>inactive</i>{")"}</span>
+                                                    :
+                                                    <span><b>{(membership.group.groupName ?? "Group " + membership.group.id)}</b></span>
+                                                }
+                                                <br/>
+                                                {membership.group.ownerSummary && 
+                                                    <span className="text-muted">Teacher{membership.group.additionalManagers && membership.group.additionalManagers.length > 0 ? "s" : ""}: {
+                                                    [membership.group.ownerSummary, ...membership.group.additionalManagers ?? []].map(extractTeacherName).join(", ")
+                                                }</span>}
+                                            </RS.Col>
+                                            <RS.Col className="d-flex flex-col justify-content-end flex-grow-0 pr-1">
+                                                {membership.membershipStatus === MEMBERSHIP_STATUS.ACTIVE && <React.Fragment>
+                                                    <RS.Button color="link" disabled={editingOtherUser} onClick={() =>
+                                                        changeMyMembershipStatus({groupId: membership.group.id as number, newStatus: MEMBERSHIP_STATUS.INACTIVE})
+                                                    }>
+                                                        Leave
+                                                    </RS.Button>
+                                                    {isPhy && <>
+                                                        <span id={`leave-group-action-${membership.group.id}`} className="icon-help membership-status-help-button" />
+                                                        <RS.UncontrolledTooltip placement="bottom" target={`leave-group-action-${membership.group.id}`}
+                                                                                modifiers={{preventOverflow: {boundariesElement: "viewport"}}}>
+                                                            If you leave a group you will no longer receive notifications of new assignments.
+                                                        </RS.UncontrolledTooltip>
+                                                    </>}
+                                                </React.Fragment>}
+
+                                                {membership.membershipStatus === MEMBERSHIP_STATUS.INACTIVE && <React.Fragment>
+                                                    <RS.Button color="link" disabled={editingOtherUser} onClick={() =>
+                                                        changeMyMembershipStatus({groupId: membership.group.id as number, newStatus: MEMBERSHIP_STATUS.ACTIVE})
+                                                    }>
+                                                        Rejoin
+                                                    </RS.Button>
+                                                    {isPhy && <>
+                                                        <span id={`rejoin-group-action-${membership.group.id}`} className="icon-help membership-status-help-button" />
+                                                        <RS.UncontrolledTooltip placement="bottom" target={`rejoin-group-action-${membership.group.id}`}
+                                                                                modifiers={{preventOverflow: {boundariesElement: "viewport"}}}>
+                                                            If you rejoin a group you will see all the assignments set since the group was created.
+                                                        </RS.UncontrolledTooltip>
+                                                    </>}
+                                                </React.Fragment>}
+                                            </RS.Col>
+                                        </div>
+                                    </li>;
+                                }}
+                            </FixedSizeList>}
+                        </ul>
+                    </div>
+                </div>
+            </div>
+            {groupMemberships && groupMemberships.length === 0 && <p className="teachers-connected text-center">
+                You are not a member of any groups.
+            </p>}
+        </>}
+    />;
 };

--- a/src/app/components/elements/panels/UserBetaFeatures.tsx
+++ b/src/app/components/elements/panels/UserBetaFeatures.tsx
@@ -1,31 +1,28 @@
 import React from "react";
 import { DisplaySettings } from "../../../../IsaacAppTypes";
-import { Button, CardBody, UncontrolledTooltip } from "reactstrap";
-import { SITE_TITLE, isAda } from "../../../services";
+import { SITE_TITLE } from "../../../services";
 import { StyledCheckbox } from "../inputs/CheckboxInput";
+import { MyAccountTab } from "./MyAccountTab";
 interface UserBetaFeaturesProps {
     displaySettings: DisplaySettings;
     setDisplaySettings: (ds: DisplaySettings | ((oldDs?: DisplaySettings) => DisplaySettings)) => void;
 }
 
 export const UserBetaFeatures = ({displaySettings, setDisplaySettings}: UserBetaFeaturesProps) => {
-    return <CardBody>
-        <p>
-            Here you can opt-in to beta features of the {SITE_TITLE} platform.
-        </p>
-        <StyledCheckbox type={"checkbox"} initialValue={displaySettings.HIDE_QUESTION_ATTEMPTS ?? false}
-            changeFunction={e => setDisplaySettings(
-                (oldDs) => ({...oldDs, HIDE_QUESTION_ATTEMPTS: e})
-            )} 
-            label={<>
-                Hide previous question attempts
-                <span id={`hide-previous-q-info`} className="icon-help mx-2" />
-                <UncontrolledTooltip placement="right-start" target={`hide-previous-q-info`}>
-                    This feature is helpful for revision, for example - you can attempt all of the questions
-                    on the website again, without seeing your previous answers.
-                </UncontrolledTooltip>
-            </>}
-            id={"hide-previous-q-attempts"}
-        />
-    </CardBody>;
+    return <MyAccountTab
+        leftColumn={<>
+            <h3>Beta Features</h3>
+            <p>Here you can opt-in to beta features of the {SITE_TITLE} platform.</p>
+        </>}
+        rightColumn={<>
+            <StyledCheckbox type={"checkbox"} initialValue={displaySettings.HIDE_QUESTION_ATTEMPTS ?? false}
+                changeFunction={e => setDisplaySettings(
+                    (oldDs) => ({...oldDs, HIDE_QUESTION_ATTEMPTS: e})
+                )} 
+                label={<p><b>Hide previous question attempts</b></p>}
+                id={"hide-previous-q-attempts"}
+            />
+            This feature is helpful for revision, for example - you can attempt all of the questions on the website again, without seeing your previous answers.
+        </>}
+    />;
 };

--- a/src/app/components/elements/panels/UserContent.tsx
+++ b/src/app/components/elements/panels/UserContent.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { MyAccountTab } from './MyAccountTab';
+import { BooleanNotation, DisplaySettings, ProgrammingLanguage, ValidationUser } from '../../../../IsaacAppTypes';
+import { UserContextAccountInput } from '../inputs/UserContextAccountInput';
+import { BooleanNotationInput } from '../inputs/BooleanNotationInput';
+import { UserContext, UserAuthenticationSettingsDTO } from '../../../../IsaacApiTypes';
+import { ProgrammingLanguageInput } from '../inputs/ProgrammingLanguageInput';
+
+interface UserContentProps {
+    userToUpdate: ValidationUser;
+    setUserToUpdate: (user: any) => void;
+    userContexts: UserContext[];
+    setUserContexts: (uc: UserContext[]) => void;
+    programmingLanguage: Nullable<ProgrammingLanguage>;
+    setProgrammingLanguage: (pl: ProgrammingLanguage) => void;
+    booleanNotation: Nullable<BooleanNotation>;
+    setBooleanNotation: (bn: BooleanNotation) => void;
+    displaySettings: Nullable<DisplaySettings>;
+    setDisplaySettings: (ds: DisplaySettings | ((oldDs?: DisplaySettings) => DisplaySettings)) => void;
+    submissionAttempted: boolean;
+    editingOtherUser: boolean;
+    userAuthSettings: UserAuthenticationSettingsDTO | null;
+}
+export const UserContent = (props: UserContentProps) => {
+    const {
+        userToUpdate, setUserToUpdate,
+        userContexts, setUserContexts,
+        programmingLanguage, setProgrammingLanguage,
+        booleanNotation, setBooleanNotation,
+        displaySettings, setDisplaySettings,
+        submissionAttempted, editingOtherUser
+    } = props;
+
+    return <MyAccountTab
+        leftColumn={<>
+            <h3>Account details</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Mi sit amet mauris commodo quis imperdiet massa tincidunt.</p>
+            <p>If you would like to delete your account please <a href="/contact?preset=accountDeletion" target="_blank" rel="noopener noreferrer">contact us</a>.</p>
+        </>}
+        rightColumn={<>
+            <UserContextAccountInput
+                user={userToUpdate} userContexts={userContexts} setUserContexts={setUserContexts}
+                displaySettings={displaySettings} setDisplaySettings={setDisplaySettings}
+                setBooleanNotation={setBooleanNotation} submissionAttempted={submissionAttempted}
+            />
+            <hr className="border-muted my-4"/>
+            <ProgrammingLanguageInput programmingLanguage={programmingLanguage} setProgrammingLanguage={setProgrammingLanguage}/>
+            <BooleanNotationInput booleanNotation={booleanNotation} setBooleanNotation={setBooleanNotation} />
+        </>}
+    />;
+};

--- a/src/app/components/elements/panels/UserContent.tsx
+++ b/src/app/components/elements/panels/UserContent.tsx
@@ -33,9 +33,8 @@ export const UserContent = (props: UserContentProps) => {
 
     return <MyAccountTab
         leftColumn={<>
-            <h3>Account details</h3>
+            <h3>Customise what content you see</h3>
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Mi sit amet mauris commodo quis imperdiet massa tincidunt.</p>
-            <p>If you would like to delete your account please <a href="/contact?preset=accountDeletion" target="_blank" rel="noopener noreferrer">contact us</a>.</p>
         </>}
         rightColumn={<>
             <UserContextAccountInput

--- a/src/app/components/elements/panels/UserDetails.tsx
+++ b/src/app/components/elements/panels/UserDetails.tsx
@@ -137,5 +137,5 @@ export const UserDetails = (props: UserDetailsProps) => {
                 <BooleanNotationInput booleanNotation={booleanNotation} setBooleanNotation={setBooleanNotation} />
             </Col>
         </Row>}
-    </CardBody>
+    </CardBody>;
 };

--- a/src/app/components/elements/panels/UserEmailPreferencesPanel.tsx
+++ b/src/app/components/elements/panels/UserEmailPreferencesPanel.tsx
@@ -1,10 +1,10 @@
-import {CardBody, Col, Row} from "reactstrap";
 import React from "react";
 import {UserEmailPreferences} from "../../../../IsaacAppTypes";
 import {AppState, useAppSelector} from "../../../state";
 import {SITE_TITLE, siteSpecific, validateEmailPreferences} from "../../../services";
 import {UserEmailPreferencesInput} from "../inputs/UserEmailPreferencesInput";
 import {Alert} from "../Alert";
+import { MyAccountTab } from "./MyAccountTab";
 
 interface UserEmailPreferencesProps {
     emailPreferences: UserEmailPreferences | null | undefined;
@@ -22,18 +22,17 @@ export const UserEmailPreferencesPanel = ({emailPreferences, setEmailPreferences
         errorMessage = "Please specify all email preferences";
     }
 
-    return <CardBody className="pb-0">
+    return <>
         {error?.type == "generalError" && <Alert title="Unable to update your account" body={error.generalError} />}
-        <Row>
-            <Col xs={12} lg={6} className="mb-4">
+        <MyAccountTab
+            leftColumn={<>
                 <h3>Set your email notification preferences</h3>
                 <p>Get important information about the {SITE_TITLE} programme delivered to your inbox. These settings can be changed at any time.</p>
                 <b>Frequency</b>: expect one email per term for News{siteSpecific(" and a monthly bulletin for Events", "")}. Assignment notifications will be sent as needed by your teacher.
-            </Col>
-            <Col xs={12} lg={6}>
-                <UserEmailPreferencesInput emailPreferences={emailPreferences} setEmailPreferences={setEmailPreferences} idPrefix={idPrefix}/>
-            </Col>
-        </Row>
-
-    </CardBody>;
+            </>}
+            rightColumn={
+                <UserEmailPreferencesInput emailPreferences={emailPreferences} setEmailPreferences={setEmailPreferences} submissionAttempted={submissionAttempted} idPrefix={idPrefix}
+            />}
+        />
+    </>;
 };

--- a/src/app/components/elements/panels/UserMFA.tsx
+++ b/src/app/components/elements/panels/UserMFA.tsx
@@ -67,14 +67,14 @@ const UserMFA = ({userToUpdate, userAuthSettings, editingOtherUser}: UserMFAProp
 
     return <CardBody className="pt-0 px-0">
         <Row>
-            <Col xs={{size: 6, offset: 3}} className="px-4">
+            <Col xs={{size: 8, offset: 2}} lg={{size: 6, offset: 3}} className="px-4">
                 <hr className="text-center" />
                 <h4>Two-factor Authentication (2FA)</h4>
             </Col>
         </Row>
         {!editingOtherUser && userAuthSettings && userAuthSettings.hasSegueAccount ?
             <Row>
-                <Col xs={{size: 6, offset: 3}} className="px-4">
+                <Col xs={{size: 8, offset: 2}} lg={{size: 6, offset: 3}} className="px-4">
                     <Row>
                         <Col>
                             <p><strong>2FA Status: </strong>{userAuthSettings.mfaStatus || successfulMFASetup ? "Enabled" : "Disabled"}</p>

--- a/src/app/components/elements/panels/UserPassword.tsx
+++ b/src/app/components/elements/panels/UserPassword.tsx
@@ -1,21 +1,23 @@
-import {Button, CardBody, Col, FormFeedback, FormGroup, Input, InputProps, Label, Row} from "reactstrap";
+import {Button, Col, FormGroup, Label, Row} from "reactstrap";
 import React, {useState} from "react";
 import {PasswordFeedback, ValidationUser} from "../../../../IsaacAppTypes";
 import {AuthenticationProvider, UserAuthenticationSettingsDTO} from "../../../../IsaacApiTypes";
 import {
     AUTHENTICATOR_FRIENDLY_NAMES_MAP,
     AUTHENTICATOR_PROVIDERS,
+    above,
     isAda,
     isPhy,
     loadZxcvbnIfNotPresent,
-    MINIMUM_PASSWORD_LENGTH,
     passwordDebounce,
     siteSpecific,
+    useDeviceSize,
     validateEmail
 } from "../../../services";
 import classNames from "classnames";
 import {linkAccount, logOutUserEverywhere, resetPassword, unlinkAccount, useAppDispatch} from "../../../state";
 import {TogglablePasswordInput} from "../inputs/TogglablePasswordInput";
+import { MyAccountTab } from "./MyAccountTab";
 
 interface UserPasswordProps {
     currentPassword?: string;
@@ -33,7 +35,8 @@ interface UserPasswordProps {
 
 const ThirdPartyAccount = ({provider, isLinked, imgCss} : {provider: AuthenticationProvider, isLinked: boolean, imgCss: string}) => {
     const dispatch = useAppDispatch();
-    return <Row className="align-items-center linked-account-button-outer ml-2 mb-1">
+    const deviceSize = useDeviceSize();
+    return <Row className={classNames("align-items-center linked-account-button-outer mb-1", {"mx-2" : above['sm'](deviceSize)})}>
         <input
             type="button"
             id="linked-accounts-no-password"
@@ -53,6 +56,7 @@ export const UserPassword = (
     {currentPassword, currentUserEmail, setCurrentPassword, myUser, setMyUser, isNewPasswordValid, userAuthSettings, setNewPassword, newPassword, editingOtherUser, submissionAttempted}: UserPasswordProps) => {
 
     const dispatch = useAppDispatch();
+    const deviceSize = useDeviceSize();
     const authenticationProvidersUsed = (provider: AuthenticationProvider) => userAuthSettings && userAuthSettings.linkedAccounts && userAuthSettings.linkedAccounts.includes(provider);
 
     const [showPasswordFields, setShowPasswordFields] = useState(false);
@@ -81,131 +85,121 @@ export const UserPassword = (
         }
     });
 
-    return <CardBody className={"pb-0"}>
-        <Row>
-            {isAda && 
-            <Col xs={{size: 12}} lg={{size: 6}} className={classNames({"px-5 mb-4 mb-lg-0" : isAda})}>
-                <h3>Account security</h3>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Mi sit amet mauris commodo quis imperdiet massa tincidunt.
-            </Col>}
-            <Col xs = {isPhy ? {size: 6, offset: 3} : {size: 12}} lg={isPhy ? {size: 6, offset: 3} : {size: 6}} className={classNames({"px-5" : isAda})}>
-                <h4>Password</h4>
-                {userAuthSettings && userAuthSettings.hasSegueAccount ? 
-                    <>  
-                        {(isPhy || (isAda && showPasswordFields)) && 
-                        <>
-                            {!editingOtherUser && 
-                            <FormGroup>
-                                <Label htmlFor="password-current">Current password</Label>
-                                <TogglablePasswordInput
-                                    id="password-current" type="password" name="current-password"
-                                    onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                                        setCurrentPassword(e.target.value)
-                                    }
-                                />
-                            </FormGroup>}
-                            <FormGroup>
-                                <Label htmlFor="new-password">New password</Label>
-                                <TogglablePasswordInput
-                                    invalid={submissionAttempted && !isNewPasswordValid}
-                                    id="new-password" type="password" name="new-password"
-                                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                                        setNewPassword(e.target.value);
-                                        setMyUser(Object.assign({}, myUser, {password: e.target.value}));
-                                        passwordDebounce(e.target.value, setPasswordFeedback);
-                                    }}
-                                    onBlur={(e: React.ChangeEvent<HTMLInputElement>) => {
-                                        passwordDebounce(e.target.value, setPasswordFeedback);
-                                    }}
-                                    onFocus={loadZxcvbnIfNotPresent}
-                                    aria-describedby="passwordValidationMessage"
-                                    disabled={!editingOtherUser && currentPassword == ""}
-                                />
-                                {passwordFeedback &&
-                                <span className='float-right small mt-1'>
-                                    <strong>Password strength: </strong>
-                                    <span id="password-strength-feedback">
-                                        {passwordFeedback.feedbackText}
-                                    </span>
-                                </span>
+    return <MyAccountTab
+        leftColumn={<>
+            <h3>Account security</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Mi sit amet mauris commodo quis imperdiet massa tincidunt.</p>
+        </>}
+        rightColumn={<>
+            <h4>Password</h4>
+            {userAuthSettings && userAuthSettings.hasSegueAccount ? 
+                <>  
+                    {(isPhy || (isAda && showPasswordFields)) && 
+                    <>
+                        {!editingOtherUser && 
+                        <FormGroup>
+                            <Label htmlFor="password-current">Current password</Label>
+                            <TogglablePasswordInput
+                                id="password-current" type="password" name="current-password"
+                                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                                    setCurrentPassword(e.target.value)
                                 }
-                            </FormGroup>
-                        </>}
-                        {isAda && !showPasswordFields && <Button className="w-100 py-2 mt-3 mb-2" outline onClick={() => setShowPasswordFields(true)}>Change password</Button>}
-                    </>
-                : !passwordResetRequested ?
-                    <React.Fragment>
-                        <Row className="pt-4">
-                            <Col className="text-center">
-                                {userAuthSettings && userAuthSettings.linkedAccounts && <p>
-                                    You do not currently have a password set for this account; you
-                                    sign in using {" "}
-                                    {(userAuthSettings.linkedAccounts).map((linked, index) => {
-                                        return <span key={index} className="text-capitalize">
-                                            {AUTHENTICATOR_FRIENDLY_NAMES_MAP[linked]}
-                                        </span>;
-                                    })}.
-                                </p>}
-                            </Col>
-                        </Row>
-                        <Row className="pb-4">
-                            <Col className="text-center">
-                                <Button className="btn-secondary" onClick={resetPasswordIfValidEmail}>
-                                    Click here to add a password
-                                </Button>
-                            </Col>
-                        </Row>
-                    </React.Fragment>
-                    :
-                    <React.Fragment>
-                        <p>
-                            <strong className="d-block">Your password reset request is being processed.</strong>
-                            <strong className="d-block">Please check your inbox.</strong>
-                        </p>
-                    </React.Fragment>
-                }
+                            />
+                        </FormGroup>}
+                        <FormGroup>
+                            <Label htmlFor="new-password">New password</Label>
+                            <TogglablePasswordInput
+                                invalid={submissionAttempted && !isNewPasswordValid}
+                                id="new-password" type="password" name="new-password"
+                                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                                    setNewPassword(e.target.value);
+                                    setMyUser(Object.assign({}, myUser, {password: e.target.value}));
+                                    passwordDebounce(e.target.value, setPasswordFeedback);
+                                }}
+                                onBlur={(e: React.ChangeEvent<HTMLInputElement>) => {
+                                    passwordDebounce(e.target.value, setPasswordFeedback);
+                                }}
+                                onFocus={loadZxcvbnIfNotPresent}
+                                aria-describedby="passwordValidationMessage"
+                                disabled={!editingOtherUser && currentPassword == ""}
+                            />
+                            {passwordFeedback &&
+                            <span className='float-right small mt-1'>
+                                <strong>Password strength: </strong>
+                                <span id="password-strength-feedback">
+                                    {passwordFeedback.feedbackText}
+                                </span>
+                            </span>
+                            }
+                        </FormGroup>
+                    </>}
+                    {isAda && !showPasswordFields && <Button className="w-100 py-2 mt-3 mb-2" outline onClick={() => setShowPasswordFields(true)}>Change password</Button>}
+                </>
+            : !passwordResetRequested ?
                 <React.Fragment>
-                    <hr className="text-center" />
-                    {connectedAccounts.length > 0 && <FormGroup>
-                        <h4>Linked {siteSpecific("Accounts", "accounts")}</h4>
-                        <Col>
-                            {connectedAccounts.map((provider) => {
-                                return authButtonsMap[provider](true);
-                            })}
+                    <Row className="pt-4">
+                        <Col className="text-center">
+                            {userAuthSettings && userAuthSettings.linkedAccounts && <p>
+                                You do not currently have a password set for this account; you
+                                sign in using {" "}
+                                {(userAuthSettings.linkedAccounts).map((linked, index) => {
+                                    return <span key={index} className="text-capitalize">
+                                        {AUTHENTICATOR_FRIENDLY_NAMES_MAP[linked]}
+                                    </span>;
+                                })}.
+                            </p>}
                         </Col>
-                    </FormGroup>}
-                    {unconnectedAccounts.length > 0 && <FormGroup>
-                        <h4>Link other accounts</h4>
-                        <Col>
-                            {unconnectedAccounts.map((provider) => {
-                                return authButtonsMap[provider](false);
-                            })}
+                    </Row>
+                    <Row className="pb-4">
+                        <Col className="text-center">
+                            <Button className="btn-secondary" onClick={resetPasswordIfValidEmail}>
+                                Click here to add a password
+                            </Button>
                         </Col>
-                    </FormGroup>}
+                    </Row>
                 </React.Fragment>
+                :
                 <React.Fragment>
-                    <hr className="text-center"/>
-                    <FormGroup>
-                        <h4>Log Out</h4>
-                        <p>
-                            {"If you forgot to log out on a device you no longer have access to, you can " +
-                            "log your account out on all devices, including this one."}
-                        </p>
-                        <Col className="text-center mt-2 px-0">
-                            {isPhy && 
-                            <div className="vertical-center ml-2">
-                                <Button onClick={() => dispatch(logOutUserEverywhere())}>
-                                    Log me out everywhere
-                                </Button>
-                            </div>}
-                            {isAda &&
-                            <Button className="w-100 py-2 mt-3 mb-2" outline onClick={() => dispatch(logOutUserEverywhere())}>
-                                Log me out everywhere
-                            </Button>}
-                        </Col>
-                    </FormGroup>
+                    <p>
+                        <strong className="d-block">Your password reset request is being processed.</strong>
+                        <strong className="d-block">Please check your inbox.</strong>
+                    </p>
                 </React.Fragment>
-            </Col>
-        </Row>
-    </CardBody>;
+            }
+            <React.Fragment>
+                <hr className="text-center" />
+                {connectedAccounts.length > 0 && <FormGroup>
+                    <h4>Linked {siteSpecific("Accounts", "accounts")}</h4>
+                    <Col>
+                        {connectedAccounts.map((provider) => {
+                            return authButtonsMap[provider](true);
+                        })}
+                    </Col>
+                </FormGroup>}
+                {unconnectedAccounts.length > 0 && <FormGroup>
+                    <h4>Link other accounts</h4>
+                    <Col>
+                        {unconnectedAccounts.map((provider) => {
+                            return authButtonsMap[provider](false);
+                        })}
+                    </Col>
+                </FormGroup>}
+            </React.Fragment>
+            <React.Fragment>
+                <hr className="text-center"/>
+                <FormGroup>
+                    <h4>Log Out</h4>
+                    <p>
+                        {"If you forgot to log out on a device you no longer have access to, you can " +
+                        "log your account out on all devices, including this one."}
+                    </p>
+                    <Col className="text-center mt-2 px-0">
+                        <Button className={classNames("w-100 py-2 mt-3 mb-2", isAda)} color="primary" outline onClick={() => dispatch(logOutUserEverywhere())}>
+                            Log {above['sm'](deviceSize) ? "me " : ""}out everywhere
+                        </Button>
+                    </Col>
+                </FormGroup>
+            </React.Fragment>
+        </>}
+    />;
 };

--- a/src/app/components/elements/panels/UserProfile.tsx
+++ b/src/app/components/elements/panels/UserProfile.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { MyAccountTab } from './MyAccountTab';
+import { FirstNameInput, LastNameInput } from '../inputs/NameInput';
+import { EmailInput } from '../inputs/EmailInput';
+import { ValidationUser } from '../../../../IsaacAppTypes';
+import { validateName, validateEmail } from '../../../services';
+import { CountryInput } from '../inputs/CountryInput';
+import { DobInput } from '../inputs/DobInput';
+import { GenderInput } from '../inputs/GenderInput';
+
+interface UserProfileProps {
+    userToUpdate: ValidationUser;
+    setUserToUpdate: (user: any) => void;
+    submissionAttempted: boolean;
+    editingOtherUser: boolean;
+}
+
+export const UserProfile = ({userToUpdate, setUserToUpdate, submissionAttempted, editingOtherUser}: UserProfileProps) => {
+    return <MyAccountTab
+        leftColumn={<>
+            <h3>Account details</h3>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Mi sit amet mauris commodo quis imperdiet massa tincidunt.</p>
+            <p>If you would like to delete your account please <a href="/contact?preset=accountDeletion" target="_blank" rel="noopener noreferrer">contact us</a>.</p>
+        </>}
+        rightColumn={<>
+            <FirstNameInput
+                userToUpdate={userToUpdate}
+                setUserToUpdate={setUserToUpdate}
+                nameValid={!!validateName(userToUpdate.givenName)}
+                submissionAttempted={submissionAttempted}
+                required={true}
+            />
+            <LastNameInput
+                userToUpdate={userToUpdate}
+                setUserToUpdate={setUserToUpdate}
+                nameValid={!!validateName(userToUpdate.familyName)}
+                submissionAttempted={submissionAttempted}
+                required={true}
+            />
+            <EmailInput
+                userToUpdate={userToUpdate}
+                setUserToUpdate={setUserToUpdate}
+                emailIsValid={!!validateEmail(userToUpdate.email)}
+                submissionAttempted={submissionAttempted}
+                required={true}
+            />
+            <hr className="text-center border-muted my-4"/>
+            <DobInput 
+                userToUpdate={userToUpdate} 
+                setUserToUpdate={setUserToUpdate} 
+                submissionAttempted={submissionAttempted} 
+                editingOtherUser={editingOtherUser}
+            />
+            <GenderInput 
+                userToUpdate={userToUpdate}
+                setUserToUpdate={setUserToUpdate} 
+                submissionAttempted={submissionAttempted}
+                required={false}
+            />
+            <CountryInput
+                userToUpdate={userToUpdate} 
+                setUserToUpdate={setUserToUpdate} 
+                submissionAttempted={submissionAttempted}
+                required={false}
+            />
+        </>}
+    />;
+};

--- a/src/app/components/pages/MyAccount.tsx
+++ b/src/app/components/pages/MyAccount.tsx
@@ -278,7 +278,7 @@ const AccountPageComponent = ({user, getChosenUserAuthSettings, error, userAuthS
                                 className={siteSpecific("mx-2", "px-2")} tabIndex={0}
                                 onClick={() => setActiveTab(ACCOUNT_TAB.account)} onKeyDown={ifKeyIsEnter(() => setActiveTab(ACCOUNT_TAB.account))}
                             >
-                                Profile
+                                {siteSpecific("Profile", "Details")}
                             </NavLink>
                         </NavItem>
                         {isAda && <NavItem className={classnames({active: activeTab === ACCOUNT_TAB.customise})}>

--- a/src/app/components/pages/MyAccount.tsx
+++ b/src/app/components/pages/MyAccount.tsx
@@ -46,6 +46,7 @@ import {
     isAda,
     isDefined,
     isDobOldEnoughForSite,
+    isPhy,
     isStaff,
     SITE_TITLE, siteSpecific,
     validateEmail,
@@ -63,6 +64,8 @@ import {skipToken} from "@reduxjs/toolkit/query";
 import { Loading } from "../handlers/IsaacSpinner";
 import {useEmailPreferenceState} from "../elements/inputs/UserEmailPreferencesInput";
 import {Alert} from "../elements/Alert";
+import { UserProfile } from '../elements/panels/UserProfile';
+import { UserContent } from '../elements/panels/UserContent';
 
 const UserMFA = lazy(() => import("../elements/panels/UserMFA"));
 
@@ -270,7 +273,7 @@ const AccountPageComponent = ({user, getChosenUserAuthSettings, error, userAuthS
             {user.loggedIn && userToUpdate.loggedIn && // We can guarantee user and myUser are logged in from the route requirements
                 <Card>
                     <Nav tabs className={classNames("my-4 flex-wrap", {"mx-4": isAda})}>
-                        <NavItem className={classnames({active: activeTab === ACCOUNT_TAB.account})}>
+                    <NavItem className={classnames({active: activeTab === ACCOUNT_TAB.account})}>
                             <NavLink
                                 className={siteSpecific("mx-2", "px-2")} tabIndex={0}
                                 onClick={() => setActiveTab(ACCOUNT_TAB.account)} onKeyDown={ifKeyIsEnter(() => setActiveTab(ACCOUNT_TAB.account))}
@@ -278,6 +281,14 @@ const AccountPageComponent = ({user, getChosenUserAuthSettings, error, userAuthS
                                 Profile
                             </NavLink>
                         </NavItem>
+                        {isAda && <NavItem className={classnames({active: activeTab === ACCOUNT_TAB.customise})}>
+                            <NavLink
+                                className={siteSpecific("mx-2", "px-2")} tabIndex={0}
+                                onClick={() => setActiveTab(ACCOUNT_TAB.customise)} onKeyDown={ifKeyIsEnter(() => setActiveTab(ACCOUNT_TAB.customise))}
+                            >
+                                Customise
+                            </NavLink>
+                        </NavItem>}
                         <NavItem className={classnames({active: activeTab === ACCOUNT_TAB.passwordreset})}>
                             <NavLink
                                 className={siteSpecific("mx-2", "px-2")} tabIndex={0}
@@ -319,7 +330,23 @@ const AccountPageComponent = ({user, getChosenUserAuthSettings, error, userAuthS
                         {error?.type == "generalError" && <Alert title="Unable to update your account" body={error.generalError} />}
                         <TabContent activeTab={activeTab}>
                             <TabPane tabId={ACCOUNT_TAB.account}>
-                                <UserDetails
+                                {isPhy && <UserDetails
+                                    userToUpdate={userToUpdate} setUserToUpdate={setUserToUpdate}
+                                    userContexts={userContextsToUpdate} setUserContexts={setUserContextsToUpdate}
+                                    programmingLanguage={myUserPreferences?.PROGRAMMING_LANGUAGE} setProgrammingLanguage={setProgrammingLanguage}
+                                    booleanNotation={myUserPreferences?.BOOLEAN_NOTATION} setBooleanNotation={setBooleanNotation}
+                                    displaySettings={myUserPreferences?.DISPLAY_SETTING} setDisplaySettings={setDisplaySettings}
+                                    submissionAttempted={attemptedAccountUpdate} editingOtherUser={editingOtherUser}
+                                    userAuthSettings={userAuthSettings}
+                                />}
+                                {isAda && <UserProfile
+                                    userToUpdate={userToUpdate} setUserToUpdate={setUserToUpdate}
+                                    submissionAttempted={attemptedAccountUpdate} editingOtherUser={editingOtherUser}
+                                />}
+                            </TabPane>
+
+                            {isAda && <TabPane tabId={ACCOUNT_TAB.customise}>
+                                <UserContent
                                     userToUpdate={userToUpdate} setUserToUpdate={setUserToUpdate}
                                     userContexts={userContextsToUpdate} setUserContexts={setUserContextsToUpdate}
                                     programmingLanguage={myUserPreferences?.PROGRAMMING_LANGUAGE} setProgrammingLanguage={setProgrammingLanguage}
@@ -328,7 +355,7 @@ const AccountPageComponent = ({user, getChosenUserAuthSettings, error, userAuthS
                                     submissionAttempted={attemptedAccountUpdate} editingOtherUser={editingOtherUser}
                                     userAuthSettings={userAuthSettings}
                                 />
-                            </TabPane>
+                            </TabPane>}
 
                             <TabPane tabId={ACCOUNT_TAB.passwordreset}>
                                 <UserPassword
@@ -382,11 +409,11 @@ const AccountPageComponent = ({user, getChosenUserAuthSettings, error, userAuthS
                 </Card>
             }
         </ShowLoading>
-        <Row className="text-muted text-center mt-3">
+        {isPhy && <Row className="text-muted text-center mt-3">
             <Col>
                 If you would like to delete your account please <a href="/contact?preset=accountDeletion" target="_blank" rel="noopener noreferrer">contact us</a>.
             </Col>
-        </Row>
+        </Row>}
     </Container>;
 };
 

--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -319,6 +319,10 @@ export const examBoardBooleanNotationMap: {[examBoard in ExamBoard]: BOOLEAN_NOT
     [EXAM_BOARD.CIE]: BOOLEAN_NOTATION.ENG,
     [EXAM_BOARD.ALL]: BOOLEAN_NOTATION.MATH,
 };
+export const booleanNotationMap: {[notation: string]: string} = {
+    [BOOLEAN_NOTATION.MATH]: "And (∧) Or (∨) Not (¬)",
+    [BOOLEAN_NOTATION.ENG]: "And (·) Or (+) Not (bar)",
+};
 
 // STAGES
 export enum STAGE {
@@ -748,7 +752,7 @@ export enum MEMBERSHIP_STATUS {
     INACTIVE = "INACTIVE",
 }
 
-export enum ACCOUNT_TAB {account, passwordreset, teacherconnections, emailpreferences, betafeatures}
+export enum ACCOUNT_TAB {account, customise, passwordreset, teacherconnections, emailpreferences, betafeatures}
 
 export enum MANAGE_QUIZ_TAB {set = 1, manage = 2}
 export enum MARKBOOK_TYPE_TAB {assignments = 1, tests = 2}

--- a/src/scss/common/my-account.scss
+++ b/src/scss/common/my-account.scss
@@ -27,6 +27,18 @@
   }
 }
 
+.remove-stage-container {
+  min-width: 16px;
+  padding: 6px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.account-dropdown {
+  flex: 1 1 0px;
+}
+
 .invalid-school {
   width: 100%;
   margin-top: 0.25rem;

--- a/src/scss/cs/my-account.scss
+++ b/src/scss/cs/my-account.scss
@@ -1,5 +1,9 @@
 @import "../common/my-account";
 
+.input-description {
+  color: #7c7c7c;
+}
+
 .linked-account-button-outer {
   border: 3px $cs-cultured solid;
   border-radius: 10px;
@@ -10,5 +14,52 @@
     padding: 5px;
     background: url("/assets/logos/raspberry-pi.png") center no-repeat content-box;
     background-size: contain !important;
+  }
+}
+
+.remove-stage-container {
+  min-width: 24px;
+  margin: 6px 0 0 6px;
+}
+
+.my-account-tab {
+  select.form-control, input.form-control {
+    height: 45px;
+    border-radius: 10px;
+    border: solid 2px #666;
+  }
+
+  select.form-control:not(.date-input-day) {
+    position: relative;
+    appearance: none;
+  }
+
+  #dob-input > .date-input-wrapper {
+    select {
+      padding: 0 1.2em;
+      border-radius: 0;
+    }
+    
+    &:first-of-type select {
+      border-radius: 10px 0 0 10px;
+    }
+
+    &:last-of-type select {
+      border-radius: 0 10px 10px 0;
+    }
+  }
+
+  .styled-dropdown-caret::after, .date-input-wrapper::after {
+    content: "";
+    position: absolute;
+    top: calc(50% - 4px);
+    right: 12px;
+    z-index: 2;
+    height: 8px;
+    width: 12px;
+    background-repeat: no-repeat;
+    background-size: contain;
+    background-image: url('/assets/chevron_down.svg');
+    pointer-events: none;
   }
 }


### PR DESCRIPTION
Implements the new tabs from the Ada signup flow redesign.

- Splits the 'Profile' tab into 'Details' and 'Customise';
- Details contains all user-centric information: name, email, DoB...
- Customise contains content-centric information: stage, level, preferred language...

- Physics functionality is entirely unchanged, layout may slightly differ in places to enable a significantly easier transition to new signup flow when they want it.