### PR TITLE
Display warning banner when attempts hidden due to revision mode

### DIFF
--- a/src/app/components/content/IsaacQuestion.tsx
+++ b/src/app/components/content/IsaacQuestion.tsx
@@ -10,7 +10,7 @@ import {
 } from "../../state";
 import {IsaacContent} from "./IsaacContent";
 import * as ApiTypes from "../../../IsaacApiTypes";
-import {BEST_ATTEMPT_HIDDEN, ContentDTO} from "../../../IsaacApiTypes";
+import {ContentDTO} from "../../../IsaacApiTypes";
 import * as RS from "reactstrap";
 import {
     below,
@@ -48,7 +48,6 @@ export const IsaacQuestion = withRouter(({doc, location}: {doc: ApiTypes.Questio
     const currentUser = useAppSelector(selectors.user.orNull);
     const questionPart = (doc.type === "isaacInlineRegion") ? useInlineRegionPart(pageQuestions) : selectQuestionPart(pageQuestions, doc.id);
     const currentAttempt = questionPart?.currentAttempt;
-    const bestAttempt = questionPart?.bestAttempt;
     const validationResponse = questionPart?.validationResponse;
     const validationResponseTags = validationResponse?.explanation?.tags;
     const correct = validationResponse?.correct || false;
@@ -139,12 +138,6 @@ export const IsaacQuestion = withRouter(({doc, location}: {doc: ApiTypes.Questio
                 <Suspense fallback={<Loading/>}>
                     <QuestionComponent questionId={doc.id as string} doc={doc} validationResponse={validationResponse} />
                 </Suspense>
-
-                {!currentAttempt && bestAttempt === BEST_ATTEMPT_HIDDEN && <div className={"w-100 text-center"}>
-                    <small className={"no-print text-muted"}>
-                        A previous attempt at this question part has been hidden.
-                    </small>
-                </div>}
 
                 {isAda &&
                     <div className="mt-4">

--- a/src/app/components/navigation/RevisionWarningBanner.tsx
+++ b/src/app/components/navigation/RevisionWarningBanner.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import * as RS from "reactstrap";
+import {AppState, selectors, useAppSelector} from "../../state";
+import {RenderNothing} from "../elements/RenderNothing";
+
+export function RevisionWarningBanner() {
+
+    const hideAttempts: boolean = useAppSelector(
+        (state: AppState) => state?.userPreferences?.DISPLAY_SETTING?.HIDE_QUESTION_ATTEMPTS
+    ) ?? false;
+    const hiddenAttempts: boolean = useAppSelector(selectors.questions.anyQuestionHidden);
+
+    if (hideAttempts && hiddenAttempts) {
+        return <RS.Alert color="warning" className={"no-print"}>
+            You have attempted this question before, but you are <a href="\account#betafeatures">hiding your past attempts</a>.
+        </RS.Alert>;
+    } else {
+        return RenderNothing;
+    }
+}

--- a/src/app/components/pages/Question.tsx
+++ b/src/app/components/pages/Question.tsx
@@ -34,6 +34,7 @@ import {SupersededDeprecatedWarningBanner} from "../navigation/SupersededDepreca
 import {CanonicalHrefElement} from "../navigation/CanonicalHrefElement";
 import {ReportButton} from "../elements/ReportButton";
 import classNames from "classnames";
+import { RevisionWarningBanner } from "../navigation/RevisionWarningBanner";
 
 interface QuestionPageProps extends RouteComponentProps<{questionId: string}> {
     questionIdOverride?: string;
@@ -103,6 +104,8 @@ export const Question = withRouter(({questionIdOverride, match, location, previe
                         <SupersededDeprecatedWarningBanner doc={doc} />
 
                         <IntendedAudienceWarningBanner doc={doc} />
+
+                        <RevisionWarningBanner />
 
                         <WithFigureNumbering doc={doc}>
                             <IsaacContent doc={doc}/>

--- a/src/app/state/selectors.tsx
+++ b/src/app/state/selectors.tsx
@@ -1,5 +1,6 @@
 import {anonymisationFunctions, anonymiseIfNeededWith, anonymiseListIfNeededWith, AppState} from "./index";
 import {NOT_FOUND} from "../services";
+import { BEST_ATTEMPT_HIDDEN } from "../../IsaacApiTypes";
 
 export const selectors = {
 
@@ -27,6 +28,9 @@ export const selectors = {
         },
         anyQuestionPreviouslyAttempted: (state: AppState) => {
             return !!state && !!state.questions && state.questions.questions.map(q => !!q.bestAttempt).reduce((prev, current) => prev || current);
+        },
+        anyQuestionHidden: (state: AppState) => {
+            return !!state && !!state.questions && state.questions.questions.map(q => q.bestAttempt === BEST_ATTEMPT_HIDDEN).reduce((prev, current) => prev || current);
         }
     },
 

--- a/src/app/state/selectors.tsx
+++ b/src/app/state/selectors.tsx
@@ -30,7 +30,7 @@ export const selectors = {
             return !!state && !!state.questions && state.questions.questions.map(q => !!q.bestAttempt).reduce((prev, current) => prev || current);
         },
         anyQuestionHidden: (state: AppState) => {
-            return !!state && !!state.questions && state.questions.questions.map(q => q.bestAttempt === BEST_ATTEMPT_HIDDEN).reduce((prev, current) => prev || current);
+            return !!state && !!state.questions && state.questions.questions.some(q => q.bestAttempt === BEST_ATTEMPT_HIDDEN);
         }
     },
 


### PR DESCRIPTION
If a user is in revision mode (thus their previous attempts are hidden)
and are attempting a question where some of the question parts have
previous attempts a banner is shown at the top of the question
explaining why their attempts have been hidden.

There is a link to the beta feature page to turn the revision mode off
if the student wishes to see their previous answer.
