### PR TITLE
Restore prominent upgrade role link to My Account

### DIFF
--- a/src/app/components/elements/AccountTypeMessage.tsx
+++ b/src/app/components/elements/AccountTypeMessage.tsx
@@ -4,25 +4,17 @@ import React from "react";
 import {UserRole} from "../../../IsaacApiTypes";
 
 
-export const AccountTypeMessage = ({role}: { role?: UserRole }) => {
+export const AccountTypeMessage = ({role, hideUpgradeMessage}: { role?: UserRole, hideUpgradeMessage?: boolean }) => {
     return <div>
-        Account type: <b>{role && UserFacingRole[role]}</b> {role == "STUDENT" &&
-        siteSpecific(
-            <span>
-                    <small>(Are you a teacher or tutor? {" "}
-                        <Link to={TEACHER_REQUEST_ROUTE} target="_blank">
-                            Upgrade your account
-                        </Link>{".)"}
-                    </small>
-            </span>,
-            <span>
-                    <p className="font-style-italic">Are you a teacher or tutor? {" "}
-                        <Link to={TEACHER_REQUEST_ROUTE} target="_blank">
-                            Upgrade your account
-                        </Link>{"."}
-                    </p>
+        You have a <strong>{role ? UserFacingRole[role] : ""}</strong> account.
+        {role === "STUDENT" && !hideUpgradeMessage &&
+            <span> If you are a teacher{siteSpecific(" or tutor", "")}, you can {" "}
+                {siteSpecific(
+                    <Link to={TEACHER_REQUEST_ROUTE} target="_blank">upgrade your account</Link>,
+                    <strong><Link to={TEACHER_REQUEST_ROUTE} target="_blank">upgrade your account</Link></strong>
+                )}
+                {"."}
             </span>
-        )
     }
-    </div>
-}
+    </div>;
+};

--- a/src/app/components/elements/AccountTypeMessage.tsx
+++ b/src/app/components/elements/AccountTypeMessage.tsx
@@ -6,7 +6,8 @@ import {UserRole} from "../../../IsaacApiTypes";
 
 export const AccountTypeMessage = ({role, hideUpgradeMessage}: { role?: UserRole, hideUpgradeMessage?: boolean }) => {
     return <div>
-        You have a <strong>{role ? UserFacingRole[role] : ""}</strong> account.
+    {role && <>
+        You have a <strong>{UserFacingRole[role]}</strong> account.
         {role === "STUDENT" && !hideUpgradeMessage &&
             <span> If you are a teacher{siteSpecific(" or tutor", "")}, you can {" "}
                 {siteSpecific(
@@ -15,6 +16,8 @@ export const AccountTypeMessage = ({role, hideUpgradeMessage}: { role?: UserRole
                 )}
                 {"."}
             </span>
+        }
+    </>
     }
     </div>;
 };

--- a/src/app/components/elements/inputs/UserContextAccountInput.tsx
+++ b/src/app/components/elements/inputs/UserContextAccountInput.tsx
@@ -208,12 +208,6 @@ export function UserContextAccountInput({
                             <span>Show content that is not for my selected qualification(s).</span>
                         </Label>}
                     </>}
-
-                    {!tutorOrAbove && <><br/>
-                        <small>
-                            If you are a teacher or tutor, <Link to={TEACHER_REQUEST_ROUTE} target="_blank">upgrade your account</Link> to choose more than one {isAda && "exam board and "}stage.
-                        </small>
-                    </>}
                 </FormGroup>;
             })}
         </div>

--- a/src/app/components/elements/modals/RequiredAccountInformationModal.tsx
+++ b/src/app/components/elements/modals/RequiredAccountInformationModal.tsx
@@ -91,7 +91,7 @@ const RequiredAccountInfoBody = () => {
             <div className="text-right text-muted required-before">
                 Required
             </div>
-            <AccountTypeMessage role={userToUpdate?.role} />
+            <AccountTypeMessage role={userToUpdate?.role} hideUpgradeMessage/>
             <RS.Row className="d-flex flex-wrap my-2">
                 {((isAda && !validateUserGender(initialUserValue)) || !validateUserContexts(initialUserContexts)) && <RS.Col lg={6}>
                     {isAda && !validateUserGender(initialUserValue) && <div className="mb-3">

--- a/src/app/components/elements/panels/UserProfile.tsx
+++ b/src/app/components/elements/panels/UserProfile.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
 import {MyAccountTab} from './MyAccountTab';
-import {GivenNameInput, FamilyNameInput} from '../inputs/NameInput';
+import {FamilyNameInput, GivenNameInput} from '../inputs/NameInput';
 import {EmailInput} from '../inputs/EmailInput';
 import {BooleanNotation, DisplaySettings, ValidationUser} from '../../../../IsaacAppTypes';
-import {isAda, isPhy, isTeacherOrAbove, SITE_TITLE, validateEmail, validateName} from '../../../services';
+import {isAda, isPhy, isTeacherOrAbove, SITE_TITLE, siteSpecific, validateEmail, validateName} from '../../../services';
 import {CountryInput} from '../inputs/CountryInput';
 import {GenderInput} from '../inputs/GenderInput';
 import {SchoolInput} from "../inputs/SchoolInput";
 import {UserContextAccountInput} from "../inputs/UserContextAccountInput";
 import {UserAuthenticationSettingsDTO, UserContext} from "../../../../IsaacApiTypes";
 import {DobInput} from "../inputs/DobInput";
-import { UserFacingRole } from '../../../services/constants';
+import {AccountTypeMessage} from "../AccountTypeMessage";
 
 interface UserProfileProps {
     userToUpdate: ValidationUser;
@@ -28,15 +28,23 @@ interface UserProfileProps {
 
 export const UserProfile = (props: UserProfileProps) => {
     const {
-        userToUpdate, setUserToUpdate, userContexts, setUserContexts, 
+        userToUpdate, setUserToUpdate, userContexts, setUserContexts,
         setBooleanNotation, displaySettings, setDisplaySettings, submissionAttempted
     } = props;
     return <MyAccountTab
         leftColumn={<>
             <h3>Account details</h3>
             <p>Here you can see and manage your account details for {SITE_TITLE}.</p>
-            <p>You have a <strong>{userToUpdate.role ? UserFacingRole[userToUpdate.role] : ""}</strong> account.</p>
-            <p>If you would like to delete your account please <strong><a href="/contact?preset=accountDeletion" target="_blank" rel="noopener noreferrer">contact us</a></strong>.</p>
+            <p>
+                <AccountTypeMessage role={userToUpdate?.role} />
+            </p>
+            <p>If you would like to delete your account please {" "}
+                {siteSpecific(
+                    <a href="/contact?preset=accountDeletion" target="_blank" rel="noopener">contact us</a>,
+                    <strong><a href="/contact?preset=accountDeletion" target="_blank" rel="noopener">contact us</a></strong>,
+                )}
+                .
+            </p>
         </>}
         rightColumn={<>
             <GivenNameInput
@@ -82,9 +90,9 @@ export const UserProfile = (props: UserProfileProps) => {
                     submissionAttempted={submissionAttempted}
                 />
             }
-            <GenderInput 
+            <GenderInput
                 userToUpdate={userToUpdate}
-                setUserToUpdate={setUserToUpdate} 
+                setUserToUpdate={setUserToUpdate}
                 submissionAttempted={submissionAttempted}
                 required={false}
             />

--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -787,13 +787,13 @@ export const ASSIGNMENT_PROGRESS_CRUMB = siteSpecific(
 );
 
 export const UserFacingRole: {[role in UserRole]: string} = {
-    ADMIN: "Admin",
-    EVENT_MANAGER: "Event Manager",
-    CONTENT_EDITOR: "Content Editor",
-    EVENT_LEADER: "Event Leader",
-    TEACHER: "Teacher",
-    TUTOR: "Tutor",
-    STUDENT: "Student"
+    ADMIN: "admin",
+    EVENT_MANAGER: "event manager",
+    CONTENT_EDITOR: "content editor",
+    EVENT_LEADER: "event leader",
+    TEACHER: "teacher",
+    TUTOR: "tutor",
+    STUDENT: "student"
 };
 
 export enum SortOrder {


### PR DESCRIPTION
Annoyingly the Ada designers want bolded links, which means a bunch of siteSpecifics. Ideas welcome on how to fix this/make it nicer!
Also remove the existing text next to the context picker since it was only shown to students but only helpful to teachers. 
Role names are now lowercase, but these are only used by the AccountTypeMessage component anyhow.