### PR TITLE
Reduce bundle size

### DIFF
--- a/src/app/components/elements/Accordion.tsx
+++ b/src/app/components/elements/Accordion.tsx
@@ -22,7 +22,7 @@ import classNames from "classnames";
 import {Markup} from "./markup";
 import {ReportAccordionButton} from "./ReportAccordionButton";
 import preventOverflow from '@popperjs/core/lib/modifiers/preventOverflow.js';
-import { debounce } from "lodash";
+import debounce from "lodash/debounce";
 
 interface AccordionsProps extends RouteComponentProps {
     id?: string;

--- a/src/app/components/elements/inputs/DobInput.tsx
+++ b/src/app/components/elements/inputs/DobInput.tsx
@@ -3,8 +3,8 @@ import * as RS from "reactstrap";
 import {ValidationUser} from "../../../../IsaacAppTypes";
 import {isDefined, isDobOldEnoughForSite, siteSpecific} from "../../../services";
 import {currentYear, DateInput} from "./DateInput";
-import { Immutable } from "immer";
-import { range } from "lodash";
+import {Immutable} from "immer";
+import range from "lodash/range";
 
 interface DobInputProps {
     userToUpdate: Immutable<ValidationUser>;

--- a/src/app/components/elements/inputs/UserContextAccountInput.tsx
+++ b/src/app/components/elements/inputs/UserContextAccountInput.tsx
@@ -20,7 +20,7 @@ import {v4 as uuid_v4} from "uuid";
 import classNames from "classnames";
 import {Immutable} from "immer";
 import {StyledDropdown} from "./DropdownInput";
-import { isUndefined } from "lodash";
+import isUndefined from "lodash/isUndefined";
 import { StyledCheckbox } from "./StyledCheckbox";
 
 interface UserContextRowProps {

--- a/src/app/components/elements/modals/GameboardCreatedModal.tsx
+++ b/src/app/components/elements/modals/GameboardCreatedModal.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {closeActiveModal, getRTKQueryErrorMessage, useAppDispatch} from "../../../state";
 import {Link} from "react-router-dom";
 import {Button, Col, Label, Row} from "reactstrap";
-import {FetchBaseQueryError} from "@reduxjs/toolkit/dist/query/fetchBaseQuery";
+import {FetchBaseQueryError} from "@reduxjs/toolkit/query";
 import {SerializedError} from "@reduxjs/toolkit";
 import {PATHS, siteSpecific} from "../../../services";
 

--- a/src/app/components/elements/panels/AddUsersToBooking.tsx
+++ b/src/app/components/elements/panels/AddUsersToBooking.tsx
@@ -12,7 +12,7 @@ import {atLeastOne, formatManageBookingActionButtonMessage, zeroOrLess} from "..
 import {DateString} from "../DateString";
 import {userBookingModal} from "../modals/UserBookingModal";
 import {AdminSearchEndpointParams} from "../../../../IsaacApiTypes";
-import produce from "immer";
+import {produce} from "immer";
 import {AugmentedEvent} from "../../../../IsaacAppTypes";
 
 interface AddUsersToBookingProps {

--- a/src/app/components/elements/panels/ManageExistingBookings.tsx
+++ b/src/app/components/elements/panels/ManageExistingBookings.tsx
@@ -24,7 +24,7 @@ import {
 import {PotentialUser, UserSchoolLookup} from "../../../../IsaacAppTypes";
 import {BookingStatus, EventBookingDTO, UserSummaryWithEmailAddressDTO} from "../../../../IsaacApiTypes";
 import {DateString} from "../DateString";
-import produce from "immer";
+import {produce} from "immer";
 import {RenderNothing} from "../RenderNothing";
 
 interface ManageExistingBookingsProps {

--- a/src/app/components/handlers/ShowLoadingQuery.tsx
+++ b/src/app/components/handlers/ShowLoadingQuery.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import {FetchBaseQueryError} from "@reduxjs/toolkit/dist/query/fetchBaseQuery";
+import {FetchBaseQueryError} from "@reduxjs/toolkit/query";
 import {SerializedError} from "@reduxjs/toolkit";
 import {IsaacSpinner} from "./IsaacSpinner";
 import {isDefined, isFound, NO_CONTENT, NOT_FOUND, SITE_TITLE, WEBMASTER_EMAIL} from "../../services";

--- a/src/app/components/pages/AdminStats.tsx
+++ b/src/app/components/pages/AdminStats.tsx
@@ -4,7 +4,7 @@ import * as RS from "reactstrap";
 import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
 import {ShowLoading} from "../handlers/ShowLoading";
 import {isDefined, siteSpecific} from "../../services";
-import produce from "immer";
+import {produce} from "immer";
 
 function asPercentage(value: number | undefined, total: number)  {
     return value !== undefined ? Math.round(100 * value / total) : 0;

--- a/src/app/components/pages/AdminUserManager.tsx
+++ b/src/app/components/pages/AdminUserManager.tsx
@@ -21,7 +21,7 @@ import {ADMIN_CRUMB, isAdmin, isDefined, isPhy} from "../../services";
 import {Link} from "react-router-dom";
 import classNames from "classnames";
 import {ShowLoading} from "../handlers/ShowLoading";
-import produce from "immer";
+import {produce} from "immer";
 import {skipToken} from "@reduxjs/toolkit/query";
 
 export const AdminUserManager = () => {

--- a/src/app/components/pages/quizzes/QuizPreview.tsx
+++ b/src/app/components/pages/quizzes/QuizPreview.tsx
@@ -13,7 +13,7 @@ import {Spacer} from "../../elements/Spacer";
 import {TitleAndBreadcrumb} from "../../elements/TitleAndBreadcrumb";
 import {Alert, Button, Container} from "reactstrap";
 import {ShowLoadingQuery} from "../../handlers/ShowLoadingQuery";
-import {FetchBaseQueryError} from "@reduxjs/toolkit/dist/query/fetchBaseQuery";
+import {FetchBaseQueryError} from "@reduxjs/toolkit/query";
 import {SerializedError} from "@reduxjs/toolkit";
 
 const QuizFooter = ({page, pageLink, ...rest}: QuizAttemptProps) =>

--- a/src/app/components/pages/quizzes/QuizTeacherFeedback.tsx
+++ b/src/app/components/pages/quizzes/QuizTeacherFeedback.tsx
@@ -37,7 +37,7 @@ import {
     Row,
     UncontrolledButtonDropdown
 } from "reactstrap";
-import {FetchBaseQueryError} from "@reduxjs/toolkit/dist/query/fetchBaseQuery";
+import {FetchBaseQueryError} from "@reduxjs/toolkit/query";
 import {SerializedError} from "@reduxjs/toolkit";
 import {ShowLoadingQuery} from "../../handlers/ShowLoadingQuery";
 

--- a/src/app/components/site/cs/RoutesCS.tsx
+++ b/src/app/components/site/cs/RoutesCS.tsx
@@ -27,7 +27,6 @@ import {RegistrationSetPreferences} from "../../pages/RegistrationSetPreferences
 import {RegistrationSuccess} from "../../pages/RegistrationSuccess";
 import {Events} from "../../pages/Events";
 import {RedirectToEvent} from "../../navigation/RedirectToEvent";
-import { QuestionFinder } from "../../pages/QuestionFinder";
 import { OnlineCourses } from "../../pages/OnlineCourses";
 import {ExamSpecificationsDirectory} from "../../pages/ExamSpecificationsDirectory";
 

--- a/src/app/components/site/cs/RoutesCS.tsx
+++ b/src/app/components/site/cs/RoutesCS.tsx
@@ -26,13 +26,13 @@ import {RegistrationTeacherConnect} from "../../pages/RegistrationTeacherConnect
 import {RegistrationSetPreferences} from "../../pages/RegistrationSetPreferences";
 import {RegistrationSuccess} from "../../pages/RegistrationSuccess";
 import {Events} from "../../pages/Events";
-import EventDetails from "../../pages/EventDetails";
 import {RedirectToEvent} from "../../navigation/RedirectToEvent";
 import { QuestionFinder } from "../../pages/QuestionFinder";
 import { OnlineCourses } from "../../pages/OnlineCourses";
 import {ExamSpecificationsDirectory} from "../../pages/ExamSpecificationsDirectory";
 
 const Equality = lazy(() => import('../../pages/Equality'));
+const EventDetails = lazy(() => import('../../pages/EventDetails'));
 
 let key = 0;
 export const RoutesCS = [

--- a/src/app/services/history.ts
+++ b/src/app/services/history.ts
@@ -1,6 +1,6 @@
 import {createBrowserHistory} from "history";
 import {registerPageChange} from "../state";
-import {TypeGuard} from "@reduxjs/toolkit/dist/tsHelpers";
+import type {TypeGuard} from "@reduxjs/toolkit/dist/tsHelpers";
 import {useEffect, useState} from "react";
 import {useLocation} from "react-router-dom";
 

--- a/src/app/state/actions/quizzes.tsx
+++ b/src/app/state/actions/quizzes.tsx
@@ -12,7 +12,7 @@ import {
 } from "../index";
 import {ContentSummaryDTO, IsaacQuizDTO, QuizFeedbackMode} from "../../../IsaacApiTypes";
 import {QuizSettingModal} from "../../components/elements/modals/QuizSettingModal";
-import { debounce } from "lodash";
+import debounce from "lodash/debounce";
 
 export const showQuizSettingModal = (quiz: ContentSummaryDTO | IsaacQuizDTO, dueDate?: Date | null, scheduledStartDate?: Date | null, feedbackMode?: QuizFeedbackMode | null) => (dispatch: AppDispatch) => {
     dispatch(openActiveModal({

--- a/src/app/state/reducers/quizState.ts
+++ b/src/app/state/reducers/quizState.ts
@@ -4,7 +4,7 @@ import {
     ChoiceDTO,
     QuizAttemptDTO,
 } from "../../../IsaacApiTypes";
-import produce, {Immutable} from "immer";
+import {produce, Immutable} from "immer";
 
 const updateQuizAttemptQuestion = (questionId: string, questionAttempt: Immutable<ChoiceDTO>) => produce<{attempt: QuizAttemptDTO}>((quizAttempt) => {
     const quizQuestions = extractQuestions(quizAttempt?.attempt.quiz);

--- a/src/app/state/slices/api/assignments.ts
+++ b/src/app/state/slices/api/assignments.ts
@@ -8,7 +8,7 @@ import {
 } from "../../../../IsaacAppTypes";
 import {GameboardDTO, IsaacQuizDTO, RegisteredUserDTO} from "../../../../IsaacApiTypes";
 import sortBy from "lodash/sortBy";
-import { skipToken } from "@reduxjs/toolkit/dist/query";
+import { skipToken } from "@reduxjs/toolkit/query";
 
 // Returns summary assignment objects without data on gameboard contents - much faster to request these from the API
 // than those returned from useGroupAssignments

--- a/src/app/state/slices/api/assignments.ts
+++ b/src/app/state/slices/api/assignments.ts
@@ -8,7 +8,6 @@ import {
 } from "../../../../IsaacAppTypes";
 import {GameboardDTO, IsaacQuizDTO, RegisteredUserDTO} from "../../../../IsaacApiTypes";
 import sortBy from "lodash/sortBy";
-import produce from "immer";
 import { skipToken } from "@reduxjs/toolkit/dist/query";
 
 // Returns summary assignment objects without data on gameboard contents - much faster to request these from the API

--- a/src/app/state/slices/api/baseApi.ts
+++ b/src/app/state/slices/api/baseApi.ts
@@ -1,4 +1,4 @@
-import {createApi} from "@reduxjs/toolkit/dist/query/react";
+import {createApi} from "@reduxjs/toolkit/query/react";
 import {
     isaacBaseQuery,
 } from "../../index";

--- a/src/app/state/slices/api/utils.ts
+++ b/src/app/state/slices/api/utils.ts
@@ -22,13 +22,14 @@ import {
     UserSummaryWithEmailAddressDTO
 } from "../../../../IsaacApiTypes";
 import {BaseQueryFn} from "@reduxjs/toolkit/query";
-import {FetchArgs, FetchBaseQueryArgs, FetchBaseQueryError} from "@reduxjs/toolkit/dist/query/fetchBaseQuery";
-import {fetchBaseQuery} from "@reduxjs/toolkit/dist/query/react";
+import {FetchArgs, FetchBaseQueryError} from "@reduxjs/toolkit/query";
+import type {FetchBaseQueryArgs} from "@reduxjs/toolkit/dist/query/fetchBaseQuery";
+import {fetchBaseQuery} from "@reduxjs/toolkit/query";
 import {errorSlice} from "../internalAppState";
 import {SerializedError} from "@reduxjs/toolkit";
 import {Dispatch} from "redux";
-import {PromiseWithKnownReason} from "@reduxjs/toolkit/dist/query/core/buildMiddleware/types";
-import {showErrorToast, showRTKQueryErrorToastIfNeeded, showSuccessToast} from "../../actions/popups";
+import type {PromiseWithKnownReason} from "@reduxjs/toolkit/dist/query/core/buildMiddleware/types";
+import {showRTKQueryErrorToastIfNeeded, showSuccessToast} from "../../actions/popups";
 
 // This is used by default as the `baseQuery` of our API slice
 export const isaacBaseQuery: BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError> = async (args, api, extraOptions) => {

--- a/src/app/state/slices/api/utils.ts
+++ b/src/app/state/slices/api/utils.ts
@@ -6,7 +6,7 @@ import {
     NO_CONTENT,
     API_REQUEST_FAILURE_MESSAGE
 } from "../../../services";
-import produce from "immer";
+import {produce} from "immer";
 import {
     AuthorisedAssignmentProgress,
     AppGroup,

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -14,7 +14,7 @@ import {
     mockUserPreferences
 } from "./data";
 import {API_PATH} from "../app/services";
-import produce from "immer";
+import {produce} from "immer";
 import {School} from "../IsaacAppTypes";
 
 export const handlers = [

--- a/src/test/testUtils.tsx
+++ b/src/test/testUtils.tsx
@@ -3,7 +3,7 @@ import {render} from "@testing-library/react/pure";
 import {server} from "../mocks/server";
 import {rest, RestHandler} from "msw";
 import {ACCOUNT_TAB, ACTION_TYPE, API_PATH, isDefined, isPhy} from "../app/services";
-import produce from "immer";
+import {produce} from "immer";
 import {mockUser} from "../mocks/data";
 import {isaacApi, requestCurrentUser, store} from "../app/state";
 import {Provider} from "react-redux";


### PR DESCRIPTION
This stops us including two versions of some libraries (RTKQuery, Immer, and Lodash) restores lazy-loading for the EventDetails component (it was lazy loaded for phy but not CS, but since there is one code base the CS import was enough to prevent lazy loading for physics too!).

Overall this reduces the initial load combined chunk size by 13%! (It also reduces the whole-of-Isaac-bundle size by 3%, too, since loading two of things is pointless).

There is at least one further obvious candidate for lazy loading, `MyAccount`, which uses a very heavyweight library not used anywhere else (`object-hash`). However, lazy loading stops working each time we do an Isaac release because the file paths are likely to have changed and the chunk doesn't exist when attempting to lazy load it. This is fine for low-traffic pages, but I think My Account is too high-traffic to risk the unhelpful error that occurs. We should review `object-hash` at some point, because it is far more complex than we need for the case we're using it for.