### PR TITLE
Fix spacing issue with multiple inline zones

### DIFF
--- a/src/app/components/elements/markup/markdownRendering.ts
+++ b/src/app/components/elements/markup/markdownRendering.ts
@@ -46,7 +46,7 @@ export const renderClozeDropZones = (markdown: string) => {
 export const renderInlineQuestionPartZones = (markdown: string) => {
     return markdown.replace(inlineQuestionRegex, (_match, id: string | undefined, params: string | undefined, width: string | undefined, height: string | undefined) => {
         const inlineId = `inline-question-${id}`;
-        return `<span id="${inlineId}" class="d-inline-block ${width ? width : ""} ${height ? height : ""})}"></span>`;
+        return `<span id="${inlineId}" class="d-inline-flex ${width ? width : ""} ${height ? height : ""})}"></span>`;
     });
 };
 


### PR DESCRIPTION
Safari's spacing around `inline-block` elements is inconsistent with other browsers. This changes the outermost display type to `inline-flex` for inline regions which seems more consistent.