### PR TITLE
Combine KS3 events filters into "Years 7, 8 & 9"

### DIFF
--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -833,6 +833,20 @@ export enum EventTypeFilter {
     "Online tutorials" = "virtual",
 }
 
+export const EventStageMap = siteSpecific(
+    {
+        "All Stages": STAGE.ALL,
+        "Years 7, 8 & 9": [STAGE.YEAR_7_AND_8, STAGE.YEAR_9].join(','),
+        "GCSE": STAGE.GCSE,
+        "A Level": STAGE.A_LEVEL,
+        "Further A": STAGE.FURTHER_A,
+        "University": STAGE.UNIVERSITY,
+    },
+    {
+        "All Stages": STAGE.ALL,
+    }
+) as {[stage: string]: string};
+
 export const GREEK_LETTERS_MAP: { [letter: string]: string } = {
     "alpha": "α",
     "beta": "β",

--- a/src/app/state/slices/api/eventsApi.ts
+++ b/src/app/state/slices/api/eventsApi.ts
@@ -60,7 +60,7 @@ const augmentEvent = (event: IsaacEventPageDTO): AugmentedEvent => {
 type EventsQueryParams = {
     typeFilter: EventTypeFilter;
     statusFilter: EventStatusFilter;
-    stageFilter: STAGE;
+    stageFilter: STAGE[];
     startIndex: number;
     limit: number;
 }
@@ -86,7 +86,7 @@ export const eventsApi = isaacApi.enhanceEndpoints({
                     show_inactive_only: false,
                     show_booked_only: statusFilter === EventStatusFilter["My booked events"],
                     show_reservations_only: statusFilter === EventStatusFilter["My event reservations"],
-                    show_stage_only: stageFilter !== STAGE.ALL ? stageFilter : undefined
+                    show_stage_only: !stageFilter.includes(STAGE.ALL) ? stageFilter.join(',') : undefined
                 }
             }),
             transformResponse: (data: {results: IsaacEventPageDTO[], totalResults: number}) => ({events: data.results.map(augmentEvent), total: data.totalResults}),


### PR DESCRIPTION
Replaces the "Year 7&8" and "Year 9" filters with one combined "Years 7, 8 & 9" filter for both.

I'd have liked to incorporate `getFilteredStageOptions` here rather than define a new `EventStageMap` for consistency with elsewhere, but we need instead to define an overrides list to apply the replacement to the result. This works but is overcomplicated and less extensible so I have returned to using a separate constant.