### PR TITLE
Add ability for student self-removal from groups

### DIFF
--- a/src/IsaacApiTypes.tsx
+++ b/src/IsaacApiTypes.tsx
@@ -320,6 +320,7 @@ export interface UserGroupDTO {
     ownerId?: number;
     created?: Date;
     lastUpdated?: Date;
+    selfRemoval?: boolean;
     token?: string;
     archived?: boolean;
     additionalManagerPrivileges?: boolean;

--- a/src/app/components/elements/modals/TeacherConnectionModalCreators.tsx
+++ b/src/app/components/elements/modals/TeacherConnectionModalCreators.tsx
@@ -147,7 +147,7 @@ export const confirmSelfRemovalModal = (userId: number, groupId: number) => {
                 the owner(s) of the group. If you remove yourself, you will no longer receive assignments.
                 <br/><br/>
                 Note that if you have granted the group owner(s) access to your data, they can still view this data after you have left the group. To revoke 
-                this access, use the Teacher Connections tab at the top of this page.
+                this access, use the Teacher Connections panel at the top of this page.
                 <br/><br/>
                 You can rejoin at any time using the code or link you used to join the group. Your progress, assignments and test scores will be retained.
             </p>

--- a/src/app/components/elements/modals/TeacherConnectionModalCreators.tsx
+++ b/src/app/components/elements/modals/TeacherConnectionModalCreators.tsx
@@ -136,3 +136,33 @@ export const releaseAllConfirmationModal = () => {
         ]
     }
 };
+
+export const confirmSelfRemovalModal = (userId: number, groupId: number) => {
+    return {
+        closeAction: () => store.dispatch(closeActiveModal()),
+        title: "Leave group",
+        body: <>
+            <p>
+                This group has enabled student self-removal. This means you can remove yourself from the group at any time, without requiring permission from 
+                the owner(s) of the group. If you remove yourself, you will no longer receive assignments.
+                <br/><br/>
+                Note that if you have granted the group owner(s) access to your data, they can still view this data after you have left the group. To revoke 
+                this access, use the Teacher Connections tab at the top of this page.
+                <br/><br/>
+                You can rejoin at any time using the code or link you used to join the group. Your progress, assignments and test scores will be retained.
+            </p>
+        </>,
+        buttons: [
+            <RS.Button key={1} color="primary" outline onClick={() => store.dispatch(closeActiveModal())}>
+                Cancel
+            </RS.Button>,
+            <RS.Button key={0} color="secondary" onClick={() => {
+                store.dispatch(authorisationsApi.endpoints.deleteGroupMember.initiate({groupId, userId})).then(() => {
+                    store.dispatch(closeActiveModal());
+                });
+            }}>
+                Leave group
+            </RS.Button>,
+        ]
+    };
+};

