### PR TITLE
Assert correct ContentSummary to GameboardItem conversion

### DIFF
--- a/src/app/services/gameboardBuilder.ts
+++ b/src/app/services/gameboardBuilder.ts
@@ -30,10 +30,23 @@ export const sortQuestions = (sortState: {[s: string]: string}, creationContext?
     return orderBy(questions, keys, order);
 };
 
+type ContentSummaryFieldsNotInGameboardItem = Exclude<keyof ContentSummary, keyof GameboardItem>;
 export const convertContentSummaryToGameboardItem = (question: ContentSummary): GameboardItem => {
-    const newQuestion = {...question, contentType: question.type};
-    delete newQuestion.type;
-    delete newQuestion.url;
+    // We use the type system to ensure we remove fields that are not in a GameboardItem as it would otherwise cause serialization errors in the backend.
+    const fieldsThatMustBeRemoved: {[field in ContentSummaryFieldsNotInGameboardItem]: undefined} = {
+        type: undefined,
+        difficulty: undefined,
+        summary: undefined,
+        level: undefined,
+        url: undefined,
+        correct: undefined,
+        deprecated: undefined,
+    };
+    const newQuestion = {
+        ...question,
+        contentType: question.type,
+        ...fieldsThatMustBeRemoved
+    };
     return newQuestion;
 };
 


### PR DESCRIPTION
There have been errors in the back-end logs from created gameboards not getting deserialized because of the inclusion of fields that do not exist in the GameboardItemDTO.
In the front-end conversion from ContentSummary objects to GameboardItems a "deprecated" field was not being removed.
This PR uses the type system to ensure that we remove all ContentSummary fields that are not expected in GameboardItems and will check at compile time if fields are removed or added to either type in the future.