### PR TITLE
Show related questions without examboard as off specification

### DIFF
--- a/src/app/components/elements/RelatedContent.tsx
+++ b/src/app/components/elements/RelatedContent.tsx
@@ -70,7 +70,7 @@ function getURLForContent(content: ContentSummaryDTO) {
 
 function renderQuestionsCS(audienceQuestions: ContentSummaryDTO[], remainingQuestions: ContentSummaryDTO[], renderItem: RenderItemFunction, conceptId: string, showConceptGameboardButton: boolean) {
 
-    if (audienceQuestions.length == 0) return null;
+    if (audienceQuestions.length + remainingQuestions.length == 0) return null;
     return <div className="d-flex align-items-stretch flex-wrap no-print">
         <div className="w-100 d-flex">
             <div className="flex-fill simple-card my-3 p-3 text-wrap">

--- a/src/app/services/userContext.ts
+++ b/src/app/services/userContext.ts
@@ -387,6 +387,9 @@ export function isIntendedAudience(intendedAudience: ContentBaseDTO['audience'],
             if (!satisfiesExamBoardCriteria) {
                 return false;
             }
+        } else if (isAda) {
+            // If no exam board specified treat as off specification (only for Ada)
+            return false;
         }
 
         // If a role is specified do we have any of those roles or greater


### PR DESCRIPTION
If a related question only has a stage (no examboard) it will be
considered "off specification" regardless of what examboard the
user has.

Furthermore, if there are related questions they will always be
displayed regardless of whether any are "on you specification".
