### PR TITLE
Remove prefix (Nuclear) docking points for Chemistry questions in Inequality

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "html-to-text": "^9.0.5",
     "identity-obj-proxy": "3.0.0",
     "immer": "^9.0.21",
-    "inequality": "1.1.2",
+    "inequality": "1.1.3",
     "inequality-grammar": "1.3.2",
     "isaac-graph-sketcher": "0.13.7",
     "js-cookie": "^3.0.5",

--- a/src/app/components/content/IsaacSymbolicChemistryQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicChemistryQuestion.tsx
@@ -172,6 +172,7 @@ const IsaacSymbolicChemistryQuestion = ({doc, questionId, readonly}: IsaacQuesti
         sketch.isUserPrivileged = () => true;
         sketch.onNotifySymbolDrag = () => undefined;
         sketch.isTrashActive = () => false;
+        sketch.editorMode = doc.isNuclear ? "nuclear" : "chemistry";
 
         sketchRef.current = sketch;
 

--- a/src/app/components/content/IsaacSymbolicChemistryQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicChemistryQuestion.tsx
@@ -274,7 +274,7 @@ const IsaacSymbolicChemistryQuestion = ({doc, questionId, readonly}: IsaacQuesti
                 availableSymbols={doc.availableSymbols}
                 initialEditorSymbols={initialEditorSymbols.current}
                 editorSeed={editorSeed}
-                editorMode="chemistry"
+                editorMode={doc.isNuclear ? "nuclear" : "chemistry"}
                 questionDoc={doc}
             />}
         </div>

--- a/src/app/components/elements/modals/inequality/InequalityModal.tsx
+++ b/src/app/components/elements/modals/inequality/InequalityModal.tsx
@@ -227,7 +227,7 @@ const InequalityMenu = React.forwardRef<HTMLDivElement, InequalityMenuProps>(({o
                 </div>}
                 {editorMode === "maths" && activeMenu === "mathsOtherFunctions" && <MathOtherFunctionsMenu activeSubMenu={activeSubMenu} menuItems={menuItems} defaultMenu={defaultMenu}/>}
 
-                {editorMode === "chemistry" && <>
+                {["chemistry", "nuclear"].includes(editorMode)  && <>
                     {activeMenu === "elements" && (isDefined(availableSymbols) && availableSymbols.length > 0
                         ? <div className="top-menu chemistry elements">
                             <ul className="sub-menu elements">
@@ -256,7 +256,7 @@ const InequalityMenu = React.forwardRef<HTMLDivElement, InequalityMenuProps>(({o
                             {menuItems.chemicalStates.map(buildIndexedMenuItem)}
                         </ul>
                     </div>}
-                    {editorMode === "chemistry" && activeMenu === "operations" && <div className="top-menu chemistry operations">
+                    {["chemistry", "nuclear"].includes(editorMode) && activeMenu === "operations" && <div className="top-menu chemistry operations">
                         <ul className="sub-menu operations">
                             {menuItems.chemicalOperations.map(buildIndexedMenuItem)}
                         </ul>
@@ -265,16 +265,16 @@ const InequalityMenu = React.forwardRef<HTMLDivElement, InequalityMenuProps>(({o
             </div>
             <div id="inequality-menu-tabs" className="menu-tabs">
                 <ul>
-                    {["maths", "chemistry"].includes(editorMode) && <InequalityMenuTab menu={"numbers"} latexTitle={"1\\, 2\\, 3"}/>}
+                    {["maths", "chemistry", "nuclear"].includes(editorMode) && <InequalityMenuTab menu={"numbers"} latexTitle={"1\\, 2\\, 3"}/>}
                     {["maths", "logic"].includes(editorMode) && <>
                         {!disableLetters && <InequalityMenuTab menu={"letters"} subMenu={editorMode === "logic" ? "upperCaseLetters" : "lowerCaseLetters"} latexTitle={"Ab\\ \\Delta \\gamma"}/>}
                         <InequalityMenuTab menu={"basicFunctions"} latexTitle={functionsTabLabel}/>
                     </>}
                     {editorMode === "maths" && <InequalityMenuTab menu={"mathsOtherFunctions"} subMenu={"trigFunctions"} latexTitle={"\\sin\\ \\int"}/>}
-                    {editorMode === "chemistry" && <>
+                    {["chemistry", "nuclear"].includes(editorMode) && <>
                         <InequalityMenuTab menu={"elements"} latexTitle={isDefined(availableSymbols) && availableSymbols.length > 0 && menuItems.chemicalElements.map(i => i.type).includes("Particle") ? "\\text{He Li}\\ \\alpha" : "\\text{H He Li}"}/>
                         {menuItems.chemicalParticles.length > 0 && <InequalityMenuTab menu={"particles"} latexTitle={"\\alpha\\ \\gamma\\ \\text{e}"}/>}
-                        <InequalityMenuTab menu={"states"} latexTitle={"(aq)\\, (g)\\, (l)"}/>
+                        {editorMode === "chemistry" && <InequalityMenuTab menu={"states"} latexTitle={"(aq)\\, (g)\\, (l)"}/>}
                         <InequalityMenuTab menu={"operations"} latexTitle={"\\rightarrow\\, \\rightleftharpoons\\, +"}/>
                     </>}
                 </ul>

--- a/src/app/components/elements/modals/inequality/constants.ts
+++ b/src/app/components/elements/modals/inequality/constants.ts
@@ -1,4 +1,4 @@
-export type EditorMode = "maths" | "logic" | "chemistry";
+export type EditorMode = "maths" | "logic" | "chemistry" | "nuclear";
 export type LogicSyntax = "binary" | "logic";
 
 export interface MenuItemProps {

--- a/src/app/components/elements/modals/inequality/utils.ts
+++ b/src/app/components/elements/modals/inequality/utils.ts
@@ -484,7 +484,7 @@ export function generateMenuItems({editorMode, logicSyntax, parsedAvailableSymbo
                 }
             } else {
                 // Everything else is a letter, unless we are doing chemistry
-                if (editorMode === "chemistry") {
+                if (["chemistry", "nuclear"].includes(editorMode)) {
                     // Available chemical elements
                     const item = generateChemicalElementMenuItem(availableSymbol);
                     if (item) {
@@ -528,7 +528,7 @@ export function generateMenuItems({editorMode, logicSyntax, parsedAvailableSymbo
                 upperCaseLetters: "ABCDEGHIJKLMNOPQRSUVWXYZ".split("").map(letter => generateSingleLetterMenuItem(letter)),
                 lowerCaseLetters: "abcdeghijklmnopqrsuvwxyz".split("").map(letter => generateSingleLetterMenuItem(letter)),
             }, true] as [MenuItems, boolean];
-        } else if (editorMode === "chemistry") {
+        } else if (["chemistry", "nuclear"].includes(editorMode)) {
             return [{
                 ...baseItems,
                 chemicalElements: CHEMICAL_ELEMENTS.map(generateChemicalElementMenuItem),

--- a/src/app/components/pages/Equality.tsx
+++ b/src/app/components/pages/Equality.tsx
@@ -297,11 +297,11 @@ const Equality = withRouter(({location}: RouteComponentProps<{}, {}, {board?: st
                 <Col md={{size: 8, offset: 2}} className="py-4 inequality-results">
                     <h4>LaTeX</h4>
                     <pre>${currentAttemptValue?.result?.tex}$</pre>
-                    {editorMode === 'chemistry' && <>
+                    {["chemistry", "nuclear"].includes(editorMode) && <>
                         <h4>MhChem</h4>
                         <pre>{currentAttemptValue?.result?.mhchem}</pre>
                     </>}
-                    {editorMode !== 'chemistry' && <>
+                    {!["chemistry", "nuclear"].includes(editorMode) && <>
                         <h4>Python</h4>
                         <pre>{currentAttemptValue?.result?.python}</pre>
                         <h4>MathML</h4>

--- a/src/app/components/pages/Equality.tsx
+++ b/src/app/components/pages/Equality.tsx
@@ -133,11 +133,11 @@ const Equality = withRouter(({location}: RouteComponentProps<{}, {}, {board?: st
         if (sketchRef.current) {
             sketchRef.current.editorMode = e.target.value as EditorMode;
         }
-    }
+    };
 
     const updateEquation = (e: ChangeEvent<HTMLInputElement>) => {
         _updateEquation(e.target.value);
-    }
+    };
 
     const _updateEquation = (input: string) => {
         // const pycode = e.target.value;
@@ -234,6 +234,7 @@ const Equality = withRouter(({location}: RouteComponentProps<{}, {}, {board?: st
     };
 
     const previewText = currentAttemptValue && currentAttemptValue.result && currentAttemptValue.result.tex;
+    const allowTextInput = editorMode === 'maths'  || (isStaff(user) && ['chemistry', 'nuclear', 'logic'].includes(editorMode));
 
     return <div>
         <Container>
@@ -243,7 +244,7 @@ const Equality = withRouter(({location}: RouteComponentProps<{}, {}, {board?: st
                 </Col>
             </Row>
             <Row>
-                <Col md={{size: 2}} className="py-4 syntax-picker mode-picker">
+                <Col md={3} className="py-4 syntax-picker mode-picker">
                     <div>
                         <Label for="inequality-mode-select">Editor mode:</Label>
                         <Input type="select" name="mode" id="inequality-mode-select" value={editorMode as string} onChange={(e: React.ChangeEvent<HTMLInputElement>) => updateEditor(e)}> 
@@ -261,8 +262,8 @@ const Equality = withRouter(({location}: RouteComponentProps<{}, {}, {board?: st
                         </Input>
                     </div>}
                 </Col>
-                <Col md={{size: 8}} className="py-4 question-panel">
-                    {(editorMode === 'maths'  || (isStaff(user) && editorMode === 'chemistry')  || (isStaff(user) && editorMode === 'nuclear') || (isStaff(user) && editorMode === 'logic')) && <div className="eqn-editor-input mt-4">
+                <Col md={8} className="pb-4 pt-md-4 question-panel">
+                    {allowTextInput && <div className="eqn-editor-input mt-md-4">
                         <div ref={hiddenEditorRef} className="equation-editor-text-entry" style={{height: 0, overflow: "hidden", visibility: "hidden"}} />
                         <InputGroup className="my-2">
                             <Input className="py-4" type="text" onChange={updateEquation} value={textInput}
@@ -270,51 +271,42 @@ const Equality = withRouter(({location}: RouteComponentProps<{}, {}, {board?: st
                             <>
                                 {siteSpecific(
                                     <Button type="button" className="eqn-editor-help pt-2" id="inequality-help" size="sm" tag="a" href="/solving_problems#symbolic_text">?</Button>,
-                                    <span id={"inequality-help"} className="icon-help-q my-auto"/>
+                                    <span id={"inequality-help"} className="icon-help-q my-auto ms-2"/>
                                 )}
-                                {editorMode === 'maths' && <UncontrolledTooltip placement="top" autohide={false} target='inequality-help'>
+                                <UncontrolledTooltip placement="top" autohide={false} target='inequality-help'>
                                     Here are some examples of expressions you can type:<br />
-                                    <br />
-                                    a*x^2 + b x + c<br />
-                                    (-b ± sqrt(b**2 - 4ac)) / (2a)<br />
-                                    1/2 mv**2<br />
-                                    log(x_a, 2) == log(x_a) / log(2)<br />
-                                    <br />
+                                    {editorMode === 'maths' && <> <br />
+                                        a*x^2 + b x + c <br />
+                                        (-b ± sqrt(b**2 - 4ac)) / (2a) <br />
+                                        1/2 mv**2 <br />
+                                        log(x_a, 2) == log(x_a) / log(2) <br />
+                                        <br /> </>}
+                                    {editorMode === 'chemistry' && <>
+                                        H2O<br />
+                                        2 H2 + O2 -&gt; 2 H2O<br />
+                                        CH3(CH2)3CH3<br />
+                                        {"NaCl(aq) -> Na^{+}(aq) +  Cl^{-}(aq)"}<br /> </>}
+                                    {editorMode === 'nuclear' && <>
+                                        {"^{238}_{92}U -> ^{4}_{2}\\alphaparticle + _{90}^{234}Th"}<br />
+                                        {"^{0}_{-1}e"}<br />
+                                        {"\\gammaray"}<br /> </>}
+                                    {editorMode === 'logic' && <>
+                                        <br />
+                                        A AND (B XOR NOT C)<br />
+                                        A &amp; (B ^ !C)<br />
+                                        T &amp; ~(F + A)<br />
+                                        1 . ~(0 + A)<br /> </>}
                                     As you type, the box below will preview the result.
-                                </UncontrolledTooltip>}
-                                {editorMode === 'chemistry' && <UncontrolledTooltip className="spaced-tooltip" placement="top" autohide={false} target='inequality-help'>
-                                    Here are some examples of expressions you can type:<br />
-                                    H2O<br />
-                                    2 H2 + O2 -&gt; 2 H2O<br />
-                                    CH3(CH2)3CH3<br />
-                                    {"NaCl(aq) -> Na^{+}(aq) +  Cl^{-}(aq)"}<br />
-                                    As you type, the box above will preview the result.
-                                </UncontrolledTooltip>}
-                                {editorMode === 'nuclear' && <UncontrolledTooltip className="spaced-tooltip" placement="top" autohide={false} target='inequality-help'>
-                                    Here are some examples of expressions you can type:<br />
-                                    {"^{238}_{92}U -> ^{4}_{2}\\alphaparticle + _{90}^{234}Th"}<br />
-                                    {"^{0}_{-1}e"}<br />
-                                    {"\\gammaray"}<br />
-                                    As you type, the box above will preview the result.
-                                </UncontrolledTooltip>}
-                                {editorMode === 'logic' && <UncontrolledTooltip placement="top" autohide={false} target='inequality-help'>
-                                    Here are some examples of expressions you can type:<br />
-                                    <br />
-                                    A AND (B XOR NOT C)<br />
-                                    A &amp; (B ^ !C)<br />
-                                    T &amp; ~(F + A)<br />
-                                    1 . ~(0 + A)<br />
-                                    As you type, the box below will preview the result.
-                                </UncontrolledTooltip>}
+                                </UncontrolledTooltip>
                             </>
                         </InputGroup>
                         <QuestionInputValidation userInput={textInput} validator={(i: string) => equalityValidator(i, editorMode)} />
                     </div>}
                     <div className="equality-page">
                         <div
-                            role="button" className={`eqn-editor-preview rounded ${!previewText ? 'empty' : ''} ${editorMode !== 'maths' ? 'mt-4' : ''}`} tabIndex={0}
+                            role="button" className={`eqn-editor-preview rounded ${!previewText ? 'empty' : ''} ${!allowTextInput && 'mt-4'}`} tabIndex={0}
                             onClick={() => setModalVisible(true)} onKeyDown={ifKeyIsEnter(() => setModalVisible(true))}
-                            dangerouslySetInnerHTML={{ __html: previewText ? katex.renderToString(previewText) : `<small>${editorMode === 'maths' ? 'or c' : 'C'}lick here to enter a formula</small>` }}
+                            dangerouslySetInnerHTML={{ __html: previewText ? katex.renderToString(previewText) : `<small>${allowTextInput ? 'or c' : 'C'}lick here to enter a formula</small>` }}
                         />
                         {modalVisible && <InequalityModal
                             close={closeModal}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5941,10 +5941,10 @@ inequality-grammar@1.3.2:
     moo "^0.5.2"
     nearley "^2.20.1"
 
-inequality@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/inequality/-/inequality-1.1.2.tgz#421ee2c0c129a74290d505bc5794fd33d261e68d"
-  integrity sha512-0aDaHc9liL0C1OrfjKd2dbHZqZKQi358WDdUrquh5AMTJvy1P66JH6/15pfj8MANaUvEk6YlFjHrZYWk6jZeLA==
+inequality@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/inequality/-/inequality-1.1.3.tgz#3bfebbfbf4b86610b63cc94a3b7a7912bc043721"
+  integrity sha512-Rptza6ybi0Zg6UjBH4IKX6IsMgoti0E5Og9XMkLYkCyjCAWHamasPDWDUEMEWO23bfiP+m21qOsvW4G4gpNh/Q==
 
 inflight@^1.0.4:
   version "1.0.6"


### PR DESCRIPTION
Prefixes represent mass and proton numbers. These are only used during Nuclear Physics questions, so can be disabled for ease-of-use in Chemistry questions.

For react-app, this basically consists of adding `"nuclear"` as an `EditorMode`, which is already passed to Inequality for it to handle. This also allows for other front-end enhancements e.g. also disabling the "state symbols" tab for Nuclear questions.

Inequality change [here](https://github.com/isaacphysics/inequality/pull/8).