### PR TITLE
Update footer to add University funding

### DIFF
--- a/src/app/components/site/phy/FooterPhy.tsx
+++ b/src/app/components/site/phy/FooterPhy.tsx
@@ -31,8 +31,8 @@ export const FooterPhy = () => (
                                 <img src="/assets/common/logos/university_of_cambridge.svg" alt='University of Cambridge website' className='footer-org-logo' />
                             </a>
                             Funded by {' '} <ExternalLink href="https://www.cam.ac.uk/">
-                            <strong>University of Cambridge</strong>.
-                            </ExternalLink>
+                                <strong>University of Cambridge</strong>
+                            </ExternalLink>.
                             
                             <br />Supported by {' '} <ExternalLink href="https://www.gov.uk/government/organisations/department-for-education">
                             <strong>Department for Education</strong>

--- a/src/app/components/site/phy/FooterPhy.tsx
+++ b/src/app/components/site/phy/FooterPhy.tsx
@@ -30,10 +30,13 @@ export const FooterPhy = () => (
                             <a href="https://www.cam.ac.uk/" target="_blank" rel="noopener" className="mt-2 mb-3">
                                 <img src="/assets/common/logos/university_of_cambridge.svg" alt='University of Cambridge website' className='footer-org-logo' />
                             </a>
-                            Funded by&nbsp;<ExternalLink href="https://www.gov.uk/government/organisations/department-for-education">
+                            Funded by {' '} <ExternalLink href="https://www.cam.ac.uk/">
+                            <strong>University of Cambridge</strong>.
+                            </ExternalLink>
+                            
+                            <br />Supported by {' '} <ExternalLink href="https://www.gov.uk/government/organisations/department-for-education">
                             <strong>Department for Education</strong>
-                            </ExternalLink>.
-                            <br />Supported by {' '}
+                            </ExternalLink> and {' '} 
                             <ExternalLink href="https://www.ogdentrust.com/">
                                 <strong>The&nbsp;Ogden&nbsp;Trust</strong>
                             </ExternalLink>.


### PR DESCRIPTION
Footer changed from:
```
"Funded by Department for Education.
Supported by The Ogden Trust."
```
to:
```
"Funded by University of Cambridge.
Supported by Department for Education and The Ogden Trust."
```