### PR TITLE
Use single difficulties across the Ada site

### DIFF
--- a/src/app/components/elements/PageTitle.tsx
+++ b/src/app/components/elements/PageTitle.tsx
@@ -5,7 +5,9 @@ import {
     filterAudienceViewsByProperties,
     isAda,
     isPhy,
+    simpleDifficultyLabelMap,
     SITE_TITLE,
+    siteSpecific,
     STAGE,
     stageLabelMap,
     useUserViewingContext
@@ -24,6 +26,7 @@ import {DifficultyIcons} from "./svg/DifficultyIcons";
 import classNames from "classnames";
 import {Helmet} from "react-helmet";
 import {Markup} from "./markup";
+import { Difficulty } from "../../../IsaacApiTypes";
 
 function AudienceViewer({audienceViews}: {audienceViews: ViewingContext[]}) {
     const userContext = useUserViewingContext();
@@ -31,17 +34,32 @@ function AudienceViewer({audienceViews}: {audienceViews: ViewingContext[]}) {
     // If there is a possible audience view that is correct for our user context, show that specific one
     const viewsToUse = viewsWithMyStage.length > 0 ? viewsWithMyStage.slice(0, 1) : audienceViews;
     const filteredViews = filterAudienceViewsByProperties(viewsToUse, AUDIENCE_DISPLAY_FIELDS);
+    const difficulties: Difficulty[] = audienceViews.map(v => v.difficulty).filter(v => v !== undefined);
 
-    return <div className="h-subtitle pt-sm-0 mb-sm-0 d-sm-flex">
-        {filteredViews.map((view, i) => <div key={`${view.stage} ${view.difficulty} ${view.examBoard}`} className={classNames("d-flex d-sm-block", {"ms-sm-2": i > 0})}>
-            {view.stage && view.stage !== STAGE.ALL && <div className={classNames("text-center align-self-center", {"fw-regular": isAda})}>
-                {stageLabelMap[view.stage]}
-            </div>}
-            {view.difficulty && <div className={"ms-2 ms-sm-0 text-center"}>
-                <DifficultyIcons difficulty={view.difficulty} />
-            </div>}
-        </div>)}
-    </div>;
+    return siteSpecific(
+        <div className="h-subtitle pt-sm-0 mb-sm-0 d-sm-flex">
+            {filteredViews.map((view, i) => <div key={`${view.stage} ${view.difficulty} ${view.examBoard}`} className={classNames("d-flex d-sm-block", {"ms-sm-2": i > 0})}>
+                {view.stage && view.stage !== STAGE.ALL && <div className={classNames("text-center align-self-center", {"fw-regular": isAda})}>
+                    {stageLabelMap[view.stage]}
+                </div>}
+                {view.difficulty && <div className={"ms-2 ms-sm-0 text-center"}>
+                    <DifficultyIcons difficulty={view.difficulty} />
+                </div>}
+            </div>)}
+        </div>,
+        <div className="h-subtitle pt-sm-0 mb-sm-0 d-sm-flex">
+            <div key={`${difficulties[0]}`} className="d-flex d-sm-block">
+                {difficulties.length > 0 && <>
+                    <div className={classNames("text-center align-self-center", {"fw-regular": isAda})}>
+                        {simpleDifficultyLabelMap[difficulties[0]]}
+                    </div>
+                    <div className={"ms-2 ms-sm-0 text-center"}>
+                        <DifficultyIcons difficulty={difficulties[0]} />
+                    </div>
+                </>}
+            </div>
+        </div>
+    );
 }
 
 export interface PageTitleProps {

--- a/src/app/components/elements/StageAndDifficultySummaryIcons.tsx
+++ b/src/app/components/elements/StageAndDifficultySummaryIcons.tsx
@@ -25,28 +25,16 @@ export function StageAndDifficultySummaryIcons({audienceViews, className, stack}
             }
         </div>,
         <div className={classNames(className, "d-sm-flex flex-wrap mt-1 align-items-baseline", {"justify-content-end": !stack})}>
-            {
-                difficulties.every((v, _i, arr) => v === arr[0])
-                ? <div key={`${difficulties[0]}`} className={classNames("align-self-center d-flex align-items-center")}>
-                    {difficulties.length > 0 && <>
-                        <div className="hierarchy-tags text-center me-2">
-                            {simpleDifficultyLabelMap[difficulties[0]]}
-                        </div>
-                        <div className="hierarchy-tags text-center">
-                            <DifficultyIcons difficulty={difficulties[0]} blank classnames="mt-n1"/>
-                        </div>
-                    </>}
-                </div>
-                : audienceViews.map(view =>
-                <div key={`${view.difficulty}`} className={classNames("align-self-center d-block text-center mx-2 my-1")}>
-                    {view.stage && view.stage !== STAGE.ALL && <div className="hierarchy-tags text-center">
-                        {stageLabelMap[view.stage]}
-                    </div>}
-                    {view.difficulty && <div className="hierarchy-tags text-center">
-                        <DifficultyIcons difficulty={view.difficulty} />
-                    </div>}
-                </div>)
-            }
+            <div key={`${difficulties[0]}`} className={classNames("align-self-center d-flex align-items-center")}>
+                {difficulties.length > 0 && <>
+                    <div className="hierarchy-tags text-center me-2">
+                        {simpleDifficultyLabelMap[difficulties[0]]}
+                    </div>
+                    <div className="hierarchy-tags text-center">
+                        <DifficultyIcons difficulty={difficulties[0]} blank classnames="mt-n1"/>
+                    </div>
+                </>}
+            </div>
         </div>,
    );
 }


### PR DESCRIPTION
Includes tidying up existing QF design code removing the check on whether all difficulties are the same. The content team for Ada do not want to set multiple difficulties that could be inconsistent.
