### PR TITLE
Restore black border to cloze items when printing

### DIFF
--- a/src/scss/common/print.scss
+++ b/src/scss/common/print.scss
@@ -40,6 +40,7 @@
 
   .cloze-item {
     color: black !important;
+    border-color: black !important;
     background-color: unset !important;
   }
 

--- a/src/scss/common/questions.scss
+++ b/src/scss/common/questions.scss
@@ -332,6 +332,7 @@
   touch-action: none;
   position: relative;
   font-size: 1rem !important;
+  border: 1px solid $border-color;
   &.is-dragging {
     opacity: 0.666;
   }


### PR DESCRIPTION
Adds both a `border-color: black;` to cloze items when printing, and a default `border-color: $border-color` for cloze questions in general so it still appears when the default forced-colors scheme is enabled (overridden normally).