### PR TITLE
Superseded / nofilter info bubbles

### DIFF
--- a/src/app/components/elements/GameboardBuilderRow.tsx
+++ b/src/app/components/elements/GameboardBuilderRow.tsx
@@ -11,7 +11,8 @@ import {
     siteSpecific,
     stageLabelMap,
     TAG_ID,
-    TAG_LEVEL
+    TAG_LEVEL,
+    isPhy
 } from "../../services";
 import React from "react";
 import {AudienceContext} from "../../../IsaacApiTypes";
@@ -21,6 +22,7 @@ import {Question} from "../pages/Question";
 import {ContentSummary, GameboardBuilderQuestions, GameboardBuilderQuestionsStackProps} from "../../../IsaacAppTypes";
 import {DifficultyIcons} from "./svg/DifficultyIcons";
 import classNames from "classnames";
+import { Spacer } from "./Spacer";
 
 interface GameboardBuilderRowInterface {
     provided?: DraggableProvided;
@@ -97,15 +99,28 @@ const GameboardBuilderRow = (
         </td>
         <td className={classNames(cellClasses, siteSpecific("w-40", "w-30"))}>
             {provided && <img src="/assets/common/icons/drag_indicator.svg" alt="Drag to reorder" className="me-1 grab-cursor" />}
-            <a className="me-2 text-wrap" href={`/questions/${question.id}`} target="_blank" rel="noopener noreferrer" title="Preview question in new tab">
-                {generateQuestionTitle(question)}
-            </a>
-            <input
-                type="image" src="/assets/common/icons/new-tab.svg" alt="Preview question" title="Preview question in modal"
-                className="pointer-cursor align-middle new-tab" onClick={() => {question.id && openQuestionModal(question.id)}}
-            />
+            <div className="d-flex">
+                <a className="me-2 text-wrap" href={`/questions/${question.id}`} target="_blank" rel="noopener noreferrer" title="Preview question in new tab">
+                    {generateQuestionTitle(question)}
+                </a>
+                <input
+                    type="image" src="/assets/common/icons/new-tab.svg" alt="Preview question" title="Preview question in modal"
+                    className="pointer-cursor align-middle new-tab" onClick={() => {if (question.id) openQuestionModal(question.id);}}
+                />
+                <Spacer />
+                {isPhy && <div className="d-flex flex-column justify-self-end">
+                    {question.supersededBy && <a 
+                        className="superseded-tag ms-1 ms-sm-3 my-1 align-self-end" 
+                        href={`/questions/${question.supersededBy}`}
+                        onClick={(e) => e.stopPropagation()}
+                    >SUPERSEDED</a>}
+                    {question.tags?.includes("nofilter") && <span
+                        className="superseded-tag ms-1 ms-sm-3 my-1 align-self-end" 
+                    >NO-FILTER</span>}
+                </div>}
+            </div>
+
             {question.subtitle && <>
-                <br/>
                 <span className="small text-muted d-none d-sm-block">{question.subtitle}</span>
             </>}
         </td>

--- a/src/app/components/elements/list-groups/ContentSummaryListGroupItem.tsx
+++ b/src/app/components/elements/list-groups/ContentSummaryListGroupItem.tsx
@@ -10,6 +10,8 @@ import {
     isAda,
     isIntendedAudience,
     isPhy,
+    isStaff,
+    isTeacherOrAbove,
     notRelevantMessage,
     SEARCH_RESULT_TYPE,
     siteSpecific,
@@ -163,6 +165,14 @@ export const ContentSummaryListGroupItem = ({item, search, displayTopicTitle, no
                         {isPhy && typeLabel && <span className={"small text-muted align-self-end d-none d-md-inline ms-2 mb-1"}>
                             ({typeLabel})
                         </span>}
+                        {isPhy && item.supersededBy && isTeacherOrAbove(user) ? <a 
+                            className="superseded-tag ms-1 ms-sm-3" 
+                            href={`/questions/${item.supersededBy}`}
+                            onClick={(e) => e.stopPropagation()}
+                        >SUPERSEDED</a> : null}
+                        {isPhy && item.tags && item.tags.includes("nofilter") && isStaff(user) ? <span
+                            className="superseded-tag ms-1 ms-sm-3"
+                        >NO-FILTER</span> : null}
                     </div>
                     {(isPhy && item.summary) && <div className="small text-muted d-none d-sm-block">
                         {item.summary}

--- a/src/app/components/elements/list-groups/ContentSummaryListGroupItem.tsx
+++ b/src/app/components/elements/list-groups/ContentSummaryListGroupItem.tsx
@@ -47,7 +47,7 @@ export const ContentSummaryListGroupItem = ({item, search, displayTopicTitle, no
 
     let linkDestination, icon, audienceViews;
     let itemClasses = "p-0 content-summary-link ";
-    itemClasses += isContentsIntendedAudience ? "bg-transparent " : "de-emphasised ";
+    itemClasses += isContentsIntendedAudience && !item.supersededBy ? "bg-transparent " : "de-emphasised ";
 
     let stack = false;
     let title = item.title;

--- a/src/scss/phy/isaac.scss
+++ b/src/scss/phy/isaac.scss
@@ -224,7 +224,7 @@ $theme-colors-border-subtle: map-merge($theme-colors-border-subtle, $custom-colo
 @import "../common/assignments";
 @import "my-account";
 @import "../common/topic";
-@import "../common/search";
+@import "search";
 @import "finder";
 @import "../common/my-progress";
 @import "gameboard";

--- a/src/scss/phy/search.scss
+++ b/src/scss/phy/search.scss
@@ -1,0 +1,21 @@
+@import "../common/search";
+
+.superseded-tag.superseded-tag {
+    width: max-content;
+    padding: 0 0.4em;
+    align-self: center;
+    font-size: small;
+    text-decoration: none;
+    color: $gray-160;
+    background-color: white;
+    border: 1px solid $gray-120;
+    border-radius: 8px;
+    transition: color 0.2s;
+    &::after {
+        display: none;
+    }
+
+    &:is(a):hover {
+        color: $gray-194;
+    }
+}


### PR DESCRIPTION
Adds "superseded" and "nofilter" info bubbles to questions when displaying on the question finder, site search and gameboard builder. 

"Superseded" questions can be seen by teachers in both the QF and site search, and will appear in the gameboard builder on questions they have previously set that have since been superseded. The "nofilter" tag can by design only be seen by staff, as these questions are not otherwise displayed. 