### PR TITLE
Use updated content IDs for toptext and modals

### DIFF
--- a/src/app/components/pages/AssignmentProgress.tsx
+++ b/src/app/components/pages/AssignmentProgress.tsx
@@ -429,9 +429,9 @@ export function AssignmentProgress({user}: {user: RegisteredUserDTO}) {
                 currentPageTitle={siteSpecific("Assignment Progress", "My markbook")}
                 subTitle={"Track your group performance" + (isPhy ? " by question" : "")}
                 help={pageHelp}
-                modalId="assignment_progress_help"
+                modalId="help_modal_assignment_progress"
             />
-            <PageFragment fragmentId={"markbook_help"} ifNotFound={RenderNothing} />
+            <PageFragment fragmentId={siteSpecific("help_toptext_assignment_progress", "markbook_help")} ifNotFound={RenderNothing} />
             <div className="w-100 text-right">
                 <InputGroup className="d-inline text-nowrap">
                     <Label className="pr-2 mt-1">Sort assignments and tests:</Label>

--- a/src/app/components/pages/GameboardBuilder.tsx
+++ b/src/app/components/pages/GameboardBuilder.tsx
@@ -214,7 +214,7 @@ const GameboardBuilder = ({user}: {user: RegisteredUserDTO}) => {
 
     return <Container id="gameboard-builder" fluid={siteSpecific(false, true)} className={classNames({"px-lg-5 px-xl-6": isAda})}>
         <div ref={sentinel}/>
-        <TitleAndBreadcrumb currentPageTitle={`${siteSpecific("Gameboard", "Quiz")} builder`} help={pageHelp} modalId="gameboard_builder_help"/>
+        <TitleAndBreadcrumb currentPageTitle={`${siteSpecific("Gameboard", "Quiz")} builder`} help={pageHelp} modalId="help_modal_gameboard_builder"/>
 
         <Card className="p-3 mt-4 mb-5">
             <CardBody>

--- a/src/app/components/pages/GameboardFilter.tsx
+++ b/src/app/components/pages/GameboardFilter.tsx
@@ -641,7 +641,7 @@ export const GameboardFilter = withRouter(({location}: RouteComponentProps) => {
     const metaDescriptionCS = "Search for the perfect computer science questions to study. For revision. For homework. For the classroom.";
 
     return <Container id="gameboard-generator" className="mb-5">
-        <TitleAndBreadcrumb currentPageTitle={siteSpecific("Choose your Questions", "Question Finder")} help={pageHelp} modalId="gameboard_filter_help"/>
+        <TitleAndBreadcrumb currentPageTitle={siteSpecific("Choose your Questions", "Question Finder")} help={pageHelp} modalId="help_modal_gameboard_filter"/>
         {isAda && <MetaDescription description={metaDescriptionCS} />}
         <CanonicalHrefElement />
 

--- a/src/app/components/pages/Groups.tsx
+++ b/src/app/components/pages/Groups.tsx
@@ -511,8 +511,8 @@ export const Groups = ({user}: {user: RegisteredUserDTO}) => {
     </span>;
 
     return <Container>
-        <TitleAndBreadcrumb currentPageTitle="Manage groups" className="mb-4" help={pageHelp} modalId="groups_help_modal" />
-        <PageFragment fragmentId={"groups_help"} ifNotFound={RenderNothing} />
+        <TitleAndBreadcrumb currentPageTitle="Manage groups" className="mb-4" help={pageHelp} modalId="help_modal_groups" />
+        <PageFragment fragmentId={siteSpecific("help_toptext_groups", "groups_help")} ifNotFound={RenderNothing} />
         <ShowLoadingQuery query={groupQuery} defaultErrorTitle={"Error fetching groups"}>
             <Row className="mb-5">
                 <Col lg={4}>

--- a/src/app/components/pages/MyAssignments.tsx
+++ b/src/app/components/pages/MyAssignments.tsx
@@ -35,8 +35,8 @@ export const MyAssignments = ({user}: {user: RegisteredUserDTO}) => {
     </span>;
 
     return <Container>
-        <TitleAndBreadcrumb currentPageTitle="My assignments" help={pageHelp} modalId="my_assignments_help" />
-        <PageFragment fragmentId={`assignments_help_${isTutorOrAbove(user) ? "teacher" : "student"}`} ifNotFound={<div className={"mt-5"}/>} />
+        <TitleAndBreadcrumb currentPageTitle="My assignments" help={pageHelp} modalId="help_modal_my_assignments" />
+        <PageFragment fragmentId={`${siteSpecific("help_toptext_assignments", "assignments_help")}_${isTutorOrAbove(user) ? "teacher" : "student"}`} ifNotFound={<div className={"mt-5"}/>} />
         <Card className={siteSpecific("my-5", "my-assignments-card")}>
             <CardBody className={siteSpecific("pt-0", "pt-2")}>
                 <ShowLoadingQuery

--- a/src/app/components/pages/SetAssignments.tsx
+++ b/src/app/components/pages/SetAssignments.tsx
@@ -529,8 +529,8 @@ export const SetAssignments = () => {
             assignees={(isDefined(modalBoard) && isDefined(modalBoard?.id) && groupsByGameboard[modalBoard.id]) || []}
         />
 
-        <TitleAndBreadcrumb currentPageTitle={siteSpecific("Set assignments", "Manage assignments")} help={pageHelp} modalId="set_assignments_help"/>
-        <PageFragment fragmentId={`set_${siteSpecific("gameboards", "quizzes")}_help`} ifNotFound={RenderNothing} />
+        <TitleAndBreadcrumb currentPageTitle={siteSpecific("Set assignments", "Manage assignments")} help={pageHelp} modalId="help_modal_set_assignments"/>
+        <PageFragment fragmentId={siteSpecific("help_toptext_set_gameboards", "set_quizzes_help")} ifNotFound={RenderNothing} />
         {isPhy && <PhyAddGameboardButtons className={"mb-4"} redirectBackTo={PATHS.SET_ASSIGNMENTS}/>}
         {groups && groups.length === 0 && <Alert color="warning">
             You have not created any groups to assign work to.

--- a/src/app/components/pages/books/chemistry_16.tsx
+++ b/src/app/components/pages/books/chemistry_16.tsx
@@ -14,7 +14,7 @@ export const Chemistry16 = () => {
     return <Container className="chemistry">
         <Col>
             <div className="book-intro">
-                <TitleAndBreadcrumb className="mb-5" currentPageTitle="Mastering essential pre-university chemistry" help={pageHelp} modalId="chemistry_book_help"/>
+                <TitleAndBreadcrumb className="mb-5" currentPageTitle="Mastering essential pre-university chemistry" help={pageHelp} modalId="help_modal_chemistry_book"/>
                 <img className="book-cover" src="/assets/phy/books/chemistry_16.jpg" alt="Cover of the book."/>
                 <PageFragment fragmentId="chemistry_16_intro"/>
             </div>

--- a/src/app/components/pages/books/phys_book_gcse.tsx
+++ b/src/app/components/pages/books/phys_book_gcse.tsx
@@ -15,7 +15,7 @@ export const PhysBookGcse = () => {
     return <Container className="physics">
         <Col>
             <div className="book-intro">
-                <TitleAndBreadcrumb className="mb-5" currentPageTitle="Mastering Essential GCSE Physics" help={pageHelp} modalId="gcse_book_help" />
+                <TitleAndBreadcrumb className="mb-5" currentPageTitle="Mastering Essential GCSE Physics" help={pageHelp} modalId="help_modal_gcse_book" />
                 <img className="book-cover" src="/assets/phy/books/phys_book_gcse.jpg" alt="Cover of the book."/>
                 <PageFragment fragmentId="phys_book_gcse_intro"/>
             </div>

--- a/src/app/components/pages/books/physics_skills_19.tsx
+++ b/src/app/components/pages/books/physics_skills_19.tsx
@@ -13,7 +13,7 @@ export const PhysicsSkills19 = () => {
     return <Container>
         <Col>
             <div className="book-intro">
-                <TitleAndBreadcrumb className="mb-5" currentPageTitle="Mastering Essential Pre-University Physics" help={pageHelp} modalId="physics_skills_19_help" />
+                <TitleAndBreadcrumb className="mb-5" currentPageTitle="Mastering Essential Pre-University Physics" help={pageHelp} modalId="help_modal_physics_skills_19" />
                 <img className="book-cover" src="/assets/phy/books/physics_skills_19.jpg" alt="Cover of the book."/>
                 <PageFragment fragmentId="physics_skills_19_intro"/>
             </div>

--- a/src/app/components/pages/books/pre_uni_maths.tsx
+++ b/src/app/components/pages/books/pre_uni_maths.tsx
@@ -14,7 +14,7 @@ export const PreUniMaths = () => {
     return <Container className="maths">
         <Col>
             <div className="book-intro">
-                <TitleAndBreadcrumb className="mb-5" currentPageTitle="Pre-University Mathematics for Sciences" help={pageHelp} modalId="maths_book_help"/>
+                <TitleAndBreadcrumb className="mb-5" currentPageTitle="Pre-University Mathematics for Sciences" help={pageHelp} modalId="help_modal_maths_book"/>
                 <img className="book-cover" src="/assets/phy/books/pre_uni_maths.jpg" alt="Cover of the book."/>
                 <PageFragment fragmentId="pre_uni_maths_intro"/>
             </div>


### PR DESCRIPTION
Currently leaves all Ada content alone, they do not use modals so are not following the updated format.