### PR TITLE
Close modals on page change

### DIFF
--- a/src/app/state/actions/index.tsx
+++ b/src/app/state/actions/index.tsx
@@ -745,6 +745,7 @@ export const redirectTo = (path: string) => {
 
 export const registerPageChange = (path: string) => {
     store.dispatch(routerPageChange(path));
+    store.dispatch(closeActiveModal());
 };
 
 export const handleServerError = () => {


### PR DESCRIPTION
When the page is changed (e.g. using the browser back button), close the active modal. This fixes cases where a modal remains open and gets stuck on 'loading' after a page change.

This assumes there are no cases where a modal should stay open after a page change.