### PR TITLE
Stop setting viewing context defaults on registration as not saved in DB

### DIFF
--- a/src/app/components/pages/RegistrationSetDetails.tsx
+++ b/src/app/components/pages/RegistrationSetDetails.tsx
@@ -100,8 +100,7 @@ export const RegistrationSetDetails = ({role}: RegistrationSetDetailsProps) => {
             setAttemptedSignUp(true);
             Object.assign(registrationUser, {loggedIn: false});
             dispatch(errorSlice.actions.clearError());
-            dispatch(registerNewUser(registrationUser, {EMAIL_PREFERENCE: EMAIL_PREFERENCE_DEFAULTS},
-                [{stage: STAGE.ALL, examBoard: EXAM_BOARD.ADA}], null));
+            dispatch(registerNewUser(registrationUser, {EMAIL_PREFERENCE: EMAIL_PREFERENCE_DEFAULTS}, undefined, null));
             trackEvent("registration", {
                 props:
                         {


### PR DESCRIPTION
The code, for the previous couple of months, has tried to set the default viewing context during registration but the back-end code ignores it. We actually do not want to be setting the default viewing context at this step in the registration because we want to continue to display the context picker to users who have not explicitly set them.