### PR TITLE
Display Stages and Difficulties as table

### DIFF
--- a/src/app/components/elements/cards/BoardCard.tsx
+++ b/src/app/components/elements/cards/BoardCard.tsx
@@ -181,7 +181,7 @@ export const BoardCard = ({user, board, boardView, assignees, toggleAssignModal,
                 </table>}
             </td>
             {isAda && <td className={basicCellClasses} data-testid={"owner"}>{formatBoardOwner(user, board)}</td>}
-            {!isSetAssignments && isPhy && <td className="align-middle text-center">{formatDate(board.creationDate)}</td>}
+            {!isSetAssignments && <td className="align-middle text-center">{formatDate(board.creationDate)}</td>}
             <td className={basicCellClasses} data-testid={"last-visited"}>{formatDate(board.lastVisited)}</td>
             {isSetAssignments && <td className={"align-middle text-center"}>
                 <Button className="set-assignments-button" color={siteSpecific("tertiary", "secondary")} size="sm" onClick={toggleAssignModal}>

--- a/src/app/components/elements/cards/BoardCard.tsx
+++ b/src/app/components/elements/cards/BoardCard.tsx
@@ -8,6 +8,7 @@ import {
     isAda,
     isAdminOrEventManager,
     isDefined,
+    isPhy,
     PATHS,
     siteSpecific,
     stageLabelMap
@@ -147,6 +148,10 @@ export const BoardCard = ({user, board, boardView, assignees, toggleAssignModal,
         </foreignObject>
     </svg>;
 
+    const stagesAndDifficultiesBorders = (i : number) => {
+        return siteSpecific(`border-left-1 border-right-1 border-top-${i === 0 ? 0 : 1} border-bottom-${i === boardStagesAndDifficulties.length - 1 ? 0 : 1}`, "border-0");
+    };
+
     return boardView == BoardViews.table ?
         <tr className={siteSpecific("board-card", "")} data-testid={"gameboard-table-row"}>
             <td className={siteSpecific("", "align-middle text-center")}>
@@ -157,16 +162,17 @@ export const BoardCard = ({user, board, boardView, assignees, toggleAssignModal,
             </td>
             <td colSpan={siteSpecific(1, isSetAssignments ? 2 : 4)} className="align-middle">
                 <a href={boardLink} className={isAda ? "font-weight-semi-bold" : ""}>{board.title}</a>
+                {isPhy && <span className="text-muted"><br/>Created by {<span data-testid={"owner"}>{formatBoardOwner(user, board)}</span>}</span>}
             </td>
             <td className={basicCellClasses + " p-0"} colSpan={2}>
                 {boardStagesAndDifficulties.length > 0 && <table className="w-100 border-0">
                     <tbody>
                     {boardStagesAndDifficulties.map(([stage,difficulties], i) => {
-                        return <tr key={stage} className={classNames({"border-0": i === 0, "border-left-0 border-right-0 border-bottom-0": i === 1})}>
-                            <td className="text-center align-middle border-0 p-1 w-50">
+                        return <tr key={stage} className={classNames({"border-0": i === 0, "border-left-0 border-right-0 border-bottom-0": i >= 1})}>
+                            <td className={`text-center align-middle ${stagesAndDifficultiesBorders(i)} p-1 w-50`}>
                                 {stageLabelMap[stage]}
                             </td>
-                            <td className="text-center align-middle border-0 p-1 w-50">
+                            <td className={`text-center align-middle ${stagesAndDifficultiesBorders(i)} p-1 w-50`}>
                                 {isAda && "("}{sortBy(difficulties, d => indexOf(Object.keys(difficultyShortLabelMap), d)).map(d => difficultyShortLabelMap[d]).join(", ")}{isAda && ")"}
                             </td>
                         </tr>;
@@ -174,32 +180,28 @@ export const BoardCard = ({user, board, boardView, assignees, toggleAssignModal,
                     </tbody>
                 </table>}
             </td>
-            <td className={basicCellClasses} data-testid={"owner"}>{formatBoardOwner(user, board)}</td>
-            {!isSetAssignments && <td className={"align-middle text-center"}>{formatDate(board.creationDate)}</td>}
+            {isAda && <td className={basicCellClasses} data-testid={"owner"}>{formatBoardOwner(user, board)}</td>}
+            {!isSetAssignments && isPhy && <td className="align-middle text-center">{formatDate(board.creationDate)}</td>}
             <td className={basicCellClasses} data-testid={"last-visited"}>{formatDate(board.lastVisited)}</td>
             {isSetAssignments && <td className={"align-middle text-center"}>
                 <Button className="set-assignments-button" color={siteSpecific("tertiary", "secondary")} size="sm" onClick={toggleAssignModal}>
                     Assign{hasAssignedGroups && "\u00a0/ Unassign"}
                 </Button>
             </td>}
-            <td className={basicCellClasses}>
+            {isAda && <td className={basicCellClasses}>
                 <div className="table-share-link">
                     <ShareLink linkUrl={boardLink} gameboardId={board.id} outline={isAda} clickAwayClose={isAda} />
                 </div>
-            </td>
+            </td>}
             {isSetAssignments && isAda && <td className={basicCellClasses}>
                 <Button outline color={"secondary"} className={"bin-icon d-inline-block outline"} onClick={confirmDeleteBoard} aria-label="Delete quiz"/>
             </td>}
             {!isSetAssignments && siteSpecific(
                 <td className={"text-center align-middle"}>
-                    <CustomInput
-                        id={`board-delete-${board.id}`}
-                        type="checkbox"
-                        checked={board && selectedBoards?.some(e => e.id === board.id)}
-                        onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                            board && updateBoardSelection(board, event.target.checked);
-                        }} aria-label="Delete gameboard"
-                    />
+                    <Button outline color="primary" className={"bin-icon d-inline-block outline"} style={{
+                        width: "20px",
+                        minWidth: "20px",
+                    }} onClick={confirmDeleteBoard} aria-label="Delete quiz"/>
                 </td>,
                 <td className={"text-center align-middle overflow-hidden"}>
                     <CustomInput

--- a/src/app/components/pages/MyGameboards.tsx
+++ b/src/app/components/pages/MyGameboards.tsx
@@ -125,19 +125,19 @@ const CSTable = (props: GameboardsTableProps) => {
                     </RS.UncontrolledTooltip>
                 </th>
                 {isAda && <th>Creator</th>}
-                {isPhy && <th>
+                <th>
                     <button className="table-button" onClick={() => boardOrder == BoardOrder.created ? setBoardOrder(BoardOrder["-created"]) : setBoardOrder(BoardOrder.created)}>
                         Created {boardOrder == BoardOrder.created ? sortIcon.ascending : boardOrder == BoardOrder["-created"] ? sortIcon.descending : sortIcon.sortable}
                     </button>
-                </th>}
+                </th>
                 
                 {siteSpecific(<>
-                    <th className={classNames({"text-center" : isPhy})}>
+                    <th className="text-center">
                         <button className="table-button" onClick={() => boardOrder == BoardOrder.visited ? setBoardOrder(BoardOrder["-visited"]) : setBoardOrder(BoardOrder.visited)}>
                             Last viewed {boardOrder == BoardOrder.visited ? sortIcon.ascending : boardOrder == BoardOrder["-visited"] ? sortIcon.descending : sortIcon.sortable}
                         </button>
                     </th>
-                    <th className={classNames({"text-center" : isPhy})}>
+                    <th className="text-center">
                         Delete
                     </th>
                 </>,

--- a/src/app/components/pages/MyGameboards.tsx
+++ b/src/app/components/pages/MyGameboards.tsx
@@ -27,6 +27,7 @@ import {
     difficultiesOrdered,
     difficultyShortLabelMap,
     formatBoardOwner,
+    isAda,
     isMobile,
     isPhy, isTutorOrAbove, matchesAllWordsInAnyOrder, PATHS,
     siteSpecific,
@@ -39,6 +40,7 @@ import {BoardCard} from "../elements/cards/BoardCard";
 import {PageFragment} from "../elements/PageFragment";
 import {RenderNothing} from "../elements/RenderNothing";
 import { Spacer } from "../elements/Spacer";
+import classNames from "classnames";
 
 interface GameboardsTableProps {
     user: RegisteredUserDTO;
@@ -58,133 +60,11 @@ interface GameboardsTableProps {
     setBoardOrder: (boardOrder: BoardOrder) => void;
 }
 const PhyTable = (props: GameboardsTableProps) => {
-    const {
-        user,
-        boards, selectedBoards, setSelectedBoards, confirmDeleteMultipleBoards,
-        boardView, switchViewAndClearSelected, boardTitleFilter, setBoardTitleFilter,
-        boardCompletion, setBoardCompletion, boardCreator, setBoardCreator,
-        boardOrder, setBoardOrder
-    } = props;
-    return <>
-        <Row>
-            <Col sm={4} lg={3}>
-                <Label className="w-100">
-                    Display in <Input type="select" value={boardView} onChange={switchViewAndClearSelected} className="p-2">
-                        {Object.values(BoardViews).map(view => <option key={view} value={view}>{view}</option>)}
-                    </Input>
-                </Label>
-            </Col>
-        </Row>
-        <Card className="mt-2 mb-5">
-            <CardBody id="boards-table">
-                <Row>
-                    <Col lg={4}>
-                        <Label className="w-100">
-                            Filter boards <Input type="text" data-testid="title-filter" onChange={(e) => setBoardTitleFilter(e.target.value)} placeholder="Filter boards by name"/>
-                        </Label>
-                    </Col>
-                    {/* TODO MT add stage selector */}
-                    {/*{SITE_SUBJECT == SITE.PHY && <Col sm={6} lg={{size: 3, offset: 1}}>*/}
-                    {/*    <Label className="w-100">Levels*/}
-                    {/*        <StyledSelect inputId="levels-select"*/}
-                    {/*            isMulti*/}
-                    {/*            options={[*/}
-                    {/*                {value: '1', label: '1'},*/}
-                    {/*                {value: '2', label: '2'},*/}
-                    {/*                {value: '3', label: '3'},*/}
-                    {/*                {value: '4', label: '4'},*/}
-                    {/*                {value: '5', label: '5'},*/}
-                    {/*                {value: '6', label: '6'},*/}
-                    {/*            ]}*/}
-                    {/*            className="basic-multi-select"*/}
-                    {/*            classNamePrefix="select"*/}
-                    {/*            placeholder="None"*/}
-                    {/*            onChange={multiSelectOnChange(setLevels)}*/}
-                    {/*        />*/}
-                    {/*    </Label>*/}
-                    {/*</Col>*/}
-                    {/*}*/}
-                    <Col sm={6} lg={{size: 2, offset: 4}}>
-                        <Label className="w-100">
-                            Creator <Input type="select" value={boardCreator} onChange={e => setBoardCreator(e.target.value as BoardCreators)}>
-                            {Object.values(BoardCreators).map(creator => <option key={creator} value={creator}>{creator}</option>)}
-                        </Input>
-                        </Label>
-                    </Col>
-                    <Col sm={6} lg={2}>
-                        <Label className="w-100">
-                            Completion <Input type="select" value={boardCompletion} onChange={e => setBoardCompletion(e.target.value as BoardCompletions)}>
-                            {Object.values(BoardCompletions).map(completion => <option key={completion} value={completion}>{completion}</option>)}
-                        </Input>
-                        </Label>
-                    </Col>
-                </Row>
-
-                <div className="overflow-auto mt-3">
-                    <Table className="mb-0">
-                        <thead>
-                        <tr>
-                            <th className="align-middle pointer-cursor">
-                                <button className="table-button" onClick={() => boardOrder == BoardOrder.completion ? setBoardOrder(BoardOrder["-completion"]) : setBoardOrder(BoardOrder.completion)}>
-                                    Completion {boardOrder == BoardOrder.completion ? sortIcon.ascending : boardOrder == BoardOrder["-completion"] ? sortIcon.descending : sortIcon.sortable}
-                                </button>
-                            </th>
-                            <th className="align-middle pointer-cursor">
-                                <button className="table-button" onClick={() => boardOrder == BoardOrder.title ? setBoardOrder(BoardOrder["-title"]) : setBoardOrder(BoardOrder.title)}>
-                                    Board name {boardOrder == BoardOrder.title ? sortIcon.ascending : boardOrder == BoardOrder["-title"] ? sortIcon.descending : sortIcon.sortable}
-                                </button>
-                            </th>
-                            <th className="text-center align-middle">Stages</th>
-                            <th className="text-center align-middle" style={{whiteSpace: "nowrap"}}>
-                                Difficulties <span id={`difficulties-help`} className="icon-help mx-1" />
-                                <RS.UncontrolledTooltip placement="bottom" target={`difficulties-help`}>
-                                    Practice: {difficultiesOrdered.slice(0, siteSpecific(3, 2)).map(d => difficultyShortLabelMap[d]).join(", ")}<br />
-                                    Challenge: {difficultiesOrdered.slice(siteSpecific(3, 2)).map(d => difficultyShortLabelMap[d]).join(", ")}
-                                </RS.UncontrolledTooltip>
-                            </th>
-                            <th className="text-center align-middle">Creator</th>
-                            <th className="text-center align-middle pointer-cursor">
-                                <button className="table-button" onClick={() => boardOrder == BoardOrder.created ? setBoardOrder(BoardOrder["-created"]) : setBoardOrder(BoardOrder.created)}>
-                                    Created {boardOrder == BoardOrder.created ? sortIcon.ascending : boardOrder == BoardOrder["-created"] ? sortIcon.descending : sortIcon.sortable}
-                                </button>
-                            </th>
-                            <th className="text-center align-middle pointer-cursor">
-                                <button className="table-button" onClick={() => boardOrder == BoardOrder.visited ? setBoardOrder(BoardOrder["-visited"]) : setBoardOrder(BoardOrder.visited)}>
-                                    Last viewed {boardOrder == BoardOrder.visited ? sortIcon.ascending : boardOrder == BoardOrder["-visited"] ? sortIcon.descending : sortIcon.sortable}
-                                </button>
-                            </th>
-                            <th className="text-center align-middle">Share</th>
-                            <th colSpan={2}>
-                                <div className="text-right align-middle">
-                                    <Button disabled={selectedBoards.length == 0} size="sm" color="link" onClick={confirmDeleteMultipleBoards}>
-                                        {`Delete (${selectedBoards.length})`}
-                                    </Button>
-                                </div>
-                            </th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        {boards?.boards
-                            .filter(board => matchesAllWordsInAnyOrder(board.title, boardTitleFilter))
-                            .filter(board => formatBoardOwner(user, board) == boardCreator || boardCreator == "All")
-                            .filter(board => boardCompletionSelection(board, boardCompletion))
-                            .map(board =>
-                                <BoardCard
-                                    key={board.id}
-                                    board={board}
-                                    selectedBoards={selectedBoards}
-                                    setSelectedBoards={setSelectedBoards}
-                                    boardView={boardView}
-                                    user={user}
-                                    boards={boards}
-                                />)
-                        }
-                        </tbody>
-                    </Table>
-                </div>
-            </CardBody>
-        </Card>
-    </>;
+    return <Card>
+        <CardBody id="boards-table">
+            <CSTable {...props} />;
+        </CardBody>
+    </Card>;
 };
 
 const CSTable = (props: GameboardsTableProps) => {
@@ -212,8 +92,8 @@ const CSTable = (props: GameboardsTableProps) => {
             <Col xs={6} md={3} lg={2} xl={2}>
                 <Label className="w-100">
                     <span className={"text-nowrap"}>Filter by Creator</span><Input type="select" value={boardCreator} onChange={e => setBoardCreator(e.target.value as BoardCreators)}>
-                    {Object.values(BoardCreators).map(creator => <option key={creator} value={creator}>{creator}</option>)}
-                </Input>
+                        {Object.values(BoardCreators).map(creator => <option key={creator} value={creator}>{creator}</option>)}
+                    </Input>
                 </Label>
             </Col>
             <Col xs={6} md={3} xl={2}>
@@ -232,38 +112,51 @@ const CSTable = (props: GameboardsTableProps) => {
                         Completion {boardOrder == BoardOrder.completion ? sortIcon.ascending : boardOrder == BoardOrder["-completion"] ? sortIcon.descending : sortIcon.sortable}
                     </button>
                 </th>
-                <th colSpan={4} className="w-100">
+                <th colSpan={isAda ? 4 : 1} className={siteSpecific("", "w-100")}>
                     <button className="table-button" onClick={() => boardOrder == BoardOrder.title ? setBoardOrder(BoardOrder["-title"]) : setBoardOrder(BoardOrder.title)}>
                         Quiz name {boardOrder == BoardOrder.title ? sortIcon.ascending : boardOrder == BoardOrder["-title"] ? sortIcon.descending : sortIcon.sortable}
                     </button>
                 </th>
-                <th colSpan={2} className="long-titled-col">
+                <th colSpan={2} className={classNames("long-titled-col", {"text-center" : isPhy})}>
                     Stages and Difficulties <span id={`difficulties-help`} className="icon-help mx-1" />
                     <RS.UncontrolledTooltip placement="bottom" target={`difficulties-help`}>
                         Practice: {difficultiesOrdered.slice(0, siteSpecific(3, 2)).map(d => difficultyShortLabelMap[d]).join(", ")}<br />
                         Challenge: {difficultiesOrdered.slice(siteSpecific(3, 2)).map(d => difficultyShortLabelMap[d]).join(", ")}
                     </RS.UncontrolledTooltip>
                 </th>
-                <th>Creator</th>
-                <th>
+                {isAda && <th>Creator</th>}
+                {isPhy && <th>
                     <button className="table-button" onClick={() => boardOrder == BoardOrder.created ? setBoardOrder(BoardOrder["-created"]) : setBoardOrder(BoardOrder.created)}>
                         Created {boardOrder == BoardOrder.created ? sortIcon.ascending : boardOrder == BoardOrder["-created"] ? sortIcon.descending : sortIcon.sortable}
                     </button>
-                </th>
-                <th>
-                    <button className="table-button" onClick={() => boardOrder == BoardOrder.visited ? setBoardOrder(BoardOrder["-visited"]) : setBoardOrder(BoardOrder.visited)}>
-                        Last viewed {boardOrder == BoardOrder.visited ? sortIcon.ascending : boardOrder == BoardOrder["-visited"] ? sortIcon.descending : sortIcon.sortable}
-                    </button>
-                </th>
-                <th>Share</th>
-                <th>
-                    {selectedBoards.length
-                        ? <Button size={"sm"} color={"link"} onClick={confirmDeleteMultipleBoards}>
-                            Delete ({selectedBoards.length})
-                        </Button>
-                        : "Delete"
-                    }
-                </th>
+                </th>}
+                
+                {siteSpecific(<>
+                    <th className={classNames({"text-center" : isPhy})}>
+                        <button className="table-button" onClick={() => boardOrder == BoardOrder.visited ? setBoardOrder(BoardOrder["-visited"]) : setBoardOrder(BoardOrder.visited)}>
+                            Last viewed {boardOrder == BoardOrder.visited ? sortIcon.ascending : boardOrder == BoardOrder["-visited"] ? sortIcon.descending : sortIcon.sortable}
+                        </button>
+                    </th>
+                    <th className={classNames({"text-center" : isPhy})}>
+                        Delete
+                    </th>
+                </>,
+                <>
+                    <th>
+                        <button className="table-button" onClick={() => boardOrder == BoardOrder.visited ? setBoardOrder(BoardOrder["-visited"]) : setBoardOrder(BoardOrder.visited)}>
+                            Last viewed {boardOrder == BoardOrder.visited ? sortIcon.ascending : boardOrder == BoardOrder["-visited"] ? sortIcon.descending : sortIcon.sortable}
+                        </button>
+                    </th>
+                    <th>Share</th>
+                    <th>
+                        {selectedBoards.length
+                            ? <Button size={"sm"} color={"link"} onClick={confirmDeleteMultipleBoards}>
+                                Delete ({selectedBoards.length})
+                            </Button>
+                            : "Delete"
+                        }
+                    </th>
+                </>)}
             </tr>
             </thead>
             <tbody>

--- a/src/app/components/pages/SetAssignments.tsx
+++ b/src/app/components/pages/SetAssignments.tsx
@@ -304,9 +304,7 @@ const PhyTable = (props: SetAssignmentsTableProps) => {
                                 name&nbsp;{boardOrder == BoardOrder.title ? sortIcon.ascending : boardOrder == BoardOrder["-title"] ? sortIcon.descending : sortIcon.sortable}
                             </button>
                         </th>
-                        <th className="text-center align-middle">Stages</th>
-                        <th className="text-center align-middle">Difficulties</th>
-                        <th className="text-center align-middle">Creator</th>
+                        <th className="text-center align-middle" colSpan={2}>Stages and Difficulties <span id={`difficulties-help`} className="icon-help mx-1" /></th>
                         <th className="text-center align-middle pointer-cursor">
                             <button className="table-button"
                                     onClick={() => boardOrder == BoardOrder.visited ? setBoardOrder(BoardOrder["-visited"]) : setBoardOrder(BoardOrder.visited)}>
@@ -314,8 +312,7 @@ const PhyTable = (props: SetAssignmentsTableProps) => {
                                 viewed&nbsp;{boardOrder == BoardOrder.visited ? sortIcon.ascending : boardOrder == BoardOrder["-visited"] ? sortIcon.descending : sortIcon.sortable}
                             </button>
                         </th>
-                        <th className="text-center align-middle">Assignments</th>
-                        <th className="text-center align-middle">Share</th>
+                        <th className="text-center align-middle">Manage</th>
                     </tr>
                     </thead>
                     <tbody>

--- a/src/scss/common/boards.scss
+++ b/src/scss/common/boards.scss
@@ -94,6 +94,10 @@ tr.board-card {
   font-weight: bold;
 }
 
+.my-gameboard-table {
+  min-width: 870px;
+}
+
 .input-options {
   float: right;
   @media only screen and (max-width:800px) {


### PR DESCRIPTION
In `/set_assignments` and `/my_gameboards`, display the Stages and Difficulties tabs as one extended table, with separating lines for easier viewing. 

To make space for this, the Creator column (which may be removed later regardless) has been moved under the Quiz Name, and the Share button has been removed given its functionality is entirely replicable simply by clicking the quiz name. 

All changes affect physics only. Ada remains unchanged.