### PR TITLE
Fix Inequality 'reading 0' exception

### DIFF
--- a/src/app/components/content/IsaacSymbolicChemistryQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicChemistryQuestion.tsx
@@ -233,7 +233,8 @@ const IsaacSymbolicChemistryQuestion = ({doc, questionId, readonly}: IsaacQuesti
                             <Button type="button" className="eqn-editor-help" id={helpTooltipId} tag="a" href="/solving_problems#symbolic_text">?</Button>,
                             <span id={helpTooltipId} className="icon-help-q my-auto"/>
                         )}
-                        {doc.isNuclear
+                        {!modalVisible ? 
+                            (doc.isNuclear
                                 ? <UncontrolledTooltip className="spaced-tooltip" placement="top" autohide={false} target={helpTooltipId}>
                                     Here are some examples of expressions you can type:<br />
                                     {"^{238}_{92}U -> ^{4}_{2}\\alphaparticle + _{90}^{234}Th"}<br />
@@ -248,7 +249,9 @@ const IsaacSymbolicChemistryQuestion = ({doc, questionId, readonly}: IsaacQuesti
                                     CH3(CH2)3CH3<br />
                                     {"NaCl(aq) -> Na^{+}(aq) +  Cl^{-}(aq)"}<br />
                                     As you type, the box above will preview the result.
-                                </UncontrolledTooltip>}
+                                </UncontrolledTooltip>
+                            )
+                        : null}
                     </>
                 </InputGroup>
                 <QuestionInputValidation userInput={textInput} validator={symbolicInputValidator} />

--- a/src/app/components/content/IsaacSymbolicLogicQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicLogicQuestion.tsx
@@ -233,7 +233,7 @@ const IsaacSymbolicLogicQuestion = ({doc, questionId, readonly}: IsaacQuestionPr
                             <Button type="button" className={classNames("eqn-editor-help", {"py-0": isAda})} id={helpTooltipId}>?</Button>,
                             <span id={helpTooltipId} className="icon-help-q my-auto"/>
                         )}
-                        <UncontrolledTooltip placement="top" autohide={false} target={helpTooltipId}>
+                        {!modalVisible && <UncontrolledTooltip placement="top" autohide={false} target={helpTooltipId}>
                             Here are some examples of expressions you can type:<br />
                             <br />
                             A AND (B XOR NOT C)<br />
@@ -241,7 +241,7 @@ const IsaacSymbolicLogicQuestion = ({doc, questionId, readonly}: IsaacQuestionPr
                             T &amp; ~(F + A)<br />
                             1 . ~(0 + A)<br />
                             As you type, the box above will preview the result.
-                        </UncontrolledTooltip>
+                        </UncontrolledTooltip>}
                     </>
                 </InputGroup>
                 <QuestionInputValidation userInput={textInput} validator={symbolicLogicInputValidator} />

--- a/src/app/components/content/IsaacSymbolicQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicQuestion.tsx
@@ -240,7 +240,7 @@ const IsaacSymbolicQuestion = ({doc, questionId, readonly}: IsaacQuestionProps<I
                         placeholder="Type your formula here"/>
                     <>
                         {siteSpecific(
-                            <RS.Button type="button" className={classNames("eqn-editor-help", {"py-0": isAda})} id={helpTooltipId} tag="a" href="/solving_problems#symbolic_text">?</RS.Button>,
+                            <RS.Button type="button" className="eqn-editor-help" id={helpTooltipId} tag="a" href="/solving_problems#symbolic_text">?</RS.Button>,
                             <span id={helpTooltipId} className="icon-help-q my-auto"/>
                         )}
                         {!modalVisible && <RS.UncontrolledTooltip placement="top" autohide={false} target={helpTooltipId}>

--- a/src/app/components/content/IsaacSymbolicQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicQuestion.tsx
@@ -243,7 +243,7 @@ const IsaacSymbolicQuestion = ({doc, questionId, readonly}: IsaacQuestionProps<I
                             <RS.Button type="button" className={classNames("eqn-editor-help", {"py-0": isAda})} id={helpTooltipId} tag="a" href="/solving_problems#symbolic_text">?</RS.Button>,
                             <span id={helpTooltipId} className="icon-help-q my-auto"/>
                         )}
-                        <RS.UncontrolledTooltip placement="top" autohide={false} target={helpTooltipId}>
+                        {!modalVisible && <RS.UncontrolledTooltip placement="top" autohide={false} target={helpTooltipId}>
                             Here are some examples of expressions you can type:<br />
                             <br />
                             a*x^2 + b x + c<br />
@@ -252,7 +252,7 @@ const IsaacSymbolicQuestion = ({doc, questionId, readonly}: IsaacQuestionProps<I
                             log(x_a, 2) == log(x_a) / log(2)<br />
                             <br />
                             As you type, the box below will preview the result.
-                        </RS.UncontrolledTooltip>
+                        </RS.UncontrolledTooltip>}
                     </>
                 </RS.InputGroup>
                 <QuestionInputValidation userInput={textInput} validator={symbolicInputValidator} />


### PR DESCRIPTION
Since the update to React 18, a new exception was firing whereby removing the element over which tooltip hover text was active would give an obscure error from inside the ReactStrap library.