### PR TITLE
Allow Greek symbols in symbolic question regex

### DIFF
--- a/src/app/components/content/IsaacSymbolicQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicQuestion.tsx
@@ -49,7 +49,7 @@ function isError(p: ParsingError | any[]): p is ParsingError {
 export const symbolicInputValidator = (input: string) => {
     const openBracketsCount = input.split('(').length - 1;
     const closeBracketsCount = input.split(')').length - 1;
-    const regexStr = "[^ 0-9A-Za-zΑ-Ωα-ω()*+,-./<=>^_±²³¼½¾×÷=]+";
+    const regexStr = "[^ 0-9A-Za-zΑ-ΡΣ-Ωα-ω()*+,-./<=>^_±²³¼½¾×÷=]+"; // not \Alpha-\Omega directly because there is a gap in the unicode range (U+03A2)
     const badCharacters = new RegExp(regexStr);
     const errors = [];
     if (/\\[a-zA-Z()]|[{}]/.test(input)) {

--- a/src/app/components/content/IsaacSymbolicQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicQuestion.tsx
@@ -49,7 +49,7 @@ function isError(p: ParsingError | any[]): p is ParsingError {
 export const symbolicInputValidator = (input: string) => {
     const openBracketsCount = input.split('(').length - 1;
     const closeBracketsCount = input.split(')').length - 1;
-    const regexStr = "[^ 0-9A-Za-z()*+,-./<=>^_±²³¼½¾×÷=]+";
+    const regexStr = "[^ 0-9A-Za-zΑ-Ωα-ω()*+,-./<=>^_±²³¼½¾×÷=]+";
     const badCharacters = new RegExp(regexStr);
     const errors = [];
     if (/\\[a-zA-Z()]|[{}]/.test(input)) {


### PR DESCRIPTION
This change will always allow *all* Greek letters, despite Inequality only converting a subset of these to their textual equivalents; this does technically mean that A and capital-alpha will be treated as different variables. However, since no question uses these symbols (or, where they do, they use the Latin-script equivalent) this will only be an issue if someone copy-pastes the symbols in from elsewhere.