### PR TITLE
Add link from 404 page to contact form preset

### DIFF
--- a/src/app/components/pages/Contact.tsx
+++ b/src/app/components/pages/Contact.tsx
@@ -37,24 +37,26 @@ const determineUrlQueryPresets = (user?: Immutable<PotentialUser> | null) => {
     let presetMessage = "";
     let presetPlaceholder = "";
 
-    if (urlQuery?.preset == "teacherRequest" && user?.loggedIn && !isTeacherOrAbove(user)) {
+    if (urlQuery?.preset === "teacherRequest" && user?.loggedIn && !isTeacherOrAbove(user)) {
         presetSubject = "Teacher Account Request";
         presetMessage = `Hello,\n\nPlease could you convert my ${SITE_TITLE} account into a teacher account.\n\nMy school is: \nI have changed my account email address to be my school email: [Yes/No]\nA link to my school website with a staff list showing my name and email (or a phone number to contact the school) is: \n\nThanks, \n\n` + user.givenName + " " + user.familyName;
-    } else if (urlQuery?.preset == 'accountDeletion' && user?.loggedIn) {
+    } else if (urlQuery?.preset === 'accountDeletion' && user?.loggedIn) {
         presetSubject = "Account Deletion Request";
         presetMessage = `Hello,\n\nPlease could you delete my ${SITE_TITLE} account.\n\nThanks, \n\n` + user.givenName + " " + user.familyName;
-    } else if (urlQuery?.preset == 'contentProblem') {
+    } else if (urlQuery?.preset === 'contentProblem') {
         presetSubject = "Content problem";
         presetPlaceholder = "Please describe the problem here."
         if (urlQuery?.accordion) {
             presetSubject += ` in "${urlQuery.accordion}"`
-        }
-        else if (urlQuery?.page) {
+        } else if (urlQuery?.page) {
             presetSubject += ` in "${urlQuery.page}"`
         }
         if (urlQuery?.section != null) {
             presetSubject += `, section "${urlQuery.section}"`
         }
+    } else if (urlQuery?.preset === 'notFound') {
+        presetSubject = "Page not found";
+        presetMessage = `Page: "${urlQuery?.page}"\n\n[Add any details about how you found this missing page here.]`;
     }
     return [
         urlQuery.subject as string || presetSubject,

--- a/src/app/components/pages/NotFound.tsx
+++ b/src/app/components/pages/NotFound.tsx
@@ -4,36 +4,31 @@ import {Container} from "reactstrap";
 import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
 import {siteSpecific} from "../../services";
 
-const PhyNotFound = () => {
-    const {pathname, state} = useLocation<{overridePathname?: string}>();
-    return <Container>
-        <div>
-            <TitleAndBreadcrumb breadcrumbTitleOverride="Unknown page" currentPageTitle="Page not found" />
-            <h3 className="my-4">
-                <small>
-                    {"We're sorry, page not found: "}
-                    <code>
-                        {(state && state.overridePathname) || pathname}
-                    </code>
-                </small>
-            </h3>
-        </div>
-    </Container>;
+const buildContactUrl = (state: {overridePathname?: string}, pathname: string) => {
+    const page = encodeURIComponent((state && state.overridePathname) || pathname);
+    return `/contact?preset=notFound&page=${page}`;
 };
 
-const CSNotFound = () => {
+export const NotFound = () => {
     const {pathname, state} = useLocation<{overridePathname?: string}>();
     return <Container>
         <div>
-            <TitleAndBreadcrumb breadcrumbTitleOverride="404" currentPageTitle="Page not found" />
+            <TitleAndBreadcrumb
+                breadcrumbTitleOverride={siteSpecific("Unknown page", "404")}
+                currentPageTitle="Page not found"
+            />
             <p className="my-4">
                 {"We're sorry, page not found: "}
                 <code>
                     {(state && state.overridePathname) || pathname}
                 </code>
             </p>
+            <p>
+                Expecting to find something here?
+                <a className="pl-1" href={buildContactUrl(state, pathname)} >
+                    Let us know <span className="sr-only">about this missing page</span>
+                </a>.
+            </p>
         </div>
     </Container>;
 };
-
-export const NotFound = siteSpecific(PhyNotFound, CSNotFound);


### PR DESCRIPTION
This brings Phy and CS into alignment, except on the breadcrumb title where the CS value of "404" remains.