### PR TITLE
Fix dragging rows on the gameboard builder

### DIFF
--- a/src/app/components/elements/GameboardBuilderRow.tsx
+++ b/src/app/components/elements/GameboardBuilderRow.tsx
@@ -61,67 +61,71 @@ const GameboardBuilderRow = (
     const isSelected = question.id !== undefined && currentQuestions.selectedQuestions.has(question.id);
 
     return filteredAudienceViews.map((view, i, arr) => <tr
-        key={`${question.id} ${i}`} ref={provided && provided.innerRef}
-        className={classnames({selected: isSelected})}
-        {...(provided && provided.draggableProps)} {...(provided && provided.dragHandleProps)}
+        key={`${question.id} ${i}`} className={classnames({selected: isSelected})}
     >
         {i === 0 && <>
             <td rowSpan={arr.length} className="w-5 text-center align-middle">
-                <RS.Input
-                    type="checkbox"
-                    id={`${provided ? "gameboard-builder" : "question-search-modal"}-include-${question.id}`}
-                    aria-label={!isSelected ? "Select question" : "Deselect question"}
-                    title={!isSelected ? "Select question" : "Deselect question"}
-                    color="secondary"
-                    className={!provided ? "isaac-checkbox mt-1" : undefined}
-                    checked={isSelected}
-                    onChange={() => {
-                        if (question.id) {
-                            const newSelectedQuestions = new Map(currentQuestions.selectedQuestions);
-                            const newQuestionOrder = [...currentQuestions.questionOrder];
-                            if (newSelectedQuestions.has(question.id)) {
-                                newSelectedQuestions.delete(question.id);
-                                newQuestionOrder.splice(newQuestionOrder.indexOf(question.id), 1);
-                            } else {
-                                newSelectedQuestions.set(question.id, {...question, creationContext});
-                                newQuestionOrder.push(question.id);
+                <div className="d-flex justify-content-center">
+                    <RS.Input
+                        type="checkbox"
+                        id={`${provided ? "gameboard-builder" : "question-search-modal"}-include-${question.id}`}
+                        aria-label={!isSelected ? "Select question" : "Deselect question"}
+                        title={!isSelected ? "Select question" : "Deselect question"}
+                        color="secondary"
+                        className={!provided ? "isaac-checkbox mt-1" : undefined}
+                        checked={isSelected}
+                        onChange={() => {
+                            if (question.id) {
+                                const newSelectedQuestions = new Map(currentQuestions.selectedQuestions);
+                                const newQuestionOrder = [...currentQuestions.questionOrder];
+                                if (newSelectedQuestions.has(question.id)) {
+                                    newSelectedQuestions.delete(question.id);
+                                    newQuestionOrder.splice(newQuestionOrder.indexOf(question.id), 1);
+                                } else {
+                                    newSelectedQuestions.set(question.id, {...question, creationContext});
+                                    newQuestionOrder.push(question.id);
+                                }
+                                currentQuestions.setSelectedQuestions(newSelectedQuestions);
+                                currentQuestions.setQuestionOrder(newQuestionOrder);
+                                if (provided) {
+                                    undoStack.push({questionOrder: currentQuestions.questionOrder, selectedQuestions: currentQuestions.selectedQuestions});
+                                    redoStack.clear();
+                                }
                             }
-                            currentQuestions.setSelectedQuestions(newSelectedQuestions);
-                            currentQuestions.setQuestionOrder(newQuestionOrder);
-                            if (provided) {
-                                undoStack.push({questionOrder: currentQuestions.questionOrder, selectedQuestions: currentQuestions.selectedQuestions});
-                                redoStack.clear();
-                            }
-                        }
-                    }}
-                />
+                        }}
+                    />
+                </div>
             </td>
             <td rowSpan={arr.length} className={classNames(cellClasses, siteSpecific("w-40", "w-30"))}>
-                {provided && <img src="/assets/common/icons/drag_indicator.svg" alt="Drag to reorder" className="me-1 grab-cursor" />}
                 <div className="d-flex">
-                    <a className="me-2 text-wrap" href={`/questions/${question.id}`} target="_blank" rel="noopener noreferrer" title="Preview question in new tab">
-                        {generateQuestionTitle(question)}
-                    </a>
-                    <input
-                        type="image" src="/assets/common/icons/new-tab.svg" alt="Preview question" title="Preview question in modal"
-                        className="pointer-cursor align-middle new-tab" onClick={() => question.id && openQuestionModal(question.id)}
-                    />
-                    <Spacer />
-                    {isPhy && <div className="d-flex flex-column justify-self-end">
-                        {question.supersededBy && <a 
-                            className="superseded-tag ms-1 ms-sm-3 my-1 align-self-end" 
-                            href={`/questions/${question.supersededBy}`}
-                            onClick={(e) => e.stopPropagation()}
-                        >SUPERSEDED</a>}
-                        {question.tags?.includes("nofilter") && <span
-                            className="superseded-tag ms-1 ms-sm-3 my-1 align-self-end" 
-                        >NO-FILTER</span>}
-                    </div>}
-                </div>
+                    {provided && <img src="/assets/common/icons/drag_indicator.svg" alt="Drag to reorder" className="me-1 grab-cursor" />}
+                    <div>
+                        <div className="d-flex">
+                            <a className="me-2 text-wrap" href={`/questions/${question.id}`} target="_blank" rel="noopener noreferrer" title="Preview question in new tab">
+                                {generateQuestionTitle(question)}
+                            </a>
+                            <input
+                                type="image" src="/assets/common/icons/new-tab.svg" alt="Preview question" title="Preview question in modal"
+                                className="pointer-cursor align-middle new-tab" onClick={() => question.id && openQuestionModal(question.id)}
+                            />
+                            <Spacer />
+                            {isPhy && <div className="d-flex flex-column justify-self-end">
+                                {question.supersededBy && <a 
+                                    className="superseded-tag ms-1 ms-sm-3 my-1 align-self-end" 
+                                    href={`/questions/${question.supersededBy}`}
+                                    onClick={(e) => e.stopPropagation()}
+                                >SUPERSEDED</a>}
+                                {question.tags?.includes("nofilter") && <span
+                                    className="superseded-tag ms-1 ms-sm-3 my-1 align-self-end" 
+                                >NO-FILTER</span>}
+                            </div>}
+                        </div>
 
-                {question.subtitle && <>
-                    <span className="small text-muted d-none d-sm-block">{question.subtitle}</span>
-                </>}
+                        {question.subtitle && <>
+                            <span className="small text-muted d-none d-sm-block">{question.subtitle}</span>
+                        </>}
+                    </div>
+                </div>
             </td>
             <td rowSpan={arr.length} className={classNames(cellClasses, siteSpecific("w-25", "w-20"))}>
                 {topicTag()}
@@ -142,4 +146,5 @@ const GameboardBuilderRow = (
         </td>}
     </tr>);
 };
+
 export default GameboardBuilderRow;

--- a/src/app/components/pages/GameboardBuilder.tsx
+++ b/src/app/components/pages/GameboardBuilder.tsx
@@ -281,28 +281,30 @@ const GameboardBuilder = ({user}: {user: RegisteredUserDTO}) => {
 
                 <div className="my-4 responsive">
                     <DragDropContext onDragEnd={reorder}>
-                        <Table bordered className="m-0">
-                            <thead>
-                            <tr>
-                                <th className="w-5"/>
-                                <th className={siteSpecific("w-40", "w-30")}>Question title</th>
-                                <th className={siteSpecific("w-25", "w-20")}>Topic</th>
-                                <th className="w-15">Stage</th>
-                                <th className="w-15">Difficulty</th>
-                                {isAda && <th className="w-15">Exam boards</th>}
-                            </tr>
-                            </thead>
-                            <Droppable droppableId="droppable">
-                                {(provided) => {
-                                    return (
-                                        <tbody ref={provided.innerRef}>
+                        <Droppable droppableId="droppable">
+                            {(providedDrop) => {
+                                return (
+                                    <Table bordered className="m-0" innerRef={providedDrop.innerRef}>
+                                        <thead>
+                                            <tr>
+                                                <th className="w-5"/>
+                                                <th className={siteSpecific("w-40", "w-30")}>Question title</th>
+                                                <th className={siteSpecific("w-25", "w-20")}>Topic</th>
+                                                <th className="w-15">Stage</th>
+                                                <th className="w-15">Difficulty</th>
+                                                {isAda && <th className="w-15">Exam boards</th>}
+                                            </tr>
+                                        </thead>
                                         {questionOrder.map((questionId, index: number) => {
                                             const question = selectedQuestions.get(questionId);
-                                            return question && question.id &&
-                                                <Draggable key={question.id} draggableId={question.id} index={index}>
-                                                    {(provided, snapshot) => (
+                                            return question && question.id && <Draggable key={question.id} draggableId={question.id} index={index}>
+                                                {(providedDrag, snapshot) => {
+                                                    return <tbody ref={providedDrag && providedDrag.innerRef} 
+                                                        className={classNames({"table-row-dragging" : snapshot.isDragging})}
+                                                        {...(providedDrag && providedDrag.draggableProps)} {...(providedDrag && providedDrag.dragHandleProps)}
+                                                    >
                                                         <GameboardBuilderRow
-                                                            provided={provided}
+                                                            provided={providedDrag}
                                                             snapshot={snapshot}
                                                             key={`gameboard-builder-row-${question.id}`}
                                                             question={question}
@@ -310,19 +312,22 @@ const GameboardBuilder = ({user}: {user: RegisteredUserDTO}) => {
                                                             undoStack={undoStack}
                                                             redoStack={redoStack}
                                                             creationContext={question.creationContext}
-                                                        />)}
-                                                </Draggable>;
+                                                        />
+                                                    </tbody>;
+                                                }}
+                                            </Draggable>;
                                         })}
-                                        {provided.placeholder}
-                                        {selectedQuestions?.size === 0 && <tr>
-                                            <td colSpan={20}>
-                                            </td>
-                                        </tr>}
+                                        <tbody >
+                                            {providedDrop.placeholder}
+                                            {selectedQuestions?.size === 0 && <tr>
+                                                <td colSpan={20}>
+                                                </td>
+                                            </tr>}
                                         </tbody>
-                                    );
-                                }}
-                            </Droppable>
-                        </Table>
+                                    </Table>
+                                );
+                            }}
+                        </Droppable>
                     </DragDropContext>
                 </div>
 

--- a/src/scss/common/table.scss
+++ b/src/scss/common/table.scss
@@ -1,0 +1,3 @@
+.table-row-dragging {
+    display: table;
+}

--- a/src/scss/cs/table.scss
+++ b/src/scss/cs/table.scss
@@ -1,3 +1,5 @@
+@import "../common/table";
+
 .table {
   text-align: left;
   th {

--- a/src/scss/phy/table.scss
+++ b/src/scss/phy/table.scss
@@ -1,3 +1,5 @@
+@import "../common/table";
+
 .table:not(.table-borderless) thead th {
     vertical-align: bottom;
     border-bottom: 2px solid $border-color;
@@ -8,8 +10,4 @@
         border-top: 1px solid $border-color;
         border-bottom-style: none;
     }
-}
-
-.table-row-dragging {
-    display: table;
 }

--- a/src/scss/phy/table.scss
+++ b/src/scss/phy/table.scss
@@ -9,3 +9,7 @@
         border-bottom-style: none;
     }
 }
+
+.table-row-dragging {
+    display: table;
+}


### PR DESCRIPTION
With the new changes to `GameboardBuilderRow`s, there are multiple rows inside a `<Draggable/>`. This is illegal usage (hence the problematic appearance), and so must be wrapped inside a parent element. Unfortunately, being a group of `<tr/>`s, the only valid parent element is a `<tbody/>`. Having multiple `tbody`s is valid in the HTML spec so this is okay; we then move the `<Droppable/>` context around the `<table/>` as that must be above the `<Draggable/>`s (and table is the only valid tag around tbody). 

This, however, worsens an issue with the existing GBR; while dragging, the `<tbody/>` loses its tablular display, and with the new changes this is particularly noticeable.  We can reset this display via `display: table`, but must only apply this while dragging, else this breaks the layout of the main table.