### PR TITLE
Change Ada isIntendedAudience to behave like isOnSpecification

### DIFF
--- a/src/app/components/elements/RelatedContent.tsx
+++ b/src/app/components/elements/RelatedContent.tsx
@@ -70,7 +70,6 @@ function getURLForContent(content: ContentSummaryDTO) {
 
 function renderQuestionsCS(audienceQuestions: ContentSummaryDTO[], remainingQuestions: ContentSummaryDTO[], renderItem: RenderItemFunction, conceptId: string, showConceptGameboardButton: boolean) {
 
-    if (audienceQuestions.length == 0) return null;
     return <div className="d-flex align-items-stretch flex-wrap no-print">
         <div className="w-100 d-flex">
             <div className="flex-fill simple-card my-3 p-3 text-wrap">

--- a/src/app/services/userContext.ts
+++ b/src/app/services/userContext.ts
@@ -366,11 +366,7 @@ export function findAudienceRecordsMatchingPartial(audience: ContentBaseDTO['aud
 export function isIntendedAudience(intendedAudience: ContentBaseDTO['audience'], userContext: UseUserContextReturnType, user: Immutable<PotentialUser> | null): boolean {
     // If no audience is specified, we default to true
     if (!intendedAudience) {
-        // TODO: another quickfix
-        if (isAda) {
-            return false;
-        }
-        return true;
+        return siteSpecific(true, false);
     }
 
     return intendedAudience.some(audienceClause => {
@@ -382,10 +378,6 @@ export function isIntendedAudience(intendedAudience: ContentBaseDTO['audience'],
                 return false;
             }
         } else if (isAda) {
-            // TODO: this is a quickfix and should be done better
-            // A proper discussion with Ada over the behaviour
-
-            // Ada behaves as "On Your Specification"
             return false;
         }
 
@@ -398,7 +390,6 @@ export function isIntendedAudience(intendedAudience: ContentBaseDTO['audience'],
                 return false;
             }
         } else if (isAda) {
-            // TODO: this is the same quickfix
             return false;
         }
 

--- a/src/app/services/userContext.ts
+++ b/src/app/services/userContext.ts
@@ -366,6 +366,10 @@ export function findAudienceRecordsMatchingPartial(audience: ContentBaseDTO['aud
 export function isIntendedAudience(intendedAudience: ContentBaseDTO['audience'], userContext: UseUserContextReturnType, user: Immutable<PotentialUser> | null): boolean {
     // If no audience is specified, we default to true
     if (!intendedAudience) {
+        // TODO: another quickfix
+        if (isAda) {
+            return false;
+        }
         return true;
     }
 
@@ -377,6 +381,12 @@ export function isIntendedAudience(intendedAudience: ContentBaseDTO['audience'],
             if (!satisfiesStageCriteria) {
                 return false;
             }
+        } else if (isAda) {
+            // TODO: this is a quickfix and should be done better
+            // A proper discussion with Ada over the behaviour
+
+            // Ada behaves as "On Your Specification"
+            return false;
         }
 
         // If exam boards are specified do we have any of them in our context
@@ -387,6 +397,9 @@ export function isIntendedAudience(intendedAudience: ContentBaseDTO['audience'],
             if (!satisfiesExamBoardCriteria) {
                 return false;
             }
+        } else if (isAda) {
+            // TODO: this is the same quickfix
+            return false;
         }
 
         // If a role is specified do we have any of those roles or greater


### PR DESCRIPTION
Ada wants a more strict check that enforces a stage and examboard to be present on a question (or item of content) for it to be considered on a user's specification.

This means that the `isIntendedAudience` needs to fail early rather than ignore stage and examboard. This is really a different function entirely and we don't necessarily want all uses of `isIntendedAudience` to behave like this on Ada. This should be changed in future after the release and the two functions used appropriately.
