### PR TITLE
Cloze dropdown scrolling and greying out

### DIFF
--- a/src/IsaacAppTypes.tsx
+++ b/src/IsaacAppTypes.tsx
@@ -413,6 +413,7 @@ export const ClozeDropRegionContext = React.createContext<{
     dropZoneValidationMap: {[p: string]: {correct?: boolean, itemId?: string} | undefined},
     shouldGetFocus: (id: string) => boolean,
     nonSelectedItems: Immutable<ClozeItemDTO>[]
+    allItems: Immutable<ClozeItemDTO>[]
 } | undefined>(undefined);
 
 export const InlineContext = React.createContext<{

--- a/src/app/components/content/IsaacClozeQuestion.tsx
+++ b/src/app/components/content/IsaacClozeQuestion.tsx
@@ -362,7 +362,7 @@ const IsaacClozeQuestion = ({doc, questionId, readonly, validationResponse}: Isa
         if (!withReplacement && previousItem) {
             // Add the previously selected item back to the options
             // if it wasn't duplicated
-            nsis.push(previousItem)
+            nsis.push(previousItem);
         }
 
         if (clearSelection) {

--- a/src/app/components/content/IsaacClozeQuestion.tsx
+++ b/src/app/components/content/IsaacClozeQuestion.tsx
@@ -367,7 +367,7 @@ const IsaacClozeQuestion = ({doc, questionId, readonly, validationResponse}: Isa
 
         if (clearSelection) {
             idvs[dropZoneIndex] = undefined;
-        } else if (!clearSelection) {
+        } else {
             idvs[dropZoneIndex] = augmentInlineItemWithUniqueReplacementID(item);
         }
 

--- a/src/app/components/content/IsaacClozeQuestion.tsx
+++ b/src/app/components/content/IsaacClozeQuestion.tsx
@@ -140,6 +140,8 @@ const IsaacClozeQuestion = ({doc, questionId, readonly, validationResponse}: Isa
 
     const [nonSelectedItems, setNonSelectedItems] = useState<Immutable<ClozeItemDTO>[]>(doc.items ? [...doc.items].map(augmentNonSelectedItemWithReplacementID) : []);
 
+    const allItems = doc.items ? [...doc.items].map(augmentNonSelectedItemWithReplacementID) : [];
+
     const registeredDropRegionIDs = useRef<Map<string, number>>(new Map()).current;
 
     const [inlineDropValues, setInlineDropValues] = useState<(Immutable<ClozeItemDTO> | undefined)[]>(() => currentAttempt?.items || []);
@@ -357,25 +359,15 @@ const IsaacClozeQuestion = ({doc, questionId, readonly, validationResponse}: Isa
         if (dropZoneIndex === -1) return;
         const previousItem = idvs[dropZoneIndex];
 
-        if (clearSelection && previousItem) {
-            if (!withReplacement) {
-                // Add the previously selected item back to the options
-                // if it wasn't duplicated
-                nsis.push(previousItem);
-            }
-            // and remove the item from the current drop zone values
+        if (!withReplacement && previousItem) {
+            // Add the previously selected item back to the options
+            // if it wasn't duplicated
+            nsis.push(previousItem)
+        }
+
+        if (clearSelection) {
             idvs[dropZoneIndex] = undefined;
         } else if (!clearSelection) {
-            const itemIndex = nsis.indexOf(item);
-
-            // Otherwise remove from item section and add to drop-zone, swapping out the previous item if it exists
-            if (!withReplacement) {
-                if (previousItem) {
-                    nsis.splice(itemIndex, 1, previousItem);
-                } else {
-                    nsis.splice(itemIndex, 1);
-                }
-            }
             idvs[dropZoneIndex] = augmentInlineItemWithUniqueReplacementID(item);
         }
 
@@ -489,7 +481,8 @@ const IsaacClozeQuestion = ({doc, questionId, readonly, validationResponse}: Isa
             inlineDropValueMap,
             shouldGetFocus,
             dropZoneValidationMap,
-            nonSelectedItems
+            nonSelectedItems,
+            allItems
         }}>
             <DndContext
                 sensors={sensors}

--- a/src/app/components/elements/markup/portals/InlineDropZones.tsx
+++ b/src/app/components/elements/markup/portals/InlineDropZones.tsx
@@ -59,7 +59,7 @@ function InlineDropRegion({id, index, emptyWidth, emptyHeight, rootElement}: {id
     const droppableId = CLOZE_DROP_ZONE_ID_PREFIX + `${index + 1}`;
     const dropdownItems = dropRegionContext?.allItems ?? [];
     const nonSelectedItems = dropRegionContext?.nonSelectedItems ?? [];
-    const nonSelectedItemIds = nonSelectedItems.map(item => item.id)
+    const nonSelectedItemIds = nonSelectedItems.map(item => item.id);
 
     useEffect(() => {
         // Register with the current cloze question on first render

--- a/src/app/components/elements/markup/portals/InlineDropZones.tsx
+++ b/src/app/components/elements/markup/portals/InlineDropZones.tsx
@@ -57,7 +57,9 @@ function InlineDropRegion({id, index, emptyWidth, emptyHeight, rootElement}: {id
     const deviceSize = useDeviceSize();
     const [isOpen, setIsOpen] = useState<boolean>(false);
     const droppableId = CLOZE_DROP_ZONE_ID_PREFIX + `${index + 1}`;
-    const dropdownItems = dropRegionContext?.nonSelectedItems ?? [];
+    const dropdownItems = dropRegionContext?.allItems ?? [];
+    const nonSelectedItems = dropRegionContext?.nonSelectedItems ?? [];
+    const nonSelectedItemIds = nonSelectedItems.map(item => item.id)
 
     useEffect(() => {
         // Register with the current cloze question on first render
@@ -122,14 +124,26 @@ function InlineDropRegion({id, index, emptyWidth, emptyHeight, rootElement}: {id
                 <span className="d-inline-block"></span>
             </DropdownItem>
             {dropdownItems.map((item, i) => {
-                return <DropdownItem key={i}
+                if (nonSelectedItemIds.includes(item.id))
+                {
+                    return <DropdownItem key={i}
                     data-unit={item || 'None'}
                     onClick={() => {dropRegionContext?.onSelect(item, droppableId, false);}}
-                >
-                    <Markup trusted-markup-encoding={"html"}>
-                        {item.value ?? ""}
-                    </Markup>
-                </DropdownItem>;
+                    >
+                        <Markup trusted-markup-encoding={"html"}>
+                            {item.value ?? ""}
+                        </Markup>
+                    </DropdownItem>;
+                }
+                else 
+                {
+                    return <DropdownItem key={i} style={{color:"darkgray", backgroundColor:"lightgray", pointerEvents:"none"}}>
+                        <Markup trusted-markup-encoding={"html"}>
+                            {item.value ?? ""}
+                        </Markup>
+                    </DropdownItem>
+                }
+                
             })}
         </DropdownMenu>
     </Dropdown>;

--- a/src/app/components/elements/markup/portals/InlineDropZones.tsx
+++ b/src/app/components/elements/markup/portals/InlineDropZones.tsx
@@ -124,9 +124,9 @@ function InlineDropRegion({id, index, emptyWidth, emptyHeight, rootElement}: {id
             </DropdownItem>
             {dropdownItems.map((item, i) => {
                 return <DropdownItem key={i}
+                className={!nonSelectedItemIds.includes(item.id) ? "invalid" : ""}
                 data-unit={item || 'None'}
-                onClick={() => {dropRegionContext?.onSelect(item, droppableId, false);}}
-                disabled={!nonSelectedItemIds.includes(item.id)}
+                onClick={nonSelectedItemIds.includes(item.id) ? (() => {dropRegionContext?.onSelect(item, droppableId, false);}) : undefined}
                 >
                     <Markup trusted-markup-encoding={"html"}>
                         {item.value ?? ""}

--- a/src/app/components/elements/markup/portals/InlineDropZones.tsx
+++ b/src/app/components/elements/markup/portals/InlineDropZones.tsx
@@ -58,8 +58,7 @@ function InlineDropRegion({id, index, emptyWidth, emptyHeight, rootElement}: {id
     const [isOpen, setIsOpen] = useState<boolean>(false);
     const droppableId = CLOZE_DROP_ZONE_ID_PREFIX + `${index + 1}`;
     const dropdownItems = dropRegionContext?.allItems ?? [];
-    const nonSelectedItems = dropRegionContext?.nonSelectedItems ?? [];
-    const nonSelectedItemIds = nonSelectedItems.map(item => item.id);
+    const nonSelectedItemIds = (dropRegionContext?.nonSelectedItems ?? []).map(item => item.id);
 
     useEffect(() => {
         // Register with the current cloze question on first render
@@ -124,26 +123,15 @@ function InlineDropRegion({id, index, emptyWidth, emptyHeight, rootElement}: {id
                 <span className="d-inline-block"></span>
             </DropdownItem>
             {dropdownItems.map((item, i) => {
-                if (nonSelectedItemIds.includes(item.id))
-                {
-                    return <DropdownItem key={i}
-                    data-unit={item || 'None'}
-                    onClick={() => {dropRegionContext?.onSelect(item, droppableId, false);}}
-                    >
-                        <Markup trusted-markup-encoding={"html"}>
-                            {item.value ?? ""}
-                        </Markup>
-                    </DropdownItem>;
-                }
-                else 
-                {
-                    return <DropdownItem key={i} style={{color:"darkgray", backgroundColor:"lightgray", pointerEvents:"none"}}>
-                        <Markup trusted-markup-encoding={"html"}>
-                            {item.value ?? ""}
-                        </Markup>
-                    </DropdownItem>
-                }
-                
+                return <DropdownItem key={i}
+                data-unit={item || 'None'}
+                onClick={() => {dropRegionContext?.onSelect(item, droppableId, false);}}
+                disabled={!nonSelectedItemIds.includes(item.id)}
+                >
+                    <Markup trusted-markup-encoding={"html"}>
+                        {item.value ?? ""}
+                    </Markup>
+                </DropdownItem>;
             })}
         </DropdownMenu>
     </Dropdown>;

--- a/src/scss/common/questions.scss
+++ b/src/scss/common/questions.scss
@@ -316,6 +316,10 @@
       display: unset;
     }
   }
+  .dropdown-menu {
+    max-height: 300px;
+    overflow-y: scroll;
+  }
 }
 
 .item-section {

--- a/src/scss/common/questions.scss
+++ b/src/scss/common/questions.scss
@@ -319,6 +319,9 @@
   .dropdown-menu {
     max-height: 300px;
     overflow-y: scroll;
+    .invalid{
+      color: darkgray;
+    }
   }
 }
 


### PR DESCRIPTION
Limits the size of cloze dropdown menus and adds scrollbar on vertical overflow.

Greys out previously selected options on non-replaceable cloze questions rather than removing them from the dropdown.

[Example for scrolling](https://isaacphysics.org/questions/hypothesis_meeples?stage=all)
[Example for non-replaceable questions](https://isaacphysics.org/questions/itsp_density_hw_q2?stage=all)