### PR TITLE
Safari Cloze DND fix

### DIFF
--- a/src/app/components/content/IsaacClozeQuestion.tsx
+++ b/src/app/components/content/IsaacClozeQuestion.tsx
@@ -107,7 +107,7 @@ const useAutoScroll = ({active, acceleration, interval}: {active: boolean; accel
     const updateScrollAmount = useCallback((scrollAmount: number, acceleration = 10, interval = 5) => {
         if (scrollAmount !== 0) {
             const scaledScrollAmount = Math.abs(scrollAmount) * scrollAmount * acceleration;
-            const doScroll = () => window.scrollBy(0, scaledScrollAmount);
+            const doScroll = () => window.scrollTo(window.scrollX, window.scrollY + scaledScrollAmount);
             const intervalId = setInterval(doScroll, interval);
             return () => clearInterval(intervalId);
         }


### PR DESCRIPTION
`window.scrollBy` seems to move elements in the DOM around incorrectly on Safari -- they appear visually in the correct place, but inspecting them shows the layout boxes do not line up with these visuals. This solves itself if you scroll even a tiny bit, but if you don't, all the dnd fields are offset. 

Seemingly `window.scrollTo` is not subject to the same curse, so this replaces scrollBy with its equivalent scrollTo.