### PR TITLE
Stop adding random unit options

### DIFF
--- a/src/app/services/numericUnits.ts
+++ b/src/app/services/numericUnits.ts
@@ -49,9 +49,7 @@ export function selectUnits(doc: IsaacNumericQuestionDTO, questionId: string, un
         addUpTo(doc.availableUnits, 6);
     }
 
-    const incorrectAvailableUnits = doc.availableUnits?.filter(unit => !doc.knownUnits?.includes(unit.trim()));
-    if (!incorrectAvailableUnits?.length && units) {
-        // If there are no manually entered incorrect units, add some random units
+    if (!(doc.availableUnits && doc.availableUnits.length > 0) && units) {
         addUpTo(units, 6);
     }
 

--- a/src/app/services/numericUnits.ts
+++ b/src/app/services/numericUnits.ts
@@ -49,7 +49,9 @@ export function selectUnits(doc: IsaacNumericQuestionDTO, questionId: string, un
         addUpTo(doc.availableUnits, 6);
     }
 
-    if (units) {
+    const incorrectAvailableUnits = doc.availableUnits?.filter(unit => !doc.knownUnits?.includes(unit.trim()));
+    if (!incorrectAvailableUnits?.length && units) {
+        // If there are no manually entered incorrect units, add some random units
         addUpTo(units, 6);
     }
 


### PR DESCRIPTION
If a question has at least one manually chosen incorrect unit option, don't add any random units to the dropdown.