### PR TITLE
Fix coordinate feedback

### DIFF
--- a/src/app/components/content/IsaacCoordinateQuestion.tsx
+++ b/src/app/components/content/IsaacCoordinateQuestion.tsx
@@ -44,7 +44,7 @@ export const coordinateInputValidator = (input: string[][]) => {
         errors.push('Simplify each part of your answer into a single decimal number.');
     }
     if (allBadChars.length > 0) {
-        const uniqueBadChars = [...new Set(allBadChars.toString())].toString().replaceAll(","," ");
+        const uniqueBadChars = [...new Set(allBadChars.toString())].filter(e => e !== ",").join(" ");
         errors.push('Some of the characters you are using are not allowed: ' + uniqueBadChars);
     }
     return errors;

--- a/src/app/components/content/IsaacCoordinateQuestion.tsx
+++ b/src/app/components/content/IsaacCoordinateQuestion.tsx
@@ -27,7 +27,7 @@ export const coordinateInputValidator = (input: string) => {
             const char = input.charAt(i);
             if (badChars.test(char)) {
                 if (!usedBadChars.includes(char)) {
-                    usedBadChars.push(char === ' ' ? 'space' : char);
+                    usedBadChars.push(char);
                 }
             }
         }

--- a/src/app/components/content/IsaacCoordinateQuestion.tsx
+++ b/src/app/components/content/IsaacCoordinateQuestion.tsx
@@ -18,23 +18,34 @@ interface CoordinateInputProps {
     remove?: () => void;
 }
 