--- a/src/app/components/elements/panels/TeacherConnections.tsx
+++ b/src/app/components/elements/panels/TeacherConnections.tsx
@@ -318,7 +318,7 @@ export const TeacherConnections = ({user, authToken, editingOtherUser, userToEdi
                                                     :
                                                     <span><b>{(membership.group.groupName ?? "Group " + membership.group.id)}</b></span>
                                                 }
-                                                {membership.group.selfRemoval && <img className="self-removal-group ml-1" src="/assets/phy/teacher_features_sprite.svg#groups" alt=""/>}
+                                                {membership.group.selfRemoval && <img className="self-removal-group ml-1" src={siteSpecific("/assets/phy/teacher_features_sprite.svg#groups", "/assets/cs/icons/group.svg")} alt=""/>}
                                                 <br/>
                                                 {membership.group.ownerSummary && 
                                                     <span className="text-muted">Teacher{membership.group.additionalManagers && membership.group.additionalManagers.length > 0 ? "s" : ""}: {

--- a/src/app/components/elements/panels/TeacherConnections.tsx
+++ b/src/app/components/elements/panels/TeacherConnections.tsx
@@ -1,12 +1,13 @@
 import React, {useEffect, useState} from "react";
 import {Link} from "react-router-dom";
 import * as RS from "reactstrap";
-import {GroupMembershipDetailDTO, PotentialUser} from "../../../../IsaacAppTypes";
+import {GroupMembershipDetailDTO, LoggedInUser, PotentialUser} from "../../../../IsaacAppTypes";
 import {
     openActiveModal,
     showErrorToast,
     useAppDispatch,
     useChangeMyMembershipStatusMutation,
+    useDeleteGroupMemberMutation,
     useGetActiveAuthorisationsQuery,
     useGetGroupMembershipsQuery, useGetOtherUserAuthorisationsQuery,
     useLazyGetTokenOwnerQuery
@@ -29,6 +30,7 @@ import {RenderNothing} from "../RenderNothing";
 import {skipToken} from "@reduxjs/toolkit/query";
 import {RegisteredUserDTO} from "../../../../IsaacApiTypes";
 import {
+    confirmSelfRemovalModal,
     releaseAllConfirmationModal,
     releaseConfirmationModal,
     revocationConfirmationModal,
@@ -92,6 +94,7 @@ export const TeacherConnections = ({user, authToken, editingOtherUser, userToEdi
     const groupQuery = (user.loggedIn && user.id) ? ((editingOtherUser && userToEdit?.id) || undefined) : skipToken;
     const {data: groupMemberships} = useGetGroupMembershipsQuery(groupQuery);
     const [changeMyMembershipStatus] = useChangeMyMembershipStatusMutation();
+    const [deleteGroupMember] = useDeleteGroupMemberMutation();
     const {data: activeAuthorisations} = useGetActiveAuthorisationsQuery((editingOtherUser && userToEdit?.id) || undefined);
     const {data: studentAuthorisations} = useGetOtherUserAuthorisationsQuery((editingOtherUser && userToEdit?.id) || undefined);
     let filteredActiveAuthorisations = activeAuthorisations;
@@ -316,6 +319,7 @@ export const TeacherConnections = ({user, authToken, editingOtherUser, userToEdi
                                                     :
                                                     <span><b>{(membership.group.groupName ?? "Group " + membership.group.id)}</b></span>
                                                 }
+                                                {membership.group.selfRemoval && <img className="self-removal-group ml-1" src="/assets/phy/teacher_features_sprite.svg#groups" alt=""/>}
                                                 <br/>
                                                 {membership.group.ownerSummary && 
                                                     <span className="text-muted">Teacher{membership.group.additionalManagers && membership.group.additionalManagers.length > 0 ? "s" : ""}: {
@@ -325,7 +329,9 @@ export const TeacherConnections = ({user, authToken, editingOtherUser, userToEdi
                                             <RS.Col className="d-flex flex-col justify-content-end flex-grow-0 pr-1">
                                                 {membership.membershipStatus === MEMBERSHIP_STATUS.ACTIVE && <React.Fragment>
                                                     <RS.Button color="link" disabled={editingOtherUser} onClick={() =>
-                                                        changeMyMembershipStatus({groupId: membership.group.id as number, newStatus: MEMBERSHIP_STATUS.INACTIVE})
+                                                        membership.group.selfRemoval 
+                                                            ? dispatch(openActiveModal(confirmSelfRemovalModal((user as LoggedInUser).id as number, membership.group.id as number)))
+                                                            : changeMyMembershipStatus({groupId: membership.group.id as number, newStatus: MEMBERSHIP_STATUS.INACTIVE})
                                                     }>
                                                         Leave
                                                     </RS.Button>

--- a/src/app/components/elements/panels/TeacherConnections.tsx
+++ b/src/app/components/elements/panels/TeacherConnections.tsx
@@ -94,7 +94,6 @@ export const TeacherConnections = ({user, authToken, editingOtherUser, userToEdi
     const groupQuery = (user.loggedIn && user.id) ? ((editingOtherUser && userToEdit?.id) || undefined) : skipToken;
     const {data: groupMemberships} = useGetGroupMembershipsQuery(groupQuery);
     const [changeMyMembershipStatus] = useChangeMyMembershipStatusMutation();
-    const [deleteGroupMember] = useDeleteGroupMemberMutation();
     const {data: activeAuthorisations} = useGetActiveAuthorisationsQuery((editingOtherUser && userToEdit?.id) || undefined);
     const {data: studentAuthorisations} = useGetOtherUserAuthorisationsQuery((editingOtherUser && userToEdit?.id) || undefined);
     let filteredActiveAuthorisations = activeAuthorisations;

--- a/src/app/components/pages/Groups.tsx
+++ b/src/app/components/pages/Groups.tsx
@@ -365,7 +365,7 @@ const GroupEditor = ({group, allGroups, user, createNewGroup, groupNameInputRef}
                                                 changeFunction={toggleSelfRemoval}
                                                 initialValue={!!group.selfRemoval}
                                             />
-                                            <Label for="self-removal" className="d-inline-block mr-2">Allow students to remove themselves from this group?</Label>
+                                            <Label for="self-removal" className="d-inline-block mr-2">Allow students to remove themselves from this group</Label>
                                         </div>
                                     </Col>
                                 </Row>

--- a/src/app/components/pages/Groups.tsx
+++ b/src/app/components/pages/Groups.tsx
@@ -14,6 +14,7 @@ import {
     Input,
     InputGroup,
     InputGroupAddon,
+    Label,
     Nav,
     NavItem,
     NavLink,
@@ -48,6 +49,7 @@ import {ShowLoadingQuery} from "../handlers/ShowLoadingQuery";
 import classNames from "classnames";
 import {PageFragment} from "../elements/PageFragment";
 import {RenderNothing} from "../elements/RenderNothing";
+import { StyledCheckbox } from "../elements/inputs/CheckboxInput";
 
 enum SortOrder {
     Alphabetical = "Alphabetical",
@@ -205,6 +207,16 @@ const GroupEditor = ({group, allGroups, user, createNewGroup, groupNameInputRef}
         }
     }
 
+    function toggleSelfRemoval() {
+        if (group) {
+            const updatedGroup = {...group, selfRemoval: !group.selfRemoval};
+            updateGroup({
+                updatedGroup,
+                message: "Group member self-removal " + (updatedGroup.selfRemoval ? "enabled" : "disabled") + "."
+            });
+        }
+    }
+
     function toggleArchived() {
         if (group) {
             const updatedGroup = {...group, archived: !group.archived};
@@ -344,6 +356,18 @@ const GroupEditor = ({group, allGroups, user, createNewGroup, groupNameInputRef}
                                             Email users
                                         </Button>
                                     </Col>}
+                                </Row>
+                                <Row>
+                                    <Col xs={12}>
+                                        <div className="d-flex">
+                                            <StyledCheckbox
+                                                id="self-removal"
+                                                changeFunction={toggleSelfRemoval}
+                                                initialValue={!!group.selfRemoval}
+                                            />
+                                            <Label for="self-removal" className="d-inline-block mr-2">Allow students to remove themselves from this group?</Label>
+                                        </div>
+                                    </Col>
                                 </Row>
                                 <div>
                                     There are {group.members.length} users in this group {" "}

--- a/src/app/state/slices/api/groupsApi.ts
+++ b/src/app/state/slices/api/groupsApi.ts
@@ -181,9 +181,9 @@ export const groupsApi = assignmentsApi.injectEndpoints({
                     });
                 },
                 successTitle: "Removal successful",
-                successMessage: "You have been removed from the group.",
+                successMessage: "User removed from the group.",
                 errorTitle: "Failed to delete",
-                errorMessage: "You have not been removed from the group, please try again."
+                errorMessage: "User not removed from the group, please try again."
             })
         }),
 

--- a/src/app/state/slices/api/groupsApi.ts
+++ b/src/app/state/slices/api/groupsApi.ts
@@ -162,21 +162,28 @@ export const groupsApi = assignmentsApi.injectEndpoints({
                 onQuerySuccess: ({groupId, userId}, _, {dispatch, getState}) => {
                     const currentUserId = getState().user.id;
                     if (currentUserId === userId) {
-                        dispatch(assignmentsApi.util.invalidateTags(["AllMyAssignments"]));
+                        dispatch(assignmentsApi.util.invalidateTags(["AllMyAssignments", "MyGroupMemberships"]));
                     }
                     [true, false].forEach(archivedGroupsOnly => {
                         dispatch(groupsApi.util.updateQueryData(
                             "getGroups",
                             archivedGroupsOnly,
                             (groups) =>
-                                groups.map(g => g.id === groupId
-                                    ? {...g, members: g.members?.filter(m => m.id !== userId)}
-                                    : g
-                                )
+                                groups.filter(g => g.selfRemoval && g.members?.find(m => m.id === userId)
+                                        ? g.id !== groupId 
+                                        : true
+                                    )
+                                    .map(g => g.id === groupId
+                                        ? {...g, members: g.members?.filter(m => m.id !== userId)}
+                                        : g
+                                    )
                         ));
                     });
                 },
-                errorTitle: "Failed to delete member"
+                successTitle: "Removal successful",
+                successMessage: "You have been removed from the group.",
+                errorTitle: "Failed to delete",
+                errorMessage: "You have not been removed from the group, please try again."
             })
         }),
 

--- a/src/scss/common/groups.scss
+++ b/src/scss/common/groups.scss
@@ -29,3 +29,8 @@
     max-width: calc(100% - 24px);
   }
 }
+
+.self-removal-group {
+  width: 20px;
+  height: 20px;
+}


### PR DESCRIPTION
Allows self-removal from groups for which this is enabled. This can be set via a new checkbox on the Manage Groups page. 