### PR TITLE
Sanitise hexagon board IDs

### DIFF
--- a/src/app/components/elements/cards/BoardCard.tsx
+++ b/src/app/components/elements/cards/BoardCard.tsx
@@ -141,7 +141,7 @@ export const BoardCard = ({user, board, boardView, assignees, toggleAssignModal,
     // Decides whether we show the "Assign/Unassign" button, along with other "Set Assignments"-specific stuff
     const isSetAssignments = isDefined(toggleAssignModal) && isDefined(assignees);
 
-    const hexagonId = `board-hex-${board.id}`;
+    const hexagonId = (`board-hex-${board.id}`).replace(/[^a-z0-9-]+/gi, '');
     const boardLink = isSetAssignments ? `/assignment/${board.id}` : `${PATHS.GAMEBOARD}#${board.id}`;
     const hasAssignedGroups = assignees && assignees.length > 0;
 


### PR DESCRIPTION
Fixes a small bug where invalid hexagon IDs could be passed to HexagonGroupsButton. This wasn't affecting the live site, but could cause an error on staging.