### PR TITLE
Phy signup preferences form improvements

### DIFF
--- a/src/app/components/elements/inputs/TrueFalseRadioInput.tsx
+++ b/src/app/components/elements/inputs/TrueFalseRadioInput.tsx
@@ -44,5 +44,5 @@ export function TrueFalseRadioInput({id, stateObject, propertyName, setStateFunc
         {invalid && <div id={`${id}-feedback`} className="required-before d-flex flex-nowrap text-center">
             required
         </div>}
-    </RS.FormGroup>
+    </RS.FormGroup>;
 }

--- a/src/app/components/elements/inputs/UserContextAccountInput.tsx
+++ b/src/app/components/elements/inputs/UserContextAccountInput.tsx
@@ -178,11 +178,6 @@ export function UserContextAccountInput({
         <div id="user-context-selector" className={classNames({"d-flex flex-wrap": isPhy})}>
 
             {userContexts.length ? userContexts.map((userContext, index) => {
-                const showPlusOption = tutorOrAbove &&
-                    index === userContexts.length - 1 &&
-                    // at least one exam board for the potential stage
-                    getFilteredStageOptions({byUserContexts: userContexts, hideFurtherA: true}).length > 0;
-
                 return <FormGroup key={index}>
                     <UserContextRow
                         userContext={userContext} showNullStageOption={userContexts.length <= 1} submissionAttempted={submissionAttempted}
@@ -220,7 +215,7 @@ export function UserContextAccountInput({
                     />
                 </Label>}
             </>}
-            {!isAda && validateUserContexts(userContexts) && <div className="mb-3 ms-2 align-content-center remove-stage-container">
+            {!isAda && tutorOrAbove && validateUserContexts(userContexts) && <div className="mb-3 ms-2 align-content-center remove-stage-container">
                 <Button
                     aria-label="Add stage"
                     className={`ms-2 align-middle btn-plus float-none pointer-cursor bg-white`}

--- a/src/app/components/pages/RegistrationSetPreferences.tsx
+++ b/src/app/components/pages/RegistrationSetPreferences.tsx
@@ -55,7 +55,7 @@ export const RegistrationSetPreferences = () => {
 
     const userPreferencesToUpdate = {
         EMAIL_PREFERENCE: emailPreferences, BOOLEAN_NOTATION: booleanNotation, DISPLAY_SETTING: displaySettings
-    }
+    };
 
     function submit(event: React.FormEvent<HTMLFormElement>) {
         event.preventDefault();
@@ -64,10 +64,11 @@ export const RegistrationSetPreferences = () => {
         if (user && isLoggedIn(user) && allRequiredInformationIsPresent(userToUpdate, userPreferencesToUpdate, userContexts)) {
             dispatch(errorSlice.actions.clearError());
             dispatch(updateCurrentUser(userToUpdate, userPreferencesToUpdate, userContexts, null, user, true));
+            if (isPhy) continueToAfterAuthPath();
         }
-
-        if (isPhy) continueToAfterAuthPath();
     }
+
+    const canSavePreferences = !isPhy || allRequiredInformationIsPresent(userToUpdate, userPreferencesToUpdate, userContexts);
 
     return <Container>
         <TitleAndBreadcrumb currentPageTitle={`Customise your account`} className="mb-4" />
@@ -92,7 +93,7 @@ export const RegistrationSetPreferences = () => {
                             <UserContextAccountInput user={userToUpdate} userContexts={userContexts}
                                 setUserContexts={setUserContexts} setBooleanNotation={setBooleanNotation}
                                 displaySettings={displaySettings} setDisplaySettings={setDisplaySettings}
-                                submissionAttempted={submissionAttempted} required={false} />
+                                submissionAttempted={submissionAttempted} required={isPhy} />
                             <hr />
 
                             {isAda && <>
@@ -112,11 +113,11 @@ export const RegistrationSetPreferences = () => {
                             />
                             <hr />
                             <Row>
-                                <Col xs={12} sm={6} lg={6} className={classNames("d-flex justify-content-center", {"justify-content-lg-end": isAda})}>
+                                <Col xs={12} sm={6} className={classNames("d-flex justify-content-center", {"justify-content-lg-end": isAda})}>
                                     <Button className={`my-2 px-2 ${siteSpecific("px-lg-0", "px-lg-3")}`} outline color="secondary" onClick={continueToAfterAuthPath}>I&apos;ll do this later</Button>
                                 </Col>
-                                <Col xs={12} sm={6} lg={6} className="d-flex justify-content-center">
-                                    <Button type="submit" className={`btn btn-primary my-2 px-2", ${siteSpecific("px-lg-0", "px-lg-3")}`}>Save preferences</Button>
+                                <Col xs={12} sm={6} className="d-flex justify-content-center">
+                                    <Button type="submit" className={`btn btn-primary my-2 px-2", ${siteSpecific("px-lg-0", "px-lg-3")}`} disabled={!canSavePreferences}>Save preferences</Button>
                                 </Col>
                             </Row>
                         </Form>

--- a/src/app/services/validation.ts
+++ b/src/app/services/validation.ts
@@ -110,7 +110,7 @@ export function allRequiredInformationIsPresent(user?: Immutable<ValidationUser>
     return user && userPreferences && validateName(user.givenName) && validateName(user.familyName)
         && validateUserContexts(userContexts, isAda)
         && (userPreferences.EMAIL_PREFERENCE === null || validateEmailPreferences(userPreferences.EMAIL_PREFERENCE))
-        && (isPhy || (!isTeacherOrAbove(user) || validateUserSchool(user)))
+        && (isPhy || (!isTeacherOrAbove(user) || validateUserSchool(user)));
 }
 
 export function validateBookingSubmission(event: AugmentedEvent, user: Immutable<UserSummaryWithEmailAddressDTO>, additionalInformation: AdditionalInformation) {


### PR DESCRIPTION
Applies changes to the final page on signup:
- Makes all fields mandatory on physics
- Disable "set preferences" button if not complete ("skip" is always accessible)