### PR TITLE
Ensure inline entries are rendered on soft link follow

### DIFF
--- a/src/IsaacAppTypes.tsx
+++ b/src/IsaacAppTypes.tsx
@@ -430,6 +430,8 @@ export const InlineContext = React.createContext<{
     setFeedbackIndex: React.Dispatch<React.SetStateAction<number | undefined>>,
     focusSelection?: boolean,
     setFocusSelection: React.Dispatch<React.SetStateAction<boolean>>,
+    initialised?: boolean,
+    setInitialised: React.Dispatch<React.SetStateAction<boolean>>,
 } | undefined>(undefined);
 export const QuizAttemptContext = React.createContext<{quizAttempt: QuizAttemptDTO | null; questionNumbers: {[questionId: string]: number}}>({quizAttempt: null, questionNumbers: {}});
 export const ExpandableParentContext = React.createContext<boolean>(false);

--- a/src/app/components/content/IsaacInlineRegion.tsx
+++ b/src/app/components/content/IsaacInlineRegion.tsx
@@ -117,6 +117,7 @@ const IsaacInlineRegion = ({doc, className}: IsaacInlineRegionProps) => {
                     inlineContext.elementToQuestionMap[elementId] = {questionId: inlineQuestion.id, type: inlineQuestion.type};
                 }
             });
+            inlineContext.setInitialised(true);
         }
     }, [inlineQuestions]);
 

--- a/src/app/components/elements/InlineContextProvider.tsx
+++ b/src/app/components/elements/InlineContextProvider.tsx
@@ -13,12 +13,14 @@ const InlineContextProvider = (props: InlineContextProviderProps) => {
     const [isModifiedSinceLastSubmission, setIsModifiedSinceLastSubmission] = React.useState(false);
     const [submitting, setSubmitting] = React.useState(false);
     const [focusSelection, setFocusSelection] = React.useState(false);
+    const [initialised, setInitialised] = React.useState(false);
     const canShowWarningToast = useRef(true).current; 
     // above is a ref because multiple questions are submitted during the same render cycle; this value needs to update during this time, which setState doesn't guarantee.
 
     return <InlineContext.Provider value={{ 
         docId: props.docId, elementToQuestionMap: questionPartIdMap, modifiedQuestionIds, setModifiedQuestionIds, isModifiedSinceLastSubmission,
-        canShowWarningToast, setIsModifiedSinceLastSubmission, feedbackIndex, setFeedbackIndex, submitting, setSubmitting, focusSelection, setFocusSelection }}
+        canShowWarningToast, setIsModifiedSinceLastSubmission, feedbackIndex, setFeedbackIndex, submitting, setSubmitting, focusSelection, setFocusSelection,
+        initialised, setInitialised}}
     >
         {props.children}
     </InlineContext.Provider>;


### PR DESCRIPTION
Adds an `initialised` flag to the inline context to account for portals rendering order differing on soft links.

Soft and hard link redirects having different rendering behaviour is the real cause and this only patches over this, so we should perhaps consider an alternative portals approach in the future.