### PR TITLE
Fix Chemistry symbols not showing up in Inequality menu

### DIFF
--- a/src/app/components/content/IsaacSymbolicChemistryQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicChemistryQuestion.tsx
@@ -211,7 +211,10 @@ const IsaacSymbolicChemistryQuestion = ({doc, questionId, readonly}: IsaacQuesti
     };
 
     const helpTooltipId = useMemo(() => `eqn-editor-help-${uuid_v4()}`, []);
-    const symbolList = parsePseudoSymbolicAvailableSymbols(doc.availableSymbols)?.map(str => str.trim().replace(/;/g, ',') ).sort().join(", ");
+    let symbolList = parsePseudoSymbolicAvailableSymbols(doc.availableSymbols)?.map(str => str.trim().replace(/;/g, ',') ).sort().join(", ");
+
+    symbolList = symbolList?.replace('electron', 'e').replace('alpha', '\\alphaparticle').replace('beta', '\\betaparticle').replace('gamma', '\\gammaray').replace('neutron', '\\neutron')//
+    .replace('proton', '\\proton').replace('neutrino', '\\neutrino').replace('antineutrino', '\\antineutrino');
 
     return (
         <div className="symbolic-question">

--- a/src/app/services/questions.ts
+++ b/src/app/services/questions.ts
@@ -152,30 +152,6 @@ export const parsePseudoSymbolicAvailableSymbols = (availableSymbols?: string[])
         } else if (theseSymbols[i] === '_no_alphabet') {
             theseSymbols.splice(i, 1);
             i += 1;
-        } else if (theseSymbols[i] === 'electron') {
-            theseSymbols.splice(i, 1, 'e');
-            i += 1;
-        } else if (theseSymbols[i] === 'alpha') {
-            theseSymbols.splice(i, 1, '\\alphaparticle');
-            i += 1;
-        } else if (theseSymbols[i] === 'beta') {
-            theseSymbols.splice(i, 1, '\\betaparticle');
-            i += 1;
-        } else if (theseSymbols[i] === 'gamma') {
-            theseSymbols.splice(i, 1, '\\gammaray');
-            i += 1;
-        } else if (['neutron', 'n'].includes(theseSymbols[i])) {
-            theseSymbols.splice(i, 1, '\\neutron');
-            i += 1;
-        } else if (theseSymbols[i] === 'proton') {
-            theseSymbols.splice(i, 1, '\\proton');
-            i += 1;
-        } else if (theseSymbols[i] === 'neutrino') {
-            theseSymbols.splice(i, 1, '\\neutrino');
-            i += 1;
-        } else if (theseSymbols[i] === 'antineutrino') {
-            theseSymbols.splice(i, 1, '\\antineutrino');
-            i += 1;
         } else {
             i += 1;
         }


### PR DESCRIPTION
Chemistry text entry symbols are not consistent with their symbol names in the rest of the app, to aid in lexing.
e.g. `alpha` -> `\alphaparticle`
(We can consider revising these text entry symbols later)

Translating this in `question.ts` caused some issues with recognizing the symbols in the wrong places, so I've reduced it just to the scope of the text where it's needed in `IsaacSymbolicChemistryQuestion.tsx` (for _"The following symbols may be useful: ..."_). 

This should make it have no effect on the rest of the app.