### PR TITLE
Various spacing issues

### DIFF
--- a/src/app/components/elements/panels/TeacherConnections.tsx
+++ b/src/app/components/elements/panels/TeacherConnections.tsx
@@ -204,7 +204,7 @@ export const TeacherConnections = ({user, authToken, editingOtherUser, userToEdi
                                 return <React.Fragment key={teacherAuthorisation.id}>
                                 <li style={style} className="py-2">
                                     <span className="icon-person-active" />
-                                    <span id={`teacher-authorisation-${teacherAuthorisation.id}`}>
+                                    <span id={`teacher-authorisation-${teacherAuthorisation.id}`} className="connections-fixed-length-text">
                                         {extractTeacherName(teacherAuthorisation)}
                                     </span>
                                     <RS.UncontrolledTooltip
@@ -258,7 +258,7 @@ export const TeacherConnections = ({user, authToken, editingOtherUser, userToEdi
                                     }
                                     return <li key={student.id} style={style} className="py-2">
                                         <span className="icon-person-active" />
-                                        <span id={`student-authorisation-${student.id}`}>
+                                        <span id={`student-authorisation-${student.id}`} className="connections-fixed-length-text">
                                             {student.givenName} {student.familyName}
                                         </span>
                                         <RS.UncontrolledTooltip
@@ -316,22 +316,31 @@ export const TeacherConnections = ({user, authToken, editingOtherUser, userToEdi
                             {sortedGroupMemberships && <FixedSizeList height={MEMBERSHIPS_ROW_HEIGHT * (Math.min(MEMBERSHIPS_MAX_VISIBLE_ROWS, sortedGroupMemberships.length ?? 0))} itemCount={sortedGroupMemberships.length ?? 0} itemSize={MEMBERSHIPS_ROW_HEIGHT} width="100%" style={{scrollbarGutter: "stable"}}>
                                 {({index, style}) => {
                                     const membership = sortedGroupMemberships[index];
-                                    return <li key={index} style={style} className={classNames("p-2 ps-3", {"inactive-group" : isAda && membership.membershipStatus === MEMBERSHIP_STATUS.INACTIVE})}>
+                                    const inactiveInGroup = membership.membershipStatus === MEMBERSHIP_STATUS.INACTIVE;
+                                    return <li key={index} style={style} className={classNames("p-2 ps-3", {"inactive-group" : isAda && inactiveInGroup})}>
                                         <div className="d-flex">
-                                            <RS.Col>
-                                                {membership.membershipStatus === MEMBERSHIP_STATUS.INACTIVE ?
-                                                    <span className="text-muted"><b>{(membership.group.groupName ?? "Group " + membership.group.id)}</b>{" ("}<i>inactive</i>{")"}</span>
-                                                    :
-                                                    <span><b>{(membership.group.groupName ?? "Group " + membership.group.id)}</b></span>
-                                                }
-                                                {membership.group.selfRemoval && <img className="self-removal-group ms-1" src={siteSpecific("/assets/phy/icons/teacher_features_sprite.svg#groups", "/assets/cs/icons/group.svg")} alt=""/>}
-                                                <br/>
-                                                {membership.group.ownerSummary && 
-                                                    <span className="text-muted">Teacher{membership.group.additionalManagers && membership.group.additionalManagers.length > 0 ? "s" : ""}: {
-                                                    [membership.group.ownerSummary, ...membership.group.additionalManagers ?? []].map(extractTeacherName).join(", ")
-                                                }</span>}
+                                            <RS.Col className="me-1">
+                                                <div className="d-flex">
+                                                    <span id={`group-membership-${index}`} className={classNames("connections-fixed-length-text", {"text-muted connection-inactive": inactiveInGroup})}>
+                                                        <b>{(membership.group.groupName ?? "Group " + membership.group.id)}</b>
+                                                    </span>
+                                                    {inactiveInGroup && <span>{" ("}<i>inactive</i>{")"}</span>}
+                                                    {membership.group.selfRemoval && <img className={classNames("self-removal-group", {"ms-1": !inactiveInGroup})} src={siteSpecific("/assets/phy/icons/teacher_features_sprite.svg#groups", "/assets/cs/icons/group.svg")} alt=""/>}
+                                                    <RS.UncontrolledTooltip
+                                                        placement="top" target={`group-membership-${index}`}
+                                                    >
+                                                        {membership.group.groupName ? membership.group.groupName : `Group ${membership.group.id}`}
+                                                    </RS.UncontrolledTooltip>
+                                                </div>
+                                                <div className="d-flex">
+                                                    {membership.group.ownerSummary && <span className="connections-fixed-length-text text-muted">
+                                                        Teacher{membership.group.additionalManagers && membership.group.additionalManagers.length > 0 ? "s" : ""}: {
+                                                            [membership.group.ownerSummary, ...membership.group.additionalManagers ?? []].map(extractTeacherName).join(", ")
+                                                        }
+                                                    </span>}
+                                                </div>
                                             </RS.Col>
-                                            <RS.Col className="d-flex flex-col justify-content-end flex-grow-0 pe-1">
+                                            <RS.Col className="d-flex flex-col justify-content-end align-items-center flex-grow-0 pe-1">
                                                 {membership.membershipStatus === MEMBERSHIP_STATUS.ACTIVE && <React.Fragment>
                                                     <RS.Button color="link" disabled={editingOtherUser} onClick={() =>
                                                         membership.group.selfRemoval 

--- a/src/app/components/pages/OnlineCourses.tsx
+++ b/src/app/components/pages/OnlineCourses.tsx
@@ -41,7 +41,7 @@ export const OnlineCourses = () => {
             /> :
             <>
                 <Row className="d-flex flex-row card-deck row-cols-1 row-cols-md-2 row-cols-lg-3 row-cols-xl-4 justify-content-between my-3">
-                    {allCourses.map(n => <NewsCard key={n.id} newsItem={n} className="ratio-5x3" showTitle />)}
+                    {allCourses.map(n => <NewsCard key={n.id} newsItem={n} showTitle />)}
                 </Row>
                 <div className="w-100 d-flex justify-content-center mb-5">
                     <Button className={"mt-3"} color={"primary"} disabled={disableLoadMore} onClick={() => setPage(p => p + 1)}>Load more courses</Button>

--- a/src/app/components/pages/quizzes/SetQuizzes.tsx
+++ b/src/app/components/pages/quizzes/SetQuizzes.tsx
@@ -158,17 +158,19 @@ function QuizAssignment({user, assignedGroups, index}: QuizAssignmentProps) {
         <tr className={`bg-white set-quiz-table-dropdown p-0 w-100 ${isExpanded ? "active" : ""}`} tabIndex={0}
             onClick={() => setIsExpanded(e => !e)} onKeyDown={ifKeyIsEnter(() => setIsExpanded(e => !e))}
         >
-            {isPhy && <td className="p-0">
-                <div id={"group-hex-" + index} className="board-subject-hexagon-container">
-                    <div className={`board-subject-hexagon ${subjects} d-flex justify-content-center align-items-center`}>
-                        <span className="set-quiz-table-group-hex" title={"Number of groups assigned"}>
-                            <strong>{assignedGroups.length}</strong>
-                            group{(!assignedGroups || assignedGroups.length != 1) && "s"}
-                            <RS.UncontrolledTooltip placement={"top"} target={"#group-hex-" + index}>{assignedGroups.length === 0 ?
-                                "No groups have been assigned."
-                                : (`Test assigned to: ` + assignedGroups.map(g => g.group).join(", "))}
-                            </RS.UncontrolledTooltip>
-                        </span>
+            {isPhy && <td className="p-0 align-content-center">
+                <div className="board-subject-hexagon-size m-auto">
+                    <div id={"group-hex-" + index} className="board-subject-hexagon-container">
+                        <div className={`board-subject-hexagon ${subjects} d-flex justify-content-center align-items-center`}>
+                            <span className="set-quiz-table-group-hex" title={"Number of groups assigned"}>
+                                <strong>{assignedGroups.length}</strong>
+                                group{(!assignedGroups || assignedGroups.length != 1) && "s"}
+                                <RS.UncontrolledTooltip placement={"top"} target={"#group-hex-" + index}>{assignedGroups.length === 0 ?
+                                    "No groups have been assigned."
+                                    : (`Test assigned to: ` + assignedGroups.map(g => g.group).join(", "))}
+                                </RS.UncontrolledTooltip>
+                            </span>
+                        </div>
                     </div>
                 </div>
             </td>}

--- a/src/scss/common/header.scss
+++ b/src/scss/common/header.scss
@@ -34,7 +34,6 @@
 
   .fade {
     transition: opacity 0.4s linear, max-height 0.3s ease-out, margin-bottom 0.3s linear, border-width 0.3s linear;
-    max-height: 300px;
   }
   .toast:not(.show) {
     max-height: 0;

--- a/src/scss/common/header.scss
+++ b/src/scss/common/header.scss
@@ -34,7 +34,7 @@
 
   .fade {
     transition: opacity 0.4s linear, max-height 0.3s ease-out, margin-bottom 0.3s linear, border-width 0.3s linear;
-    max-height: 200px;
+    max-height: 300px;
   }
   .toast:not(.show) {
     max-height: 0;

--- a/src/scss/common/my-account.scss
+++ b/src/scss/common/my-account.scss
@@ -147,6 +147,19 @@
   .icon-person-active {
     margin-top: 2px;
   }
+
+  .connections-fixed-length-text {
+    display: inline-block;
+    max-height: 24px;
+    width: max-content;
+    max-width: 264px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    &.connection-inactive {
+      max-width: 207px; // include space for "(inactive)" (57px)
+    }
+  }
 }
 .revoke-teacher {
   float: right;

--- a/src/scss/phy/questions.scss
+++ b/src/scss/phy/questions.scss
@@ -59,16 +59,19 @@
   }
   // Make sure the banner does not overflow on reorder questions on Phy
   div:not(.expansion-layout) > .validation-response-panel {
-    &.correct {
+    &.correct, &.almost {
       margin-left: -1rem;
       margin-right: -1rem;
-      margin-bottom: -2.75rem;
       padding-left: 1.5rem !important;
       padding-right: 1.5rem !important;
       @include media-breakpoint-up(md) {
         margin-left: -4rem;
         margin-right: -4rem;
       }
+    }
+    &.correct {
+      // correct (only) hides the "Check my answer" button, so does not need the bottom spacing
+      margin-bottom: -2.75rem;
     }
   }
 


### PR DESCRIPTION
Fixes a number of spacing and text overlap issues found during regression testing:

- Teacher connections panel rows must be fixed height (by virtue of React Window) so each line of text is now limited to that one line and will cut off with an ellipsis if longer;
- For the groups panel only, the full, non-cut-off group title will show on hover (and is accessible through screenreader, as are all cut-off strings);
- Fixes Ada Online Courses overlap on Firefox;
- Aligns the Phy board hexagon on Set Tests;
- Extends the max-height of toasts.