### PR TITLE
Allow codeTabs to have non codeSnippet children

### DIFF
--- a/src/app/components/content/IsaacCodeTabs.tsx
+++ b/src/app/components/content/IsaacCodeTabs.tsx
@@ -1,9 +1,8 @@
-import React, {lazy, ReactElement, useEffect, useState} from "react";
+import React, {ReactElement, useEffect, useState} from "react";
 import {Tabs} from "../elements/Tabs";
 import {CodeSnippetDTO} from "../../../IsaacApiTypes";
 import {isDefined, programmingLanguagesMap, useUserPreferences} from "../../services";
-
-const IsaacCodeSnippet = lazy(() => import("./IsaacCodeSnippet"));
+import { IsaacContent } from "./IsaacContent";
 
 interface IsaacCodeTabsProps {
     doc: {children: {title?: string; children?: CodeSnippetDTO[]}[]};
@@ -18,9 +17,7 @@ export const IsaacCodeTabs = (props: any) => {
     children.forEach((child, index) => {
         const titleFromSnippet = child?.children && child?.children?.length > 0 && child?.children[0].language && programmingLanguagesMap[child.children[0].language.toUpperCase()];
         const tabTitle = titleFromSnippet || child.title || `Tab ${index + 1}`;
-        if (isDefined(child.children)) {
-            tabTitlesToContent[tabTitle] = <IsaacCodeSnippet doc={child.children[0]} />;
-        }
+        tabTitlesToContent[tabTitle] = <IsaacContent doc={child} />;
     });
 
     const tabTitles = Object.keys(tabTitlesToContent);
@@ -31,7 +28,7 @@ export const IsaacCodeTabs = (props: any) => {
         }
     }, [preferredProgrammingLanguage, tabTitles]);
 
-    return <Tabs className="isaac-tab" tabContentClass="pt-4" activeTabOverride={defaultTabIndex !== -1 ? defaultTabIndex + 1 : 1}>
+    return <Tabs className="isaac-tab card card-body border bg-white pb-2 mb-4" tabContentClass="pt-4" activeTabOverride={defaultTabIndex !== -1 ? defaultTabIndex + 1 : 1}>
         {tabTitlesToContent}
     </Tabs>;
 };

--- a/src/app/components/content/IsaacContentValueOrChildren.tsx
+++ b/src/app/components/content/IsaacContentValueOrChildren.tsx
@@ -25,7 +25,7 @@ export const IsaacContentValueOrChildren = ({value, encoding, children}: Content
                 contentChunks.push(currentChunk);
             }
             currentChunk = [child];
