### PR TITLE
Remove ampersands from report URLs

### DIFF
--- a/src/app/components/elements/ReportAccordionButton.tsx
+++ b/src/app/components/elements/ReportAccordionButton.tsx
@@ -22,7 +22,7 @@ export const ReportAccordionButton = ({pageId, sectionId, sectionTitle, sectionI
             params +=`&page=${pageId}`
             // In absence of an ID, the section titles are likely most useful in locating the problem
             if (sectionTitle) {
-                params +=`&section=${sectionTitle}`
+                params +=`&section=${sectionTitle.replaceAll("&", "_")}`
             }
         }
         return params

--- a/src/app/components/elements/ReportAccordionButton.tsx
+++ b/src/app/components/elements/ReportAccordionButton.tsx
@@ -22,7 +22,7 @@ export const ReportAccordionButton = ({pageId, sectionId, sectionTitle, sectionI
             params +=`&page=${pageId}`
             // In absence of an ID, the section titles are likely most useful in locating the problem
             if (sectionTitle) {
-                params +=`&section=${sectionTitle.replaceAll("&", "_")}`
+                params +=`&section=${encodeURIComponent(sectionTitle)}`
             }
         }
         return params

--- a/src/app/services/userViewingContext.ts
+++ b/src/app/services/userViewingContext.ts
@@ -135,7 +135,7 @@ export function useUserViewingContext(): UseUserContextReturnType {
 
     // Replace query params
     useEffect(() => {
-        const actualParams = queryString.parse(window.location.search);
+        const actualParams = queryString.parse(window.location.search, {decode: false});
         if (stage !== actualParams.stage || (!isPhy && examBoard !== actualParams.examBoard)) {
             try {
                 history.replace({


### PR DESCRIPTION
When the report flag is clicked on a specific question part, ensure the section title passed to the report page's
URL does not contain ampersands.