### PR TITLE
Fix 'Allow another attempt' button visibility

### DIFF
--- a/src/app/components/elements/quiz/QuizProgressCommon.tsx
+++ b/src/app/components/elements/quiz/QuizProgressCommon.tsx
@@ -239,7 +239,7 @@ export function ResultsTable<Q extends QuestionType>({assignmentId,
                                                     </div>
                                                 </Button>
                                                 {!returningQuizToStudent && dropdownOpen?.[index] && <>
-                                                    {duedate && duedate.valueOf() > TODAY().valueOf() &&
+                                                    {(!duedate || duedate.valueOf() > TODAY().valueOf()) &&
                                                         (studentProgress.completed) &&
                                                         <div className="py-2 px-3">
                                                             <Button size="sm" onClick={() => returnToStudent(studentProgress.user.id)}>Allow another attempt</Button>


### PR DESCRIPTION
Changing the conditional on the due date so that if a due date does not exist the 'Allow another attempt' button is
still shown.