-        } else if (child.layout == "accordion" || child.layout == "tabs") {
+        } else if (child.layout == "accordion" || child.layout == "tabs" || child.type == "codeTabs") {
             if (currentChunk.length > 0) {
                 contentChunks.push(currentChunk);
             }

--- a/src/app/components/content/IsaacSymbolicChemistryQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicChemistryQuestion.tsx
@@ -48,39 +48,8 @@ function isError(p: ParsingError | any[]): p is ParsingError {
     return p.hasOwnProperty("error");
 }
 
-export const symbolicInputValidator = (input: string) => {
-    const openRoundBracketsCount = input.split("(").length - 1;
-    const closeRoundBracketsCount = input.split(")").length - 1;
-    const openSquareBracketsCount = input.split("[").length - 1;
-    const closeSquareBracketsCount = input.split("]").length - 1;
-    const openCurlyBracketsCount = input.split("{").length - 1;
-    const closeCurlyBracketsCount = input.split("}").length - 1;
-    const regexStr = /[^ 0-9A-Za-z()[\]{}*+,-./<=>^_\\]+/;
-    const badCharacters = new RegExp(regexStr);
-    const errors = [];
-    if (badCharacters.test(input)) {
-        const usedBadChars: string[] = [];
-        for(let i = 0; i < input.length; i++) {
-            const char = input.charAt(i);
-            if (badCharacters.test(char)) {
-                if (!usedBadChars.includes(char)) {
-                    usedBadChars.push(char);
-                }
-            }
-        }
-        errors.push('Some of the characters you are using are not allowed: ' + usedBadChars.join(" "));
-    }
-    if (openRoundBracketsCount !== closeRoundBracketsCount
-       || openSquareBracketsCount !== closeSquareBracketsCount
-       || openCurlyBracketsCount !== closeCurlyBracketsCount) {
-        // Rather than a long message about which brackets need closing
-        errors.push('You are missing some brackets.');
-    }
-    if (/\.[0-9]/.test(input)) {
-        errors.push('Please convert decimal numbers to fractions.');
-    }
-    return errors;
-};
+const availableChemistryMetaSymbols: string[] = 
+    ["_state_symbols", "_plus", "_minus", "_fraction", "_right_arrow", "_equilibrium_arrow", "_brackets_round", "_brackets_square", "_dot" ];  
 
 const IsaacSymbolicChemistryQuestion = ({doc, questionId, readonly}: IsaacQuestionProps<IsaacSymbolicChemistryQuestionDTO>) => {
 
@@ -97,6 +66,45 @@ const IsaacSymbolicChemistryQuestion = ({doc, questionId, readonly}: IsaacQuesti
     if (currentAttempt && currentAttempt.value) {
         currentAttemptValue = jsonHelper.parseOrDefault(currentAttempt.value, {result: {tex: '\\textrm{PLACEHOLDER HERE}'}});
     }
+
+    const hasMetaSymbols = doc.availableSymbols?.some(symbol => availableChemistryMetaSymbols.includes(symbol));
+
+    const symbolicInputValidator = (input: string) => {
+        const openRoundBracketsCount = input.split("(").length - 1;
+        const closeRoundBracketsCount = input.split(")").length - 1;
+        const openSquareBracketsCount = input.split("[").length - 1;
+        const closeSquareBracketsCount = input.split("]").length - 1;
+        const openCurlyBracketsCount = input.split("{").length - 1;
+        const closeCurlyBracketsCount = input.split("}").length - 1;
+        const regexStr = /[^ 0-9A-Za-z()[\]{}*+,-./<=>^_\\]+/;
+        const badCharacters = new RegExp(regexStr);
+        const errors = [];
+        if (badCharacters.test(input)) {
+            const usedBadChars: string[] = [];
+            for(let i = 0; i < input.length; i++) {
+                const char = input.charAt(i);
+                if (badCharacters.test(char)) {
+                    if (!usedBadChars.includes(char)) {
+                        usedBadChars.push(char);
+                    }
+                }
+            }
+            errors.push('Some of the characters you are using are not allowed: ' + usedBadChars.join(" "));
+        }
+        if (openRoundBracketsCount !== closeRoundBracketsCount
+           || openSquareBracketsCount !== closeSquareBracketsCount
+           || openCurlyBracketsCount !== closeCurlyBracketsCount) {
+            // Rather than a long message about which brackets need closing
+            errors.push('You are missing some brackets.');
+        }
+        if (/\.[0-9]/.test(input)) {
+            errors.push('Please convert decimal numbers to fractions.');
+        }
+        if ((!doc.availableSymbols?.includes("_state_symbols") && hasMetaSymbols) && /\(s\)|\(l\)|\(aq\)|\(g\)/.test(input)) {
+            errors.push('This question does not require state symbols.');
+        }
+        return errors;
+    };
 
     function currentAttemptMhchemExpression(): string {
         return (currentAttemptValue?.result && currentAttemptValue.result.mhchem) || "";

--- a/src/app/components/content/IsaacSymbolicChemistryQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicChemistryQuestion.tsx
@@ -48,8 +48,39 @@ function isError(p: ParsingError | any[]): p is ParsingError {
     return p.hasOwnProperty("error");
 }
 
-const availableChemistryMetaSymbols: string[] = 
-    ["_state_symbols", "_plus", "_minus", "_fraction", "_right_arrow", "_equilibrium_arrow", "_brackets_round", "_brackets_square", "_dot" ];  
+export const symbolicInputValidator = (input: string) => {
+    const openRoundBracketsCount = input.split("(").length - 1;
+    const closeRoundBracketsCount = input.split(")").length - 1;
+    const openSquareBracketsCount = input.split("[").length - 1;
+    const closeSquareBracketsCount = input.split("]").length - 1;
+    const openCurlyBracketsCount = input.split("{").length - 1;
+    const closeCurlyBracketsCount = input.split("}").length - 1;
+    const regexStr = /[^ 0-9A-Za-z()[\]{}*+,-./<=>^_\\]+/;
+    const badCharacters = new RegExp(regexStr);
+    const errors = [];
+    if (badCharacters.test(input)) {
+        const usedBadChars: string[] = [];
+        for(let i = 0; i < input.length; i++) {
+            const char = input.charAt(i);
+            if (badCharacters.test(char)) {
+                if (!usedBadChars.includes(char)) {
+                    usedBadChars.push(char);
+                }
+            }
+        }
+        errors.push('Some of the characters you are using are not allowed: ' + usedBadChars.join(" "));
+    }
+    if (openRoundBracketsCount !== closeRoundBracketsCount
+       || openSquareBracketsCount !== closeSquareBracketsCount
+       || openCurlyBracketsCount !== closeCurlyBracketsCount) {
+        // Rather than a long message about which brackets need closing
+        errors.push('You are missing some brackets.');
+    }
+    if (/\.[0-9]/.test(input)) {
+        errors.push('Please convert decimal numbers to fractions.');
+    }
+    return errors;
+};
 
 const IsaacSymbolicChemistryQuestion = ({doc, questionId, readonly}: IsaacQuestionProps<IsaacSymbolicChemistryQuestionDTO>) => {
 
@@ -66,45 +97,6 @@ const IsaacSymbolicChemistryQuestion = ({doc, questionId, readonly}: IsaacQuesti
     if (currentAttempt && currentAttempt.value) {
         currentAttemptValue = jsonHelper.parseOrDefault(currentAttempt.value, {result: {tex: '\\textrm{PLACEHOLDER HERE}'}});
     }
-
-    const hasMetaSymbols = doc.availableSymbols?.some(symbol => availableChemistryMetaSymbols.includes(symbol));
-
-    const symbolicInputValidator = (input: string) => {
-        const openRoundBracketsCount = input.split("(").length - 1;
-        const closeRoundBracketsCount = input.split(")").length - 1;
-        const openSquareBracketsCount = input.split("[").length - 1;
-        const closeSquareBracketsCount = input.split("]").length - 1;
-        const openCurlyBracketsCount = input.split("{").length - 1;
-        const closeCurlyBracketsCount = input.split("}").length - 1;
-        const regexStr = /[^ 0-9A-Za-z()[\]{}*+,-./<=>^_\\]+/;
-        const badCharacters = new RegExp(regexStr);
-        const errors = [];
-        if (badCharacters.test(input)) {
-            const usedBadChars: string[] = [];
-            for(let i = 0; i < input.length; i++) {
-                const char = input.charAt(i);
-                if (badCharacters.test(char)) {
-                    if (!usedBadChars.includes(char)) {
-                        usedBadChars.push(char);
-                    }
-                }
-            }
-            errors.push('Some of the characters you are using are not allowed: ' + usedBadChars.join(" "));
-        }
-        if (openRoundBracketsCount !== closeRoundBracketsCount
-           || openSquareBracketsCount !== closeSquareBracketsCount
-           || openCurlyBracketsCount !== closeCurlyBracketsCount) {
-            // Rather than a long message about which brackets need closing
-            errors.push('You are missing some brackets.');
-        }
-        if (/\.[0-9]/.test(input)) {
-            errors.push('Please convert decimal numbers to fractions.');
-        }
-        if ((!doc.availableSymbols?.includes("_state_symbols") && hasMetaSymbols) && /\(s\)|\(l\)|\(aq\)|\(g\)/.test(input)) {
-            errors.push('This question does not require state symbols.');
-        }
-        return errors;
-    };
 
     function currentAttemptMhchemExpression(): string {
         return (currentAttemptValue?.result && currentAttemptValue.result.mhchem) || "";


### PR DESCRIPTION
In an effort to finally implement `codeTabs` into the app (to allow a user's preferred programming language to be automatically selected), it was found that they don't work for tabs with anything other than a single `codeSnippet` child. 

This genericises the child to all children in a `Content` block, which is then handled by `Tabs` as normal.