### PR TITLE
Fix spacing issues for inline questions

### DIFF
--- a/src/app/components/elements/markup/markdownRendering.ts
+++ b/src/app/components/elements/markup/markdownRendering.ts
@@ -46,7 +46,7 @@ export const renderClozeDropZones = (markdown: string) => {
 export const renderInlineQuestionPartZones = (markdown: string) => {
     return markdown.replace(inlineQuestionRegex, (_match, id: string | undefined, params: string | undefined, width: string | undefined, height: string | undefined) => {
         const inlineId = `inline-question-${id}`;
-        return `<span id="${inlineId}" class="d-inline-flex ${width ? width : ""} ${height ? height : ""})}"></span>`;
+        return `<span id="${inlineId}" class="d-inline-flex justify-content-center ${width ? width : ""} ${height ? height : ""})}"></span>`;
     });
 };
 

--- a/src/scss/common/questions.scss
+++ b/src/scss/common/questions.scss
@@ -79,6 +79,9 @@
       min-width: 36px !important;
       border-radius: 0 5px 5px 0;
       border: none;
+      &:active {
+        border: none !important;
+      }
     }
     &.display-unit {
       margin-bottom: -2px;


### PR DESCRIPTION
- Clicking unit buttons would add a border and thus increase the size of the button by 2px, but the adjacent input would not change;
- Since fixing inline regions on Safari by changing the inline span to use `d-inline-flex`, elements with whitespace to either side are now left-aligned rather than the usual centre-aligned. This adds a `justify-content-center` to remedy this.