### PR TITLE
Stretch numeric question's unit box to fit long units

### DIFF
--- a/src/app/components/content/IsaacNumericQuestion.tsx
+++ b/src/app/components/content/IsaacNumericQuestion.tsx
@@ -168,8 +168,8 @@ const IsaacNumericQuestion = ({doc, questionId, validationResponse, readonly}: I
                 </IsaacContentValueOrChildren>
             </div>
             <Row className="no-print">
-                <Col className="d-flex flex-column flex-sm-row flex-md-column flex-lg-row">
-                    <div className="numeric-value w-100 w-sm-50 w-md-100 w-lg-50">
+                <Col className="d-flex flex-column flex-md-row">
+                    <div className="numeric-value w-100 w-md-50">
                         <Label className="w-100">
                             Value <br />
                             <InputGroup className={"feedback-zone nq-feedback separate-input-group"}>
@@ -197,8 +197,8 @@ const IsaacNumericQuestion = ({doc, questionId, validationResponse, readonly}: I
                             </InputGroup>
                         </Label>
                     </div>
-                    {(doc.requireUnits || doc.displayUnit) && <div className="unit-selection w-100 w-sm-50 w-md-100 w-lg-25">
-                        <Label className="w-100 ml-sm-2 ml-md-0 ml-lg-5">
+                    {(doc.requireUnits || doc.displayUnit) && <div className="unit-selection w-100 w-md-50">
+                        <Label className="w-100 w-md-auto pl-md-5">
                             Unit{noDisplayUnit && "s"} <br/>
                             <Dropdown disabled={readonly} isOpen={isOpen && noDisplayUnit} toggle={() => {setIsOpen(!isOpen);}}>
                                 <DropdownToggle

--- a/src/scss/common/questions.scss
+++ b/src/scss/common/questions.scss
@@ -48,11 +48,11 @@
   .unit-selection {
     .dropdown-menu {
       width: 100%;
-      min-width: unset;
+      min-width: max-content;
     }
     button.btn {
       padding: 0.25rem 1.5rem;
-      min-width: unset;
+      min-width: 192px;
       width: 100%;
       &.selected {
         border-radius: 0;


### PR DESCRIPTION
Decouples numeric questions' unit box from the fixed grid sizes previously imposed to allow auto resizing based on the content. Keeps the previous min-width of 192px in place; will only expand from this if necessary.