### PR TITLE
Add new ExamSpecification page for SQA

### DIFF
--- a/src/app/components/pages/ExamSpecificationsDirectory.tsx
+++ b/src/app/components/pages/ExamSpecificationsDirectory.tsx
@@ -45,7 +45,9 @@ export const ExamSpecificationsDirectory = () => {
                     </CardBody>
                     <CardFooter className={"border-top-0 pb-3"}>
                         <Button className="justify-content-end" color='secondary' outline tag={Link}
-                                to="/exam_specifications_england">Show me</Button>
+                            to="/exam_specifications_england">
+                            Show me
+                        </Button>
                     </CardFooter>
                 </Card>
             </Col>
@@ -64,7 +66,7 @@ export const ExamSpecificationsDirectory = () => {
                         </CardText>
                     </CardBody>
                     <CardFooter className={"border-top-0 pb-3"}>
-                        <Button color='secondary' outline tag={Link} to="/concepts/sqa_computing_science">
+                        <Button color='secondary' outline tag={Link} to="/exam_specifications_scotland">
                             Show me
                         </Button>
                     </CardFooter>

--- a/src/app/components/site/cs/HomepageCS.tsx
+++ b/src/app/components/site/cs/HomepageCS.tsx
@@ -69,9 +69,9 @@ export const HomepageCS = () => {
                                 <li><b>Complete curriculums:</b> For
                                     {" "}<a href={"/exam_specifications_england#gcse/aqa"}>GCSE</a>,
                                     {" "}<a href={"/exam_specifications_england#a_level/aqa"}>A&nbsp;Level</a>,
-                                    {" "}<a href={"/concepts/sqa_computing_science?examBoard=sqa&stage=scotland_national_5"}>National&nbsp;5</a>,
-                                    {" "}<a href={"/concepts/sqa_computing_science?examBoard=sqa&stage=scotland_higher"}>Higher</a>, and
-                                    {" "}<a href={"/concepts/sqa_computing_science?examBoard=sqa&stage=scotland_advanced_higher"}>Advanced&nbsp;Higher</a></li>
+                                    {" "}<a href={"/exam_specifications_scotland#scotland_national_5/sqa"}>National&nbsp;5</a>,
+                                    {" "}<a href={"/exam_specifications_scotland#scotland_higher/sqa"}>Higher</a>, and
+                                    {" "}<a href={"/exam_specifications_scotland#scotland_advanced_higher/sqa"}>Advanced&nbsp;Higher</a></li>
                             </ul>
                             {!isLoggedIn(user) &&
                                 <Button className="mt-3" tag={Link} to="/register" color="primary">Join</Button>

--- a/src/app/components/site/cs/RoutesCS.tsx
+++ b/src/app/components/site/cs/RoutesCS.tsx
@@ -4,7 +4,7 @@ import {AllTopics} from "../../pages/AllTopics";
 import StaticPageRoute from "../../navigation/StaticPageRoute";
 import {Topic} from "../../pages/Topic";
 import {Redirect} from "react-router";
-import {EXAM_BOARD, isLoggedIn, isStaff, isTeacherOrAbove, isTutorOrAbove} from "../../../services";
+import {EXAM_BOARD, isLoggedIn, isStaff, isTeacherOrAbove, isTutorOrAbove, STAGE} from "../../../services";
 import {SingleAssignmentProgress} from "../../pages/SingleAssignmentProgress";
 import {ExamSpecifications} from "../../pages/ExamSpecifications";
 import {News} from "../../pages/News";
@@ -88,6 +88,9 @@ export const RoutesCS = [
     <TrackedRoute key={key++} exact path="/topics/:topicName" component={Topic} />,
     <TrackedRoute key={key++} exact path="/exam_specifications_england" component={ExamSpecifications} />,
     <TrackedRoute key={key++} exact path="/exam_specifications_wales" component={ExamSpecifications} componentProps={{'examBoardFilter': [EXAM_BOARD.WJEC]}} />,
+    <TrackedRoute key={key++} exact path="/exam_specifications_scotland" component={ExamSpecifications}
+        componentProps={{'examBoardFilter': [EXAM_BOARD.SQA], 'stageFilter': [STAGE.SCOTLAND_NATIONAL_5,
+            STAGE.SCOTLAND_HIGHER, STAGE.SCOTLAND_ADVANCED_HIGHER]}} />,
     <TrackedRoute key={key++} exact path="/exam_specifications" component={ExamSpecificationsDirectory} />,
 
     // News


### PR DESCRIPTION
Replaces the temporary concept page for SQA exam specifications with a new `ExamSpecifications`-based page.