### PR TITLE
Add attempt date to revision mode warning banner

### DIFF
--- a/src/IsaacAppTypes.tsx
+++ b/src/IsaacAppTypes.tsx
@@ -109,8 +109,8 @@ export type Action =
     | {type: ACTION_TYPE.GLOSSARY_TERMS_RESPONSE_SUCCESS; terms: ApiTypes.GlossaryTermDTO[]}
     | {type: ACTION_TYPE.GLOSSARY_TERMS_RESPONSE_FAILURE}
 
-    | {type: ACTION_TYPE.QUESTION_REGISTRATION; questions: ApiTypes.QuestionDTO[]; accordionClientId?: string, isQuiz?: boolean}
-    | {type: ACTION_TYPE.QUESTION_DEREGISTRATION; questionIds: string[]}
+    | {type: ACTION_TYPE.QUESTION_REGISTRATION; questions: ApiTypes.QuestionDTO[]; accordionClientId?: string, mostRecentCorrectAttemptDate?: Date, isQuiz?: boolean}
+    | {type: ACTION_TYPE.QUESTION_DEREGISTRATION; questionIds: string[], mostRecentQuestionAttempt?: Date}
     | {type: ACTION_TYPE.QUESTION_ATTEMPT_REQUEST; questionId: string; attempt: Immutable<ApiTypes.ChoiceDTO>}
     | {type: ACTION_TYPE.QUESTION_ATTEMPT_RESPONSE_SUCCESS; questionId: string; response: ApiTypes.QuestionValidationResponseDTO}
     | {type: ACTION_TYPE.QUESTION_ATTEMPT_RESPONSE_FAILURE; questionId: string; lock?: Date}

--- a/src/app/components/navigation/RevisionWarningBanner.tsx
+++ b/src/app/components/navigation/RevisionWarningBanner.tsx
@@ -9,10 +9,21 @@ export function RevisionWarningBanner() {
         (state: AppState) => state?.userPreferences?.DISPLAY_SETTING?.HIDE_QUESTION_ATTEMPTS
     ) ?? false;
     const hiddenAttempts: boolean = useAppSelector(selectors.questions.anyQuestionHidden);
+    const mostRecentAttemptDate = useAppSelector(selectors.questions.getMostRecentCorrectAttemptDate);
 
     if (hideAttempts && hiddenAttempts) {
+        const timespan = !mostRecentAttemptDate ? undefined : (
+            mostRecentAttemptDate < new Date(new Date().setFullYear(new Date().getFullYear() - 1)) ? "more than 1 year ago" :
+            mostRecentAttemptDate < new Date(new Date().setMonth(new Date().getMonth() - 1)) ? "in the last 12 months" :
+            mostRecentAttemptDate < new Date(new Date().setDate(new Date().getDate() - 7)) ? "in the last month" :
+            "in the last week"
+        );
+
         return <RS.Alert color="warning" className={"no-print"}>
-            You have attempted this question before, but you are <a href="\account#betafeatures">hiding your past attempts</a>.
+            <span>You are currently in <a href="\account#betafeatures">revision mode</a> which hides your previous attempts.</span>
+            {timespan && <>
+                <br/><br/><span>You answered this question correctly {timespan}.</span>
+            </>}
         </RS.Alert>;
     } else {
         return RenderNothing;

--- a/src/app/services/questions.ts
+++ b/src/app/services/questions.ts
@@ -186,3 +186,11 @@ export const submitCurrentAttempt = (questionPart: AppQuestionDTO | undefined, d
         }
     }
 };
+
+export const getMostRecentCorrectAttemptDate = (questions: AppQuestionDTO[] | undefined) => {
+    return questions?.filter(q => q.bestAttempt?.correct).map(q => q.bestAttempt?.dateAttempted).reduce((prev, current) => {
+        if (!prev) return current;
+        if (!current) return prev;
+        return prev > current ? prev : current;
+    }, undefined);
+};

--- a/src/app/state/middleware/hidePreviousQuestionAttempt.ts
+++ b/src/app/state/middleware/hidePreviousQuestionAttempt.ts
@@ -1,7 +1,7 @@
 import {Dispatch, Middleware, MiddlewareAPI} from "redux";
 import {BEST_ATTEMPT_HIDDEN} from "../../../IsaacApiTypes";
 import {Action} from "../../../IsaacAppTypes";
-import {ACTION_TYPE} from "../../services";
+import {ACTION_TYPE, getMostRecentCorrectAttemptDate} from "../../services";
 
 export const hidePreviousQuestionAttemptMiddleware: Middleware = (middlewareApi: MiddlewareAPI) => (dispatch: Dispatch) => async (action: Action) => {
     if (action.type === ACTION_TYPE.QUESTION_REGISTRATION) {
@@ -13,9 +13,10 @@ export const hidePreviousQuestionAttemptMiddleware: Middleware = (middlewareApi:
                     ...q,
                     bestAttempt: q.bestAttempt && BEST_ATTEMPT_HIDDEN
                 })),
+                mostRecentCorrectAttemptDate: getMostRecentCorrectAttemptDate(action.questions),
                 accordionClientId: action.accordionClientId
             });
         }
     }
     return dispatch(action);
-}
+};

--- a/src/app/state/selectors.tsx
+++ b/src/app/state/selectors.tsx
@@ -31,7 +31,10 @@ export const selectors = {
         },
         anyQuestionHidden: (state: AppState) => {
             return !!state && !!state.questions && state.questions.questions.some(q => q.bestAttempt === BEST_ATTEMPT_HIDDEN);
-        }
+        },
+        getMostRecentCorrectAttemptDate: (state: AppState) => {
+            return !!state && state.questions?.mostRecentCorrectAttemptDate;
+        },
     },
 
     user:  {

--- a/src/test/state/reducers.test.tsx
+++ b/src/test/state/reducers.test.tsx
@@ -19,8 +19,8 @@ import {
 
 const ignoredTestAction: Action = {type: ACTION_TYPE.TEST_ACTION};
 
-function q(questions: AppQuestionDTO[]): { questions: AppQuestionDTO[]; pageCompleted: boolean } {
-    return {questions, pageCompleted: false};
+function q(questions: AppQuestionDTO[]): { questions: AppQuestionDTO[]; pageCompleted: boolean; mostRecentCorrectAttemptDate: Date | undefined} {
+    return {questions, pageCompleted: false, mostRecentCorrectAttemptDate: undefined};
 }
 
 function removeRTKProperties(state: AppState) {


### PR DESCRIPTION
Replaces the text for the revision mode warning banner with new copy that includes an approximation of the date of the most recent **correct** attempt. The date is hidden (but helper text remains) if no such correct attempt exists.