### PR TITLE
Differentiate `data-unit` across undefined / empty unit

### DIFF
--- a/src/app/components/elements/inputs/InlineNumericEntryZone.tsx
+++ b/src/app/components/elements/inputs/InlineNumericEntryZone.tsx
@@ -109,7 +109,7 @@ export const InlineNumericEntryZone = ({width, height, questionDTO, setModified,
             <DropdownMenu end>
                 {selectedUnits.map((unit) =>
                     <DropdownItem key={wrapUnitForSelect(unit)}
-                        data-unit={unit || 'None'}
+                        data-unit={isDefined(unit) ? (unit || 'None') : undefined}
                         className={unit && unit === currentAttempt?.units ? "btn bg-grey selected" : ""}
                         onClick={(e: FormEvent) => {updateCurrentAttempt({newUnits: unit}); e.preventDefault();}}
                     >


### PR DESCRIPTION
Prevents duplication of `data-unit=None` in unit selection for both the empty selection and the genuine "no unit" selection.