### PR TITLE
Alias account tab hash anchors

### DIFF
--- a/src/app/components/pages/MyAccount.tsx
+++ b/src/app/components/pages/MyAccount.tsx
@@ -58,7 +58,8 @@ import {
     validatePassword,
     isTeacherOrAbove,
     isFirstLoginInPersistence,
-    ACCOUNT_TABS
+    ACCOUNT_TABS,
+    ACCOUNT_TABS_ALIASES
 } from "../../services";
 import queryString from "query-string";
 import {Link, withRouter} from "react-router-dom";
@@ -225,9 +226,8 @@ const AccountPageComponent = ({user, getChosenUserAuthSettings, error, userAuthS
         // @ts-ignore
         const tab: ACCOUNT_TAB =
             (authToken && ACCOUNT_TAB.teacherconnections) ||
-            // This feel particularly bad
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (hashAnchor && ACCOUNT_TAB[hashAnchor as any]) ||
+            (hashAnchor && hashAnchor in ACCOUNT_TAB && ACCOUNT_TAB[hashAnchor as keyof typeof ACCOUNT_TAB]) ||
+            (hashAnchor && hashAnchor in ACCOUNT_TABS_ALIASES && ACCOUNT_TABS_ALIASES[hashAnchor as string]) ||
             ACCOUNT_TAB.account;
         setActiveTab(tab);
     }, [hashAnchor, authToken]);

--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -822,6 +822,13 @@ export const ACCOUNT_TABS : AccountTabs[] = [
     {tab: ACCOUNT_TAB.betafeatures, title: "Beta", hiddenIfEditingOtherUser: true},
 ];
 
+// we can't change the names of tabs as we have historic links to them, so use aliases to use updated names instead
+export const ACCOUNT_TABS_ALIASES: {[alias: string]: ACCOUNT_TAB} = {
+    "security": ACCOUNT_TAB.passwordreset,
+    "connections": ACCOUNT_TAB.teacherconnections,
+    "notifications": ACCOUNT_TAB.emailpreferences,
+};
+
 export enum MANAGE_QUIZ_TAB {set = 1, manage = 2}
 export enum MARKBOOK_TYPE_TAB {assignments = 1, tests = 2}
 


### PR DESCRIPTION
Adds `#security`, `#connections` and `#notifications`, to be shorter and/or in-line with the tab headings.

**Does not remove the old anchors.** All prior links still work.