### PR TITLE
Fix touchscreen dropdowns

### DIFF
--- a/src/app/components/content/IsaacClozeQuestion.tsx
+++ b/src/app/components/content/IsaacClozeQuestion.tsx
@@ -13,6 +13,7 @@ import {
     NULL_CLOZE_ITEM,
     NULL_CLOZE_ITEM_ID,
     isDefined,
+    isTouchDevice,
     useCurrentQuestionAttempt,
     useDeviceSize
 } from "../../services";
@@ -497,7 +498,7 @@ const IsaacClozeQuestion = ({doc, questionId, readonly, validationResponse}: Isa
                     {doc.children}
                 </IsaacContentValueOrChildren>
 
-                {deviceSize !== "xs" && <>
+                {(!(deviceSize === "xs" || isTouchDevice())) && <>
                     {/* The item attached to the users cursor while dragging (just for display, shouldn't contain useDraggable/useSortable hooks) */}
                     <DragOverlay>
                         {activeItem && <Badge className="p-2 cloze-item is-dragging">

--- a/src/app/services/device.ts
+++ b/src/app/services/device.ts
@@ -8,7 +8,7 @@ export const isMobile = () => {
 export const isNotMobile = !isMobile();
 
 export const isTouchDevice = () => {
-    return ('ontouchstart' in window) || (navigator.maxTouchPoints > 0);
+    return ('ontouchstart' in window) || (navigator.maxTouchPoints > 0 && navigator.maxTouchPoints != 256);
 };
 
 export const isNotTouchDevice = () => !isTouchDevice();


### PR DESCRIPTION
Some versions of Firefox set maxTouchPoints to 256, incorrectly flagging the device as touchscreen.