### PR TITLE
Add indicator by 'Work to do'

### DIFF
--- a/src/app/components/site/cs/HeaderCS.tsx
+++ b/src/app/components/site/cs/HeaderCS.tsx
@@ -101,7 +101,7 @@ export const HeaderCS = () => {
                                             <LinkItem to={PATHS.SET_ASSIGNMENTS}>Manage assignments</LinkItem>
                                             <LinkItem to="/set_tests">Manage tests</LinkItem>
                                             <LinkItem to={PATHS.ASSIGNMENT_PROGRESS}>My markbook</LinkItem>
-                                            <LinkItem to={PATHS.MY_ASSIGNMENTS}>Work to do</LinkItem>
+                                            <LinkItem to={PATHS.MY_ASSIGNMENTS}>Work to do {<MenuBadge count={assignmentsCount} message="incomplete assignments" />}</LinkItem>
                                         </>
                                     :
                                         <>


### PR DESCRIPTION
On Ada CS, show teachers an indicator by 'Work to do' if they have assignments to complete.