### PR TITLE
Fully fix "reading 0" exception around Inequality

### DIFF
--- a/src/app/components/content/IsaacSymbolicQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicQuestion.tsx
@@ -1,4 +1,4 @@
-import React, {ChangeEvent, lazy, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState} from "react";
+import React, {ChangeEvent, lazy, Suspense, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState} from "react";
 import * as RS from "reactstrap";
 import {IsaacContentValueOrChildren} from "./IsaacContentValueOrChildren";
 import {FormulaDTO, IsaacSymbolicQuestionDTO} from "../../../IsaacApiTypes";
@@ -224,15 +224,17 @@ const IsaacSymbolicQuestion = ({doc, questionId, readonly}: IsaacQuestionProps<I
                 </IsaacContentValueOrChildren>
             </div>
             {/* TODO Accessibility */}
-            {modalVisible && <InequalityModal
-                close={closeModalAndReturnToScrollPosition}
-                onEditorStateChange={updateState}
-                availableSymbols={doc.availableSymbols}
-                initialEditorSymbols={initialEditorSymbols.current}
-                editorSeed={editorSeed}
-                editorMode="maths"
-                questionDoc={doc}
-            />}
+            {modalVisible && <Suspense fallback={<div>Loading...</div>}>
+                <InequalityModal
+                    close={closeModalAndReturnToScrollPosition}
+                    onEditorStateChange={updateState}
+                    availableSymbols={doc.availableSymbols}
+                    initialEditorSymbols={initialEditorSymbols.current}
+                    editorSeed={editorSeed}
+                    editorMode="maths"
+                    questionDoc={doc}
+                />
+            </Suspense>}
             {!readonly && <div className="eqn-editor-input">
                 <div ref={hiddenEditorRef} className="equation-editor-text-entry" style={{height: 0, overflow: "hidden", visibility: "hidden"}} />
                 <RS.InputGroup className="my-2 separate-input-group">
@@ -243,7 +245,7 @@ const IsaacSymbolicQuestion = ({doc, questionId, readonly}: IsaacQuestionProps<I
                             <RS.Button type="button" className="eqn-editor-help" id={helpTooltipId} tag="a" href="/solving_problems#symbolic_text">?</RS.Button>,
                             <span id={helpTooltipId} className="icon-help-q my-auto"/>
                         )}
-                        {!modalVisible && <RS.UncontrolledTooltip placement="top" autohide={false} target={helpTooltipId}>
+                        {<RS.UncontrolledTooltip placement="top" autohide={false} target={helpTooltipId}>
                             Here are some examples of expressions you can type:<br />
                             <br />
                             a*x^2 + b x + c<br />


### PR DESCRIPTION
InequalityModal is a lazily-loaded component, loaded when the user opens the inequality box. Being lazy, while the component data is being fetched after being required, it *suspends*. A suspended component will not render anything until all the data has been fetched, at which point the entire parent is rerendered -- *unless* it exists around a `<Suspense/>` boundary, in which case the component defined in the `fallback` prop  is rendered in the meantime, and *only the contents of the Suspense boundary are rendered*.

Previously, `<InequalityModal/>` did not have a `<Suspense/>` without a wrapper boundary. Therefore, the **entire** parent div was rerendering once the data loaded. Included in the parent component is 1. the entire contents of the question, and 2. the help component. The latter, and potentially the former, can contain one of React's `<Tooltip/>` components, used in the symbolic question's help menu, and in the content in the form of e.g. inline glossary terms. Since the parent was being rerendered, these components were also being rerendered. 

Separately,`<Tooltip/>`s in particular use a `<Fade/>` to slowly fade out of view on mouse exit. This happens **after** unmount is called on the component. The `<Tooltip/>` (which is in the process of unmounting) runs its unmount method first, which has the effect of [setting `_targets` to null](https://github.com/reactstrap/reactstrap/blob/090bc1eeb19bcc269970151d330c6bc03f731635/src/TooltipPopoverWrapper.js#L109).

If the rerender caused by the parent occurs during this unmounting process, the `render()` function inside the `<Tooltip/>` is still called. This function [references `_targets[0]`](https://github.com/reactstrap/reactstrap/blob/090bc1eeb19bcc269970151d330c6bc03f731635/src/TooltipPopoverWrapper.js#L332), which raises a NPE if it has been set to null by the unmount.

To fix this, inequality modal has been wrapped in a `<Suspense/>`. This means only the `<InequalityModal/>` component is rerendered, preventing any `<Tooltips/>`' `render()` functions activating.

This also removes the old fix to the Symbolic Question's `<RS.UncontrolledTooltip/>`.