### PR TITLE
Use cloze dropdowns on touchscreens

### DIFF
--- a/src/app/components/elements/markup/portals/InlineDropZones.tsx
+++ b/src/app/components/elements/markup/portals/InlineDropZones.tsx
@@ -125,9 +125,9 @@ function InlineDropRegion({id, index, emptyWidth, emptyHeight, rootElement}: {id
             </DropdownItem>
             {dropdownItems.map((item, i) => {
                 return <DropdownItem key={i}
-                className={!nonSelectedItemIds.includes(item.id) ? "invalid" : ""}
-                data-unit={item || 'None'}
-                onClick={nonSelectedItemIds.includes(item.id) ? (() => {dropRegionContext?.onSelect(item, droppableId, false);}) : undefined}
+                    className={!nonSelectedItemIds.includes(item.id) ? "invalid" : ""}
+                    data-unit={item || 'None'}
+                    onClick={nonSelectedItemIds.includes(item.id) ? (() => {dropRegionContext?.onSelect(item, droppableId, false);}) : undefined}
                 >
                     <Markup trusted-markup-encoding={"html"}>
                         {item.value ?? ""}

--- a/src/app/components/elements/markup/portals/InlineDropZones.tsx
+++ b/src/app/components/elements/markup/portals/InlineDropZones.tsx
@@ -9,7 +9,7 @@ import {useDroppable} from "@dnd-kit/core";
 import {CSS} from "@dnd-kit/utilities";
 import {useSortable} from "@dnd-kit/sortable";
 import classNames from "classnames";
-import {CLOZE_DROP_ZONE_ID_PREFIX, NULL_CLOZE_ITEM, isAda, isDefined, isPhy, useDeviceSize} from "../../../../services";
+import {CLOZE_DROP_ZONE_ID_PREFIX, NULL_CLOZE_ITEM, isAda, isDefined, isPhy, isTouchDevice, useDeviceSize} from "../../../../services";
 import { Markup } from "..";
 
 export function Item({item, id, type, overrideOver, isCorrect}: {item: Immutable<ItemDTO>, id: string, type: "drop-zone" | "item-section", overrideOver?: boolean, isCorrect?: boolean}) {
@@ -139,7 +139,7 @@ function InlineDropRegion({id, index, emptyWidth, emptyHeight, rootElement}: {id
 
     if (dropRegionContext && droppableTarget) {
         return ReactDOM.createPortal(
-            ((navigator.maxTouchPoints) || (deviceSize === "xs")) ? dropdownZone : draggableDropZone,
+            ((isTouchDevice()) || (deviceSize === "xs")) ? dropdownZone : draggableDropZone,
             droppableTarget
         );
     }

--- a/src/app/components/elements/markup/portals/InlineDropZones.tsx
+++ b/src/app/components/elements/markup/portals/InlineDropZones.tsx
@@ -139,7 +139,7 @@ function InlineDropRegion({id, index, emptyWidth, emptyHeight, rootElement}: {id
 
     if (dropRegionContext && droppableTarget) {
         return ReactDOM.createPortal(
-            deviceSize === "xs" ? dropdownZone : draggableDropZone,
+            ((navigator.maxTouchPoints) || (deviceSize === "xs")) ? dropdownZone : draggableDropZone,
             droppableTarget
         );
     }


### PR DESCRIPTION
Use dropdowns instead of drop zones for cloze questions on any touchscreen device. Keep the size breakpoint for small screens of any type.

Using maxTouchPoints for this seems to work, but there's probably a neater way to actually detect the device type.