### PR TITLE
Context Picker on Physics Search, layout improvements

### DIFF
--- a/src/app/components/elements/inputs/UserContextPicker.tsx
+++ b/src/app/components/elements/inputs/UserContextPicker.tsx
@@ -36,7 +36,6 @@ export const UserContextPicker = ({className, hideLabels = true}: {className?: s
         examBoard: isAda && !filteredExamBoardOptions.map(s => s.value).includes(userContext.examBoard),
     };
     const showUnusualContextMessage = unusual.stage || unusual.examBoard;
-    const showHideOtherContentSelector = isAda;
     const showStageSelector = getFilteredStageOptions({byUser: user}).length > 1 || showUnusualContextMessage;
     const showExamBoardSelector = isAda && (getFilteredExamBoardOptions({byUser: user}).length > 1 || showUnusualContextMessage);
 
@@ -116,8 +115,8 @@ export const UserContextPicker = ({className, hideLabels = true}: {className?: s
         </RS.Row>
         
 
-        {/* Other content Selector */}
-        {showHideOtherContentSelector && <RS.Row className="w-100 px-0 m-0 pb-2 justify-content-end">
+        {/* "Show other content" selector */}
+        {isAda && <RS.Row className="w-100 px-0 m-0 pb-2 justify-content-end">
             <FormGroup className="w-auto m-0">
                 <Label className="d-inline-block m-0" htmlFor="uc-show-other-content-check">Show other content? </Label>
                 <CustomInput

--- a/src/app/components/elements/inputs/UserContextPicker.tsx
+++ b/src/app/components/elements/inputs/UserContextPicker.tsx
@@ -47,11 +47,11 @@ export const UserContextPicker = ({className, hideLabels = true}: {className?: s
     return <RS.Col className={`d-flex flex-column w-100 px-0 mt-2 context-picker-container no-print ${className}`}>
         <RS.Row sm={12} md={7} lg={siteSpecific(7, 8)} xl={siteSpecific(7, 9)} className={`d-flex m-0 p-0 justify-content-md-end`}> 
             {/* Stage Selector */}
-            <FormGroup className="w-100 d-flex justify-content-end m-0">
+            <FormGroup className={`w-100 d-flex justify-content-end m-0`}>
                 {showStageSelector && <>
                     {!hideLabels && <Label className="d-inline-block pr-2" htmlFor="uc-stage-select">Stage</Label>}
                     <Input
-                        className={`flex-grow-1 d-inline-block pl-2 pr-0 mb-2 ${showExamBoardSelector ? "mr-1" : "ml-1"}`} type="select" id="uc-stage-select"
+                        className={`flex-grow-1 d-inline-block pl-2 pr-0 mb-2 ${showExamBoardSelector ? "mr-1" : ""}`} type="select" id="uc-stage-select"
                         aria-label={hideLabels ? "Stage" : undefined}
                         value={userContext.stage}
                         onChange={e => {
@@ -90,7 +90,7 @@ export const UserContextPicker = ({className, hideLabels = true}: {className?: s
                 {showExamBoardSelector && <>
                     {!hideLabels && <Label className="d-inline-block pr-2" htmlFor="uc-exam-board-select">Exam Board</Label>}
                     <Input
-                        className={`flex-grow-1 d-inline-block pl-2 pr-0 mb-2 ${showStageSelector ? "ml-1" : "mr-1"}`} type="select" id="uc-exam-board-select"
+                        className={`flex-grow-1 d-inline-block pl-2 pr-0 mb-2 ${showStageSelector ? "ml-1" : ""}`} type="select" id="uc-exam-board-select"
                         aria-label={hideLabels ? "Exam Board" : undefined}
                         value={userContext.examBoard}
                         onChange={e => {

--- a/src/app/components/elements/inputs/UserContextPicker.tsx
+++ b/src/app/components/elements/inputs/UserContextPicker.tsx
@@ -8,6 +8,7 @@ import {
     getFilteredStageOptions,
     history,
     isAda,
+    siteSpecific,
     STAGE,
     stageLabelMap,
     useQueryParams,
@@ -18,7 +19,6 @@ import {
     transientUserContextSlice,
     useAppDispatch,
     useAppSelector,
-    useGetSegueEnvironmentQuery
 } from "../../../state";
 import queryString from "query-string";
 
@@ -27,7 +27,6 @@ export const UserContextPicker = ({className, hideLabels = true}: {className?: s
     const qParams = useQueryParams();
     const user = useAppSelector(selectors.user.orNull);
     const userContext = useUserContext();
-    const {data: segueEnvironment} = useGetSegueEnvironmentQuery();
 
     const filteredExamBoardOptions = getFilteredExamBoardOptions({byUser: user, byStages: [userContext.stage], includeNullOptions: true});
     const filteredStages = getFilteredStageOptions({byUser: user, includeNullOptions: true});
@@ -37,7 +36,7 @@ export const UserContextPicker = ({className, hideLabels = true}: {className?: s
         examBoard: isAda && !filteredExamBoardOptions.map(s => s.value).includes(userContext.examBoard),
     };
     const showUnusualContextMessage = unusual.stage || unusual.examBoard;
-    const showHideOtherContentSelector = isAda && segueEnvironment === "DEV";
+    const showHideOtherContentSelector = isAda;
     const showStageSelector = getFilteredStageOptions({byUser: user}).length > 1 || showUnusualContextMessage;
     const showExamBoardSelector = isAda && (getFilteredExamBoardOptions({byUser: user}).length > 1 || showUnusualContextMessage);
 
@@ -45,25 +44,14 @@ export const UserContextPicker = ({className, hideLabels = true}: {className?: s
         ? filteredExamBoardOptions.filter(eb => eb.value !== EXAM_BOARD.ALL)[0]
         : undefined;
 
-    return <div className="d-flex context-picker-container">
-        <RS.Row className="m-0 w-100">
-            {/* Other content Selector */}
-            <RS.Col xs={{size: 12, order: 2}} lg={{size: 5, order: 0}} className="pl-0 pr-2 m-0 align-self-center pb-2">
-                {showHideOtherContentSelector && <FormGroup className={`d-flex align-items-center m-0 float-lg-right ${className}`}>
-                    <Label className="d-inline-block m-0" htmlFor="uc-show-other-content-check">Show other content? </Label>
-                    <CustomInput
-                        className="w-auto d-inline-block ml-2 pr-0" type="checkbox" id="uc-show-other-content-check"
-                        checked={userContext.showOtherContent}
-                        onChange={e => dispatch(transientUserContextSlice.actions.setShowOtherContent(e.target.checked))}
-                    />
-                </FormGroup>}
-            </RS.Col>
-            <RS.Col xs={12} lg={7} className={`d-flex m-0 mb-2 p-0 justify-content-lg-end ${className}`}> 
-                {/* Stage Selector */}
-                {showStageSelector && <FormGroup className={`${showExamBoardSelector ? "mr-2 mb-0" : ""} ${className}`}>
+    return <RS.Col className="d-flex flex-column w-100 px-0 mt-2 context-picker-container">
+        <RS.Row sm={12} md={7} lg={siteSpecific(7, 8)} xl={siteSpecific(7, 9)} className={`d-flex m-0 p-0 justify-content-md-end ${className}`}> 
+            {/* Stage Selector */}
+            <FormGroup className={`${className} w-100 justify-content-end`}>
+                {showStageSelector && <>
                     {!hideLabels && <Label className="d-inline-block pr-2" htmlFor="uc-stage-select">Stage</Label>}
                     <Input
-                        className="w-auto d-inline-block pl-1 pr-0" type="select" id="uc-stage-select"
+                        className={`flex-grow-1 d-inline-block pl-2 pr-0 mb-2 ${showExamBoardSelector ? "mr-sm-1" : "ml-sm-1"}`} type="select" id="uc-stage-select"
                         aria-label={hideLabels ? "Stage" : undefined}
                         value={userContext.stage}
                         onChange={e => {
@@ -96,13 +84,13 @@ export const UserContextPicker = ({className, hideLabels = true}: {className?: s
                             </option>
                         }
                     </Input>
-                </FormGroup>}
+                </>}
 
                 {/* Exam Board Selector */}
-                {showExamBoardSelector && <FormGroup className={className}>
+                {showExamBoardSelector && <>
                     {!hideLabels && <Label className="d-inline-block pr-2" htmlFor="uc-exam-board-select">Exam Board</Label>}
                     <Input
-                        className="w-auto d-inline-block pl-1 pr-0" type="select" id="uc-exam-board-select"
+                        className={`flex-grow-1 d-inline-block pl-2 pr-0 mb-2 ${showStageSelector ? "ml-sm-1" : "mr-sm-1"}`} type="select" id="uc-exam-board-select"
                         aria-label={hideLabels ? "Exam Board" : undefined}
                         value={userContext.examBoard}
                         onChange={e => {
@@ -123,9 +111,22 @@ export const UserContextPicker = ({className, hideLabels = true}: {className?: s
                             </option>
                         }
                     </Input>
-                </FormGroup>}
-            </RS.Col>
+                </>}
+            </FormGroup>
         </RS.Row>
+        
+
+        {/* Other content Selector */}
+        {showHideOtherContentSelector && <RS.Row className="w-100 px-0 m-0 pb-2 justify-content-end">
+            <FormGroup className={`w-auto ${className}`}>
+                <Label className="d-inline-block m-0" htmlFor="uc-show-other-content-check">Show other content? </Label>
+                <CustomInput
+                    className="d-inline-block ml-2 pr-0" type="checkbox" id="uc-show-other-content-check"
+                    checked={userContext.showOtherContent}
+                    onChange={e => dispatch(transientUserContextSlice.actions.setShowOtherContent(e.target.checked))}
+                />
+            </FormGroup>
+        </RS.Row>}
 
         {showUnusualContextMessage && <div className="mt-2 ml-1">
             <span id={`unusual-viewing-context-explanation`} className="icon-help mx-1" />
@@ -141,5 +142,5 @@ export const UserContextPicker = ({className, hideLabels = true}: {className?: s
                 {unusual.examBoard && !unusual.stage && `The exam board was specified by your ${userContext.explanation.examBoard}.`}
             </RS.UncontrolledTooltip>
         </div>}
-    </div>;
+    </RS.Col>;
 };

--- a/src/app/components/elements/inputs/UserContextPicker.tsx
+++ b/src/app/components/elements/inputs/UserContextPicker.tsx
@@ -44,14 +44,14 @@ export const UserContextPicker = ({className, hideLabels = true}: {className?: s
         ? filteredExamBoardOptions.filter(eb => eb.value !== EXAM_BOARD.ALL)[0]
         : undefined;
 
-    return <RS.Col className="d-flex flex-column w-100 px-0 mt-2 context-picker-container">
-        <RS.Row sm={12} md={7} lg={siteSpecific(7, 8)} xl={siteSpecific(7, 9)} className={`d-flex m-0 p-0 justify-content-md-end ${className}`}> 
+    return <RS.Col className={`d-flex flex-column w-100 px-0 mt-2 context-picker-container no-print ${className}`}>
+        <RS.Row sm={12} md={7} lg={siteSpecific(7, 8)} xl={siteSpecific(7, 9)} className={`d-flex m-0 p-0 justify-content-md-end`}> 
             {/* Stage Selector */}
-            <FormGroup className={`${className} w-100 justify-content-end`}>
+            <FormGroup className="w-100 d-flex justify-content-end m-0">
                 {showStageSelector && <>
                     {!hideLabels && <Label className="d-inline-block pr-2" htmlFor="uc-stage-select">Stage</Label>}
                     <Input
-                        className={`flex-grow-1 d-inline-block pl-2 pr-0 mb-2 ${showExamBoardSelector ? "mr-sm-1" : "ml-sm-1"}`} type="select" id="uc-stage-select"
+                        className={`flex-grow-1 d-inline-block pl-2 pr-0 mb-2 ${showExamBoardSelector ? "mr-1" : "ml-1"}`} type="select" id="uc-stage-select"
                         aria-label={hideLabels ? "Stage" : undefined}
                         value={userContext.stage}
                         onChange={e => {
@@ -90,7 +90,7 @@ export const UserContextPicker = ({className, hideLabels = true}: {className?: s
                 {showExamBoardSelector && <>
                     {!hideLabels && <Label className="d-inline-block pr-2" htmlFor="uc-exam-board-select">Exam Board</Label>}
                     <Input
-                        className={`flex-grow-1 d-inline-block pl-2 pr-0 mb-2 ${showStageSelector ? "ml-sm-1" : "mr-sm-1"}`} type="select" id="uc-exam-board-select"
+                        className={`flex-grow-1 d-inline-block pl-2 pr-0 mb-2 ${showStageSelector ? "ml-1" : "mr-1"}`} type="select" id="uc-exam-board-select"
                         aria-label={hideLabels ? "Exam Board" : undefined}
                         value={userContext.examBoard}
                         onChange={e => {
@@ -118,7 +118,7 @@ export const UserContextPicker = ({className, hideLabels = true}: {className?: s
 
         {/* Other content Selector */}
         {showHideOtherContentSelector && <RS.Row className="w-100 px-0 m-0 pb-2 justify-content-end">
-            <FormGroup className={`w-auto ${className}`}>
+            <FormGroup className="w-auto m-0">
                 <Label className="d-inline-block m-0" htmlFor="uc-show-other-content-check">Show other content? </Label>
                 <CustomInput
                     className="d-inline-block ml-2 pr-0" type="checkbox" id="uc-show-other-content-check"

--- a/src/app/components/pages/Concept.tsx
+++ b/src/app/components/pages/Concept.tsx
@@ -5,7 +5,7 @@ import {Col, Container, Row} from "reactstrap";
 import {ShowLoading} from "../handlers/ShowLoading";
 import {IsaacContent} from "../content/IsaacContent";
 import {IsaacQuestionPageDTO} from "../../../IsaacApiTypes";
-import {DOCUMENT_TYPE, isAda, isPhy, useNavigation} from "../../services";
+import {DOCUMENT_TYPE, above, below, isAda, isPhy, useDeviceSize, useNavigation} from "../../services";
 import {DocumentSubject, GameboardContext} from "../../../IsaacAppTypes";
 import {RelatedContent} from "../elements/RelatedContent";
 import {WithFigureNumbering} from "../elements/WithFigureNumbering";
@@ -29,12 +29,26 @@ interface ConceptPageProps {
     location: {search: string};
     preview?: boolean;
 }
+
 export const Concept = withRouter(({match: {params}, location: {search}, conceptIdOverride, preview}: ConceptPageProps) => {
     const dispatch = useAppDispatch();
     const conceptId = conceptIdOverride || params.conceptId;
     useEffect(() => {dispatch(fetchDoc(DOCUMENT_TYPE.CONCEPT, conceptId));}, [conceptId]);
     const doc = useAppSelector((state: AppState) => state?.doc || null);
     const navigation = useNavigation(doc);
+    const deviceSize = useDeviceSize();
+
+    const ManageButtons = () => <div className="no-print d-flex justify-content-end mt-1 ml-2">
+        <div className="question-actions">
+            <ShareLink linkUrl={`/concepts/${conceptId}${search || ""}`} />
+            </div>
+            <div className="question-actions not-mobile">
+            <PrintButton />
+            </div>
+            <div className="question-actions">
+            <ReportButton pageId={conceptId}/>
+        </div>
+    </div>;
 
     return <ShowLoading until={doc} thenRender={supertypedDoc => {
         const doc = supertypedDoc as IsaacQuestionPageDTO & DocumentSubject;
@@ -52,19 +66,12 @@ export const Concept = withRouter(({match: {params}, location: {search}, concept
                     <CanonicalHrefElement />
                 </>}
                 <EditContentButton doc={doc} />
-                <div className="no-print d-flex align-items-center mt-4">
-                    <div className="mr-sm-1 ml-auto">
-                        <UserContextPicker className="no-print" />
-                    </div>
-                    <div className="question-actions">
-                        <ShareLink linkUrl={`/concepts/${conceptId}${search || ""}`} />
-                    </div>
-                    <div className="question-actions not-mobile">
-                        <PrintButton />
-                    </div>
-                    <div className="question-actions">
-                        <ReportButton pageId={conceptId}/>
-                    </div>
+
+                {below["sm"](deviceSize) && <ManageButtons />}
+
+                <div className="d-flex mr-sm-1 flex-grow-1">
+                    <UserContextPicker />
+                    {above["md"](deviceSize) && <ManageButtons />}
                 </div>
 
                 <Row className="concept-content-container">

--- a/src/app/components/pages/Concept.tsx
+++ b/src/app/components/pages/Concept.tsx
@@ -69,7 +69,7 @@ export const Concept = withRouter(({match: {params}, location: {search}, concept
 
                 {below["sm"](deviceSize) && <ManageButtons />}
 
-                <div className="d-flex mr-sm-1 flex-grow-1">
+                <div className="d-flex align-items-center mr-sm-1 flex-grow-1">
                     <UserContextPicker />
                     {above["md"](deviceSize) && <ManageButtons />}
                 </div>

--- a/src/app/components/pages/Search.tsx
+++ b/src/app/components/pages/Search.tsx
@@ -128,11 +128,11 @@ export const Search = withRouter((props: RouteComponentProps) => {
                             </RS.Col>
                             <RS.Col sm={12} md={7} lg={siteSpecific(7, 8)} xl={siteSpecific(7, 9)}>
                                 <RS.Form inline className="search-filters">
-                                    <RS.Row className="w-100 align-items-center m-0">
+                                    <RS.Row className="w-100 align-items-center justify-content-end m-0">
                                         <RS.Label htmlFor="document-filter" className="d-none d-lg-inline-block mr-1">
                                             {`Filter${siteSpecific("","s")}:`}
                                         </RS.Label>
-                                        <div className="flex-grow-1">
+                                        <div className="search-filters-select-containter">
                                             <StyledSelect
                                                 inputId="document-filter" isMulti
                                                 placeholder="No page type filter"

--- a/src/app/components/pages/Search.tsx
+++ b/src/app/components/pages/Search.tsx
@@ -132,7 +132,7 @@ export const Search = withRouter((props: RouteComponentProps) => {
                                         <RS.Label htmlFor="document-filter" className="d-none d-lg-inline-block mr-1">
                                             {`Filter${siteSpecific("","s")}:`}
                                         </RS.Label>
-                                        <div className="search-filters-select-containter">
+                                        <div className="search-filters-select-container">
                                             <StyledSelect
                                                 inputId="document-filter" isMulti
                                                 placeholder="No page type filter"

--- a/src/app/components/pages/Search.tsx
+++ b/src/app/components/pages/Search.tsx
@@ -128,26 +128,30 @@ export const Search = withRouter((props: RouteComponentProps) => {
                             </RS.Col>
                             <RS.Col sm={12} md={7} lg={siteSpecific(7, 8)} xl={siteSpecific(7, 9)}>
                                 <RS.Form inline className="search-filters">
-                                    <RS.Label htmlFor="document-filter" className="d-none d-lg-inline-block mr-1">
-                                        {`Filter${siteSpecific("","s")}:`}
-                                    </RS.Label>
-                                    <StyledSelect
-                                        inputId="document-filter" isMulti
-                                        placeholder="No page type filter"
-                                        value={filtersState}
-                                        options={
-                                            [DOCUMENT_TYPE.CONCEPT, DOCUMENT_TYPE.QUESTION, DOCUMENT_TYPE.GENERIC]
-                                                .concat(siteSpecific([DOCUMENT_TYPE.EVENT], [DOCUMENT_TYPE.TOPIC_SUMMARY]))
-                                                .map(itemise)
-                                        }
-                                        className="basic-multi-select w-100 w-md-75 w-lg-50 mb-2 mb-md-0"
-                                        classNamePrefix="select"
-                                        onChange={selectOnChange(setFiltersState, false)}
-                                        styles={selectStyle}
-                                    />
-                                    {isAda && <RS.Label className="mt-2 mb-2 mb-md-0 mx-0">
-                                        <UserContextPicker className="text-right" />
-                                    </RS.Label>}
+                                    <RS.Row className="w-100 align-items-center m-0">
+                                        <RS.Label htmlFor="document-filter" className="d-none d-lg-inline-block mr-1">
+                                            {`Filter${siteSpecific("","s")}:`}
+                                        </RS.Label>
+                                        <div className="flex-grow-1">
+                                            <StyledSelect
+                                                inputId="document-filter" isMulti
+                                                placeholder="No page type filter"
+                                                value={filtersState}
+                                                options={
+                                                    [DOCUMENT_TYPE.CONCEPT, DOCUMENT_TYPE.QUESTION, DOCUMENT_TYPE.GENERIC]
+                                                        .concat(siteSpecific([DOCUMENT_TYPE.EVENT], [DOCUMENT_TYPE.TOPIC_SUMMARY]))
+                                                        .map(itemise)
+                                                }
+                                                className="basic-multi-select w-100 w-md-75 w-lg-50 mb-2 mb-md-0"
+                                                classNamePrefix="select"
+                                                onChange={selectOnChange(setFiltersState, false)}
+                                                styles={selectStyle}
+                                            />
+                                        </div>
+
+                                    </RS.Row>
+
+                                    <UserContextPicker className="text-right" />
                                 </RS.Form>
                             </RS.Col>
                         </RS.CardHeader>

--- a/src/app/components/pages/Search.tsx
+++ b/src/app/components/pages/Search.tsx
@@ -151,7 +151,7 @@ export const Search = withRouter((props: RouteComponentProps) => {
 
                                     </RS.Row>
 
-                                    <UserContextPicker className="text-right" />
+                                    <UserContextPicker />
                                 </RS.Form>
                             </RS.Col>
                         </RS.CardHeader>

--- a/src/app/components/pages/Topic.tsx
+++ b/src/app/components/pages/Topic.tsx
@@ -42,7 +42,7 @@ export const Topic = withRouter(({match: {params: {topicName}}}: {match: {params
             <Row>
                 <Col className={"py-3 mw-760"}>
                     <div className="d-flex justify-content-end">
-                        <UserContextPicker className="justify-content-end" />
+                        <UserContextPicker />
                     </div>
                     {!(atLeastOne(relatedConceptsForSpecificViewingContext.length) || atLeastOne(relatedQuestionsForSpecificViewingContext.length)) &&
                         <IntendedAudienceWarningBanner doc={topicPage} />

--- a/src/scss/common/pages.scss
+++ b/src/scss/common/pages.scss
@@ -146,8 +146,9 @@ main {
     }
 }
 
-.context-picker-container {
+.context-picker-container select {
   @include media-breakpoint-up(lg) {
-    min-width: 600px;
+    max-width: 200px;
   }
+  flex-basis: 0;
 }

--- a/src/scss/common/pages.scss
+++ b/src/scss/common/pages.scss
@@ -147,12 +147,8 @@ main {
 }
 
 .context-picker-container select {
-  @include media-breakpoint-down(sm) {
-    // for large sm only, widens the select precisely enough to fill the width;
-    // we usually only want 200px, but it looks odd when it fills ~85% of the screen
-    max-width: 253px;
+  @include media-breakpoint-up(sm) {
+    max-width: 200px;
   }
-
-  max-width: 200px;
   flex-basis: 0;
 }

--- a/src/scss/common/pages.scss
+++ b/src/scss/common/pages.scss
@@ -147,8 +147,12 @@ main {
 }
 
 .context-picker-container select {
-  @include media-breakpoint-up(lg) {
-    max-width: 200px;
+  @include media-breakpoint-down(sm) {
+    // for large sm only, widens the select precisely enough to fill the width;
+    // we usually only want 200px, but it looks odd when it fills ~85% of the screen
+    max-width: 253px;
   }
+
+  max-width: 200px;
   flex-basis: 0;
 }

--- a/src/scss/common/search.scss
+++ b/src/scss/common/search.scss
@@ -101,6 +101,8 @@ nav.search {
   }
 }
 
-.search-filters > div {
+.search-filters-select-containter {
+  flex-grow: 1;
   flex-flow: row nowrap;
+  max-width: 520px;
 }

--- a/src/scss/common/search.scss
+++ b/src/scss/common/search.scss
@@ -100,3 +100,7 @@ nav.search {
     }
   }
 }
+
+.search-filters > div {
+  flex-flow: row nowrap;
+}

--- a/src/scss/common/search.scss
+++ b/src/scss/common/search.scss
@@ -101,7 +101,7 @@ nav.search {
   }
 }
 
-.search-filters-select-containter {
+.search-filters-select-container {
   flex-grow: 1;
   flex-flow: row nowrap;
   max-width: 520px;

--- a/src/scss/cs/pages.scss
+++ b/src/scss/cs/pages.scss
@@ -77,3 +77,10 @@
     }
   }
 }
+
+.context-picker-container select {
+  @include media-breakpoint-down(sm) {
+    // for large sm only, widens the select precisely enough to fill the width
+    max-width: 253px;
+  }
+}


### PR DESCRIPTION
Adds a context picker for physics search, allowing a workaround for issues with only the first context being displayed. Also restructures the code to hugely simplify both how the UserContextPicker is used and the produced DOM by preferring the typical Bootstrap-style format.

Note for reviewer, the context picker is (now) used in 3 places on both sites:
- search
- concept pages
- topic summary pages