### PR TITLE
Fix mobile screen button layouts

### DIFF
--- a/src/app/components/site/phy/HomepagePhy.tsx
+++ b/src/app/components/site/phy/HomepagePhy.tsx
@@ -36,12 +36,12 @@ export const HomepagePhy = () => {
                         <Col lg={7} className={above["lg"](deviceSize) ? `align-items-stretch d-flex flex-column` : ""}>
                             {!(user && user.loggedIn) && <Row className="align-self-end mt-2 mt-lg-0 mb-1 mb-lg-0">
                                 <Col className="col-6 col-lg-auto ps-lg-0 pe-1 pe-sm-2">
-                                    <Button size={above['lg'](deviceSize) || deviceSize === "xs" ? "sm" : ""} tag={Link} to="/login" color="primary" outline className="btn-block">
+                                    <Button size={above['lg'](deviceSize) || deviceSize === "xs" ? "sm" : ""} tag={Link} to="/login" color="primary" outline block className="btn-block">
                                         Log in
                                     </Button>
                                 </Col>
                                 <Col className="col-6 col-lg-auto ps-lg-0 ps-1 ps-sm-2">
-                                    <Button size={above['lg'](deviceSize) || deviceSize === "xs" ? "sm" : ""} tag={Link} to="/register" color="secondary" className="btn-block">
+                                    <Button size={above['lg'](deviceSize) || deviceSize === "xs" ? "sm" : ""} tag={Link} to="/register" color="secondary" block className="btn-block">
                                         Sign up
                                     </Button>
                                 </Col>

--- a/src/scss/common/button.scss
+++ b/src/scss/common/button.scss
@@ -37,6 +37,10 @@
             margin-bottom: 0.5rem;
         }
     }
+
+    .col-xs-12 .col-sm-6 > button {
+      width: 100%;
+    }
 }
 
 // What on earth does this do and why when I remove it does it break input addon buttons?


### PR DESCRIPTION
Pretty straightforward change. The code was probably broken by the bootstrap update. 

I don't see any reason why we might want to set a column to `xs={12}/sm={6}` without also making a contained button take up that width, and I'm pretty confident it's not doing any damage right now. However still definitely worth a test since it's a site-wide change to buttons. 

Also changes a specific set of buttons on the logged out Physics homepage to `block` to perform the missing work `btn-block` no longer does.