### PR TITLE
Remove redirect to non-existent ada route

### DIFF
--- a/src/app/components/elements/panels/TeacherConnections.tsx
+++ b/src/app/components/elements/panels/TeacherConnections.tsx
@@ -137,7 +137,7 @@ export const TeacherConnections = ({user, authToken, editingOtherUser, userToEdi
             dispatch(showErrorToast("No group code provided", "You have to enter a group code!"));
             return;
         }
-        else if (isFirstLoginInPersistence()) {
+        else if (isPhy && isFirstLoginInPersistence()) {
             history.push("/register/group_invitation?authToken=" + encodeURIComponent(sanitisedToken));
         }
         else {


### PR DESCRIPTION
If an Ada user tries to join a group via the account page's connections tab any time during their first session after registration they get redirected to a page which only exists for Physics. It is possible that there are other routes to this broken redirect.

I'm unsure if the redirect is wanted in this particular case for Physics users either. My understanding was that the new page would only be used during the registration process but this requirement might have been asked for during discussion with the content team.