### PR TITLE
Make image aspect ratios consistent per page

### DIFF
--- a/src/app/components/elements/cards/NewsCard.tsx
+++ b/src/app/components/elements/cards/NewsCard.tsx
@@ -14,7 +14,7 @@ interface NewsCardProps extends CardProps {
 const PhysicsNewsCard = ({newsItem, showTitle, ...props}: NewsCardProps) => {
     const {title, value, image, url} = newsItem;
 
-    return <Card data-testid={"news-pod"} className={"card-neat news-card"} {...props}>
+    return <Card data-testid={"news-pod"} {...props} className={classNames("card-neat news-card", props.className)}>
         {image && <a href={url} className="focus-target">
             <CardImg
                 top
@@ -57,7 +57,7 @@ const PhysicsNewsCard = ({newsItem, showTitle, ...props}: NewsCardProps) => {
 
 export const AdaNewsCard = ({newsItem, showTitle, ...props}: NewsCardProps) => {
     const {title, value, image, url} = newsItem;
-    return <Card data-testid={"news-pod"} className={classNames("news-card border-0 pb-3 my-3 my-xl-0")} {...props}>
+    return <Card data-testid={"news-pod"} {...props} className={classNames("news-card card-neat border-0 pb-3 my-3 my-xl-0", props.className)}>
         {image && <a href={url} className={"w-100"}>
             <CardImg
                 className={"news-card-image"}

--- a/src/app/components/pages/OnlineCourses.tsx
+++ b/src/app/components/pages/OnlineCourses.tsx
@@ -41,7 +41,7 @@ export const OnlineCourses = () => {
             /> : 
             <>
                 <CardDeck className="justify-content-center mt-4">
-                    {allCourses.map(n => <NewsCard key={n.id} newsItem={n} showTitle />)}
+                    {allCourses.map(n => <NewsCard key={n.id} newsItem={n} className="ratio-5x3" showTitle />)}
                 </CardDeck>
                 <div className="w-100 d-flex justify-content-center mb-5">
                     <Button className={"mt-3"} color={"primary"} disabled={disableLoadMore} onClick={() => setPage(p => p + 1)}>Load more courses</Button>

--- a/src/scss/common/_mixins.scss
+++ b/src/scss/common/_mixins.scss
@@ -258,19 +258,5 @@ $breakpoints: (
 }
 
 @mixin aspect-ratio($width, $height) {
-  position: relative;
-  &:before {
-    display: block;
-    content: '';
-    width: 100%;
-    padding-top: math.div($height, $width) * 100%;
-  }
-  > img {
-    position: absolute;
-    top: 0.25rem;
-    left: 0.25rem;
-    right: 0.25rem;
-    bottom: 0.25rem;
-    width: calc(100% - 0.5rem);
-  }
+  aspect-ratio: calc($width / $height);
 }

--- a/src/scss/common/cards.scss
+++ b/src/scss/common/cards.scss
@@ -11,7 +11,9 @@
     box-shadow: 0 2px 30px 0 $shadow-08;
   }
   .news-card-image {
-    @include aspect-ratio(100, 59);
+    @include aspect-ratio(4, 3);
+    width: 100%;
+    object-fit: cover;
   }
   // Nomensa's image offset code, if we decide to use
   //.news-card-image {
@@ -134,7 +136,6 @@
   }
 }
 .basic-card {
-  @include aspect-ratio(145, 93);
   background-color: $white;
   box-shadow: 0 2px 30px 0 $shadow-08;
   height: 100%;
@@ -187,7 +188,7 @@
     }
 
     a img {
-      height: 180px;
+      @include aspect-ratio(5, 3);
       object-fit: cover;
     }
   }

--- a/src/scss/common/elements.scss
+++ b/src/scss/common/elements.scss
@@ -22,7 +22,11 @@
 }
 
 .ratio-16x9 {
-  aspect-ratio: 16/9;
+  @include aspect-ratio(16, 9);
+}
+
+.ratio-5x3 {
+  @include aspect-ratio(5, 3);
 }
 
 .content-video-container {

--- a/src/scss/phy/cards.scss
+++ b/src/scss/phy/cards.scss
@@ -40,7 +40,7 @@
   margin-bottom: 1.5rem;
 
   a img {
-    height: 180px;
+    @include aspect-ratio(5, 3);
     object-fit: cover;
   }
 }


### PR DESCRIPTION
Forces images into the same aspect ratio.

Isaac:
- News Pods: 5:3

Ada:
- News Pods: 4:3
- Online Courses Pods: 5:3