### PR TITLE
Dropdown usability improvements

### DIFF
--- a/src/app/components/elements/inputs/InlineNumericEntryZone.tsx
+++ b/src/app/components/elements/inputs/InlineNumericEntryZone.tsx
@@ -1,4 +1,4 @@
-import React, { FormEvent, useState } from "react";
+import React, { FormEvent, useRef, useState } from "react";
 import { Dropdown, DropdownItem, DropdownMenu, DropdownToggle, Input } from "reactstrap";
 import classNames from "classnames";
 import { Markup } from "../markup";
@@ -48,7 +48,9 @@ export const InlineNumericEntryZone = ({width, height, questionDTO, setModified,
 
     const unit = questionDTO.displayUnit ?? currentAttempt?.units;
 
-    return <div {...rest} 
+    const entryZoneRef = useRef<HTMLDivElement>(null);
+
+    return <div {...rest} ref={entryZoneRef}
         className={classNames("inline-numeric-container w-100", rest.className, correctnessClass(valueCorrectness === "NOT_SUBMITTED" ? "NOT_SUBMITTED" : correctness))}
     >
         <div className={"feedback-zone inline-nq-feedback w-100"}
@@ -106,7 +108,7 @@ export const InlineNumericEntryZone = ({width, height, questionDTO, setModified,
                     </div>}
                 </div>
             </DropdownToggle>
-            <DropdownMenu container="body" end>
+            <DropdownMenu container={entryZoneRef.current?.closest(".question-content") as HTMLElement || "body"} end>
                 {selectedUnits.map((unit) =>
                     <DropdownItem key={wrapUnitForSelect(unit)}
                         data-unit={isDefined(unit) ? (unit || 'None') : undefined}

--- a/src/app/components/elements/inputs/InlineNumericEntryZone.tsx
+++ b/src/app/components/elements/inputs/InlineNumericEntryZone.tsx
@@ -106,7 +106,7 @@ export const InlineNumericEntryZone = ({width, height, questionDTO, setModified,
                     </div>}
                 </div>
             </DropdownToggle>
-            <DropdownMenu end>
+            <DropdownMenu container="body" end>
                 {selectedUnits.map((unit) =>
                     <DropdownItem key={wrapUnitForSelect(unit)}
                         data-unit={isDefined(unit) ? (unit || 'None') : undefined}

--- a/src/app/components/elements/markup/portals/InlineDropZones.tsx
+++ b/src/app/components/elements/markup/portals/InlineDropZones.tsx
@@ -115,7 +115,7 @@ function InlineDropRegion({id, index, emptyWidth, emptyHeight, rootElement}: {id
                 {!item && <img className={classNames("dropzone-dropdown", {"active": isOpen})} src="/assets/common/icons/chevron_down.svg" alt="expand dropdown"></img>}
             </div>
         </DropdownToggle>
-        <DropdownMenu end>
+        <DropdownMenu container="body" end>
             {/* Dummy option added to clear selection */}
             <DropdownItem
                 data-unit={'None'}

--- a/src/app/components/elements/markup/portals/InlineDropZones.tsx
+++ b/src/app/components/elements/markup/portals/InlineDropZones.tsx
@@ -1,6 +1,6 @@
 import {ClozeDropRegionContext} from "../../../../../IsaacAppTypes";
 import ReactDOM from "react-dom";
-import React, {useContext, useEffect, useState} from "react";
+import React, {useContext, useEffect, useRef, useState} from "react";
 import {ContentDTO, ItemDTO} from "../../../../../IsaacApiTypes";
 import {IsaacContentValueOrChildren} from "../../../content/IsaacContentValueOrChildren";
 import {Badge, Dropdown, DropdownItem, DropdownMenu, DropdownToggle} from "reactstrap";
@@ -96,12 +96,14 @@ function InlineDropRegion({id, index, emptyWidth, emptyHeight, rootElement}: {id
         }
     </span>;
 
+    const zoneRef = useRef<HTMLDivElement>(null);
+
     const dropdownZone = <Dropdown
         isOpen={isOpen}
         toggle={() => {setIsOpen(!isOpen);}}
         className="cloze-dropdown"
     >
-        <DropdownToggle className={classNames("toggle", {"empty": !item, "p-1": isPhy, "p-2": isAda})} style={{minHeight: height, width: width}}>
+        <DropdownToggle className={classNames("toggle", {"empty": !item, "p-1": isPhy, "p-2": isAda})} style={{minHeight: height, width: width}} innerRef={zoneRef}>
             <div className={classNames("d-flex cloze-item feedback-zone", {"feedback-showing": isDefined(isCorrect), "p-2": isAda && !!item})}>
                 <span className={"visually-hidden"}>{item?.altText ?? item?.value ?? "cloze item without a description"}</span>
                 <span aria-hidden={true}>
@@ -115,7 +117,7 @@ function InlineDropRegion({id, index, emptyWidth, emptyHeight, rootElement}: {id
                 {!item && <img className={classNames("dropzone-dropdown", {"active": isOpen})} src="/assets/common/icons/chevron_down.svg" alt="expand dropdown"></img>}
             </div>
         </DropdownToggle>
-        <DropdownMenu container="body" end>
+        <DropdownMenu container={zoneRef.current?.closest(".question-content") as HTMLElement || "body"} end>
             {/* Dummy option added to clear selection */}
             <DropdownItem
                 data-unit={'None'}


### PR DESCRIPTION
Ensures dropdowns are not cut off by ancestor elements with `overflow`s set (e.g. tables). This works by moving the container of the dropdown from being a child of the source `<DropdownToggle/>` button to being a child of the closest `question-content` ancestor for inline and cloze dropdowns. This ensures that relevant CSS styling can still be applied -- for example, to ensure the max-height of a `cloze-question.dropdown` is adhered to.