### PR TITLE
Fix duplicate exam boards

### DIFF
--- a/src/app/components/elements/GameboardBuilderRow.tsx
+++ b/src/app/components/elements/GameboardBuilderRow.tsx
@@ -125,7 +125,7 @@ const GameboardBuilderRow = (
         {isAda && <td className={classNames(cellClasses, "w-15")}>
             {filteredAudienceViews.map((audienceView, i, collection) => <>
                 {/* was `findAudienceRecordsMatchingPartial(question.audience, audienceView).map(...)` but it seemed to be broken */}
-                {question.audience?.map((audienceRecord) => audienceRecord.examBoard?.map((examBoard) => tagIcon(examBoardLabelMap[examBoard])))}
+                {Array.from(new Set(question.audience?.map((audienceRecord) => audienceRecord.examBoard).flat())).map((examBoard) => tagIcon(examBoardLabelMap[examBoard!]))}
                 {/* When this becomes more common we should solve separation via a new row and merge other columns */}
                 {i + 1 < collection.length && <hr className="text-center" />}
             </>)}


### PR DESCRIPTION
On Ada CS, prevent the quiz builder listing an exam board more than once for the same question.