### PR TITLE
Question finder URL not updating when field removed

### DIFF
--- a/src/app/components/pages/GameboardFilter.tsx
+++ b/src/app/components/pages/GameboardFilter.tsx
@@ -572,6 +572,11 @@ export const GameboardFilter = withRouter(({location}: RouteComponentProps) => {
             delete params.questionCategories;
             delete params.title;
             if (params.subjects === allTags) delete params.subjects;
+
+            // seemingly necessary to remove old query params
+            // if we upgrade to react-router-dom 6, navigate(..., replace=true) in the if-else below should remove the need for this
+            history.replace({search: "", state: location.state});
+
             if (isFound(gameboard)) {
                 history.replace({search: queryString.stringify(params, {encode: false}), hash: gameboard.id, state: location.state});
             } else {

--- a/src/app/components/pages/GameboardFilter.tsx
+++ b/src/app/components/pages/GameboardFilter.tsx
@@ -573,10 +573,6 @@ export const GameboardFilter = withRouter(({location}: RouteComponentProps) => {
             delete params.title;
             if (params.subjects === allTags) delete params.subjects;
 
-            // seemingly necessary to remove old query params
-            // if we upgrade to react-router-dom 6, navigate(..., replace=true) in the if-else below should remove the need for this
-            history.replace({search: "", state: location.state});
-
             if (isFound(gameboard)) {
                 history.replace({search: queryString.stringify(params, {encode: false}), hash: gameboard.id, state: location.state});
             } else {

--- a/src/app/services/userContext.ts
+++ b/src/app/services/userContext.ts
@@ -153,7 +153,6 @@ export function useUserContext(): UseUserContextReturnType {
                 history.replace({
                     ...window.location,
                     search: queryString.stringify({
-                        ...queryParams,
                         ...actualParams,
                         stage,
                         examBoard: isAda ? examBoard : undefined,
@@ -165,7 +164,7 @@ export function useUserContext(): UseUserContextReturnType {
                 // trying to render, causing a loop and a spike in client-side errors.
             }
         }
-    }, [stage, examBoard, queryParams.stage, queryParams.examBoard]);
+    }, [stage, examBoard]);
 
     return {
         stage, setStage, examBoard, setExamBoard, explanation,


### PR DESCRIPTION
Provides a temporary solution for the URL parameters not updating as stage/topic/fields in the Question Finder page are removed from the search.

Seemingly, `history.replace` does not update a search query if the new parameters are a strict subset of the ones provided previously; this solution therefore resets them before replacing.

A much better solution exists with `react-router-dom` v6, which we should consider upgrading to alongside the planned React upgrade.