### PR TITLE
Apply figure padding only when top level of content

### DIFF
--- a/src/scss/phy/questions.scss
+++ b/src/scss/phy/questions.scss
@@ -32,11 +32,16 @@
 .question-component .question-content {
   font-family: $primary-font;
 }
-.question-panel > .content-chunk > .content-value, .figure-panel {
+.question-panel > .content-chunk > .content-value {
   background: none;
   box-shadow: none;
   padding: 0 0.25rem;
   font-weight: 400;
+}
+
+.content-chunk > .figure-panel {
+  // if a figure is in the top level of a content block, indent it. otherwise (i.e. when inside a layout component), leave it for that component to handle
+  padding: 0 3rem;
 }
 
 .question-panel .isaac-accordion {
@@ -47,7 +52,7 @@
     line-height: 1.6;
   }
   // Make sure that reorder questions have a background when they expand on Phy
-  .question-component:not(.expansion-layout), .figure-panel {
+  .question-component:not(.expansion-layout) {
     background: none;
     box-shadow: none;
     padding: 0 !important;


### PR DESCRIPTION
This, while simple in concept, affects **every figure** on the site so should receive fairly heavy testing.