-export const coordinateInputValidator = (input: string) => {
+export const coordinateInputValidator = (input: string[][]) => {
     const errors: string[] = [];
-    const badChars = new RegExp("[^ 0-9-.,]+");
-    if (badChars.test(input)) {
-        const usedBadChars: string[] = []; 
-        for (let i = 0; i < input.length; i++) {
-            const char = input.charAt(i);
-            if (badChars.test(char)) {
-                if (!usedBadChars.includes(char)) {
-                    usedBadChars.push(char);
-                }
+    const allBadChars: string[] = [];
+    let containsComma = false;
+    let containsOperator = false;
+    input.forEach((coordinate) => {
+        coordinate.forEach((value) => {
+            if (value.includes(",")) {
+                containsComma = true;
             }
-        }
-        errors.push('Some of the characters you are using are not allowed: ' + usedBadChars.join(" "));
+            if (/[0-9]\s*[+/÷\-x×]\s*[0-9]/.test(value)) {
+                containsOperator = true;
+            }
+            const foundBadChars =  [...value.matchAll(/[^ 0-9+-.eE]/g)];
+            if (foundBadChars.length > 0) {
+                allBadChars.push(foundBadChars.toString());
+            }
+        });
+    });
+    if (containsComma) {
+        errors.push('Your answer should not contain commas. Enter each part of your answer in a separate box.');
     }
-    if (/[0-9]\s*[+/÷\-x×]\s*[0-9]/.test(input)) {
+    if (containsOperator) {
         errors.push('Simplify each part of your answer into a single decimal number.');
+    }
+    if (allBadChars.length > 0) {
+        const uniqueBadChars = [...new Set(allBadChars.toString())].toString().replaceAll(","," ");
+        errors.push('Some of the characters you are using are not allowed: ' + uniqueBadChars);
     }
     return errors;
 };
@@ -128,7 +139,7 @@ const IsaacCoordinateQuestion = ({doc, questionId, readonly}: IsaacQuestionProps
                     onChange={value => updateItem(0, value)}
                 />
         }
-        <QuestionInputValidation userInput={currentAttempt?.items?.map(answer => ((answer.x ?? "").concat(",", answer.y ?? ""))).toString() ?? ""} validator={coordinateInputValidator}/>
+        <QuestionInputValidation userInput={currentAttempt?.items?.map(answer => [answer.x ?? "", answer.y ?? ""]) ?? []} validator={coordinateInputValidator}/>
         {!doc.numberOfCoordinates && <Button color="secondary" size="sm" className="mt-3" onClick={() => updateItem(currentAttempt?.items?.length ?? 1, {...DEFAULT_COORDINATE_ITEM})}>Add coordinate</Button>}
     </div>;
 };

--- a/src/app/components/content/IsaacCoordinateQuestion.tsx
+++ b/src/app/components/content/IsaacCoordinateQuestion.tsx
@@ -19,9 +19,22 @@ interface CoordinateInputProps {
 }
 
 export const coordinateInputValidator = (input: string) => {
-    const errors = [];
+    const errors: string[] = [];
+    const badChars = new RegExp("[^ 0-9-.,]+");
+    if (badChars.test(input)) {
+        const usedBadChars: string[] = []; 
+        for (let i = 0; i < input.length; i++) {
+            const char = input.charAt(i);
+            if (badChars.test(char)) {
+                if (!usedBadChars.includes(char)) {
+                    usedBadChars.push(char === ' ' ? 'space' : char);
+                }
+            }
+        }
+        errors.push('Some of the characters you are using are not allowed: ' + usedBadChars.join(" "));
+    }
     if (/[0-9]\s*[+/÷\-x×]\s*[0-9]/.test(input)) {
-        errors.push('Simplify your answer into a single decimal number.');
+        errors.push('Simplify each part of your answer into a single decimal number.');
     }
     return errors;
 };
@@ -115,7 +128,7 @@ const IsaacCoordinateQuestion = ({doc, questionId, readonly}: IsaacQuestionProps
                     onChange={value => updateItem(0, value)}
                 />
         }
-        <QuestionInputValidation userInput={currentAttempt?.items?.map(answer => ((answer.x ?? "").concat(" ", answer.y ?? ""))).toString() ?? ""} validator={coordinateInputValidator}/>
+        <QuestionInputValidation userInput={currentAttempt?.items?.map(answer => ((answer.x ?? "").concat(",", answer.y ?? ""))).toString() ?? ""} validator={coordinateInputValidator}/>
         {!doc.numberOfCoordinates && <Button color="secondary" size="sm" className="mt-3" onClick={() => updateItem(currentAttempt?.items?.length ?? 1, {...DEFAULT_COORDINATE_ITEM})}>Add coordinate</Button>}
     </div>;
 };

--- a/src/app/components/content/IsaacNumericQuestion.tsx
+++ b/src/app/components/content/IsaacNumericQuestion.tsx
@@ -26,17 +26,23 @@ import { selectUnits, wrapUnitForSelect } from "../../services/numericUnits";
 
 export const numericInputValidator = (input: string) => {
     const regexStr = "[^ 0-9EXex(){},.+*/\\^×÷-]+";
-    const badCharacters = new RegExp(regexStr, "g");
+    const badCharacters = new RegExp(regexStr);
     const operatorExpression = new RegExp(".*[0-9][+/÷-]\\.?[0-9]+");
     const missingExponentSymbol = new RegExp(".*?10-([0-9]+).*?");
     const errors = [];
 
-    const usedBadChars =  [...input.matchAll(badCharacters)];
-    const uniqueBadChars = [...new Set([...usedBadChars.toString()])].filter(e => e !== ",").join(" ");
-    if (usedBadChars.length > 0) {
-        errors.push('Some of the characters you are using are not allowed: ' + uniqueBadChars);
+    if (badCharacters.test(input)) {
+        const usedBadChars: string[] = []; 
+        for(let i = 0; i < input.length; i++) {
+            const char = input.charAt(i);
+            if (badCharacters.test(char)) {
+                if (!usedBadChars.includes(char)) {
+                    usedBadChars.push(char === ' ' ? 'space' : char);
+                }
+            }
+        }
+        errors.push('Some of the characters you are using are not allowed: ' + usedBadChars.join(" "));
     }
-
     if (missingExponentSymbol.test(input)) {
         errors.push('Use a correct exponent symbol, e.g. 10^-3 or 10**-3.');
     } else if (operatorExpression.test(input)) {

--- a/src/app/components/content/IsaacNumericQuestion.tsx
+++ b/src/app/components/content/IsaacNumericQuestion.tsx
@@ -26,23 +26,17 @@ import { selectUnits, wrapUnitForSelect } from "../../services/numericUnits";
 
 export const numericInputValidator = (input: string) => {
     const regexStr = "[^ 0-9EXex(){},.+*/\\^×÷-]+";
-    const badCharacters = new RegExp(regexStr);
+    const badCharacters = new RegExp(regexStr, "g");
     const operatorExpression = new RegExp(".*[0-9][+/÷-]\\.?[0-9]+");
     const missingExponentSymbol = new RegExp(".*?10-([0-9]+).*?");
     const errors = [];
 
-    if (badCharacters.test(input)) {
-        const usedBadChars: string[] = []; 
-        for(let i = 0; i < input.length; i++) {
-            const char = input.charAt(i);
-            if (badCharacters.test(char)) {
-                if (!usedBadChars.includes(char)) {
-                    usedBadChars.push(char === ' ' ? 'space' : char);
-                }
-            }
-        }
-        errors.push('Some of the characters you are using are not allowed: ' + usedBadChars.join(" "));
+    const usedBadChars =  [...input.matchAll(badCharacters)];
+    const uniqueBadChars = [...new Set([...usedBadChars.toString()])].toString().replaceAll(",", " ");
+    if (usedBadChars.length > 0) {
+        errors.push('Some of the characters you are using are not allowed: ' + uniqueBadChars);
     }
+
     if (missingExponentSymbol.test(input)) {
         errors.push('Use a correct exponent symbol, e.g. 10^-3 or 10**-3.');
     } else if (operatorExpression.test(input)) {

--- a/src/app/components/content/IsaacNumericQuestion.tsx
+++ b/src/app/components/content/IsaacNumericQuestion.tsx
@@ -32,7 +32,7 @@ export const numericInputValidator = (input: string) => {
     const errors = [];
 
     const usedBadChars =  [...input.matchAll(badCharacters)];
-    const uniqueBadChars = [...new Set([...usedBadChars.toString()])].toString().replaceAll(",", " ");
+    const uniqueBadChars = [...new Set([...usedBadChars.toString()])].filter(e => e !== ",").join(" ");
     if (usedBadChars.length > 0) {
         errors.push('Some of the characters you are using are not allowed: ' + uniqueBadChars);
     }


### PR DESCRIPTION
For coordinate questions: change the way coordinates are concatenated before being validated to avoid negative numbers erroneously being flagged as invalid.

Also implement invalid character checks in the same style as numeric questions.