### PR TITLE
Add Ada Online Courses page

### DIFF
--- a/src/app/components/elements/cards/NewsCard.tsx
+++ b/src/app/components/elements/cards/NewsCard.tsx
@@ -4,6 +4,7 @@ import {Button, Card, CardBody, CardFooter, CardImg, CardProps, CardText, CardTi
 import {IsaacPodDTO} from "../../../../IsaacApiTypes";
 import {apiHelper, isAppLink, siteSpecific} from "../../../services";
 import classNames from "classnames";
+import { ExternalLink } from "../ExternalLink";
 
 interface NewsCardProps extends CardProps {
     newsItem: IsaacPodDTO;
@@ -73,8 +74,12 @@ export const AdaNewsCard = ({newsItem, showTitle, ...props}: NewsCardProps) => {
                 <p>{value}</p>
             </CardBody>
         </>}
-        {url && !url?.startsWith("http") && isAppLink(url) && <CardFooter className={"border-top-0 p-4"}>
-            <Button outline color={"secondary"} tag={Link} to={url}>Read more</Button>
+        {url && <CardFooter className={"border-top-0 p-4"}>
+            {!url?.startsWith("http") && isAppLink(url) ? (   
+                <Button outline color={"secondary"} tag={Link} to={url}>Read more</Button>
+            ) : (
+                <Button outline color={"secondary"} tag={ExternalLink} href={url}>Find out more</Button>
+            )}
         </CardFooter>}
     </Card>;
 };

--- a/src/app/components/pages/OnlineCourses.tsx
+++ b/src/app/components/pages/OnlineCourses.tsx
@@ -1,0 +1,52 @@
+import {Button, CardDeck, Container} from "reactstrap";
+import {NewsCard} from "../elements/cards/NewsCard";
+import React, { useEffect } from "react";
+import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
+import {MetaDescription} from "../elements/MetaDescription";
+import {useGetNewsPodListQuery} from "../../state";
+import {ShowLoadingQuery} from "../handlers/ShowLoadingQuery";
+import {NEWS_PODS_PER_PAGE} from "../../services";
+import { IsaacPodDTO } from "../../../IsaacApiTypes";
+import { PageFragment } from "../elements/PageFragment";
+
+export const OnlineCourses = () => {
+    const [page, setPage] = React.useState(0);
+    const [allCourses, setAllCourses] = React.useState([] as IsaacPodDTO[]); // each query fetches a new page; this acts as a cache for all the news fetched so far
+    const [disableLoadMore, setDisableLoadMore] = React.useState(false);
+
+    const onlineCourseQuery = useGetNewsPodListQuery({subject: "online_courses", startIndex: page * NEWS_PODS_PER_PAGE});
+
+    useEffect(() => {
+        onlineCourseQuery.refetch().then((value) => {
+            if (value.status === "fulfilled" && value.data !== undefined) {
+                setAllCourses(n => n.concat((value.data as IsaacPodDTO[]).slice(0, NEWS_PODS_PER_PAGE)));
+                if (value.data.length < NEWS_PODS_PER_PAGE) {
+                    setDisableLoadMore(true);
+                }
+            }
+        });
+    }, [page]);
+
+    const metaDescription = ""; // TODO
+
+    return <Container>
+        <TitleAndBreadcrumb currentPageTitle={"Online courses"} />
+        <MetaDescription description={metaDescription} />
+        <PageFragment fragmentId={"online_courses_help"} />
+        {allCourses.length === 0 ? 
+            <ShowLoadingQuery
+                query={onlineCourseQuery}
+                thenRender={() => <div className={"w-100 text-left"}><h4>No courses to display...</h4></div>}
+                defaultErrorTitle={"Error fetching online courses"}
+            /> : 
+            <>
+                <CardDeck className="justify-content-center mt-4">
+                    {allCourses.map(n => <NewsCard key={n.id} newsItem={n} showTitle />)}
+                </CardDeck>
+                <div className="w-100 d-flex justify-content-center mb-5">
+                    <Button className={"mt-3"} color={"primary"} disabled={disableLoadMore} onClick={() => setPage(p => p + 1)}>Load more courses</Button>
+                </div>
+            </>
+        }
+    </Container>;
+};

--- a/src/app/components/pages/OnlineCourses.tsx
+++ b/src/app/components/pages/OnlineCourses.tsx
@@ -27,7 +27,7 @@ export const OnlineCourses = () => {
         });
     }, [page]);
 
