### PR TITLE
Use dropdown menus for cloze questions on mobile

### DIFF
--- a/src/IsaacAppTypes.tsx
+++ b/src/IsaacAppTypes.tsx
@@ -31,6 +31,7 @@ import {
     TAG_LEVEL
 } from "./app/services";
 import {Immutable} from "immer";
+import { UniqueIdentifier } from "@dnd-kit/core";
 
 export type Action =
     | {type: ACTION_TYPE.TEST_ACTION}
@@ -394,10 +395,12 @@ export const AccordionSectionContext = React.createContext<{id: string | undefin
 export const QuestionContext = React.createContext<string | undefined>(undefined);
 export const ClozeDropRegionContext = React.createContext<{
     register: (id: string, index: number) => void,
+    onSelect: (item: Immutable<ClozeItemDTO>, dropZoneId: UniqueIdentifier, clearSelection: boolean) => void,
     questionPartId: string, readonly: boolean,
     inlineDropValueMap: {[p: string]: ClozeItemDTO},
     dropZoneValidationMap: {[p: string]: {correct?: boolean, itemId?: string} | undefined},
-    shouldGetFocus: (id: string) => boolean
+    shouldGetFocus: (id: string) => boolean,
+    nonSelectedItems: Immutable<ClozeItemDTO>[]
 } | undefined>(undefined);
 
 export const InlineContext = React.createContext<{

--- a/src/app/components/content/IsaacClozeQuestion.tsx
+++ b/src/app/components/content/IsaacClozeQuestion.tsx
@@ -10,6 +10,8 @@ import {
 import {
     CLOZE_DROP_ZONE_ID_PREFIX,
     CLOZE_ITEM_SECTION_ID,
+    NULL_CLOZE_ITEM,
+    NULL_CLOZE_ITEM_ID,
     isDefined,
     useCurrentQuestionAttempt,
     useDeviceSize
@@ -46,11 +48,6 @@ const augmentInlineItemWithUniqueReplacementID = (idv: Immutable<ClozeItemDTO> |
 const augmentNonSelectedItemWithReplacementID = (item: Immutable<ClozeItemDTO>) => ({...item, replacementId: item.id});
 const itemNotNullAndNotInAttempt = (currentAttempt: {items?: (Immutable<ItemDTO> | undefined)[]}) => (i: Immutable<ClozeItemDTO> | undefined) => i ? !currentAttempt.items?.map(si => si?.id).includes(i.id) : false;
 
-const NULL_CLOZE_ITEM_ID = "NULL_CLOZE_ITEM" as const;
-const NULL_CLOZE_ITEM: ItemDTO = {
-    type: "item",
-    id: NULL_CLOZE_ITEM_ID
-};
 const replaceNullItems = (items: readonly Immutable<ItemDTO>[] | undefined) => items?.map(i => i.id === NULL_CLOZE_ITEM_ID ? undefined : i);
 
 const ItemSection = ({id, items}: {id: string, items: Immutable<ClozeItemDTO>[]}) => {

--- a/src/app/components/content/IsaacClozeQuestion.tsx
+++ b/src/app/components/content/IsaacClozeQuestion.tsx
@@ -116,6 +116,7 @@ const useAutoScroll = ({active, acceleration, interval}: {active: boolean; accel
 
     useEffect(() => {
         return updateScrollAmount(scrollAmount, acceleration, interval);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [scrollAmount, acceleration, interval]);
 
     useEffect(() => {
@@ -126,8 +127,9 @@ const useAutoScroll = ({active, acceleration, interval}: {active: boolean; accel
                 window.removeEventListener("mousemove", autoScrollListener);
                 window.removeEventListener("touchmove", autoScrollListener);
                 setScrollAmount(0);
-            }
+            };
         }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [active]);
 };
 
@@ -145,6 +147,7 @@ const IsaacClozeQuestion = ({doc, questionId, readonly, validationResponse}: Isa
 
     const [inlineDropValues, setInlineDropValues] = useState<(Immutable<ClozeItemDTO> | undefined)[]>(() => currentAttempt?.items || []);
     // Whenever the inlineDropValues change or a drop region is added, computes a map from drop region id -> drop region value
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     const inlineDropValueMap = useMemo<{[p: string]: ClozeItemDTO}>(() => Array.from(registeredDropRegionIDs.entries()).reduce((dict, [dropId, i]) => Object.assign(dict, {[dropId]: inlineDropValues[i]}), {}), [inlineDropValues]);
 
     // Compute map used to highlight each inline drop-zone with whether it is correct or not
@@ -157,6 +160,7 @@ const IsaacClozeQuestion = ({doc, questionId, readonly, validationResponse}: Isa
             // drop-zone.
             setDropZoneValidationMap(Array.from(registeredDropRegionIDs.entries()).reduce((dict, [dropId, i]) => Object.assign(dict, {[dropId]: {correct: itemsCorrect.at(i), itemId: inlineDropValueMap[dropId]?.id}}), {}));
         }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [itemsCorrect, inlineDropValueMap]);
 
     // Manual management of which draggable item gets focus at the end of the drag. The new focus id is set in onDragEnd,

--- a/src/app/components/content/IsaacClozeQuestion.tsx
+++ b/src/app/components/content/IsaacClozeQuestion.tsx
@@ -352,10 +352,10 @@ const IsaacClozeQuestion = ({doc, questionId, readonly, validationResponse}: Isa
         const nsis = [...nonSelectedItems];
         const idvs = [...inlineDropValues];
 
-        const toIndex = inlineDropIndex(dropZoneId as string) ?? idvs.findIndex(i => i?.replacementId === dropZoneId);
+        const dropZoneIndex = inlineDropIndex(dropZoneId as string) ?? idvs.findIndex(i => i?.replacementId === dropZoneId);
         // Cancel if error
-        if (toIndex === -1) return;
-        const previousItem = idvs[toIndex];
+        if (dropZoneIndex === -1) return;
+        const previousItem = idvs[dropZoneIndex];
 
         if (clearSelection && previousItem) {
             if (!withReplacement) {
@@ -364,19 +364,19 @@ const IsaacClozeQuestion = ({doc, questionId, readonly, validationResponse}: Isa
                 nsis.push(previousItem);
             }
             // and remove the item from the current drop zone values
-            idvs.splice(toIndex, 1);
+            idvs[dropZoneIndex] = undefined;
         } else if (!clearSelection) {
-            const fromIndex = nsis.indexOf(item);
+            const itemIndex = nsis.indexOf(item);
 
             // Otherwise remove from item section and add to drop-zone, swapping out the previous item if it exists
             if (!withReplacement) {
                 if (previousItem) {
-                    nsis.splice(fromIndex, 1, previousItem);
+                    nsis.splice(itemIndex, 1, previousItem);
                 } else {
-                    nsis.splice(fromIndex, 1);
+                    nsis.splice(itemIndex, 1);
                 }
             }
-            idvs[toIndex] = augmentInlineItemWithUniqueReplacementID(item);
+            idvs[dropZoneIndex] = augmentInlineItemWithUniqueReplacementID(item);
         }
 
         updateAttempt(idvs);

--- a/src/app/components/elements/markup/portals/InlineDropZones.tsx
+++ b/src/app/components/elements/markup/portals/InlineDropZones.tsx
@@ -108,10 +108,11 @@ function InlineDropRegion({id, index, emptyWidth, emptyHeight, rootElement}: {id
         toggle={() => {setIsOpen(!isOpen);}}
     >
         <DropdownToggle style={{minHeight: height, minWidth: width}}>
-            <div>
+            <div className={"d-flex"}>
                 <Markup trusted-markup-encoding={"html"}>
                     {dropdownValue}
                 </Markup>
+                <img className={classNames("icon-dropdown", {"active": isOpen})} src="/assets/common/icons/chevron_down.svg" alt="expand dropdown"></img>
             </div>
         </DropdownToggle>
         <DropdownMenu right>

--- a/src/app/components/elements/markup/portals/InlineDropZones.tsx
+++ b/src/app/components/elements/markup/portals/InlineDropZones.tsx
@@ -41,6 +41,7 @@ export function Item({item, id, type, overrideOver, isCorrect}: {item: Immutable
             const el = document.getElementById(id);
             el?.focus();
         }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [dropRegionContext?.shouldGetFocus]);
 
     return <Badge id={id} className={classNames(type === "item-section" && "m-2", "p-2 cloze-item feedback-zone", isDefined(isCorrect) && "feedback-showing")} style={style} innerRef={setNodeRef} {...listeners} {...attributes}>
@@ -68,6 +69,7 @@ function InlineDropRegion({id, index, emptyWidth, emptyHeight, rootElement}: {id
     useEffect(() => {
         // Register with the current cloze question on first render
         dropRegionContext?.register(droppableId, index);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     useEffect(() => {

--- a/src/app/components/elements/markup/portals/InlineDropZones.tsx
+++ b/src/app/components/elements/markup/portals/InlineDropZones.tsx
@@ -1,15 +1,22 @@
 import {ClozeDropRegionContext} from "../../../../../IsaacAppTypes";
 import ReactDOM from "react-dom";
-import React, {useContext, useEffect} from "react";
+import React, {useContext, useEffect, useState} from "react";
 import {ContentDTO, ItemDTO} from "../../../../../IsaacApiTypes";
 import {IsaacContentValueOrChildren} from "../../../content/IsaacContentValueOrChildren";
-import {Badge} from "reactstrap";
+import {Badge, Dropdown, DropdownItem, DropdownMenu, DropdownToggle} from "reactstrap";
 import {Immutable} from "immer";
 import {useDroppable} from "@dnd-kit/core";
 import {CSS} from "@dnd-kit/utilities";
 import {useSortable} from "@dnd-kit/sortable";
 import classNames from "classnames";
-import {CLOZE_DROP_ZONE_ID_PREFIX, isDefined} from "../../../../services";
+import {CLOZE_DROP_ZONE_ID_PREFIX, isDefined, useDeviceSize} from "../../../../services";
+import { Markup } from "..";
+
+const NULL_CLOZE_ITEM_ID = "NULL_CLOZE_ITEM" as const;
+const NULL_CLOZE_ITEM: ItemDTO = {
+    type: "item",
+    id: NULL_CLOZE_ITEM_ID
+};
 
 export function Item({item, id, type, overrideOver, isCorrect}: {item: Immutable<ItemDTO>, id: string, type: "drop-zone" | "item-section", overrideOver?: boolean, isCorrect?: boolean}) {
     const {attributes, listeners, setNodeRef, isDragging, isOver, transform, transition} = useSortable({
@@ -52,12 +59,24 @@ export function Item({item, id, type, overrideOver, isCorrect}: {item: Immutable
 // Inline droppables rendered for each registered drop region
 function InlineDropRegion({id, index, emptyWidth, emptyHeight, rootElement}: {id: string; index: number; emptyWidth?: string; emptyHeight?: string; rootElement?: HTMLElement}) {
     const dropRegionContext = useContext(ClozeDropRegionContext);
+    const deviceSize = useDeviceSize();
+    const [dropdownValue, setDropdownValue] = useState<string>("");
+    const [isOpen, setIsOpen] = useState<boolean>(false);
     const droppableId = CLOZE_DROP_ZONE_ID_PREFIX + `${index + 1}`;
+    const dropdownItems = dropRegionContext?.nonSelectedItems ?? [];
 
     useEffect(() => {
         // Register with the current cloze question on first render
         dropRegionContext?.register(droppableId, index);
     }, []);
+
+    useEffect(() => {
+        // Use the drop-zone region state
+        if (dropRegionContext) {
+            setDropdownValue(dropRegionContext.inlineDropValueMap[droppableId]?.value ?? "");
+        }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [dropRegionContext?.inlineDropValueMap]);
 
     const item = dropRegionContext ? dropRegionContext.inlineDropValueMap[droppableId] : undefined;
 
@@ -77,18 +96,53 @@ function InlineDropRegion({id, index, emptyWidth, emptyHeight, rootElement}: {id
     const height = (item || !emptyHeight) ? "auto" : (emptyHeight + "px");
     const width = (item || !emptyWidth) ? "auto" : (emptyWidth + "px");
 
+    const draggableDropZone = <span
+        style={{minHeight: height, minWidth: width}}
+        className={classNames("d-inline-block cloze-drop-zone", !item && `rounded bg-grey border ${isOver ? "border-dark" : "border-light"}`)}
+        ref={setNodeRef}
+    >
+        {item
+            ? <Item item={item} id={item.replacementId as string} isCorrect={isCorrect} type={"drop-zone"} overrideOver={isOver}/>
+            : <>&nbsp;<span className={"sr-only"}>drop zone</span></>
+        }
+    </span>;
+
+    const dropdownZone = <Dropdown
+        isOpen={isOpen}
+        toggle={() => {setIsOpen(!isOpen);}}
+    >
+        <DropdownToggle style={{minHeight: height, minWidth: width}}>
+            <div>
+                <Markup trusted-markup-encoding={"html"}>
+                    {dropdownValue}
+                </Markup>
+            </div>
+        </DropdownToggle>
+        <DropdownMenu right>
+            {/* Dummy option added to clear selection */}
+            <DropdownItem
+                data-unit={'None'}
+                onClick={() => {dropRegionContext?.onSelect(NULL_CLOZE_ITEM, droppableId, true);}}
+            >
+                <span className="d-inline-block"></span>
+            </DropdownItem>
+            {dropdownItems.map((item, i) => {
+                console.log(item.encoding);
+                return <DropdownItem key={i}
+                    data-unit={item || 'None'}
+                    onClick={() => {dropRegionContext?.onSelect(item, droppableId, false);}}
+                >
+                    <Markup trusted-markup-encoding={"html"}>
+                        {item.value ?? ""}
+                    </Markup>
+                </DropdownItem>;
+            })}
+        </DropdownMenu>
+    </Dropdown>;
+
     if (dropRegionContext && droppableTarget) {
         return ReactDOM.createPortal(
-            <span
-                style={{minHeight: height, minWidth: width}}
-                className={classNames("d-inline-block cloze-drop-zone", !item && `rounded bg-grey border ${isOver ? "border-dark" : "border-light"}`)}
-                ref={setNodeRef}
-            >
-                {item
-                    ? <Item item={item} id={item.replacementId as string} isCorrect={isCorrect} type={"drop-zone"} overrideOver={isOver}/>
-                    : <>&nbsp;<span className={"sr-only"}>drop zone</span></>
-                }
-            </span>,
+            deviceSize === "xs" ? dropdownZone : draggableDropZone,
             droppableTarget
         );
     }

--- a/src/app/components/elements/markup/portals/InlineDropZones.tsx
+++ b/src/app/components/elements/markup/portals/InlineDropZones.tsx
@@ -9,14 +9,8 @@ import {useDroppable} from "@dnd-kit/core";
 import {CSS} from "@dnd-kit/utilities";
 import {useSortable} from "@dnd-kit/sortable";
 import classNames from "classnames";
-import {CLOZE_DROP_ZONE_ID_PREFIX, isDefined, useDeviceSize} from "../../../../services";
+import {CLOZE_DROP_ZONE_ID_PREFIX, NULL_CLOZE_ITEM, isDefined, useDeviceSize} from "../../../../services";
 import { Markup } from "..";
-
-const NULL_CLOZE_ITEM_ID = "NULL_CLOZE_ITEM" as const;
-const NULL_CLOZE_ITEM: ItemDTO = {
-    type: "item",
-    id: NULL_CLOZE_ITEM_ID
-};
 
 export function Item({item, id, type, overrideOver, isCorrect}: {item: Immutable<ItemDTO>, id: string, type: "drop-zone" | "item-section", overrideOver?: boolean, isCorrect?: boolean}) {
     const {attributes, listeners, setNodeRef, isDragging, isOver, transform, transition} = useSortable({

--- a/src/app/components/elements/modals/ExtendDueDateModal.tsx
+++ b/src/app/components/elements/modals/ExtendDueDateModal.tsx
@@ -33,7 +33,6 @@ export const ExtendDueDateModal = (props: ExtendDueDateModalProps) => {
     const dispatch = useAppDispatch();
 
     const setValidDueDate = () => {
-        console.log(isUpdatingQuiz, numericQuizAssignmentId, !dueDate, currDueDate == dueDate);
         if (isUpdatingQuiz || !numericQuizAssignmentId || !dueDate || currDueDate == dueDate) {
             return;
         }

--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -12,6 +12,7 @@ import {
     ExamBoard,
     IsaacFastTrackQuestionPageDTO,
     IsaacQuestionPageDTO,
+    ItemDTO,
     QuantityDTO,
     Stage,
     StringChoiceDTO,
@@ -982,6 +983,11 @@ export const CLOZE_ITEM_SECTION_ID = "non-selected-items";
 export const CLOZE_DROP_ZONE_ID_PREFIX = "drop-zone-";
 // Matches: [drop-zone], [drop-zone|w-50], [drop-zone|h-50] or [drop-zone|w-50h-200]
 export const dropZoneRegex = /\[drop-zone(?<params>\|(?<index>i-\d+?)?(?<width>w-\d+?)?(?<height>h-\d+?)?)?]/g;
+export const NULL_CLOZE_ITEM_ID = "NULL_CLOZE_ITEM" as const;
+export const NULL_CLOZE_ITEM: ItemDTO = {
+    type: "item",
+    id: NULL_CLOZE_ITEM_ID
+};
 
 // Matches: [inline-question:questionId], [inline-question:questionId|w-50], [inline-question:questionId|h-50] or [inline-question:questionId|w-50h-200]
 export const inlineQuestionRegex = /\[inline-question:(?<id>[a-zA-Z0-9_-]+?)(?<params>\|(?<width>w-\d+?)?(?<height>h-\d+?)?)?]/g;

--- a/src/scss/common/icons.scss
+++ b/src/scss/common/icons.scss
@@ -26,7 +26,6 @@ polygon.fill-secondary {
   position: absolute;
   align-self: center;
   right: 5px;
-  filter: invert(1);
 
   &.active {
     transform: rotate(180deg);

--- a/src/scss/common/icons.scss
+++ b/src/scss/common/icons.scss
@@ -21,3 +21,16 @@
 polygon.fill-secondary {
   fill: $secondary;
 }
+
+.icon-dropdown {
+  position: absolute;
+  align-self: center;
+  right: 5px;
+  filter: invert(1);
+
+  &.active {
+    transform: rotate(180deg);
+    -webkit-transform: rotate(180deg);
+    -ms-transform: rotate(180deg);
+  }
+}

--- a/src/scss/common/print.scss
+++ b/src/scss/common/print.scss
@@ -26,7 +26,7 @@
     display: initial !important;
   }
 
-  .cloze-drop-zone {
+  .cloze-drop-zone, .cloze-dropdown {
     border: grey solid 1px !important;
     background-color: transparent !important;
   }

--- a/src/scss/common/questions.scss
+++ b/src/scss/common/questions.scss
@@ -329,9 +329,19 @@
   }
 }
 
-.cloze-drop-zone {
+.cloze-drop-zone, .cloze-dropdown {
   &.incorrect {
     filter: drop-shadow(0 0 0.3rem red);
+  }
+}
+
+.cloze-dropdown {
+  min-width: unset !important; // Bootstrap thinks its important
+  &.empty.empty {
+    &, &:hover, &:active, &:focus { // Apply regardless of hover
+      border: grey solid 1px !important;
+      background-color: transparent !important;
+    }
   }
 }
 

--- a/src/scss/cs/questions.scss
+++ b/src/scss/cs/questions.scss
@@ -47,10 +47,18 @@
   color: $cs-black;
 }
 
-.cloze-drop-zone {
+.cloze-drop-zone, .cloze-dropdown {
   &.border {
     border-style: dashed !important; // necessary because Bootstrap has no border style utilities
   }
+}
+
+.cloze-dropdown {
+    &:not(.empty) {
+        // Remove button styling when full
+        border: 0 !important;
+        border-radius: 0;
+    }
 }
 
 // Symbolic questions


### PR DESCRIPTION
When the screen is small (e.g. a mobile device) the drop zones are converted to dropdown menus with the available items. The item tray is removed.

If there is no replacement then selecting an item removes it from other dropdowns. A blank option is added to allow for resetting individual zones.

This requires a new handler function in the IsaacClozeQuestion component that is passed to the InlineDropZone rendering component through the DropRegionContext. This is an altered version of the onDragEnd handler.
