### PR TITLE
Improvement/inline-box-widths

### DIFF
--- a/src/app/components/elements/inputs/InlineNumericEntryZone.tsx
+++ b/src/app/components/elements/inputs/InlineNumericEntryZone.tsx
@@ -50,9 +50,9 @@ export const InlineNumericEntryZone = ({width, height, questionDTO, setModified,
     }, [value, unit, setModified]);
 
     return <div {...rest} 
-        className={classNames("inline-numeric-container", rest.className, correctnessClass(valueCorrectness === "NOT_SUBMITTED" ? "NOT_SUBMITTED" : correctness))}
+        className={classNames("inline-numeric-container w-100", rest.className, correctnessClass(valueCorrectness === "NOT_SUBMITTED" ? "NOT_SUBMITTED" : correctness))}
     >
-        <div className={"feedback-zone inline-nq-feedback"}
+        <div className={"feedback-zone inline-nq-feedback w-100"}
             style={{
                 ...(height && {height: `${height}px`}),
             }}

--- a/src/scss/common/elements.scss
+++ b/src/scss/common/elements.scss
@@ -215,28 +215,14 @@ button.btn.btn-link.login-b,
   cursor: grab;
 }
 
-.w-5 {
-  width: 5% !important;
-}
+@each $name, $size in $element-sizes {
+  .w-#{$name} {
+    width: $size !important;
+  }
 
-.w-10 {
-  width: 10% !important;
-}
-
-.w-15 {
-  width: 15% !important;
-}
-
-.w-20 {
-  width: 20% !important;
-}
-
-.w-30 {
-  width: 30% !important;
-}
-
-.w-40 {
-  width: 40% !important;
+  .h-#{$name} {
+    height: $size !important;
+  }
 }
 
 .overflow-visible {

--- a/src/scss/common/questions.scss
+++ b/src/scss/common/questions.scss
@@ -101,6 +101,10 @@
       }
     }
   }
+
+  input {
+    padding: 0 calc(min(1.2em, 20%));
+  }
 }
 
 .symbolic-question, .equality-page {

--- a/src/scss/cs/isaac.scss
+++ b/src/scss/cs/isaac.scss
@@ -299,6 +299,19 @@ $grid-breakpoints: (
   // xxl: 1400px // we don't need xxl
 );
 
+$element-sizes: (
+    5: 5%, 
+    10: 10%,
+    20: 20%,
+    30: 30%,
+    40: 40%,
+    50: 50%,
+    60: 60%,
+    70: 70%,
+    80: 80%,
+    90: 90%,
+);
+
 $container-max-widths: (
   sm: 540px,
   md: 720px,

--- a/src/scss/phy/isaac.scss
+++ b/src/scss/phy/isaac.scss
@@ -109,6 +109,19 @@ $grid-breakpoints: (
   // xxl: 1400px // we don't need xxl
 );
 
+$element-sizes: (
+    5: 5%, 
+    10: 10%,
+    20: 20%,
+    30: 30%,
+    40: 40%,
+    50: 50%,
+    60: 60%,
+    70: 70%,
+    80: 80%,
+    90: 90%,
+);
+
 $spacer: 1rem !default;
 $spacers: map-merge($spacers, ( // Special Bootstrap variable that is used to generate spacing classes (e.g. pd-md-6)
     6: ($spacer * 6.25) // 100px-ish


### PR DESCRIPTION
Fixes some issues regarding the widths of inline boxes as used by content:

- `w-60`, `w-70`, `w-80` and `w-90` never existed. These classes would not have done anything

- The internal padding on the inputs were too big on small inputs (e.g. w-5, w-10), which caused the input to overflow to the right

- The widths of the containers beneath the element that is given the content-defined class were incorrect.