### PR TITLE
"All exam boards" context picker improvements

### DIFF
--- a/src/app/components/elements/inputs/UserContextPicker.tsx
+++ b/src/app/components/elements/inputs/UserContextPicker.tsx
@@ -66,6 +66,10 @@ export const UserContextPicker = ({className, hideLabels = true}: {className?: s
                                 if (possibleExamBoards.length > 0 && !possibleExamBoards.includes(EXAM_BOARD.ALL)) {
                                     examBoard = possibleExamBoards[0];
                                 }
+                                // If we only have one possible exam board besides All, use that.
+                                else if (possibleExamBoards.length === 2 && possibleExamBoards.includes(EXAM_BOARD.ALL)) {
+                                    examBoard = possibleExamBoards.filter(eb => eb !== EXAM_BOARD.ALL)[0];
+                                }
                                 newParams.examBoard = examBoard;
                                 dispatch(transientUserContextSlice.actions.setExamBoard(examBoard));
                             }

--- a/src/app/components/navigation/IntendedAudienceWarningBanner.tsx
+++ b/src/app/components/navigation/IntendedAudienceWarningBanner.tsx
@@ -4,6 +4,7 @@ import {ContentBaseDTO} from "../../../IsaacApiTypes";
 import {examBoardLabelMap, isIntendedAudience, stageLabelMap, useUserContext} from "../../services";
 import {selectors, useAppSelector} from "../../state";
 import {RenderNothing} from "../elements/RenderNothing";
+import { Link } from "react-router-dom";
 
 export function IntendedAudienceWarningBanner({doc}: {doc: ContentBaseDTO}) {
     const user = useAppSelector(selectors.user.orNull);
@@ -17,6 +18,9 @@ export function IntendedAudienceWarningBanner({doc}: {doc: ContentBaseDTO}) {
     return <RS.Alert color="warning" className={"no-print"}>
         {`There is no content on this page for ${examBoardLabelMap[userContext.examBoard]} ${stageLabelMap[userContext.stage]}. ` +
         "You can change your preferences "}
-        <strong>by updating your profile <a href="\account">here</a>.</strong>
+        <strong>by updating your profile <Link to="\account">here</Link>.</strong>
+        <br/><br/>
+        {"If you think that the page is incorrectly tagged, please "}
+        <strong><Link to={`/contact?preset=contentProblem&page=${doc.id}`}>contact us</Link></strong>.
     </RS.Alert>;
 }


### PR DESCRIPTION
When changing the stage in the context picker, if the possible exam boards had just one option besides All, it would visually display this option but not modify the URL. As such, the "no content" warning could describe a different exam board to that which was visually shown.

This also updates the text of the warning banner per request.