### PR TITLE
Add country field validation to Ada signup flow

### DIFF
--- a/src/app/components/elements/inputs/CountryInput.tsx
+++ b/src/app/components/elements/inputs/CountryInput.tsx
@@ -12,12 +12,13 @@ interface CountryInputProps {
     className?: string;
     userToUpdate: Immutable<ValidationUser>;
     setUserToUpdate: (user: Immutable<ValidationUser>) => void;
+    countryCodeValid: boolean;
     submissionAttempted: boolean;
     idPrefix?: string;
     required: boolean;
 }
 
-export const CountryInput = ({className, userToUpdate, setUserToUpdate, submissionAttempted, idPrefix="account", required}: CountryInputProps) => {
+export const CountryInput = ({className, userToUpdate, setUserToUpdate, countryCodeValid, submissionAttempted, idPrefix="account", required}: CountryInputProps) => {
     const {data: allCountryOptions} = useGetCountriesQuery();
     const {data: priorityCountryOptions} = useGetPriorityCountriesQuery();
 
@@ -27,7 +28,8 @@ export const CountryInput = ({className, userToUpdate, setUserToUpdate, submissi
         <StyledDropdown
             id={`${idPrefix}-country-select`}
             value={userToUpdate && userToUpdate.countryCode}
-            invalid={submissionAttempted && required && userToUpdate.countryCode == null}
+            invalid={submissionAttempted && required && !countryCodeValid}
+            feedback="Please select your country."
             onChange={(e: ChangeEvent<HTMLInputElement>) =>
                 setUserToUpdate(Object.assign({}, userToUpdate, e.target.value ? {countryCode: e.target.value} : {countryCode: null}))
             }
@@ -44,8 +46,5 @@ export const CountryInput = ({className, userToUpdate, setUserToUpdate, submissi
                 }
             )}
         </StyledDropdown>
-        <FormFeedback>
-            Please select a country.
-        </FormFeedback>
     </RS.FormGroup>;
 };

--- a/src/app/components/elements/inputs/DropdownInput.tsx
+++ b/src/app/components/elements/inputs/DropdownInput.tsx
@@ -1,9 +1,10 @@
 import classNames from "classnames";
 import React from "react";
-import {Input, InputProps} from "reactstrap";
+import {FormFeedback, Input, InputProps} from "reactstrap";
 
 export interface StyledDropdownProps extends InputProps {
     value: string | number | undefined;
+    feedback?: string;
 }
 
 export const StyledDropdown = (props: StyledDropdownProps) => {
@@ -11,5 +12,8 @@ export const StyledDropdown = (props: StyledDropdownProps) => {
         <Input type="select" {...props} className={classNames("form-control d-inline-block pl-3 pr-4 mt-1 mt-sm-0 " + props.className)}>
             {props.children}
         </Input>
+        <FormFeedback>
+            {props.feedback}
+        </FormFeedback>
     </div>;
 };

--- a/src/app/components/elements/panels/UserProfile.tsx
+++ b/src/app/components/elements/panels/UserProfile.tsx
@@ -3,7 +3,16 @@ import {MyAccountTab} from './MyAccountTab';
 import {FamilyNameInput, GivenNameInput} from '../inputs/NameInput';
 import {EmailInput} from '../inputs/EmailInput';
 import {BooleanNotation, DisplaySettings, ValidationUser} from '../../../../IsaacAppTypes';
-import {isAda, isPhy, isTeacherOrAbove, SITE_TITLE, siteSpecific, validateEmail, validateName} from '../../../services';
+import {
+    isAda,
+    isPhy,
+    isTeacherOrAbove,
+    SITE_TITLE,
+    siteSpecific,
+    validateCountryCode,
+    validateEmail,
+    validateName
+} from '../../../services';
 import {CountryInput} from '../inputs/CountryInput';
 import {GenderInput} from '../inputs/GenderInput';
 import {SchoolInput} from "../inputs/SchoolInput";
@@ -73,6 +82,7 @@ export const UserProfile = (props: UserProfileProps) => {
                 <CountryInput
                     userToUpdate={userToUpdate}
                     setUserToUpdate={setUserToUpdate}
+                    countryCodeValid={validateCountryCode(userToUpdate.countryCode)}
                     submissionAttempted={submissionAttempted}
                     required={true}
                 />

--- a/src/app/components/pages/RegistrationSetDetails.tsx
+++ b/src/app/components/pages/RegistrationSetDetails.tsx
@@ -20,6 +20,7 @@ import {
     persistence,
     SITE_TITLE,
     trackEvent,
+    validateCountryCode,
     validateEmail,
     validateName,
     validatePassword,
@@ -70,6 +71,7 @@ export const RegistrationSetDetails = ({role}: RegistrationSetDetailsProps) => {
     const familyNameIsValid = validateName(registrationUser.familyName);
     const passwordIsValid = validatePassword(registrationUser.password || "");
     const schoolIsValid = validateUserSchool(registrationUser);
+    const countryCodeIsValid = validateCountryCode(registrationUser.countryCode);
     const error = useAppSelector((state) => state?.error);
     const errorMessage = extractErrorMessage(error);
 
@@ -77,8 +79,8 @@ export const RegistrationSetDetails = ({role}: RegistrationSetDetailsProps) => {
         event.preventDefault()
         setAttemptedSignUp(true);
 
-        if (familyNameIsValid && givenNameIsValid && passwordIsValid && emailIsValid && ((role == 'STUDENT') || schoolIsValid)
-            && tosAccepted ) {
+        if (familyNameIsValid && givenNameIsValid && passwordIsValid && emailIsValid && countryCodeIsValid &&
+            ((role == 'STUDENT') || schoolIsValid) && tosAccepted ) {
             persistence.session.save(KEY.FIRST_LOGIN, FIRST_LOGIN_STATE.FIRST_LOGIN);
 
             setAttemptedSignUp(true)
@@ -147,6 +149,7 @@ export const RegistrationSetDetails = ({role}: RegistrationSetDetailsProps) => {
                                 className="my-4"
                                 userToUpdate={registrationUser}
                                 setUserToUpdate={setRegistrationUser}
+                                countryCodeValid={countryCodeIsValid}
                                 submissionAttempted={attemptedSignUp}
                                 required={true}
                             />

--- a/src/app/services/validation.ts
+++ b/src/app/services/validation.ts
@@ -17,6 +17,10 @@ export function validateName(userName?: string | null) {
     return userName && userName.length > 0 && userName.length <= 255 && !userName.includes('*')
 }
 
+export function validateCountryCode(countryCode: string | undefined) {
+    return !!countryCode;
+}
+
 export const validateEmail = (email?: string) => {
     return email && email.length > 0 && email.includes("@");
 };


### PR DESCRIPTION
While the field would display as `invalid`, this wasn't preventing form submission as it should. The form feedback for the field also wasn't displaying because `<FormFeedback />` needs to be adjacent to `<Input />`.

I didn't add this to the submission check on My Account, as it might be confusing for users to be unable to update fields on other tabs due to country now being truly required, but maybe there's an argument for doing that.