### PR TITLE
Remove transparent background from wildcards

### DIFF
--- a/src/app/components/pages/Gameboard.tsx
+++ b/src/app/components/pages/Gameboard.tsx
@@ -110,7 +110,7 @@ const GameboardItemComponent = ({gameboard, question}: {gameboard: GameboardDTO,
 };
 
 export const Wildcard = ({wildcard}: {wildcard: IsaacWildcard}) => {
-    const itemClasses = "p-3 content-summary-link text-info bg-transparent";
+    const itemClasses = classNames("content-summary-link text-info bg-white", {"p-3": isPhy, "p-0": isAda});
     const icon = <img src="/assets/common/wildcard.svg" alt="Optional extra information icon"/>;
     return <ListGroupItem key={wildcard.id} className={itemClasses}>
         <a href={wildcard.url} className="align-items-center">


### PR DESCRIPTION
I believe we used to rely on the `ListGroup` background to show the white colour here but a change at some point has removed this. Now using the same base classes as a question.