### PR TITLE
Move user context tooltip

### DIFF
--- a/src/app/components/elements/inputs/UserContextPicker.tsx
+++ b/src/app/components/elements/inputs/UserContextPicker.tsx
@@ -116,6 +116,21 @@ export const UserContextPicker = ({className, hideLabels = true}: {className?: s
                         }
                     </Input>
                 </>}
+                
+                {showUnusualContextMessage && <div className="mt-2 ms-1">
+                    <span id={`unusual-viewing-context-explanation`} className="icon-help mx-1" />
+                    <RS.UncontrolledTooltip placement="bottom" target={`unusual-viewing-context-explanation`}>
+                        You are seeing {stageLabelMap[userContext.stage]} {isAda ? examBoardLabelMap[userContext.examBoard] : ""}{" "}
+                        content, which is different to your account settings. <br />
+                        {unusual.stage && unusual.examBoard && <>
+                            {userContext.explanation.stage === userContext.explanation.examBoard ?
+                                `The stage and exam board were specified by your ${userContext.explanation.stage}.` :
+                                `The stage was specified by your ${userContext.explanation.stage} and the exam board by your ${userContext.explanation.examBoard}.`}
+                        </>}
+                        {unusual.stage && !unusual.examBoard && `The stage was specified by your ${userContext.explanation.stage}.`}
+                        {unusual.examBoard && !unusual.stage && `The exam board was specified by your ${userContext.explanation.examBoard}.`}
+                    </RS.UncontrolledTooltip>
+                </div>}
             </FormGroup>
         </RS.Row>
         
@@ -131,20 +146,5 @@ export const UserContextPicker = ({className, hideLabels = true}: {className?: s
                 />
             </FormGroup>
         </RS.Row>}
-
-        {showUnusualContextMessage && <div className="mt-2 ms-1">
-            <span id={`unusual-viewing-context-explanation`} className="icon-help mx-1" />
-            <RS.UncontrolledTooltip placement="bottom" target={`unusual-viewing-context-explanation`}>
-                You are seeing {stageLabelMap[userContext.stage]} {isAda ? examBoardLabelMap[userContext.examBoard] : ""}{" "}
-                content, which is different to your account settings. <br />
-                {unusual.stage && unusual.examBoard && <>
-                    {userContext.explanation.stage === userContext.explanation.examBoard ?
-                        `The stage and exam board were specified by your ${userContext.explanation.stage}.` :
-                        `The stage was specified by your ${userContext.explanation.stage} and the exam board by your ${userContext.explanation.examBoard}.`}
-                </>}
-                {unusual.stage && !unusual.examBoard && `The stage was specified by your ${userContext.explanation.stage}.`}
-                {unusual.examBoard && !unusual.stage && `The exam board was specified by your ${userContext.explanation.examBoard}.`}
-            </RS.UncontrolledTooltip>
-        </div>}
     </RS.Col>;
 };


### PR DESCRIPTION
The 'unusual viewing context' tooltip icon shows in different places depending on account type. This should move it to always be next to the stage (and exam board) selector.