### PR TITLE
Create new teaching order page

### DIFF
--- a/src/app/components/pages/TeachingOrders.tsx
+++ b/src/app/components/pages/TeachingOrders.tsx
@@ -12,10 +12,18 @@ enum TEACHING_ORDER_STAGE {
     ADVANCED_Y2 = "Advanced Y2"
 }
 
+const sanitiseStageTab = (stageTab: string) => stageTab.replace(" ", "_").toLowerCase();
+const sanitisedStageTabsMap = Object.fromEntries(Object.keys(TEACHING_ORDER_STAGE).map(stage => [sanitiseStageTab(stage), stage]));
+
+const getStageFromURL = () : TEACHING_ORDER_STAGE | undefined => {
+    const urlStage = window.location.hash.slice(1);
+    return sanitisedStageTabsMap[urlStage] as TEACHING_ORDER_STAGE | undefined;
+};
+
 export const TeachingOrders = () => {
     const TEACHING_ORDER_STAGES = Object.keys(TEACHING_ORDER_STAGE);
-    const [stageTab, setStageTab] = useState<typeof TEACHING_ORDER_STAGES[number]>(TEACHING_ORDER_STAGES[0]);
-    const [stageTabOverride, _setStageTabOverride] = useState<number | undefined>(TEACHING_ORDER_STAGES.indexOf(stageTab) + 1 || undefined);
+    const [stageTab, setStageTab] = useState<typeof TEACHING_ORDER_STAGES[number]>(getStageFromURL() || TEACHING_ORDER_STAGE.CORE_Y1);
+    const [stageTabOverride, _setStageTabOverride] = useState<number | undefined>(Object.values(sanitisedStageTabsMap).indexOf(stageTab) + 1 || undefined);
     const [fragmentId, setFragmentId] = useState<string>("");
 
     const metaDescription = (stageTab === TEACHING_ORDER_STAGE.CORE_Y1 || stageTab === TEACHING_ORDER_STAGE.CORE_Y2)

--- a/src/app/components/pages/TeachingOrders.tsx
+++ b/src/app/components/pages/TeachingOrders.tsx
@@ -1,0 +1,55 @@
+import React, { ReactElement, useEffect, useState } from "react";
+import { Col, Container, Row } from "reactstrap";
+import { Tabs } from "../elements/Tabs";
+import { PageFragment } from "../elements/PageFragment";
+import { TitleAndBreadcrumb } from "../elements/TitleAndBreadcrumb";
+import { MetaDescription } from "../elements/MetaDescription";
+
+enum TEACHING_ORDER_STAGE {
+    CORE_Y1 = "Core Y1",
+    CORE_Y2 = "Core Y2",
+    ADVANCED_Y1 = "Advanced Y1",
+    ADVANCED_Y2 = "Advanced Y2"
+}
+
+export const TeachingOrders = () => {
+    const TEACHING_ORDER_STAGES = Object.keys(TEACHING_ORDER_STAGE);
+    const [stageTab, setStageTab] = useState<typeof TEACHING_ORDER_STAGES[number]>(TEACHING_ORDER_STAGES[0]);
+    const [stageTabOverride, _setStageTabOverride] = useState<number | undefined>(TEACHING_ORDER_STAGES.indexOf(stageTab) + 1 || undefined);
+    const [fragmentId, setFragmentId] = useState<string>("");
+
+    const metaDescription = (stageTab === TEACHING_ORDER_STAGE.CORE_Y1 || stageTab === TEACHING_ORDER_STAGE.CORE_Y2)
+        ? "Discover our free Core computer science topics and questions. Learn or revise for your exams with us today."
+        : "Discover our free Advanced computer science topics and questions. Learn or revise for your exams with us today.";
+
+    const tabTitlesToContent: {[title: string]: ReactElement} = {};
+    for (const stageName of Object.values(TEACHING_ORDER_STAGE)) {
+        tabTitlesToContent[stageName] = <></>;
+    }
+
+    const stageTabs = <Tabs style={"buttons"} className={"mt-3"} tabContentClass={"mt-3"}
+        activeTabOverride={stageTabOverride}
+        onActiveTabChange={(n) => {
+            setStageTab(TEACHING_ORDER_STAGES[n-1]);
+        }}
+    >
+        {tabTitlesToContent}
+    </Tabs>;
+
+    useEffect(() => {
+        const sanitisedStageTab = stageTab.replace(" ", "_").toLowerCase();
+        setFragmentId(`ada_teaching_order_${sanitisedStageTab}`);
+        location.replace(`#${sanitisedStageTab}`);
+    }, [stageTab]);
+
+    return <Container>
+        <TitleAndBreadcrumb currentPageTitle={"Suggested teaching order"} />
+        <MetaDescription description={metaDescription} />
+        {stageTabs}
+        <Row>
+            <Col lg={{size: 8, offset: 2}}>
+                {fragmentId && <PageFragment fragmentId={fragmentId}/>}
+            </Col>
+        </Row>
+    </Container>;
+};

--- a/src/app/components/pages/TeachingOrders.tsx
+++ b/src/app/components/pages/TeachingOrders.tsx
@@ -45,7 +45,7 @@ export const TeachingOrders = () => {
     </Tabs>;
 
     useEffect(() => {
-        const sanitisedStageTab = stageTab.replace(" ", "_").toLowerCase();
+        const sanitisedStageTab = sanitiseStageTab(stageTab);
         setFragmentId(`ada_teaching_order_${sanitisedStageTab}`);
         location.replace(`#${sanitisedStageTab}`);
     }, [stageTab]);

--- a/src/app/components/site/cs/RoutesCS.tsx
+++ b/src/app/components/site/cs/RoutesCS.tsx
@@ -16,6 +16,7 @@ import {QuizTeacherFeedback} from "../../pages/quizzes/QuizTeacherFeedback";
 import {QuizPreview} from "../../pages/quizzes/QuizPreview";
 import {QuizDoFreeAttempt} from "../../pages/quizzes/QuizDoFreeAttempt";
 import {TeacherAccountSelfUpgrade} from "../../pages/TeacherAccountSelfUpgrade";
+import {TeachingOrders} from "../../pages/TeachingOrders";
 import {RegistrationStart} from "../../pages/RegistrationStart";
 import {RegistrationRoleSelect} from "../../pages/RegistrationRoleSelect";
 import {RegistrationAgeCheck} from "../../pages/RegistrationAgeCheck";
@@ -92,6 +93,7 @@ export const RoutesCS = [
         componentProps={{'examBoardFilter': [EXAM_BOARD.SQA], 'stageFilter': [STAGE.SCOTLAND_NATIONAL_5,
             STAGE.SCOTLAND_HIGHER, STAGE.SCOTLAND_ADVANCED_HIGHER]}} />,
     <TrackedRoute key={key++} exact path="/exam_specifications" component={ExamSpecificationsDirectory} />,
+    <TrackedRoute key={key++} exact path="/ada_teaching_order" component={TeachingOrders}/>,
 
     // News
     <TrackedRoute key={key++} exact path="/news" component={News} />,


### PR DESCRIPTION
On Ada, create a new suggested teaching order page. This is in addition to the current page until the relevant fragments are created.