### PR TITLE
Mobile: more space for accordion title and indicator

### DIFF
--- a/src/app/components/elements/Accordion.tsx
+++ b/src/app/components/elements/Accordion.tsx
@@ -2,8 +2,10 @@ import React, {useEffect, useRef, useState} from "react";
 import * as RS from "reactstrap";
 import {RouteComponentProps, withRouter} from "react-router-dom";
 import {
+    above,
     ALPHABET,
     audienceStyle,
+    below,
     DOCUMENT_TYPE,
     isAda,
     isAQuestionLikeDoc,
@@ -11,6 +13,7 @@ import {
     NOT_FOUND,
     scrollVerticallyIntoView,
     siteSpecific,
+    useDeviceSize,
     useUserContext
 } from "../../services";
 import {AppState, logAction, selectors, useAppDispatch, useAppSelector} from "../../state";
@@ -37,9 +40,10 @@ let nextClientId = 0;
 
 export const Accordion = withRouter(({id, trustedTitle, index, children, startOpen, deEmphasised, disabled, audienceString, location: {hash}}: AccordionsProps) => {
     const dispatch = useAppDispatch();
-    const userContext = useUserContext();
     const componentId = useRef(uuid_v4().slice(0, 4)).current;
     const page = useAppSelector((state: AppState) => (state && state.doc) || null);
+
+    const deviceSize = useDeviceSize();
 
     // Toggle
     const isFirst = index === 0;
@@ -168,12 +172,17 @@ export const Accordion = withRouter(({id, trustedTitle, index, children, startOp
                 }}
                 aria-expanded={isOpen ? "true" : "false"}
             >
-                {isConceptPage && audienceString && <span className={"stage-label badge-secondary d-flex align-items-center p-1 " +
+                {isConceptPage && audienceString && <span className={"stage-label badge-secondary d-flex align-items-center p-2 " +
                     "justify-content-center " + classNames({[audienceStyle(audienceString)]: isAda})}>
-                    {siteSpecific(audienceString, audienceString.split("\n").map((line, i, arr) => <>{line}{i < arr.length && <br/>}</>))}
+                    {siteSpecific(
+                        audienceString, 
+                        (above["sm"](deviceSize) ? audienceString : audienceString.replaceAll(",", "\n")).split("\n").map((line, i, arr) => <>
+                            {line}{i < arr.length && <br/>}
+                        </>)
+                    )}
                 </span>}
                 <div className="accordion-title pl-3">
-                    <RS.Row>
+                    <RS.Row className="h-100 align-items-center">
                         {/* FIXME Revisit this maybe? https://github.com/isaacphysics/isaac-react-app/pull/473#discussion_r841556455 */}
                         <span className="accordion-part p-3 text-secondary">Part {ALPHABET[(index as number) % ALPHABET.length]}  {" "}</span>
                         {trustedTitle && <div className="p-3">

--- a/src/app/components/elements/list-groups/TopicSummaryLinks.tsx
+++ b/src/app/components/elements/list-groups/TopicSummaryLinks.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import * as RS from "reactstrap";
 import {ContentSummaryDTO} from "../../../../IsaacApiTypes";
 import {
+    above,
     audienceStyle,
     DOCUMENT_TYPE,
     documentTypePathPrefix,
@@ -11,6 +12,7 @@ import {
     notRelevantMessage,
     siteSpecific,
     stringifyAudience,
+    useDeviceSize,
     useUserContext
 } from "../../../services";
 import {Link} from "react-router-dom";
@@ -21,6 +23,7 @@ import {Markup} from "../markup";
 export function TopicSummaryLinks({items, search}: {items: ContentSummaryDTO[]; search?: string}) {
     const userContext = useUserContext();
     const user = useAppSelector(selectors.user.orNull);
+    const deviceSize = useDeviceSize();
 
     return <RS.ListGroup className="mt-4 link-list list-group-links">
         {items
@@ -49,7 +52,12 @@ export function TopicSummaryLinks({items, search}: {items: ContentSummaryDTO[]; 
                         block color="link" className={"d-flex align-items-stretch " + classNames({"de-emphasised": item.deEmphasised})}
                     >
                         <div className={"stage-label badge-primary d-flex align-items-center justify-content-center " + classNames({[audienceStyle(audienceString)]: isAda})}>
-                            {siteSpecific(audienceString, audienceString.split("\n").map((line, i, arr) => <>{line}{i < arr.length && <br/>}</>))}
+                            {siteSpecific(
+                            audienceString, 
+                            (above["sm"](deviceSize) ? audienceString : audienceString.replaceAll(",", "\n")).split("\n").map((line, i, arr) => <>
+                                {line}{i < arr.length && <br/>}
+                            </>)
+                        )}
                         </div>
                         <div className="title pl-3 d-flex">
                             <div className="p-3">

--- a/src/scss/common/accordions.scss
+++ b/src/scss/common/accordions.scss
@@ -14,8 +14,8 @@
   text-align: center;
 
   @include media-breakpoint-down(xs) {
-    min-width: 120px;
-    max-width: 120px;
+    min-width: 105px;
+    max-width: 105px;
   }
 }
 
@@ -109,7 +109,7 @@
         background-image: url('/assets/chevron_down.svg');
         background-repeat: no-repeat;
         background-position: right;
-        width: 20px;
+        width: 30px;
         height: 10px;
         margin-right: 1rem;
         margin-top: auto;

--- a/src/scss/common/topic.scss
+++ b/src/scss/common/topic.scss
@@ -50,6 +50,11 @@
       min-width: 130px;
       max-width: 130px;
       text-align: center;
+
+      @include respond-below(xs) {
+        min-width: 105px;
+        max-width: 105px;
+      }
     }
 
     &:hover {


### PR DESCRIPTION
On mobile only, replaces comma-separated stage names with newlines to allow more horizontal space for accordion titles and the dropdown indicator.