### PR TITLE
Update/research notification banner

### DIFF
--- a/src/app/components/navigation/CookieBanner.tsx
+++ b/src/app/components/navigation/CookieBanner.tsx
@@ -3,7 +3,7 @@ import {Link} from "react-router-dom";
 import * as RS from 'reactstrap';
 import Cookies from 'js-cookie';
 import {logAction, useAppDispatch} from "../../state";
-import {isPhy, siteSpecific} from "../../services";
+import {isAda, isPhy, siteSpecific} from "../../services";
 
 const COOKIE_COOKIE = "isaacCookiesAccepted";
 
@@ -33,14 +33,15 @@ export const CookieBanner = () => {
                     </h3>
                 </RS.Col>
                 <RS.Col xs={12} sm={10} md={8}>
-                    <small>Use of this website and the information entered is being recorded. This data is used to support research
-                    into online learning at the University of Cambridge. Cookies are used to support this functionality.
-                    Full details are in the <Link to="/privacy">privacy policy</Link> and <Link to="/cookies">cookie policy</Link>.
-                    Do you agree to participate in this research?</small>
+                    <small>
+                        Use of this website and the information entered is being recorded.
+                        This data is used to support research into online learning at the University of Cambridge{isAda ? " and the Raspberry Pi Foundation" : ""}.
+                        Full details are in the <Link to="/privacy">privacy policy</Link>.
+                    </small>
                 </RS.Col>
                 <RS.Col xs={12} md={3} className="text-center">
                     <RS.Button color="primary" outline={isPhy} className="mt-3 mb-2 d-block d-md-inline-block banner-button" onClick={clickDismiss}>
-                        I Agree
+                        {siteSpecific("Got It", "Got it")}
                     </RS.Button>
                 </RS.Col>
             </RS.Row>

--- a/src/app/components/navigation/IsaacApp.tsx
+++ b/src/app/components/navigation/IsaacApp.tsx
@@ -47,7 +47,7 @@ import {AuthError} from "../pages/AuthError";
 import {SessionExpired} from "../pages/SessionExpired";
 import {ConsistencyError} from "../pages/ConsistencyError";
 import {Search} from "../pages/Search";
-import {CookieBanner} from "./CookieBanner";
+import {ResearchNotificationBanner} from "./ResearchNotificationBanner";
 import {EmailVerificationBanner} from "./EmailVerificationBanner";
 import {Toasts} from "./Toasts";
 import {AdminUserManager} from "../pages/AdminUserManager";
@@ -143,7 +143,7 @@ export const IsaacApp = () => {
         <SiteSpecific.Header />
         <Toasts />
         <ActiveModals />
-        <CookieBanner />
+        <ResearchNotificationBanner />
         <UnsupportedBrowserBanner />
         <DowntimeWarningBanner />
         <EmailVerificationBanner />

--- a/src/app/components/navigation/ResearchNotificationBanner.tsx
+++ b/src/app/components/navigation/ResearchNotificationBanner.tsx
@@ -5,19 +5,19 @@ import Cookies from 'js-cookie';
 import {logAction, useAppDispatch} from "../../state";
 import {isAda, isPhy, siteSpecific} from "../../services";
 
-const COOKIE_COOKIE = "isaacCookiesAccepted";
+const RESEARCH_NOTIFICATION_COOKIE = "researchNotificationDismissed";
 
-export const CookieBanner = () => {
+export const ResearchNotificationBanner = () => {
     const dispatch = useAppDispatch();
     const [show, setShown] = useState(() => {
-        const currentCookieValue = Cookies.get(COOKIE_COOKIE);
+        const currentCookieValue = Cookies.get(RESEARCH_NOTIFICATION_COOKIE);
         return currentCookieValue != "1";
     });
 
     function clickDismiss() {
         setShown(false);
-        Cookies.set(COOKIE_COOKIE, "1", {expires: 720 /* days*/});
-        const eventDetails = {type: "ACCEPT_COOKIES"};
+        Cookies.set(RESEARCH_NOTIFICATION_COOKIE, "1", {expires: 720 /* days*/});
+        const eventDetails = {type: "RESEARCH_NOTIFICATION_DISMISSED"};
         dispatch(logAction(eventDetails));
     }
 

--- a/src/app/components/navigation/ResearchNotificationBanner.tsx
+++ b/src/app/components/navigation/ResearchNotificationBanner.tsx
@@ -21,15 +21,15 @@ export const ResearchNotificationBanner = () => {
         dispatch(logAction(eventDetails));
     }
 
-    return show ? <div className="banner d-print-none" id="cookie-banner">
+    return show ? <div className="banner d-print-none" id="research-banner">
         <RS.Container className="py-3">
             <RS.Row style={{alignItems: "center"}}>
                 <RS.Col xs={12} sm={2} md={1}>
                     <h3 className="text-center">
-                        <span role="presentation" aria-labelledby="cookies-heading">
+                        <span role="presentation" aria-labelledby="research-heading">
                             <img className={siteSpecific("mt-n2 mt-sm-0 mt-md-n1", "mt-n1 mt-sm-1")} src="/assets/common/icons/info.svg" style={{height: "1.5rem"}} alt="" />
                         </span>
-                        <span id="cookies-heading" className="d-inline-block d-sm-none">&nbsp;Cookies</span>
+                        <span id="research-heading" className="d-inline-block d-sm-none">&nbsp;Research</span>
                     </h3>
                 </RS.Col>
                 <RS.Col xs={12} sm={10} md={8}>


### PR DESCRIPTION
This change will require a quick discussion at the tech meeting before merging as Ada would like to propose a slight tweak to the copy (as can be seen in Trello).

The banner's associated cookie is renamed to reflect its new meaning. This will mean that every user will see this banner again. As it is the start of a new academic year, I believe that is acceptable.