-    const metaDescription = ""; // TODO
+    const metaDescription = "Browse the Raspberry Pi Foundation’s free online courses for educators and choose from a range of computing topics.";
 
     return <Container>
         <TitleAndBreadcrumb currentPageTitle={"Online courses"} />

--- a/src/app/components/site/cs/HeaderCS.tsx
+++ b/src/app/components/site/cs/HeaderCS.tsx
@@ -81,7 +81,7 @@ export const HeaderCS = () => {
                         <NavigationSection title={"Events"}>
                             <LinkItem to="/pages/teacher_mentoring_2024">Teacher mentoring</LinkItem>
                             <LinkItem to="/pages/student_challenges">Student challenges</LinkItem>
-                            <LinkItem to="/online_courses">Online courses</LinkItem>
+                            <LinkItem to="/pages/online_courses">Online courses</LinkItem>
                         </NavigationSection>
 
                         <NavigationSection title={"Help"}>

--- a/src/app/components/site/cs/HeaderCS.tsx
+++ b/src/app/components/site/cs/HeaderCS.tsx
@@ -79,8 +79,9 @@ export const HeaderCS = () => {
                         </NavigationSection>}
 
                         <NavigationSection title={"Events"}>
-                            <LinkItem to="/pages/teacher_mentoring_2024">Teacher events</LinkItem>
+                            <LinkItem to="/pages/teacher_mentoring_2024">Teacher mentoring</LinkItem>
                             <LinkItem to="/pages/student_challenges">Student challenges</LinkItem>
+                            <LinkItem to="/online_courses">Online courses</LinkItem>
                         </NavigationSection>
 
                         <NavigationSection title={"Help"}>

--- a/src/app/components/site/cs/RoutesCS.tsx
+++ b/src/app/components/site/cs/RoutesCS.tsx
@@ -91,7 +91,7 @@ export const RoutesCS = [
     <TrackedRoute key={key++} exact path="/news" component={News} />,
 
     // Online Courses
-    <TrackedRoute key={key++} exact path="/online_courses" component={OnlineCourses} />,
+    <TrackedRoute key={key++} exact path="/pages/online_courses" component={OnlineCourses} />,
 
     // Books: FIXME ADA are we going to include these?
     // <TrackedRoute key={key++} exact path="/books/workbook_20_aqa" component={Workbook20AQA}/>,

--- a/src/app/components/site/cs/RoutesCS.tsx
+++ b/src/app/components/site/cs/RoutesCS.tsx
@@ -29,6 +29,7 @@ import {Events} from "../../pages/Events";
 import EventDetails from "../../pages/EventDetails";
 import {RedirectToEvent} from "../../navigation/RedirectToEvent";
 import { QuestionFinder } from "../../pages/QuestionFinder";
+import { OnlineCourses } from "../../pages/OnlineCourses";
 
 const Equality = lazy(() => import('../../pages/Equality'));
 
@@ -88,6 +89,9 @@ export const RoutesCS = [
 
     // News
     <TrackedRoute key={key++} exact path="/news" component={News} />,
+
+    // Online Courses
+    <TrackedRoute key={key++} exact path="/online_courses" component={OnlineCourses} />,
 
     // Books: FIXME ADA are we going to include these?
     // <TrackedRoute key={key++} exact path="/books/workbook_20_aqa" component={Workbook20AQA}/>,


### PR DESCRIPTION
Adds a news-style page for external RPF online courses. Uses the same pods endpoint as news, but with the `online_courses` tag.