### PR TITLE
Fix incorrectly disabled "Extend due date" button on tests

### DIFF
--- a/src/app/components/pages/quizzes/SetQuizzes.tsx
+++ b/src/app/components/pages/quizzes/SetQuizzes.tsx
@@ -242,7 +242,7 @@ function QuizAssignment({user, assignedGroups, index}: QuizAssignmentProps) {
                                         More
                                     </RS.DropdownToggle>
                                     <RS.DropdownMenu>
-                                        <RS.DropdownItem color="tertiary" size="sm" disabled={isUpdatingQuiz || !assignment?.dueDate} onClick={() => {
+                                        <RS.DropdownItem color="tertiary" size="sm" disabled={isUpdatingQuiz || !assignedGroup.assignment?.dueDate} onClick={() => {
                                             setSelectedQuiz(assignedGroup.assignment);
                                             setIsModalOpen(true);
                                         }}>


### PR DESCRIPTION
Uses the assignment set to one specific group, rather than the generic assignment used earlier in the code.