### PR TITLE
Prevent screenreader page jump on question submission

### DIFF
--- a/src/app/components/content/IsaacQuestion.tsx
+++ b/src/app/components/content/IsaacQuestion.tsx
@@ -159,7 +159,7 @@ export const IsaacQuestion = withRouter(({doc, location}: {doc: ApiTypes.Questio
                     className={`validation-response-panel p-3 mt-3 ${correct ? "correct" : almost ? "almost" : ""}`}
                 >
                     {/*eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex*/}
-                    <div tabIndex={0} className="pb-1" role="alert" ref={feedbackRef}>
+                    <div tabIndex={-1} className="pb-1" ref={feedbackRef}>
                         {
                             isInlineQuestion && numCorrectInlineQuestions ?
                                 <h1 className="m-0">{correct ? "Correct!" : numCorrectInlineQuestions > 0 ? "Almost..." : "Incorrect"}</h1> :

--- a/src/app/components/content/IsaacQuestion.tsx
+++ b/src/app/components/content/IsaacQuestion.tsx
@@ -1,4 +1,4 @@
-import React, {Suspense, useContext, useEffect, useRef} from "react";
+import React, {Suspense, useContext, useEffect, useRef, useState} from "react";
 import {
     deregisterQuestions,
     registerQuestions,

--- a/src/app/components/content/IsaacQuestion.tsx
+++ b/src/app/components/content/IsaacQuestion.tsx
@@ -53,6 +53,7 @@ export const IsaacQuestion = withRouter(({doc, location}: {doc: ApiTypes.Questio
     const fastTrackInfo = useFastTrackInformation(doc, location, canSubmit, correct);
     const deviceSize = useDeviceSize();
     const feedbackRef = useRef<HTMLDivElement>(null);
+    const [hasSubmitted, setHasSubmitted] = useState<boolean>(false);
 
     const {confidenceState, setConfidenceState, validationPending, setValidationPending, confidenceDisabled, recordConfidence, showQuestionFeedback} = useConfidenceQuestionsValues(
         currentGameboard?.tags?.includes("CONFIDENCE_RESEARCH_BOARD"),
@@ -89,7 +90,10 @@ export const IsaacQuestion = withRouter(({doc, location}: {doc: ApiTypes.Questio
 
     // Focus on the feedback banner after submission
     useEffect(() => {
-        if (validationResponse) feedbackRef.current?.focus();
+        if (hasSubmitted) {
+            feedbackRef.current?.focus();
+        }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [validationResponse]);
 
     // Select QuestionComponent from the question part's document type (or default)
@@ -125,6 +129,7 @@ export const IsaacQuestion = withRouter(({doc, location}: {doc: ApiTypes.Questio
         <RS.Form onSubmit={(event) => {
             if (event) {event.preventDefault();}
             submitCurrentAttempt(questionPart, doc.id as string, currentGameboard, currentUser, dispatch);
+            setHasSubmitted(true);
         }}>
             <div className={
                 classNames(


### PR DESCRIPTION
After submission the focus on the page resets to `body` which means
using a screenreader (or tabbing) takes the user to the top of the page.

As the submit button disappears after a correct submission the response
banner is focused instead. This way the user can continue from the
question answer. This does require making the `div` tabbable,
which should ideally mean that element is responsive (which it is not),
as otherwise it cannot be focused on.
