### PR TITLE
Restore NavBar mobile alignment

### DIFF
--- a/src/app/components/navigation/NavigationBar.tsx
+++ b/src/app/components/navigation/NavigationBar.tsx
@@ -111,7 +111,7 @@ export const NavigationBar = ({children}: {children: React.ReactNode}) => {
 
     return <MenuOpenContext.Provider value={{menuOpen, setMenuOpen}}>
         <Navbar className="main-nav p-0" color="light" light expand="md">
-            <NavbarToggler onClick={() => setMenuOpen(!menuOpen)} aria-label={menuOpen ? 'Close menu' : 'Open menu'}>
+            <NavbarToggler className="end-0 translate-middle-x" onClick={() => setMenuOpen(!menuOpen)} aria-label={menuOpen ? 'Close menu' : 'Open menu'}>
                 Menu
             </NavbarToggler>
 


### PR DESCRIPTION
'MENU' button was moved too close to search icon on small/medium screens. This restores spacing to the original layout.