### PR TITLE
Ada accordion adjustments

### DIFF
--- a/src/app/components/elements/Accordion.tsx
+++ b/src/app/components/elements/Accordion.tsx
@@ -169,7 +169,7 @@ export const Accordion = withRouter(({id, trustedTitle, index, children, startOp
                 }}
                 aria-expanded={isOpen ? "true" : "false"}
             >
-                {isConceptPage && audienceString && <span className={"stage-label badge-secondary d-flex align-items-center " +
+                {isConceptPage && audienceString && <span className={"stage-label badge-secondary d-flex align-items-center p-1 " +
                     "justify-content-center " + classNames({[audienceStyle(audienceString)]: isAda})}>
                     {siteSpecific(audienceString, audienceString.split("\n").map((line, i, arr) => <>{line}{i < arr.length && <br/>}</>))}
                 </span>}

--- a/src/app/components/elements/Accordion.tsx
+++ b/src/app/components/elements/Accordion.tsx
@@ -170,7 +170,7 @@ export const Accordion = withRouter(({id, trustedTitle, index, children, startOp
             >
                 {isConceptPage && audienceString && <span className={"stage-label badge-secondary d-flex align-items-center " +
                     "justify-content-center " + classNames({[audienceStyle(audienceString)]: isAda})}>
-                    {audienceString}
+                    {audienceString.split("\n").map((line, i, arr) => <>{line}{i < arr.length && <br/>}</>)}
                 </span>}
                 <div className="accordion-title pl-3">
                     <RS.Row>

--- a/src/app/components/elements/Accordion.tsx
+++ b/src/app/components/elements/Accordion.tsx
@@ -11,6 +11,7 @@ import {
     NOT_FOUND,
     notRelevantMessage,
     scrollVerticallyIntoView,
+    siteSpecific,
     useUserContext
 } from "../../services";
 import {AppState, logAction, selectors, useAppDispatch, useAppSelector} from "../../state";
@@ -170,7 +171,7 @@ export const Accordion = withRouter(({id, trustedTitle, index, children, startOp
             >
                 {isConceptPage && audienceString && <span className={"stage-label badge-secondary d-flex align-items-center " +
                     "justify-content-center " + classNames({[audienceStyle(audienceString)]: isAda})}>
-                    {audienceString.split("\n").map((line, i, arr) => <>{line}{i < arr.length && <br/>}</>)}
+                    {siteSpecific(audienceString, audienceString.split("\n").map((line, i, arr) => <>{line}{i < arr.length && <br/>}</>))}
                 </span>}
                 <div className="accordion-title pl-3">
                     <RS.Row>

--- a/src/app/components/elements/list-groups/TopicSummaryLinks.tsx
+++ b/src/app/components/elements/list-groups/TopicSummaryLinks.tsx
@@ -9,6 +9,7 @@ import {
     isIntendedAudience,
     makeIntendedAudienceComparator,
     notRelevantMessage,
+    siteSpecific,
     stringifyAudience,
     useUserContext
 } from "../../../services";
@@ -40,29 +41,32 @@ export function TopicSummaryLinks({items, search}: {items: ContentSummaryDTO[]; 
             .filter(item => !item.hidden)
 
             // Render remaining items
-            .map((item, index) => <RS.ListGroupItem key={item.id} className="topic-summary-link">
-                <RS.Button
-                    tag={Link} to={{pathname: `/${documentTypePathPrefix[DOCUMENT_TYPE.CONCEPT]}/${item.id}`, search}}
-                    block color="link" className={"d-flex align-items-stretch " + classNames({"de-emphasised": item.deEmphasised})}
-                >
-                    <div className={"stage-label badge-primary d-flex align-items-center justify-content-center " + classNames({[audienceStyle(stringifyAudience(item.audience, userContext))]: isAda})}>
-                        {stringifyAudience(item.audience, userContext)}
-                    </div>
-                    <div className="title pl-3 d-flex">
-                        <div className="p-3">
-                            <Markup encoding={"latex"}>
-                                {item.title}
-                            </Markup>
+            .map((item, index) => {
+                const audienceString = stringifyAudience(item.audience, userContext);
+                return <RS.ListGroupItem key={item.id} className="topic-summary-link">
+                    <RS.Button
+                        tag={Link} to={{pathname: `/${documentTypePathPrefix[DOCUMENT_TYPE.CONCEPT]}/${item.id}`, search}}
+                        block color="link" className={"d-flex align-items-stretch " + classNames({"de-emphasised": item.deEmphasised})}
+                    >
+                        <div className={"stage-label badge-primary d-flex align-items-center justify-content-center " + classNames({[audienceStyle(audienceString)]: isAda})}>
+                            {siteSpecific(audienceString, audienceString.split("\n").map((line, i, arr) => <>{line}{i < arr.length && <br/>}</>))}
                         </div>
-                        {item.deEmphasised && <div className="ml-auto mr-3 d-flex align-items-center">
-                            <span id={`audience-help-${index}`} className="icon-help mx-1" />
-                            <RS.UncontrolledTooltip placement="bottom" target={`audience-help-${index}`}>
-                                {`This content has ${notRelevantMessage(userContext)}.`}
-                            </RS.UncontrolledTooltip>
-                        </div>}
-                    </div>
-                </RS.Button>
-            </RS.ListGroupItem>)
+                        <div className="title pl-3 d-flex">
+                            <div className="p-3">
+                                <Markup encoding={"latex"}>
+                                    {item.title}
+                                </Markup>
+                            </div>
+                            {item.deEmphasised && <div className="ml-auto mr-3 d-flex align-items-center">
+                                <span id={`audience-help-${index}`} className="icon-help mx-1" />
+                                <RS.UncontrolledTooltip placement="bottom" target={`audience-help-${index}`}>
+                                    {`This content has ${notRelevantMessage(userContext)}.`}
+                                </RS.UncontrolledTooltip>
+                            </div>}
+                        </div>
+                    </RS.Button>
+                </RS.ListGroupItem>;
+            })
         }
     </RS.ListGroup>;
 }

--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -296,9 +296,9 @@ export const stageLabelMap: {[stage in Stage]: string} = {
     a_level: "A\u00A0Level",
     further_a: "Further\u00A0A",
     university: "University",
-    scotland_national_5: "National 5",
+    scotland_national_5: "N5",
     scotland_higher: "Higher",
-    scotland_advanced_higher: "Adv. Higher",
+    scotland_advanced_higher: "Adv Higher",
     all: "All stages",
 };
 

--- a/src/app/services/userContext.ts
+++ b/src/app/services/userContext.ts
@@ -454,12 +454,39 @@ export function stringifyAudience(audience: ContentDTO["audience"], userContext:
     const audienceStages = Array.from(stagesSet).sort(comparatorFromOrderedValues(stagesOrdered));
     // if you are one of the options - only show that option
     const stagesFilteredByUserContext = audienceStages.filter(s => userContext.stage === s);
-    let stagesToView = stagesFilteredByUserContext.length > 0 ? stagesFilteredByUserContext : audienceStages;
+    const stagesToView = stagesFilteredByUserContext.length > 0 ? stagesFilteredByUserContext : audienceStages;
     // If common, could find substrings and report ranges i.e, GCSE to University
+    
+    if (isAda) {
+        // Ada currently (subject to change) want to show the stages as 3 groups:
+        // - GCSE & A Level
+        // - National 5 & Higher
+        // - Advanced Higher
+        // with intra-group separation by commas, inter-group separation by newlines
 
-    // CS would like to show All stages instead of GCSE & A Level - that will work until we have more stages
-    if (isAda && stagesToView.includes(STAGE.GCSE) && stagesToView.includes(STAGE.A_LEVEL)) {
-        stagesToView = [STAGE.ALL];
+        const result = stagesToView.reduce((acc, label) => {
+            if ([STAGE.GCSE, STAGE.A_LEVEL].includes(label as STAGE)) {
+                acc[0].push(label);
+            } else if ([STAGE.SCOTLAND_NATIONAL_5, STAGE.SCOTLAND_HIGHER].includes(label as STAGE)) {
+                acc[1].push(label);
+            } else if ([STAGE.SCOTLAND_ADVANCED_HIGHER].includes(label as STAGE)) {
+                acc[2].push(label);
+            }
+            return acc;
+        }, [[], [], []] as Stage[][]);
+
+        // FIXME: use result.findLastIndex when supported
+        // const lastNonEmptyIndex = result.findLastIndex((labels) => labels.length > 0);
+        const reversed = result.slice().reverse();
+        const lastNonEmptyIndex = (result.length - 1) - reversed.findIndex(((labels) => labels.length > 0));
+
+        return result.reduce((acc, labels, index) => {
+            if (labels.length === 0) return acc;
+            let labelStrings = labels.map((label) => stageLabelMap[label]).join(", ");
+            // do not include a newline after the last group
+            labelStrings += (index < lastNonEmptyIndex ? "\n" : "");
+            return acc + labelStrings;
+        }, "");
     }
 
     return stagesToView.map(stage => stageLabelMap[stage]).join(" & ");

--- a/src/app/services/userContext.ts
+++ b/src/app/services/userContext.ts
@@ -437,6 +437,12 @@ export function audienceStyle(audienceString: string): string {
             return "stage-label-alevel";
         case stageLabelMap.gcse:
             return "stage-label-gcse";
+        case stageLabelMap.scotland_national_5:
+            return "stage-label-national-5";
+        case stageLabelMap.scotland_higher:
+            return "stage-label-higher";
+        case stageLabelMap.scotland_advanced_higher:
+            return "stage-label-advanced-higher";
         default:
             return "stage-label-all";
     }

--- a/src/scss/common/accordions.scss
+++ b/src/scss/common/accordions.scss
@@ -9,7 +9,6 @@
 
 .stage-label {
   font-family: $secondary-font;
-  padding: 0.5rem;
   min-width: 130px;
   max-width: 130px;
   text-align: center;

--- a/src/scss/common/topic.scss
+++ b/src/scss/common/topic.scss
@@ -46,7 +46,7 @@
 
     .stage-label {
       font-family: $secondary-font;
-      padding: 1rem;
+      padding: 0.3rem;
       min-width: 130px;
       max-width: 130px;
       text-align: center;

--- a/src/scss/cs/accordions.scss
+++ b/src/scss/cs/accordions.scss
@@ -39,6 +39,11 @@
   background: $cs-white;
   border-top: 1px solid $cs-cultured;
 
+  margin-top: 4px;
+  &:first-of-type {
+    margin-top: 0;
+  }
+
   .content-value {
     h3 {
       border-bottom: 2px solid #00000010;

--- a/src/scss/cs/accordions.scss
+++ b/src/scss/cs/accordions.scss
@@ -1,6 +1,6 @@
 @import "../common/accordions";
 
-.stage-label-gcse, .stage-label-alevel, .stage-label-all {
+.stage-label-gcse, .stage-label-alevel, .stage-label-national-5, .stage-label-higher, .stage-label-advanced-higher, .stage-label-all {
   color: black;
   font-weight: 600;
   text-wrap: none;
@@ -15,6 +15,18 @@
 
 .stage-label-alevel {
   background-color: $a-level-colour;
+}
+
+.stage-label-national-5 {
+  background-color: $national-5-colour;
+}
+
+.stage-label-higher {
+  background-color: $higher-colour;
+}
+
+.stage-label-advanced-higher {
+  background-color: $adv-higher-colour;
 }
 
 .stage-label-all {
@@ -39,7 +51,7 @@
   background: $cs-white;
   border-top: 1px solid $cs-cultured;
 
-  margin-top: 4px;
+  margin-top: 2px;
   &:first-of-type {
     margin-top: 0;
   }

--- a/src/scss/cs/accordions.scss
+++ b/src/scss/cs/accordions.scss
@@ -40,6 +40,10 @@
 .accordion .accordion-header {
   span, button, button:hover {
     color: black !important;
+
+    &.stage-label-higher, &.de-emphasised > span {
+      color: white !important;
+    }
   }
 
   h2 {

--- a/src/scss/cs/accordions.scss
+++ b/src/scss/cs/accordions.scss
@@ -6,7 +6,7 @@
   text-wrap: none;
   font-size: 12pt !important;
   line-height: 14pt;
-  padding: 0.4rem 0.5rem;
+  padding: 0.3rem 0.5rem;
 }
 
 .stage-label-gcse {

--- a/src/scss/cs/accordions.scss
+++ b/src/scss/cs/accordions.scss
@@ -45,10 +45,6 @@
   }
 
   .content-value {
-    h3 {
-      border-bottom: 2px solid #00000010;
-    }
-
     h3, h4 {
       font-size: 1.25rem !important;
       font-weight: inherit;

--- a/src/scss/cs/accordions.scss
+++ b/src/scss/cs/accordions.scss
@@ -4,9 +4,8 @@
   color: black;
   font-weight: 600;
   text-wrap: none;
-  font-size: 12pt !important;
-  line-height: 14pt;
-  padding: 0.3rem 0.5rem;
+  font-size: 1rem !important;
+  line-height: 1.15rem;
 }
 
 .stage-label-gcse {

--- a/src/scss/cs/accordions.scss
+++ b/src/scss/cs/accordions.scss
@@ -4,6 +4,9 @@
   color: black;
   font-weight: 600;
   text-wrap: none;
+  font-size: 12pt !important;
+  line-height: 14pt;
+  padding: 0.4rem 0.5rem;
 }
 
 .stage-label-gcse {

--- a/src/scss/cs/isaac.scss
+++ b/src/scss/cs/isaac.scss
@@ -253,8 +253,11 @@ $purple: $dark-pink-300; // Something to do with links
 // Stage colours
 // Used for staged accordion sections - we currently do not distinguish by colours
 $gcse-colour: $pink-400;
-$all-stages-colour: $yellow-400;
 $a-level-colour: $cyan-400;
+$national-5-colour: $pink-400;
+$higher-colour: $dark-pink-400;
+$adv-higher-colour: $cyan-400;
+$all-stages-colour: $yellow-400;
 
 // Button/input colours
 $light-hover-dark-pink: $dark-pink-200;


### PR DESCRIPTION
- Remove "all stages" from Ada, show comma-separated (but no commas between lines) list of all applicable stages
- Reuse GCSE/A Level colours for N5 / Adv Higher, use dark pink for Higher
- Minor styling changes to fit above changes in accordions, remove accordion-h3 underline.