### PR TITLE
Ignore default exam board if set by query param

### DIFF
--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -346,6 +346,7 @@ export const CS_EXAM_BOARDS_BY_STAGE: {[stage in typeof STAGES_CS[number]]: Exam
 };
 
 export const EXAM_BOARD_NULL_OPTIONS = [EXAM_BOARD.ALL];
+export const EXAM_BOARD_DEFAULT_OPTION = siteSpecific(EXAM_BOARD.ALL, EXAM_BOARD.ADA);
 
 export const EXAM_BOARD_ITEM_OPTIONS = Object.keys(EXAM_BOARD).map(s => ({value: s, label: examBoardLabelMap[s as EXAM_BOARD]}));
 

--- a/src/app/services/userViewingContext.ts
+++ b/src/app/services/userViewingContext.ts
@@ -2,6 +2,7 @@ import {
     comparatorFromOrderedValues,
     CS_EXAM_BOARDS_BY_STAGE,
     EXAM_BOARD,
+    EXAM_BOARD_DEFAULT_OPTION,
     EXAM_BOARD_NULL_OPTIONS,
     examBoardLabelMap,
     history,
@@ -70,17 +71,25 @@ export function useUserViewingContext(): UseUserContextReturnType {
     // Exam Board
     let examBoard: EXAM_BOARD;
     const examBoardQueryParam = queryParams.examBoard as EXAM_BOARD | undefined;
-    if (isPhy) {
+    // Set the exam board in order of precedence:
+    if (isPhy) { // Physics has no exam boards and so use the "null" option of ALL.
         examBoard = EXAM_BOARD.ALL;
-    } else if (examBoardQueryParam && Object.values(EXAM_BOARD).includes(examBoardQueryParam) && !EXAM_BOARD_NULL_OPTIONS.includes(examBoardQueryParam)) {
+    } else if ( // A valid exam board is specified by the query params (but is not the default exam board option).
+        examBoardQueryParam && Object.values(EXAM_BOARD).includes(examBoardQueryParam) &&
+        EXAM_BOARD_DEFAULT_OPTION !== examBoardQueryParam
+    ) {
         examBoard = examBoardQueryParam;
         explanation.examBoard = urlMessage;
-    } else if (isDefined(transientUserContext?.examBoard)) {
+    } else if ( // An exam board has been selected via the context picker within this (redux) session.
+        isDefined(transientUserContext?.examBoard)
+    ) {
         examBoard = transientUserContext?.examBoard;
-    } else if (isLoggedIn(user) && user.registeredContexts?.length && user.registeredContexts[0].examBoard) {
+    } else if ( // An exam board preference has been set on the account.
+        isLoggedIn(user) && user.registeredContexts?.length && user.registeredContexts[0].examBoard
+    ) {
         examBoard = user.registeredContexts[0].examBoard as EXAM_BOARD;
-    } else {
-        examBoard = isAda ? EXAM_BOARD.ADA : EXAM_BOARD.ALL;
+    } else {  // We use the default exam board option.
+        examBoard = EXAM_BOARD_DEFAULT_OPTION;
     }
 
     // Whether stage and examboard are the default


### PR DESCRIPTION
There is an order of precedence that we follow when deciding which exam board to use for a user's viewing context. Query params have the highest precedence as the user should see the same page content that the link sender was intending to show you. For the same reason, the query params are updated to reflect the viewing context so that people's links copied from the URL bar are correct.

If we follow a link with no query params as a signed in user, for the initial render we don't know whether you're signed in or not so give you the default values and, dutifully, update the query params. When we then receive the signed in response we would like the account preferences to override it (as there were no query params initially) so the work around is to ignore the case when the query params are the default params. 

A better solution exists but will need to wait until the next release.