### PR TITLE
Fix LaTeX vertical clipping

### DIFF
--- a/src/scss/phy/isaac.scss
+++ b/src/scss/phy/isaac.scss
@@ -257,10 +257,11 @@ p small {
 .katex.katex {
     font-size: 1.1em;
     white-space: nowrap !important;
-    overflow-x: auto;
+    overflow-x: clip;
     overflow-y: hidden;
     padding-top: 0.25rem !important;
     padding-bottom: 0.25rem !important;
+    display: inline-flex;
 }
 
 body {


### PR DESCRIPTION
Originally marked as a Firefox issue, but I was also able to recreate it in Chrome. 

This is a change to all LaTeX in Isaac, so may be worth reviewing more pages, but all the ones I've checked (e.g. https://isaacphysics.org/concepts/cm_matrices?stage=all https://isaacphysics.org/questions/reflection_symmetry_2e?stage=all) seem fine