### PR TITLE
Show warning for double inequalities

### DIFF
--- a/src/app/components/content/IsaacSymbolicQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicQuestion.tsx
@@ -76,7 +76,7 @@ export const symbolicInputValidator = (input: string) => {
     if (/\.[0-9]/.test(input)) {
         errors.push('Please convert decimal numbers to fractions.');
     }
-    if (/[<>=].*[<>=]/.test(input)) {
+    if (/[<>=].+[<>=]/.test(input)) {
         errors.push('We are not able to accept double equations or inequalities.');
     }
     const invTrig = input.match(/(((sin|cos|tan|sec|cosec|cot)(h?))(\^|\*\*)[({]?-1[)}]?)/);

--- a/src/app/components/content/IsaacSymbolicQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicQuestion.tsx
@@ -76,6 +76,9 @@ export const symbolicInputValidator = (input: string) => {
     if (/\.[0-9]/.test(input)) {
         errors.push('Please convert decimal numbers to fractions.');
     }
+    if (/[<>=].*[<>=]/.test(input)) {
+        errors.push('We are not able to accept double equations or inequalities.');
+    }
     const invTrig = input.match(/(((sin|cos|tan|sec|cosec|cot)(h?))(\^|\*\*)[({]?-1[)}]?)/);
     if (invTrig != null) {
         const trigFunction = invTrig[2];

--- a/src/app/components/content/IsaacSymbolicQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicQuestion.tsx
@@ -77,7 +77,7 @@ export const symbolicInputValidator = (input: string) => {
         errors.push('Please convert decimal numbers to fractions.');
     }
     if (/[<>=].+[<>=]/.test(input)) {
-        errors.push('We are not able to accept double equations or inequalities.');
+        errors.push('We are not able to accept double inequalities, and answers will never require them.');
     }
     const invTrig = input.match(/(((sin|cos|tan|sec|cosec|cot)(h?))(\^|\*\*)[({]?-1[)}]?)/);
     if (invTrig != null) {
@@ -88,7 +88,7 @@ export const symbolicInputValidator = (input: string) => {
         else {
             errors.push("To create the inverse " + trigFunction + " function, use 'arc" + trigFunction +"'.");
         }
-    }      
+    }
     if (/[A-Zbd-z](sin|cos|tan|log|ln|sqrt)\(/.test(input)) {
         // A warning about a common mistake naive users may make (no warning for asin or arcsin though):
         return ["Make sure to use spaces or * signs before function names like 'sin' or 'sqrt'!"];

--- a/src/test/components/content/IsaacNumericQuestion.test.tsx
+++ b/src/test/components/content/IsaacNumericQuestion.test.tsx
@@ -1,6 +1,4 @@
-import { numericInputValidator } from "../../../app/components/content/IsaacNumericQuestion";
-import { symbolicInputValidator } from "../../../app/components/content/IsaacSymbolicQuestion";
-import { symbolicLogicInputValidator } from "../../../app/components/content/IsaacSymbolicLogicQuestion";
+import {numericInputValidator} from "../../../app/components/content/IsaacNumericQuestion";
 
 describe("IsaacNumericQuestion", () => {
     it("Numeric Question Validator matches correctly", async () => {
@@ -30,47 +28,10 @@ describe("IsaacNumericQuestion", () => {
         expect(numericInputValidator("5+9e10")).toEqual(['Simplify your answer into a single decimal number.']);
         expect(numericInputValidator(".2/.1")).toEqual(['Simplify your answer into a single decimal number.']);
         expect(numericInputValidator("500-520")).toEqual(['Simplify your answer into a single decimal number.']);
-        
+
         // separators
         expect(numericInputValidator("5 000 000")).toEqual(['Do not use commas or spaces as thousand separators when entering your answer.']);
         expect(numericInputValidator("5,000,000")).toEqual(['Do not use commas or spaces as thousand separators when entering your answer.']);
         expect(numericInputValidator("5,0001e234")).toEqual(['Do not use commas or spaces as thousand separators when entering your answer.']);
-    });
-
-    it("Symbolic Question Validator matches correctly", async () => {
-
-        // empty input
-        expect(symbolicInputValidator("")).toEqual([]);
-
-        // bad chars
-        expect(symbolicInputValidator("4E%14")).toEqual(['Some of the characters you are using are not allowed: %']);
-        expect(symbolicInputValidator("-abcd531efg#")).toEqual(['Some of the characters you are using are not allowed: #']);
-
-        // misc errors
-        expect(symbolicInputValidator("((x+1))")).toEqual([]);
-        expect(symbolicInputValidator("((x+1)))")).toEqual(['You are missing some opening brackets.']);
-        expect(symbolicInputValidator("(((x+1))")).toEqual(['You are missing some closing brackets.']);
-        expect(symbolicInputValidator(".5")).toEqual(['Please convert decimal numbers to fractions.']);
-        expect(symbolicInputValidator("1/2")).toEqual([]);
-        expect(symbolicInputValidator("asin(x)")).toEqual([]);
-        expect(symbolicInputValidator("bsin(x)")).toEqual(["Make sure to use spaces or * signs before function names like 'sin' or 'sqrt'!"]);
-        expect(symbolicInputValidator("a<=b")).toEqual([]);
-        expect(symbolicInputValidator("a<b<c")).toEqual(['We are not able to accept double equations or inequalities.']);
-    });
-
-    it("Symbolic Question Validator matches correctly", async () => {
-
-        // empty input
-        expect(symbolicLogicInputValidator("")).toEqual([]);
-
-        // bad chars
-        expect(symbolicLogicInputValidator("A∧B∨C>+1")).toEqual(['Some of the characters you are using are not allowed: >']);
-
-        // misc errors
-        expect(symbolicLogicInputValidator("A & B & (C | D) & ~E")).toEqual([]);
-        expect(symbolicLogicInputValidator("A \\land B \\land (C \\lor B) \\land \\not E")).toEqual(['LaTeX syntax is not supported.', 'Some of the characters you are using are not allowed: \\']);
-        expect(symbolicLogicInputValidator("((A&B))")).toEqual([]);
-        expect(symbolicLogicInputValidator("((A&B)))")).toEqual(['You are missing some opening brackets.']);
-        expect(symbolicLogicInputValidator("(((A&B))")).toEqual(['You are missing some closing brackets.']);
     });
 });

--- a/src/test/components/content/IsaacNumericQuestion.test.tsx
+++ b/src/test/components/content/IsaacNumericQuestion.test.tsx
@@ -54,6 +54,8 @@ describe("IsaacNumericQuestion", () => {
         expect(symbolicInputValidator("1/2")).toEqual([]);
         expect(symbolicInputValidator("asin(x)")).toEqual([]);
         expect(symbolicInputValidator("bsin(x)")).toEqual(["Make sure to use spaces or * signs before function names like 'sin' or 'sqrt'!"]);
+        expect(symbolicInputValidator("a<=b")).toEqual([]);
+        expect(symbolicInputValidator("a<b<c")).toEqual(['We are not able to accept double equations or inequalities.']);
     });
 
     it("Symbolic Question Validator matches correctly", async () => {

--- a/src/test/components/content/IsaacSymbolicQuestion.test.tsx
+++ b/src/test/components/content/IsaacSymbolicQuestion.test.tsx
@@ -1,0 +1,43 @@
+import {symbolicInputValidator} from "../../../app/components/content/IsaacSymbolicQuestion";
+import {symbolicLogicInputValidator} from "../../../app/components/content/IsaacSymbolicLogicQuestion";
+
+describe("IsaacSymbolicQuestion", () => {
+
+    it("Symbolic Question Validator matches correctly", async () => {
+
+        // empty input
+        expect(symbolicInputValidator("")).toEqual([]);
+
+        // bad chars
+        expect(symbolicInputValidator("4E%14")).toEqual(['Some of the characters you are using are not allowed: %']);
+        expect(symbolicInputValidator("-abcd531efg#")).toEqual(['Some of the characters you are using are not allowed: #']);
+
+        // misc errors
+        expect(symbolicInputValidator("((x+1))")).toEqual([]);
+        expect(symbolicInputValidator("((x+1)))")).toEqual(['You are missing some opening brackets.']);
+        expect(symbolicInputValidator("(((x+1))")).toEqual(['You are missing some closing brackets.']);
+        expect(symbolicInputValidator(".5")).toEqual(['Please convert decimal numbers to fractions.']);
+        expect(symbolicInputValidator("1/2")).toEqual([]);
+        expect(symbolicInputValidator("asin(x)")).toEqual([]);
+        expect(symbolicInputValidator("bsin(x)")).toEqual(["Make sure to use spaces or * signs before function names like 'sin' or 'sqrt'!"]);
+        expect(symbolicInputValidator("a<=b")).toEqual([]);
+        expect(symbolicInputValidator("a == 3")).toEqual([]);
+        expect(symbolicInputValidator("a<b<c")).toEqual(['We are not able to accept double inequalities, and answers will never require them.']);
+    });
+
+    it("Symbolic Question Validator matches correctly", async () => {
+
+        // empty input
+        expect(symbolicLogicInputValidator("")).toEqual([]);
+
+        // bad chars
+        expect(symbolicLogicInputValidator("A∧B∨C>+1")).toEqual(['Some of the characters you are using are not allowed: >']);
+
+        // misc errors
+        expect(symbolicLogicInputValidator("A & B & (C | D) & ~E")).toEqual([]);
+        expect(symbolicLogicInputValidator("A \\land B \\land (C \\lor B) \\land \\not E")).toEqual(['LaTeX syntax is not supported.', 'Some of the characters you are using are not allowed: \\']);
+        expect(symbolicLogicInputValidator("((A&B))")).toEqual([]);
+        expect(symbolicLogicInputValidator("((A&B)))")).toEqual(['You are missing some opening brackets.']);
+        expect(symbolicLogicInputValidator("(((A&B))")).toEqual(['You are missing some closing brackets.']);
+    });
+});


### PR DESCRIPTION
If a symbolic input contains more than one equals/inequality sign, show instant feedback that this is not allowed.