### PR TITLE
Allow for inline q details to be undefined on 1st render after soft-link-follow

### DIFF
--- a/src/app/components/content/IsaacInlineRegion.tsx
+++ b/src/app/components/content/IsaacInlineRegion.tsx
@@ -103,18 +103,18 @@ const IsaacInlineRegion = ({doc, className}: IsaacInlineRegionProps) => {
     const inlineContext = useContext(InlineContext);
 
     const pageQuestions = useAppSelector(selectors.questions.getQuestions);
-    const inlineRegionDTO = selectQuestionPart(pageQuestions, doc.id) as IsaacInlineRegionDTO;
+    const inlineRegionDTO = selectQuestionPart(pageQuestions, doc.id) as IsaacInlineRegionDTO | undefined;
 
     useEffect(() => {
         if (inlineContext) {
-            inlineRegionDTO.inlineQuestions?.forEach(inlineQuestion => {
+            inlineRegionDTO?.inlineQuestions?.forEach(inlineQuestion => {
                 if (inlineQuestion.id && inlineQuestion.type) {
                     const elementId = (inlineQuestion.id.split("|").at(-1)?.replace("inline-question:", "inline-question-") + "-input") ?? "unknown";
                     inlineContext.elementToQuestionMap[elementId] = {questionId: inlineQuestion.id, type: inlineQuestion.type};
                 }
             });
         }
-    }, [inlineRegionDTO.inlineQuestions]);
+    }, [inlineRegionDTO?.inlineQuestions]);
 
     useEffect(() => {
         // once the final question part to a region has been submitted, show the feedback box
@@ -128,10 +128,9 @@ const IsaacInlineRegion = ({doc, className}: IsaacInlineRegionProps) => {
 
     // Register the inline question parts in Redux, so we can access previous/current attempts
     useEffect(() => {
-        inlineRegionDTO.inlineQuestions && dispatch(registerQuestions(inlineRegionDTO.inlineQuestions, inlineContext?.docId));
+        inlineRegionDTO?.inlineQuestions && dispatch(registerQuestions(inlineRegionDTO.inlineQuestions, inlineContext?.docId));
         return () => dispatch(deregisterQuestions([inlineContext?.docId as string]));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [dispatch, inlineContext?.docId]);
+    }, [dispatch, inlineContext?.docId, inlineRegionDTO?.inlineQuestions]);
 
     return <div className={`question-content inline-region ${className}`}>
         <IsaacContentValueOrChildren value={doc.value} encoding={doc.encoding}>

--- a/src/app/components/elements/markup/portals/InlineEntryZone.tsx
+++ b/src/app/components/elements/markup/portals/InlineEntryZone.tsx
@@ -103,7 +103,7 @@ const InlineEntryZoneBase = ({inlineSpanId, className, width, height, root}: Inl
     }, [inlineContext?.focusSelection]);
 
     if (!questionId || !questionDTO ) {
-        console.error(`Inline question element (id: ${questionId}, dto: ${questionDTO}) not found.`);
+        // On following a soft link, the way that we register questions and build elementToQuestionMap means that on first render this questionId and questionDTO will be undefined.
         return null;
     }
 


### PR DESCRIPTION
On following a soft-link to an inline question, the new page's IsaacInlineRegion is rendered before the questions have been registered and elementToQuestionMap has been built. We have updated the type to allow for this and, importantly, added the value to the dependencies of the useEffect that registers the question parts so that the inline regions render when the data is available.