### PR TITLE
Set email preference defaults on account creation for Ada

### DIFF
--- a/src/app/components/pages/RegistrationSetDetails.tsx
+++ b/src/app/components/pages/RegistrationSetDetails.tsx
@@ -14,6 +14,7 @@ import {
 } from "reactstrap";
 import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
 import {
+    EMAIL_PREFERENCE_DEFAULTS,
     EXAM_BOARD,
     FIRST_LOGIN_STATE,
     history,
@@ -88,7 +89,8 @@ export const RegistrationSetDetails = ({role}: RegistrationSetDetailsProps) => {
             setAttemptedSignUp(true);
             Object.assign(registrationUser, {loggedIn: false});
             dispatch(errorSlice.actions.clearError());
-            dispatch(registerNewUser(registrationUser, {}, [{stage: STAGE.ALL, examBoard: EXAM_BOARD.ADA}], null));
+            dispatch(registerNewUser(registrationUser, {EMAIL_PREFERENCE: EMAIL_PREFERENCE_DEFAULTS},
+                [{stage: STAGE.ALL, examBoard: EXAM_BOARD.ADA}], null));
             trackEvent("registration", {
                     props:
                         {

--- a/src/app/components/pages/RegistrationSetDetails.tsx
+++ b/src/app/components/pages/RegistrationSetDetails.tsx
@@ -92,11 +92,11 @@ export const RegistrationSetDetails = ({role}: RegistrationSetDetailsProps) => {
             dispatch(registerNewUser(registrationUser, {EMAIL_PREFERENCE: EMAIL_PREFERENCE_DEFAULTS},
                 [{stage: STAGE.ALL, examBoard: EXAM_BOARD.ADA}], null));
             trackEvent("registration", {
-                    props:
+                props:
                         {
                             provider: "SEGUE"
                         }
-                }
+            }
             );
         }
     };


### PR DESCRIPTION
In the old signup flow, the required account info modal would pop up incessantly if this was left undefined (although could still be skipped). In the new flow, the preferences stage of the flow is a lot easier to skip once and forget about, so it's best to set this upon initial account creation and update it later.