### PR TITLE
Inline feedback index on soft links

### DIFF
--- a/src/app/components/elements/markup/portals/InlineEntryZone.tsx
+++ b/src/app/components/elements/markup/portals/InlineEntryZone.tsx
@@ -47,7 +47,7 @@ const InlineEntryZoneBase = ({inlineSpanId, className, width, height, root}: Inl
     const questionType = inlineContext?.elementToQuestionMap?.[inlineInputId]?.type ?? "isaacStringMatchQuestion";
     const questionDTO = selectQuestionPart(pageQuestions, questionId);
 
-    const [elementIndex, _setElementIndex] = useState<number>(Object.keys(inlineContext?.elementToQuestionMap ?? {}).indexOf(inlineInputId));
+    const elementIndex = Object.keys(inlineContext?.elementToQuestionMap ?? {}).indexOf(inlineInputId);
     const [isSelectedFeedback, setIsSelectedFeedback] = useState<boolean>(false);
 
     const [correctness, setCorrectness] = useState<QuestionCorrectness>("NOT_SUBMITTED");

--- a/src/app/components/elements/markup/portals/InlineEntryZone.tsx
+++ b/src/app/components/elements/markup/portals/InlineEntryZone.tsx
@@ -120,7 +120,7 @@ const InlineEntryZoneBase = ({inlineSpanId, className, width, height, root}: Inl
                 return <InlineNumericEntryZone 
                     correctness={correctness}
                     questionDTO={questionDTO as IsaacNumericQuestionDTO & AppQuestionDTO} 
-                    className={classNames(className, "inline-part", {"selected-feedback": isSelectedFeedback})}
+                    className={classNames("inline-part", {"selected-feedback": isSelectedFeedback})}
                     width={width}
                     height={height}
                     setModified={setModified}
@@ -132,7 +132,7 @@ const InlineEntryZoneBase = ({inlineSpanId, className, width, height, root}: Inl
                 return <InlineStringEntryZone 
                     correctness={correctness}
                     questionDTO={questionDTO as IsaacStringMatchQuestionDTO & AppQuestionDTO} 
-                    className={classNames(className, "inline-part", {"selected-feedback": isSelectedFeedback})}
+                    className={classNames("inline-part", {"selected-feedback": isSelectedFeedback})}
                     width={width}
                     height={height}
                     setModified={setModified}

--- a/src/app/components/elements/markup/portals/InlineEntryZone.tsx
+++ b/src/app/components/elements/markup/portals/InlineEntryZone.tsx
@@ -120,7 +120,7 @@ const InlineEntryZoneBase = ({inlineSpanId, className, width, height, root}: Inl
                 return <InlineNumericEntryZone 
                     correctness={correctness}
                     questionDTO={questionDTO as IsaacNumericQuestionDTO & AppQuestionDTO} 
-                    className={classNames("inline-part", {"selected-feedback": isSelectedFeedback})}
+                    className={classNames(className, "inline-part", {"selected-feedback": isSelectedFeedback})}
                     width={width}
                     height={height}
                     setModified={setModified}
@@ -132,7 +132,7 @@ const InlineEntryZoneBase = ({inlineSpanId, className, width, height, root}: Inl
                 return <InlineStringEntryZone 
                     correctness={correctness}
                     questionDTO={questionDTO as IsaacStringMatchQuestionDTO & AppQuestionDTO} 
-                    className={classNames("inline-part", {"selected-feedback": isSelectedFeedback})}
+                    className={classNames(className, "inline-part", {"selected-feedback": isSelectedFeedback})}
                     width={width}
                     height={height}
                     setModified={setModified}


### PR DESCRIPTION
Prevent the inline feedback index showing as 0 when loading a page with inline questions from the "next question" button on a gameboard.