### PR TITLE
Add pagination and attempt data to question finder

### DIFF
--- a/src/IsaacApiTypes.tsx
+++ b/src/IsaacApiTypes.tsx
@@ -734,6 +734,10 @@ export interface ResultsWrapper<T> {
     totalResults?: number;
 }
 
+export interface SearchResultsWrapper<T> extends ResultsWrapper<T> {
+    nextSearchOffset?: number;
+}
+
 export interface Address {
     addressLine1?: string;
     addressLine2?: string;

--- a/src/IsaacAppTypes.tsx
+++ b/src/IsaacAppTypes.tsx
@@ -552,6 +552,7 @@ export interface QuestionSearchQuery {
     difficulties?: string;
     examBoards?: string;
     fasttrack?: boolean;
+    hideCompleted?: boolean;
     startIndex?: number;
     limit?: number;
 }

--- a/src/app/components/elements/inputs/StyledCheckbox.tsx
+++ b/src/app/components/elements/inputs/StyledCheckbox.tsx
@@ -30,7 +30,7 @@ export const StyledCheckbox = (props : InputProps) => {
                 onKeyDown={(e) => ifKeyIsEnter(() => {onCheckChange({...e, target: {...e.currentTarget, checked: !e.currentTarget.checked}}); e.preventDefault();})(e)}
             />
         </div>
-        {props.label && <label htmlFor={id} className="pt-1" {...props.label.props}/>}
+        {props.label && <label htmlFor={id} className={classNames("pt-1", {"text-muted" : props.disabled})} {...props.label.props}/>}
         <Spacer/>
     </div>;
 };

--- a/src/app/components/elements/list-groups/ContentSummaryListGroupItem.tsx
+++ b/src/app/components/elements/list-groups/ContentSummaryListGroupItem.tsx
@@ -169,7 +169,7 @@ export const LinkToContentSummaryList = ({items, search, displayTopicTitle, ...r
     className?: string;
     cssModule?: any;
 }) => {
-    return <ListGroup {...rest} className={classNames("link-list list-group-links", {"mb-3": isPhy})}>
+    return <ListGroup {...rest} className="link-list list-group-links mb-3">
         {items.map(item => <ContentSummaryListGroupItem item={item} search={search} key={item.type + "/" + item.id} displayTopicTitle={displayTopicTitle}/>)}
     </ListGroup>;
 };

--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -156,7 +156,7 @@ export const api = {
         get: (id: string): AxiosPromise<ApiTypes.IsaacQuestionPageDTO> => {
             return endpoint.get(`/pages/questions/${id}`);
         },
-        search: (query: QuestionSearchQuery): AxiosPromise<ApiTypes.ResultsWrapper<ApiTypes.ContentSummaryDTO>> => {
+        search: (query: QuestionSearchQuery): AxiosPromise<ApiTypes.SearchResultsWrapper<ApiTypes.ContentSummaryDTO>> => {
             return endpoint.get(`/pages/questions/`, {
                 params: query,
             });

--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -946,6 +946,8 @@ export const GRAY_120 = '#c9cad1';
 
 export const SEARCH_CHAR_LENGTH_LIMIT = 255;
 
+export const SEARCH_RESULTS_PER_PAGE = 30;
+
 export const GAMEBOARD_UNDO_STACK_SIZE_LIMIT = 10;
 
 export const QUESTION_FINDER_CONCEPT_LABEL_PLACEHOLDER = "Loading...";

--- a/src/app/state/reducers/gameboardsState.ts
+++ b/src/app/state/reducers/gameboardsState.ts
@@ -1,8 +1,8 @@
-import {ContentSummaryDTO, ResultsWrapper} from "../../../IsaacApiTypes";
+import {ContentSummaryDTO, SearchResultsWrapper} from "../../../IsaacApiTypes";
 import {Action} from "../../../IsaacAppTypes";
 import {ACTION_TYPE} from "../../services";
 
-type QuestionSearchResultState = ResultsWrapper<ContentSummaryDTO> | null;
+type QuestionSearchResultState = SearchResultsWrapper<ContentSummaryDTO> | null;
 export const questionSearchResult = (questionSearchResult: QuestionSearchResultState = null, action: Action) => {
     switch(action.type) {
         case ACTION_TYPE.QUESTION_SEARCH_RESPONSE_SUCCESS: {

--- a/src/scss/common/checkbox.scss
+++ b/src/scss/common/checkbox.scss
@@ -23,15 +23,15 @@
           background: #000;
           border-color: #000;
   
-          &:hover {
+          &:hover, &:disabled {
             background: #333;
             border-color: #333;
           }
         }
   
-        &:not(.checked):hover {
-          background: #eee;
-          border-color: #222;
+        &:not(.checked):hover, &:not(.checked):disabled {
+          background: #f8f8f8;
+          border-color: #666;
         }
 
         &:focus {


### PR DESCRIPTION
- Highlights results in the question finder green if previously answered correctly (using the same marking as related questions);
- Adds a toggle to hide previously answered questions;
- Adds a "Load More" button, which pulls `min(30, relevant_questions_remaining)` questions from the backend.