### PR TITLE
Revert invalid group greying in Set Quiz modal

### DIFF
--- a/src/app/components/elements/modals/QuizSettingModal.tsx
+++ b/src/app/components/elements/modals/QuizSettingModal.tsx
@@ -89,7 +89,7 @@ export function QuizSettingModal({quiz, dueDate: initialDueDate, scheduledStartD
         });
     }
 
-    const isAssignmentSetToThisGroup = (group: Item<number>, assignment?: QuizAssignmentDTO) => assignment ? (assignment.quizId === quiz.id && assignment.groupId === group.value && (assignment.dueDate ? assignment.dueDate.valueOf() < Date.now() : true)) : false;
+    const isAssignmentSetToThisGroup = (group: Item<number>, assignment?: QuizAssignmentDTO) => assignment ? (assignment.quizId === quiz.id && assignment.groupId === group.value && (assignment.dueDate ? assignment.dueDate.valueOf() > Date.now() : true)) : false;
     const alreadyAssignedToAGroup = selectedGroups.some(group => quizAssignments?.some(assignment => isAssignmentSetToThisGroup(group, assignment)));
     
     const groupInvalid = validated.has('group') && selectedGroups.length === 0 || alreadyAssignedToAGroup;    
@@ -105,10 +105,7 @@ export function QuizSettingModal({quiz, dueDate: initialDueDate, scheduledStartD
                 query={groupsQuery}
                 defaultErrorTitle={"Error fetching groups"}
                 thenRender={groups => {
-                    function appGroupToItem(g: AppGroup): Item<number> {return {label: g.groupName as string, value: g.id as number}; }
-                    function quizToAssignment(g: AppGroup): QuizAssignmentDTO | undefined { return quizAssignments?.find(assignment => assignment.quizId === quiz.id && assignment.groupId === g.id); }
-                    
-                    const groupOptions = groups.map((g: AppGroup) => ({...appGroupToItem(g), isDisabled: isAssignmentSetToThisGroup(appGroupToItem(g), quizToAssignment(g))}));
+                    const groupOptions = groups.map((g: AppGroup) => {return {label: g.groupName as string, value: g.id as number}; });
 
                     return <StyledSelect isMulti placeholder="Select groups"
                         options={groupOptions}
@@ -121,10 +118,6 @@ export function QuizSettingModal({quiz, dueDate: initialDueDate, scheduledStartD
                         isSearchable
                         menuPortalTarget={document.body}
                         styles={{
-                            option: (base, selectProps) => ({
-                                ...base,
-                                backgroundColor: selectProps.isFocused && selectProps.isDisabled ? 'transparent' : base.backgroundColor
-                            }),
                             control: (styles) => ({...styles, ...(groupInvalid ? {borderColor: '#dc3545'} : {})}),
                             menuPortal: base => ({...base, zIndex: 9999}),
                         }}


### PR DESCRIPTION
A change [here](https://github.com/isaacphysics/isaac-react-app/pull/1071) added a front-end warning and disabling of invalid groups (for which the quiz had already been set) in the dropdown menu.

This reverts the disabling in the dropdown menu (since it was unclear what was happening) but keeps the front-end warning.

(I also noticed that the check for passing due date was checking for the past instead of the future so that's been fixed here too)

