### PR TITLE
Correctly update group when removing user

### DIFF
--- a/src/app/components/pages/Groups.tsx
+++ b/src/app/components/pages/Groups.tsx
@@ -131,7 +131,7 @@ const MemberInfo = ({group, member, user}: MemberInfoProps) => {
                     <Tooltip tipText="This user has not yet verified their email." className="icon-email-status unverified" />
                 }
                 {member.groupMembershipInformation && member.groupMembershipInformation.status == "INACTIVE" &&
-                    <Tooltip tipText="This user has set their status to inactive for this group. This means they will no longer see new assignments."> (inactive in group)</Tooltip>
+                    <Tooltip className="ml-1" tipText="This user has set their status to inactive for this group. This means they will no longer see new assignments.">(inactive in group)</Tooltip>
                 }
             </div>
         </div>

--- a/src/app/state/slices/api/groupsApi.ts
+++ b/src/app/state/slices/api/groupsApi.ts
@@ -162,21 +162,17 @@ export const groupsApi = assignmentsApi.injectEndpoints({
                 onQuerySuccess: ({groupId, userId}, _, {dispatch, getState}) => {
                     const currentUserId = getState().user.id;
                     if (currentUserId === userId) {
-                        dispatch(assignmentsApi.util.invalidateTags(["AllMyAssignments", "MyGroupMemberships"]));
+                        dispatch(assignmentsApi.util.invalidateTags(["AllMyAssignments", "MyGroupMemberships", "Groups"]));
                     }
                     [true, false].forEach(archivedGroupsOnly => {
                         dispatch(groupsApi.util.updateQueryData(
                             "getGroups",
                             archivedGroupsOnly,
                             (groups) =>
-                                groups.filter(g => g.selfRemoval && g.members?.find(m => m.id === userId)
-                                        ? g.id !== groupId 
-                                        : true
-                                    )
-                                    .map(g => g.id === groupId
-                                        ? {...g, members: g.members?.filter(m => m.id !== userId)}
-                                        : g
-                                    )
+                                groups.map(g => g.id === groupId
+                                    ? {...g, members: g.members?.filter(m => m.id !== userId)}
+                                    : g
+                                )
                         ));
                     });
                 },


### PR DESCRIPTION
Invalidates the Groups tag in RTK as to pull the updated group data when removing a user. This prevents the need for filtering groups after making the request, which was previously buggy.