### PR TITLE
Add group join page to signup flow

### DIFF
--- a/src/app/components/elements/panels/TeacherConnections.tsx
+++ b/src/app/components/elements/panels/TeacherConnections.tsx
@@ -147,8 +147,7 @@ export const TeacherConnections = ({user, authToken, editingOtherUser, userToEdi
 
     useEffect(() => {
         if (authToken && user.loggedIn && user.id) {
-            const path = "/register/group_invitation?authToken=" + authToken;
-            history.push(path);
+            authenticateWithTokenAfterPrompt(user.id, authToken);
         }
     }, [authToken]);
 

--- a/src/app/components/elements/panels/TeacherConnections.tsx
+++ b/src/app/components/elements/panels/TeacherConnections.tsx
@@ -141,13 +141,14 @@ export const TeacherConnections = ({user, authToken, editingOtherUser, userToEdi
             // TODO use whether the token owner is a tutor or not to display to the student a warning about sharing
             //      their data
             // TODO highlight teachers who have already been granted access? (see verification modal code)
-            history.push("register/group_invitation");
+            dispatch(openActiveModal(tokenVerificationModal(userId, sanitisedToken, usersToGrantAccess)) as any);
         }
     };
 
     useEffect(() => {
         if (authToken && user.loggedIn && user.id) {
-            authenticateWithTokenAfterPrompt(user.id, authToken);
+            const path = "/register/group_invitation?authToken=" + authToken;
+            history.push(path);
         }
     }, [authToken]);
 

--- a/src/app/components/elements/panels/TeacherConnections.tsx
+++ b/src/app/components/elements/panels/TeacherConnections.tsx
@@ -137,15 +137,15 @@ export const TeacherConnections = ({user, authToken, editingOtherUser, userToEdi
             dispatch(showErrorToast("No group code provided", "You have to enter a group code!"));
             return;
         }
-        const {data: usersToGrantAccess} = await getTokenOwner(sanitisedToken);
-        if (usersToGrantAccess && usersToGrantAccess.length) {
-            // TODO use whether the token owner is a tutor or not to display to the student a warning about sharing
-            //      their data
-            // TODO highlight teachers who have already been granted access? (see verification modal code)
-            if (isFirstLoginInPersistence() && sanitisedToken) {
-                history.push("/register/group_invitation?authToken="+sanitisedToken);
-            }
-            else {
+        else if (isFirstLoginInPersistence()) {
+            history.push("/register/group_invitation?authToken="+sanitisedToken);
+        }
+        else {
+            const {data: usersToGrantAccess} = await getTokenOwner(sanitisedToken);
+            if (usersToGrantAccess && usersToGrantAccess.length) {
+                // TODO use whether the token owner is a tutor or not to display to the student a warning about sharing
+                //      their data
+                // TODO highlight teachers who have already been granted access? (see verification modal code)
                 dispatch(openActiveModal(tokenVerificationModal(userId, sanitisedToken, usersToGrantAccess)) as any);
             }
         }

--- a/src/app/components/elements/panels/TeacherConnections.tsx
+++ b/src/app/components/elements/panels/TeacherConnections.tsx
@@ -14,7 +14,6 @@ import {
 } from "../../../state";
 import {
     extractTeacherName,
-    history,
     isAda,
     isLoggedIn,
     isPhy,
@@ -305,7 +304,7 @@ export const TeacherConnections = ({user, authToken, editingOtherUser, userToEdi
             <ul>
                 <li>{`Active group memberships mean you ${siteSpecific("will receive assignments set to that group by teachers in it." ,"can receive assignments from the teachers in that group.")}`}</li>
                 <li>{`Setting your membership inactive means you won’t receive any assignments ${siteSpecific("set to", "from the teachers in")} that group. You can set yourself as active again at any time.`}</li>
-                <li>If you want to permanently leave a group, ask you teacher remove you.</li>
+                <li>If you want to permanently leave a group, ask your teacher to remove you.</li>
             </ul>
             <div className="my-groups-table-section overflow-auto">
                 <div className="connect-list">

--- a/src/app/components/elements/panels/TeacherConnections.tsx
+++ b/src/app/components/elements/panels/TeacherConnections.tsx
@@ -14,7 +14,9 @@ import {
 } from "../../../state";
 import {
     extractTeacherName,
+    history,
     isAda,
+    isFirstLoginInPersistence,
     isLoggedIn,
     isPhy,
     isStudent,
@@ -140,7 +142,12 @@ export const TeacherConnections = ({user, authToken, editingOtherUser, userToEdi
             // TODO use whether the token owner is a tutor or not to display to the student a warning about sharing
             //      their data
             // TODO highlight teachers who have already been granted access? (see verification modal code)
-            dispatch(openActiveModal(tokenVerificationModal(userId, sanitisedToken, usersToGrantAccess)) as any);
+            if (isFirstLoginInPersistence() && sanitisedToken) {
+                history.push("/register/group_invitation?authToken="+sanitisedToken);
+            }
+            else {
+                dispatch(openActiveModal(tokenVerificationModal(userId, sanitisedToken, usersToGrantAccess)) as any);
+            }
         }
     };
 

--- a/src/app/components/elements/panels/TeacherConnections.tsx
+++ b/src/app/components/elements/panels/TeacherConnections.tsx
@@ -14,6 +14,7 @@ import {
 } from "../../../state";
 import {
     extractTeacherName,
+    history,
     isAda,
     isLoggedIn,
     isPhy,
@@ -140,7 +141,7 @@ export const TeacherConnections = ({user, authToken, editingOtherUser, userToEdi
             // TODO use whether the token owner is a tutor or not to display to the student a warning about sharing
             //      their data
             // TODO highlight teachers who have already been granted access? (see verification modal code)
-            dispatch(openActiveModal(tokenVerificationModal(userId, sanitisedToken, usersToGrantAccess)) as any);
+            history.push("register/group_invitation");
         }
     };
 

--- a/src/app/components/elements/panels/TeacherConnections.tsx
+++ b/src/app/components/elements/panels/TeacherConnections.tsx
@@ -138,7 +138,7 @@ export const TeacherConnections = ({user, authToken, editingOtherUser, userToEdi
             return;
         }
         else if (isFirstLoginInPersistence()) {
-            history.push("/register/group_invitation?authToken="+sanitisedToken);
+            history.push("/register/group_invitation?authToken=" + encodeURIComponent(sanitisedToken));
         }
         else {
             const {data: usersToGrantAccess} = await getTokenOwner(sanitisedToken);

--- a/src/app/components/pages/MyAccount.tsx
+++ b/src/app/components/pages/MyAccount.tsx
@@ -56,7 +56,8 @@ import {
     validateEmail,
     validateEmailPreferences,
     validatePassword,
-    isTeacherOrAbove
+    isTeacherOrAbove,
+    isFirstLoginInPersistence
 } from "../../services";
 import queryString from "query-string";
 import {Link, withRouter} from "react-router-dom";
@@ -261,7 +262,7 @@ const AccountPageComponent = ({user, getChosenUserAuthSettings, error, userAuthS
 
     const accountInfoChanged = contextsChanged || userChanged || otherPreferencesChanged || (emailPreferencesChanged && activeTab == ACCOUNT_TAB.emailpreferences);
     useEffect(() => {
-        if (accountInfoChanged && !saving) {
+        if (accountInfoChanged && !isFirstLoginInPersistence() && !saving) {
             return history.block("If you leave this page without saving, your account changes will be lost. Are you sure you would like to leave?");
         }
     }, [accountInfoChanged, saving]);

--- a/src/app/components/pages/RegistrationGroupInvite.tsx
+++ b/src/app/components/pages/RegistrationGroupInvite.tsx
@@ -39,32 +39,40 @@ export const RegistrationGroupInvite = ()  => {
     if(!isGroupValid){
         return <Container>
             <TitleAndBreadcrumb currentPageTitle={`Group not found`} className="mb-4" />
-            <p>You came here via a group join link, but the group code is invalid.</p>
-            <RS.Button color="primary" outline onClick={() => {history.push("/account#teacherconnections");}}>
-                Go to teacher connections
-            </RS.Button>
+            <RS.Card className="my-5">
+                <RS.CardBody>
+                    <p>You came here via a group join link, but the group code is invalid.</p>
+                    <RS.Button color="primary" outline onClick={() => {history.push("/account#teacherconnections");}}>
+                        Go to teacher connections
+                    </RS.Button>
+                </RS.CardBody>
+            </RS.Card>
         </Container>;
     }
     return <Container>
         <TitleAndBreadcrumb currentPageTitle={`Join group`} className="mb-4" />
-        <p>You came here via a group join link. Are you happy to join the group and allow
-        these teachers to see your work and progress?</p>
-        <RS.Table bordered>
-            <tbody>
-                {usersToGrantAccess?.map((member: any) => (<tr key={member.id}>
-                    <td>
-                        <span className="group-table-person" />
-                        {extractTeacherName(member)} - ({member.email})
-                    </td>
-                </tr>))}
-            </tbody>
-        </RS.Table>
-        <RS.Button color="primary" outline onClick={() => {history.push("/account");}}>
-            No, skip this
-        </RS.Button>
-        {" "}
-        <RS.Button color="secondary" onClick={() => {store.dispatch(authorisationsApi.endpoints.authenticateWithToken.initiate(authenticationToken)); history.push("/account");}}>
-            Yes, join the group
-        </RS.Button>
+        <RS.Card className="my-5">
+            <RS.CardBody>
+                <p>You came here via a group join link. Are you happy to join the group and allow
+                these teachers to see your work and progress?</p>
+                <RS.Table bordered>
+                    <tbody>
+                        {usersToGrantAccess?.map((member: any) => (<tr key={member.id}>
+                            <td>
+                                <span className="group-table-person" />
+                                {extractTeacherName(member)} - ({member.email})
+                            </td>
+                        </tr>))}
+                    </tbody>
+                </RS.Table>
+                <RS.Button color="primary" outline onClick={() => {history.push("/account");}}>
+                    No, skip this
+                </RS.Button>
+                {" "}
+                <RS.Button color="secondary" onClick={() => {store.dispatch(authorisationsApi.endpoints.authenticateWithToken.initiate(authenticationToken)); history.push("/account");}}>
+                    Yes, join the group
+                </RS.Button>
+            </RS.CardBody>  
+        </RS.Card>
     </Container>;
 };

--- a/src/app/components/pages/RegistrationGroupInvite.tsx
+++ b/src/app/components/pages/RegistrationGroupInvite.tsx
@@ -40,6 +40,9 @@ export const RegistrationGroupInvite = ()  => {
         return <Container>
             <TitleAndBreadcrumb currentPageTitle={`Group not found`} className="mb-4" />
             <p>You came here via a group join link, but the group code is invalid.</p>
+            <RS.Button color="primary" outline onClick={() => {history.push("/account#teacherconnections");}}>
+                Go to teacher connections
+            </RS.Button>
         </Container>;
     }
     return <Container>

--- a/src/app/components/pages/RegistrationGroupInvite.tsx
+++ b/src/app/components/pages/RegistrationGroupInvite.tsx
@@ -1,0 +1,57 @@
+import {Container} from "reactstrap";
+import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
+import React, { useEffect, useState } from "react";
+import * as RS from "reactstrap";
+import { extractTeacherName, history, KEY, persistence } from "../../services";
+import { authorisationsApi, store, useLazyGetTokenOwnerQuery } from "../../state";
+import { UserSummaryWithEmailAddressDTO } from "../../../IsaacApiTypes";
+
+export const RegistrationGroupInvite = ()  => {
+    const [getTokenOwner] = useLazyGetTokenOwnerQuery();
+    const authenticateWithTokenAfterPrompt = async (token: string | null) => {
+        const sanitisedToken = token?.split("?authToken=").at(-1)?.toUpperCase().replace(/ /g,'') ?? "";
+        const {data: usersToGrantAccess} = await getTokenOwner(sanitisedToken);
+        if (usersToGrantAccess && usersToGrantAccess.length){
+            return usersToGrantAccess;
+        }
+    };
+    
+    persistence.save(KEY.AFTER_AUTH_PATH, window.location.pathname);
+    const urlParams = new URLSearchParams(location.search);
+    const afterAuthPath = urlParams.get("authToken") ?? "";
+    const [authenticationToken, _] = useState<string>(afterAuthPath);
+    // need to handle persistence.remove etc
+    const codeIsValid = authenticationToken && authenticationToken.length > 0;
+    
+    const [usersToGrantAccess, setUsersToGrantAccess] = useState<UserSummaryWithEmailAddressDTO[] | undefined>();
+
+    useEffect(()=>{
+        if (codeIsValid) {
+            authenticateWithTokenAfterPrompt(authenticationToken).then((result) => {
+                setUsersToGrantAccess(result);
+            });
+        }
+    }, []) ;
+
+    return <Container>
+        <TitleAndBreadcrumb currentPageTitle={`Join group`} className="mb-4" />
+        <p>You came here via a group join link. Are you happy to join the group and allow
+        these teachers to see your work and progress?</p>
+        <RS.Table bordered>
+            <tbody>
+                {usersToGrantAccess?.map((member: any) => (<tr key={member.id}>
+                    <td>
+                        <span className="group-table-person" />
+                        {extractTeacherName(member)} - ({member.email})
+                    </td>
+                </tr>))}
+            </tbody>
+        </RS.Table>
+        <RS.Button color="primary" outline onClick={() => {history.push("/account");}}>
+            No, skip this
+        </RS.Button>
+        <RS.Button color="secondary" onClick={() => {store.dispatch(authorisationsApi.endpoints.authenticateWithToken.initiate("NGVZVB")); history.push("/account");}}>
+            Yes, join the group
+        </RS.Button>
+    </Container>;
+};

--- a/src/app/components/site/phy/RoutesPhy.tsx
+++ b/src/app/components/site/phy/RoutesPhy.tsx
@@ -56,7 +56,7 @@ export const RoutesPhy = [
     <TrackedRoute key={key++} exact path="/register/student/additional_info" component={RegistrationAgeCheckParentalConsent} />,
     <TrackedRoute key={key++} exact path="/register/student/age_denied" component={RegistrationAgeCheckFailed} />,
     <TrackedRoute key={key++} exact path="/register/student/details" component={RegistrationSetDetails} componentProps={{'role': 'STUDENT'}} />,
-    <TrackedRoute key={key++} exact path="/register/group_invitation" component={RegistrationGroupInvite} componentProps={{'role': 'STUDENT'}} />,
+    <TrackedRoute key={key++} exact path="/register/group_invitation" component={RegistrationGroupInvite} />,
     <TrackedRoute key={key++} exact path="/register/connect" ifUser={isLoggedIn} component={RegistrationTeacherConnect} />,
     <TrackedRoute key={key++} exact path="/register/preferences" ifUser={isLoggedIn} component={RegistrationSetPreferences} />,
     <TrackedRoute key={key++} exact path="/register/success" ifUser={isLoggedIn} component={RegistrationSuccess} />,

--- a/src/app/components/site/phy/RoutesPhy.tsx
+++ b/src/app/components/site/phy/RoutesPhy.tsx
@@ -41,6 +41,7 @@ import { RegistrationSetDetails } from "../../pages/RegistrationSetDetails";
 import { RegistrationTeacherConnect } from "../../pages/RegistrationTeacherConnect";
 import { RegistrationSuccess } from "../../pages/RegistrationSuccess";
 import { RegistrationSetPreferences } from "../../pages/RegistrationSetPreferences";
+import { RegistrationGroupInvite } from "../../pages/RegistrationGroupInvite";
 
 const Equality = lazy(() => import('../../pages/Equality'));
 const EventDetails = lazy(() => import('../../pages/EventDetails'));
@@ -55,6 +56,7 @@ export const RoutesPhy = [
     <TrackedRoute key={key++} exact path="/register/student/additional_info" component={RegistrationAgeCheckParentalConsent} />,
     <TrackedRoute key={key++} exact path="/register/student/age_denied" component={RegistrationAgeCheckFailed} />,
     <TrackedRoute key={key++} exact path="/register/student/details" component={RegistrationSetDetails} componentProps={{'role': 'STUDENT'}} />,
+    <TrackedRoute key={key++} exact path="/register/group_invitation" component={RegistrationGroupInvite} componentProps={{'role': 'STUDENT'}} />,
     <TrackedRoute key={key++} exact path="/register/connect" ifUser={isLoggedIn} component={RegistrationTeacherConnect} />,
     <TrackedRoute key={key++} exact path="/register/preferences" ifUser={isLoggedIn} component={RegistrationSetPreferences} />,
     <TrackedRoute key={key++} exact path="/register/success" ifUser={isLoggedIn} component={RegistrationSuccess} />,


### PR DESCRIPTION
When users sign up following a group join link, add a page after the signup flow to confirm that they want to share their data with teachers. This replaces a modal with similar behaviour.

This could just be an extra question at the bottom of the signup page, but the new buttons would look confusing next to the existing Back/Continue buttons.

The exact wording used and failure modes might also need to be reconsidered - currently users can complete the entire signup flow before finding out their link was invalid.