### PR TITLE
Fix inline box positioning on Safari

### DIFF
--- a/src/app/components/elements/inputs/InlineNumericEntryZone.tsx
+++ b/src/app/components/elements/inputs/InlineNumericEntryZone.tsx
@@ -49,19 +49,24 @@ export const InlineNumericEntryZone = ({width, height, questionDTO, setModified,
         setModified(true);
     }, [value, unit, setModified]);
 
-    return <div {...rest} className={classNames("d-inline-flex inline-numeric-container", rest.className, correctnessClass(valueCorrectness === "NOT_SUBMITTED" ? "NOT_SUBMITTED" : correctness))}>
-        <div className={"feedback-zone inline-nq-feedback"}>
+    return <div {...rest} 
+        className={classNames("inline-numeric-container", rest.className, correctnessClass(valueCorrectness === "NOT_SUBMITTED" ? "NOT_SUBMITTED" : correctness))}
+    >
+        <div className={"feedback-zone inline-nq-feedback"}
+            style={{
+                ...(height && {height: `${height}px`}),
+            }}
+        >
             <Input 
                 ref={focusRef}
                 className={classNames(
-                    "inline-input force-print",
+                    "inline-input force-print h-100",
                     {"units-shown" : questionDTO.requireUnits || !noDisplayUnit}, 
                     // if the answer is incorrect because the units are wrong but the value is correct, hide the green outline from the value
                     correctnessClass((correctness === "INCORRECT" && valueCorrectness === "CORRECT") ? "NOT_SUBMITTED" : valueCorrectness)
                 )}
                 style={{
                     ...(width && {width: `${width}px`}), 
-                    ...(height && {height: `${height}px`}),
                 }}
                 value={value ?? ""}
                 onChange={(e) => {
@@ -76,7 +81,15 @@ export const InlineNumericEntryZone = ({width, height, questionDTO, setModified,
             </div>}
         </div>
 
-        {(questionDTO.requireUnits || !noDisplayUnit) && <Dropdown disabled={readonly} isOpen={isOpen && noDisplayUnit} toggle={() => {setIsOpen(!isOpen);}} className={classNames("inline-unit-dropdown d-flex justify-content-center", {"display-unit": !noDisplayUnit})}>
+        {(questionDTO.requireUnits || !noDisplayUnit) && <Dropdown 
+                disabled={readonly} 
+                isOpen={isOpen && noDisplayUnit} 
+                toggle={() => {setIsOpen(!isOpen);}} 
+                className={classNames("inline-unit-dropdown justify-content-center", {"display-unit": !noDisplayUnit})}
+                style={{
+                    ...(height && {height: `${height}px`}),
+                }}
+        >
             <DropdownToggle
                 disabled={readonly || !noDisplayUnit}
                 className={classNames("feedback-zone pl-2 pr-0 py-0", {"pr-4": showFeedback(unitCorrectness), "border-dark": !noDisplayUnit})}

--- a/src/app/components/elements/inputs/InlineNumericEntryZone.tsx
+++ b/src/app/components/elements/inputs/InlineNumericEntryZone.tsx
@@ -60,8 +60,8 @@ export const InlineNumericEntryZone = ({width, height, questionDTO, setModified,
             <Input 
                 ref={focusRef}
                 className={classNames(
-                    "inline-input force-print h-100",
-                    {"units-shown" : questionDTO.requireUnits || !noDisplayUnit}, 
+                    "force-print h-100",
+                    {"units-shown" : questionDTO.requireUnits || !noDisplayUnit},
                     // if the answer is incorrect because the units are wrong but the value is correct, hide the green outline from the value
                     correctnessClass((correctness === "INCORRECT" && valueCorrectness === "CORRECT") ? "NOT_SUBMITTED" : valueCorrectness)
                 )}

--- a/src/app/components/elements/inputs/InlineNumericEntryZone.tsx
+++ b/src/app/components/elements/inputs/InlineNumericEntryZone.tsx
@@ -54,7 +54,7 @@ export const InlineNumericEntryZone = ({width, height, questionDTO, setModified,
             <Input 
                 ref={focusRef}
                 className={classNames(
-                    "force-print",
+                    "inline-input force-print",
                     {"units-shown" : questionDTO.requireUnits || !noDisplayUnit}, 
                     // if the answer is incorrect because the units are wrong but the value is correct, hide the green outline from the value
                     correctnessClass((correctness === "INCORRECT" && valueCorrectness === "CORRECT") ? "NOT_SUBMITTED" : valueCorrectness)

--- a/src/app/components/elements/inputs/InlineStringEntryZone.tsx
+++ b/src/app/components/elements/inputs/InlineStringEntryZone.tsx
@@ -24,7 +24,11 @@ export const InlineStringEntryZone = ({width, height, questionDTO, focusRef, set
     return <div className={"feedback-zone inline-nq-feedback"}>
         <Input 
             {...rest}
-            className={classNames("force-print", rest.className, correctnessClass(correctness))}
+            className={classNames(
+                "inline-input force-print", 
+                rest.className, 
+                correctnessClass(correctness)
+            )}
             ref={focusRef}
             value={value}
             style={{width: `${width}px`, height: `${height}px`}}

--- a/src/app/components/elements/inputs/InlineStringEntryZone.tsx
+++ b/src/app/components/elements/inputs/InlineStringEntryZone.tsx
@@ -25,8 +25,8 @@ export const InlineStringEntryZone = ({width, height, questionDTO, focusRef, set
         <Input 
             {...rest}
             className={classNames(
-                "inline-input force-print", 
-                rest.className, 
+                "force-print",
+                rest.className,
                 correctnessClass(correctness)
             )}
             ref={focusRef}

--- a/src/app/components/elements/markup/markdownRendering.ts
+++ b/src/app/components/elements/markup/markdownRendering.ts
@@ -46,7 +46,7 @@ export const renderClozeDropZones = (markdown: string) => {
 export const renderInlineQuestionPartZones = (markdown: string) => {
     return markdown.replace(inlineQuestionRegex, (_match, id: string | undefined, params: string | undefined, width: string | undefined, height: string | undefined) => {
         const inlineId = `inline-question-${id}`;
-        return `<span id="${inlineId}" class="d-inline-flex justify-content-center ${width ? width : ""} ${height ? height : ""})}"></span>`;
+        return `<span id="${inlineId}" class="inline-outer-container ${width ? width : ""} ${height ? height : ""}"></span>`;
     });
 };
 

--- a/src/scss/common/questions.scss
+++ b/src/scss/common/questions.scss
@@ -384,6 +384,10 @@
   }
 }
 
+input.inline-input {
+  display: inline-flex;
+}
+
 .question-actions {
   align-self: flex-start;
   &.question-actions-leftmost {

--- a/src/scss/common/questions.scss
+++ b/src/scss/common/questions.scss
@@ -66,7 +66,19 @@
   }
 }
 
+// .feedback-zone {
+//   display: inline-block;
+// }
+
+.inline-outer-container {
+  display: inline-flex;
+  justify-content: center;
+  width: max-content;
+  vertical-align: middle;
+}
+
 .inline-numeric-container {
+  display: inline-flex;
   border-radius: 5px;
 
   @media screen {
@@ -77,6 +89,7 @@
 
   .inline-unit-dropdown {
     button.btn {
+      display: block;
       height: 100%;
       min-width: 36px !important;
       border-radius: 0 5px 5px 0;
@@ -88,7 +101,6 @@
     &.display-unit {
       margin-bottom: -2px;
       button.btn {
-        height: calc(100% - 2px) !important;
         border: 1px solid black;
       }
     }
@@ -382,10 +394,6 @@
       right: 10px;
     }
   }
-}
-
-input.inline-input {
-  display: inline-flex;
 }
 
 .question-actions {

--- a/src/scss/common/questions.scss
+++ b/src/scss/common/questions.scss
@@ -66,10 +66,6 @@
   }
 }
 
-// .feedback-zone {
-//   display: inline-block;
-// }
-
 .inline-outer-container {
   display: inline-flex;
   justify-content: center;


### PR DESCRIPTION
Fixes the issue with boxes appearing too high until they are typed in on Safari. No noticeable differences on any other browser.