### PR TITLE
Prevent blank answer submission

### DIFF
--- a/src/app/components/content/IsaacQuestion.tsx
+++ b/src/app/components/content/IsaacQuestion.tsx
@@ -48,7 +48,8 @@ export const IsaacQuestion = withRouter(({doc, location}: {doc: ApiTypes.Questio
     const validationResponseTags = validationResponse?.explanation?.tags;
     const correct = validationResponse?.correct || false;
     const locked = questionPart?.locked;
-    const canSubmit = canAttemptQuestionType.isSuccess && questionPart?.canSubmit && !locked || false;
+    const hasValue = (currentAttempt?.type === "quantity") ? (currentAttempt.value != null && currentAttempt.value != "") : true;
+    const canSubmit = hasValue && canAttemptQuestionType.isSuccess && questionPart?.canSubmit && !locked || false;
     const sigFigsError = isPhy && validationResponseTags?.includes("sig_figs");
     const tooManySigFigsError = sigFigsError && validationResponseTags?.includes("sig_figs_too_many");
     const tooFewSigFigsError = sigFigsError && validationResponseTags?.includes("sig_figs_too_few");


### PR DESCRIPTION
Prevent the submission of a numerical answer that has no value, regardless of whether it has units.

The null and "" cases are both needed depending on whether the question has been previously attempted.