### PR TITLE
Deselect QF filters for multiple contexts

### DIFF
--- a/src/app/components/elements/panels/QuestionFinderFilterPanel.tsx
+++ b/src/app/components/elements/panels/QuestionFinderFilterPanel.tsx
@@ -210,7 +210,7 @@ export function QuestionFinderFilterPanel(props: QuestionFinderFilterPanelProps)
             <CollapsibleList
                 title={listTitles.stage} expanded={listState.stage.state}
                 toggle={() => listStateDispatch({type: "toggle", id: "stage", focus: below["md"](deviceSize)})}
-                numberSelected={searchStages.includes(STAGE.ALL) ? 0 : searchStages.length}
+                numberSelected={searchStages.includes(STAGE.ALL) ? searchStages.length - 1 : searchStages.length}
             >
                 {getFilteredStageOptions().map((stage, index) => (
                     <div className="w-100 ps-3 py-1 bg-white" key={index}>

--- a/src/app/components/elements/panels/QuestionFinderFilterPanel.tsx
+++ b/src/app/components/elements/panels/QuestionFinderFilterPanel.tsx
@@ -210,7 +210,7 @@ export function QuestionFinderFilterPanel(props: QuestionFinderFilterPanelProps)
             <CollapsibleList
                 title={listTitles.stage} expanded={listState.stage.state}
                 toggle={() => listStateDispatch({type: "toggle", id: "stage", focus: below["md"](deviceSize)})}
-                numberSelected={searchStages.includes(STAGE.ALL) ? searchStages.length - 1 : searchStages.length}
+                numberSelected={(isAda && searchStages.includes(STAGE.ALL)) ? searchStages.length - 1 : searchStages.length}
             >
                 {getFilteredStageOptions().map((stage, index) => (
                     <div className="w-100 ps-3 py-1 bg-white" key={index}>

--- a/src/app/components/elements/panels/QuestionFinderFilterPanel.tsx
+++ b/src/app/components/elements/panels/QuestionFinderFilterPanel.tsx
@@ -210,7 +210,7 @@ export function QuestionFinderFilterPanel(props: QuestionFinderFilterPanelProps)
             <CollapsibleList
                 title={listTitles.stage} expanded={listState.stage.state}
                 toggle={() => listStateDispatch({type: "toggle", id: "stage", focus: below["md"](deviceSize)})}
-                numberSelected={searchStages.length}
+                numberSelected={searchStages.includes(STAGE.ALL) ? 0 : searchStages.length}
             >
                 {getFilteredStageOptions().map((stage, index) => (
                     <div className="w-100 ps-3 py-1 bg-white" key={index}>

--- a/src/app/components/pages/QuestionFinder.tsx
+++ b/src/app/components/pages/QuestionFinder.tsx
@@ -3,9 +3,11 @@ import {AppState, clearQuestionSearch, logAction, searchQuestions, useAppDispatc
 import debounce from "lodash/debounce";
 import {
     arrayFromPossibleCsv,
+    EXAM_BOARD,
     EXAM_BOARD_NULL_OPTIONS,
     getFilteredExamBoardOptions,
     isAda,
+    isLoggedIn,
     isPhy,
     Item,
     itemiseTag,
@@ -96,6 +98,7 @@ function getInitialQuestionStatuses(params: ListParams): QuestionStatus {
 
 export const QuestionFinder = withRouter(({location}: RouteComponentProps) => {
     const dispatch = useAppDispatch();
+    const user = useAppSelector((state: AppState) => state && state.user);
     const userContext = useUserViewingContext();
     const params: ListParams = useQueryParams(false);
     const history = useHistory();
@@ -115,14 +118,20 @@ export const QuestionFinder = withRouter(({location}: RouteComponentProps) => {
     const [populatedUserContext, setPopulatedUserContext] = useState(false);
 
     useEffect(function populateFromUserContext() {
-        if (!STAGE_NULL_OPTIONS.includes(userContext.stage)) {
-            setSearchStages(arr => arr.length > 0 ? arr : [userContext.stage]);
+        if (isAda && isLoggedIn(user) && user.registeredContexts && user.registeredContexts.length > 1) {
+            setSearchStages([STAGE.ALL]);
+            setSearchExamBoards([EXAM_BOARD.ALL]);
         }
-        if (!EXAM_BOARD_NULL_OPTIONS.includes(userContext.examBoard)) {
-            setSearchExamBoards(arr => arr.length > 0 ? arr : [userContext.examBoard]);
+        else  {
+            if (!STAGE_NULL_OPTIONS.includes(userContext.stage)) {
+                setSearchStages(arr => arr.length > 0 ? arr : [userContext.stage]);
+            }
+            if (!EXAM_BOARD_NULL_OPTIONS.includes(userContext.examBoard)) {
+                setSearchExamBoards(arr => arr.length > 0 ? arr : [userContext.examBoard]);
+            }
         }
         setPopulatedUserContext(!!userContext.stage && !!userContext.examBoard);
-    }, [userContext.stage, userContext.examBoard]);
+    }, [userContext.stage, userContext.examBoard, user]);
 
     // this acts as an "on complete load", needed as we can only correctly update the URL once we have the user context *and* React has processed the above setStates
     useEffect(() => {

--- a/src/app/services/userViewingContext.ts
+++ b/src/app/services/userViewingContext.ts
@@ -62,6 +62,8 @@ export function useUserViewingContext(): UseUserContextReturnType {
         explanation.stage = urlMessage;
     } else if (isDefined(transientUserContext.stage)) {
         stage = transientUserContext.stage;
+    } else if (isAda && isLoggedIn(user) && user.registeredContexts && user.registeredContexts.length > 1) {
+        stage = STAGE.ALL;
     } else if (isLoggedIn(user) && user.registeredContexts?.length && user.registeredContexts[0].stage) {
         stage = user.registeredContexts[0].stage as STAGE;
     } else {
@@ -84,6 +86,10 @@ export function useUserViewingContext(): UseUserContextReturnType {
         isDefined(transientUserContext?.examBoard)
     ) {
         examBoard = transientUserContext?.examBoard;
+    } else if ( // On Ada: multiple exam board preferences have been set on the account.
+        isAda && isLoggedIn(user) && user.registeredContexts && user.registeredContexts.length > 1
+    ) {
+        examBoard = EXAM_BOARD.ALL;
     } else if ( // An exam board preference has been set on the account.
         isLoggedIn(user) && user.registeredContexts?.length && user.registeredContexts[0].examBoard
     ) {

--- a/src/app/services/userViewingContext.ts
+++ b/src/app/services/userViewingContext.ts
@@ -62,8 +62,6 @@ export function useUserViewingContext(): UseUserContextReturnType {
         explanation.stage = urlMessage;
     } else if (isDefined(transientUserContext.stage)) {
         stage = transientUserContext.stage;
-    } else if (isAda && isLoggedIn(user) && user.registeredContexts && user.registeredContexts.length > 1) {
-        stage = STAGE.ALL;
     } else if (isLoggedIn(user) && user.registeredContexts?.length && user.registeredContexts[0].stage) {
         stage = user.registeredContexts[0].stage as STAGE;
     } else {
@@ -86,10 +84,6 @@ export function useUserViewingContext(): UseUserContextReturnType {
         isDefined(transientUserContext?.examBoard)
     ) {
         examBoard = transientUserContext?.examBoard;
-    } else if ( // On Ada: multiple exam board preferences have been set on the account.
-        isAda && isLoggedIn(user) && user.registeredContexts && user.registeredContexts.length > 1
-    ) {
-        examBoard = EXAM_BOARD.ALL;
     } else if ( // An exam board preference has been set on the account.
         isLoggedIn(user) && user.registeredContexts?.length && user.registeredContexts[0].examBoard
     ) {


### PR DESCRIPTION
On Ada, if a user has more than one context set on their account preferences, don't set any question finder filters by default.

Users with a single context set should have the filters set as before.