### PR TITLE
Add logged event for Question Finder search

### DIFF
--- a/src/app/components/pages/QuestionFinder.tsx
+++ b/src/app/components/pages/QuestionFinder.tsx
@@ -216,7 +216,7 @@ export const QuestionFinder = withRouter(({location}: RouteComponentProps) => {
 
             dispatch(logAction({
                 type: "SEARCH_QUESTIONS",
-                events: {searchString, topics, examBoards, book, stages, difficulties, startIndex}
+                events: {searchString, topics, book, stages, difficulties, examBoards, questionStatuses, startIndex}
             }));
         }, 250),
         [nothingToSearchFor]

--- a/src/app/components/pages/QuestionFinder.tsx
+++ b/src/app/components/pages/QuestionFinder.tsx
@@ -1,47 +1,40 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState} from "react";
-import {
-    AppState,
-    clearQuestionSearch, logAction,
-    searchQuestions,
-    useAppDispatch,
-    useAppSelector
-} from "../../state";
+import React, {useCallback, useEffect, useMemo, useState} from "react";
+import {AppState, clearQuestionSearch, logAction, searchQuestions, useAppDispatch, useAppSelector} from "../../state";
 import debounce from "lodash/debounce";
 import {
-    tags,
+    arrayFromPossibleCsv,
     EXAM_BOARD_NULL_OPTIONS,
     getFilteredExamBoardOptions,
     isAda,
     isPhy,
     Item,
-    logEvent,
+    itemiseTag,
+    SEARCH_CHAR_LENGTH_LIMIT,
+    SEARCH_RESULTS_PER_PAGE,
     siteSpecific,
     STAGE,
-    useUserViewingContext,
     STAGE_NULL_OPTIONS,
-    useQueryParams,
-    arrayFromPossibleCsv,
-    toSimpleCSV,
     TAG_ID,
-    itemiseTag,
-    SEARCH_RESULTS_PER_PAGE,
-    SEARCH_CHAR_LENGTH_LIMIT,
+    tags,
+    toSimpleCSV,
+    useQueryParams,
+    useUserViewingContext,
 } from "../../services";
 import {ContentSummaryDTO, Difficulty, ExamBoard} from "../../../IsaacApiTypes";
 import {IsaacSpinner} from "../handlers/IsaacSpinner";
-import { RouteComponentProps, useHistory, withRouter } from "react-router";
-import { LinkToContentSummaryList } from "../elements/list-groups/ContentSummaryListGroupItem";
-import { ShowLoading } from "../handlers/ShowLoading";
-import { TitleAndBreadcrumb } from "../elements/TitleAndBreadcrumb";
-import { MetaDescription } from "../elements/MetaDescription";
-import { CanonicalHrefElement } from "../navigation/CanonicalHrefElement";
+import {RouteComponentProps, useHistory, withRouter} from "react-router";
+import {LinkToContentSummaryList} from "../elements/list-groups/ContentSummaryListGroupItem";
+import {ShowLoading} from "../handlers/ShowLoading";
+import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
+import {MetaDescription} from "../elements/MetaDescription";
+import {CanonicalHrefElement} from "../navigation/CanonicalHrefElement";
 import classNames from "classnames";
 import queryString from "query-string";
-import { PageFragment } from "../elements/PageFragment";
+import {PageFragment} from "../elements/PageFragment";
 import {RenderNothing} from "../elements/RenderNothing";
-import { Button, Card, CardBody, CardHeader, Col, Container, Input, InputGroup, Label, Row } from "reactstrap";
-import { QuestionFinderFilterPanel } from "../elements/panels/QuestionFinderFilterPanel";
-import { Tier, TierID } from "../elements/svg/HierarchyFilter";
+import {Button, Card, CardBody, CardHeader, Col, Container, Input, InputGroup, Label, Row} from "reactstrap";
+import {QuestionFinderFilterPanel} from "../elements/panels/QuestionFinderFilterPanel";
+import {Tier, TierID} from "../elements/svg/HierarchyFilter";
 
 export interface QuestionStatus {
     notAttempted: boolean;

--- a/src/app/components/pages/QuestionFinder.tsx
+++ b/src/app/components/pages/QuestionFinder.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState} from "react";
 import {
     AppState,
-    clearQuestionSearch,
+    clearQuestionSearch, logAction,
     searchQuestions,
     useAppDispatch,
     useAppSelector
@@ -74,7 +74,6 @@ export const QuestionFinder = withRouter(({location}: RouteComponentProps) => {
     const userContext = useUserViewingContext();
     const params: {[key: string]: string | string[] | undefined} = useQueryParams(false);
     const history = useHistory();
-    const eventLog = useRef<object[]>([]).current; // persist state but do not rerender on mutation
 
     const [searchTopics, setSearchTopics] = useState<string[]>(arrayFromPossibleCsv(params.topics));
     const [searchQuery, setSearchQuery] = useState<string>(params.query ? (params.query instanceof Array ? params.query[0] : params.query) : "");
@@ -192,7 +191,10 @@ export const QuestionFinder = withRouter(({location}: RouteComponentProps) => {
                 limit: SEARCH_RESULTS_PER_PAGE + 1 // request one more than we need, as to know if there are more results
             }));
 
-            logEvent(eventLog,"SEARCH_QUESTIONS", {searchString, topics, examBoards, book, stages, difficulties, startIndex});
+            dispatch(logAction({
+                type: "SEARCH_QUESTIONS",
+                events: {searchString, topics, examBoards, book, stages, difficulties, startIndex}
+            }));
         }, 250),
         [nothingToSearchFor]
     );

--- a/src/app/components/pages/QuestionFinder.tsx
+++ b/src/app/components/pages/QuestionFinder.tsx
@@ -215,7 +215,7 @@ export const QuestionFinder = withRouter(({location}: RouteComponentProps) => {
             }));
 
             dispatch(logAction({
-                type: "SEARCH_QUESTIONS",
+                type: "QUESTION_FINDER_SEARCH",
                 events: {searchString, topics, book, stages, difficulties, examBoards, questionStatuses, startIndex}
             }));
         }, 250),

--- a/src/app/components/pages/QuestionFinder.tsx
+++ b/src/app/components/pages/QuestionFinder.tsx
@@ -215,9 +215,7 @@ export const QuestionFinder = withRouter(({location}: RouteComponentProps) => {
             }));
 
             dispatch(logAction({
-                type: "QUESTION_FINDER_SEARCH",
-                events: {searchString, topics, book, stages, difficulties, examBoards, questionStatuses, startIndex}
-            }));
+                type: "QUESTION_FINDER_SEARCH", searchString, ...filterParams, book, stages, difficulties, examBoards, questionStatuses, startIndex}));
         }, 250),
         [nothingToSearchFor]
     );


### PR DESCRIPTION
Adds a new logged event for Question Finder search, for example:

`QUESTION_FINDER_SEARCH`| ... | `"{""events"": {""book"": [], ""stages"": [""gcse""], ""topics"": [], ""examBoards"": [""ocr""], ""startIndex"": 0, ""difficulties"": [], ""searchString"": ""e"", ""questionStatuses"": {""complete"": false, ""tryAgain"": false, ""notAttempted"": false}}}"`
