### PR TITLE
Adds warning when setting same quiz to class multiple times

### DIFF
--- a/src/app/components/elements/modals/QuizSettingModal.tsx
+++ b/src/app/components/elements/modals/QuizSettingModal.tsx
@@ -1,5 +1,5 @@
 import React, {ChangeEvent, useState} from "react";
-import {ContentSummaryDTO, IsaacQuizDTO, QuizFeedbackMode} from "../../../../IsaacApiTypes";
+import {ContentSummaryDTO, IsaacQuizDTO, QuizAssignmentDTO, QuizFeedbackMode} from "../../../../IsaacApiTypes";
 import {
     AppDispatch,
     closeActiveModal,
@@ -47,6 +47,8 @@ interface QuizSettingModalProps {
     feedbackMode?: QuizFeedbackMode | null;
 }
 
+let allQuizAssignments: QuizAssignmentDTO[] | undefined;
+
 export function QuizSettingModal({quiz, dueDate: initialDueDate, scheduledStartDate: initialScheduledStartDate, feedbackMode: initialFeedbackMode}: QuizSettingModalProps) {
     const dispatch: AppDispatch = useAppDispatch();
     const groupsQuery = useGetGroupsQuery(false);
@@ -60,7 +62,7 @@ export function QuizSettingModal({quiz, dueDate: initialDueDate, scheduledStartD
     const [scheduledStartDate, setScheduledStartDate] = useState<Date | null>(initialScheduledStartDate ?? null);
     const [feedbackMode, setFeedbackMode] = useState<QuizFeedbackMode | null>(initialFeedbackMode ?? null);
 
-    const allQuizAssignments = useGetQuizAssignmentsSetByMeQuery().data;
+    allQuizAssignments = !allQuizAssignments ? useGetQuizAssignmentsSetByMeQuery().data : allQuizAssignments;
 
     const yearRange = range(currentYear, currentYear + 5);
 
@@ -85,6 +87,7 @@ export function QuizSettingModal({quiz, dueDate: initialDueDate, scheduledStartD
                 setDueDate(null);
                 setScheduledStartDate(null);
                 setFeedbackMode(null);
+                allQuizAssignments = undefined;
             }
         });
     }


### PR DESCRIPTION
Previously on re-submitting an active test, a toast would warn that _"You cannot reassign a test until the due date has passed."_ 

This change makes it fail earlier (on the front-end), displaying red warning text below the "**...group(s)**" input and disabling the "**Set Test**" button.

---

I am making use of a top-level `let` as a workaround to stop polling the backend on every change to the Set Tests modal. Since the value only changes on successfully setting a test, it does not need a re-render so this should be fine - however I'm very open to suggestions for another solution.