### PR TITLE
Hide context picker for non-staff users

### DIFF
--- a/src/app/components/elements/inputs/UserContextPicker.tsx
+++ b/src/app/components/elements/inputs/UserContextPicker.tsx
@@ -29,6 +29,9 @@ export const UserContextPicker = ({className, hideLabels = true}: {className?: s
     const user = useAppSelector(selectors.user.orNull);
     const userContext = useUserViewingContext();
 
+    const allExamBoardOptions = getFilteredExamBoardOptions();
+    const allStages = getFilteredStageOptions();
+
     const filteredExamBoardOptions = getFilteredExamBoardOptions({byUser: user, byStages: [userContext.stage], includeNullOptions: true});
     const filteredStages = getFilteredStageOptions({byUser: user, includeNullOptions: true});
 
@@ -79,15 +82,7 @@ export const UserContextPicker = ({className, hideLabels = true}: {className?: s
                                 dispatch(transientUserContextSlice.actions.setStage(stage));
                             }}
                         >
-                            {filteredStages.map(item => <option key={item.value} value={item.value}>{item.label}</option>)}
-                            {/* If the userContext.stage is not in the user's normal list of options (following link with q. params) add it */}
-                            {!filteredStages.map(s => s.value).includes(userContext.stage) &&
-                                <option key={userContext.stage} value={userContext.stage}>
-                                    {"*"}
-                                    {getFilteredStageOptions().filter(o => o.value === userContext.stage)[0]?.label}
-                                    {"*"}
-                                </option>
-                            }
+                            {allStages.map(item => <option key={item.value} value={item.value}>{item.label}</option>)}
                         </Input>
                     </>}
 
@@ -104,15 +99,7 @@ export const UserContextPicker = ({className, hideLabels = true}: {className?: s
                         >
                             {onlyOneBoard 
                                 ? <option value={onlyOneBoard.value}>{onlyOneBoard.label}</option> 
-                                : filteredExamBoardOptions.map(item => <option key={item.value} value={item.value}>{item.label}</option>)
-                            }
-                            {/* If the userContext.examBoard is not in the user's normal list of options (following link with q. params) add it */}
-                            {!filteredExamBoardOptions.map(s => s.value).includes(userContext.examBoard) &&
-                                <option key={userContext.examBoard} value={userContext.examBoard}>
-                                    {"*"}
-                                    {getFilteredExamBoardOptions().filter(o => o.value === userContext.examBoard)[0]?.label}
-                                    {"*"}
-                                </option>
+                                : allExamBoardOptions.map(item => <option key={item.value} value={item.value}>{item.label}</option>)
                             }
                         </Input>
                     </>}

--- a/src/app/components/elements/inputs/UserContextPicker.tsx
+++ b/src/app/components/elements/inputs/UserContextPicker.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import * as RS from "reactstrap";
 import {FormGroup, Input, Label} from "reactstrap";
 import {
@@ -29,11 +29,9 @@ export const UserContextPicker = ({className, hideLabels = true}: {className?: s
     const user = useAppSelector(selectors.user.orNull);
     const userContext = useUserViewingContext();
 
-    const allExamBoardOptions = getFilteredExamBoardOptions();
-    const allStages = getFilteredStageOptions();
-
     const filteredExamBoardOptions = getFilteredExamBoardOptions({byUser: user, byStages: [userContext.stage], includeNullOptions: true});
     const filteredStages = getFilteredStageOptions({byUser: user, includeNullOptions: true});
+    const allStages = getFilteredStageOptions();
 
     const unusual = {
         stage: !filteredStages.map(s => s.value).includes(userContext.stage),
@@ -46,6 +44,12 @@ export const UserContextPicker = ({className, hideLabels = true}: {className?: s
     const onlyOneBoard : {label: string, value: EXAM_BOARD} | undefined = filteredExamBoardOptions.length === 2 && filteredExamBoardOptions.map(eb => eb.value).includes(EXAM_BOARD.ALL)
         ? filteredExamBoardOptions.filter(eb => eb.value !== EXAM_BOARD.ALL)[0]
         : undefined;
+
+    const [currentStage, setCurrentStage] = useState<STAGE>(userContext.stage);
+
+    useEffect(() => {
+        setCurrentStage(userContext.stage);
+    }, [userContext.stage]);
 
     if (isStaff(user)) {
         return <RS.Col className={`d-flex flex-column w-100 px-0 mt-2 context-picker-container no-print ${className}`}>
@@ -99,7 +103,8 @@ export const UserContextPicker = ({className, hideLabels = true}: {className?: s
                         >
                             {onlyOneBoard 
                                 ? <option value={onlyOneBoard.value}>{onlyOneBoard.label}</option> 
-                                : allExamBoardOptions.map(item => <option key={item.value} value={item.value}>{item.label}</option>)
+                                : getFilteredExamBoardOptions({byStages: [currentStage], includeNullOptions: true})
+                                    .map(item => <option key={item.value} value={item.value}>{item.label}</option>)
                             }
                         </Input>
                     </>}

--- a/src/app/components/elements/inputs/UserContextPicker.tsx
+++ b/src/app/components/elements/inputs/UserContextPicker.tsx
@@ -8,6 +8,7 @@ import {
     getFilteredStageOptions,
     history,
     isAda,
+    isStaff,
     siteSpecific,
     STAGE,
     stageLabelMap,
@@ -43,106 +44,108 @@ export const UserContextPicker = ({className, hideLabels = true}: {className?: s
         ? filteredExamBoardOptions.filter(eb => eb.value !== EXAM_BOARD.ALL)[0]
         : undefined;
 
-    return <RS.Col className={`d-flex flex-column w-100 px-0 mt-2 context-picker-container no-print ${className}`}>
-        <RS.Row sm={12} md={7} lg={siteSpecific(7, 8)} xl={siteSpecific(7, 9)} className={`d-flex m-0 p-0 justify-content-md-end`}> 
-            {/* Stage Selector */}
-            <FormGroup className={`form-group w-100 d-flex justify-content-end m-0`}>
-                {showStageSelector && <>
-                    {!hideLabels && <Label className="d-inline-block pe-2" htmlFor="uc-stage-select">Stage</Label>}
-                    <Input
-                        className={`flex-grow-1 d-inline-block ps-2 pe-0 mb-2 ${showExamBoardSelector ? "me-1" : ""}`} type="select" id="uc-stage-select"
-                        aria-label={hideLabels ? "Stage" : undefined}
-                        value={userContext.stage}
-                        onChange={e => {
-                            const newParams: {[key: string]: unknown} = {...qParams, stage: e.target.value};
-                            const stage = e.target.value as STAGE;
-                            if (isAda) {
-                                // Derive exam board selection so that it is a valid option
-                                // Try to use default preferences (Stage All, Ada) otherwise default to All.
-                                let examBoard = stage === STAGE.ALL ? EXAM_BOARD.ADA : EXAM_BOARD.ALL;
-                                const possibleExamBoards =
-                                    getFilteredExamBoardOptions({byUser: user, byStages: [stage], includeNullOptions: true})
-                                        .map(eb => eb.value);
-                                // If we have possible valid exam board options but All is not one of them, use one of those.
-                                if (possibleExamBoards.length > 0 && !possibleExamBoards.includes(EXAM_BOARD.ALL)) {
-                                    examBoard = possibleExamBoards[0];
+    if (isStaff(user)) {
+        return <RS.Col className={`d-flex flex-column w-100 px-0 mt-2 context-picker-container no-print ${className}`}>
+            <RS.Row sm={12} md={7} lg={siteSpecific(7, 8)} xl={siteSpecific(7, 9)} className={`d-flex m-0 p-0 justify-content-md-end`}> 
+                {/* Stage Selector */}
+                <FormGroup className={`form-group w-100 d-flex justify-content-end m-0`}>
+                    {showStageSelector && <>
+                        {!hideLabels && <Label className="d-inline-block pe-2" htmlFor="uc-stage-select">Stage</Label>}
+                        <Input
+                            className={`flex-grow-1 d-inline-block ps-2 pe-0 mb-2 ${showExamBoardSelector ? "me-1" : ""}`} type="select" id="uc-stage-select"
+                            aria-label={hideLabels ? "Stage" : undefined}
+                            value={userContext.stage}
+                            onChange={e => {
+                                const newParams: {[key: string]: unknown} = {...qParams, stage: e.target.value};
+                                const stage = e.target.value as STAGE;
+                                if (isAda) {
+                                    // Derive exam board selection so that it is a valid option
+                                    // Try to use default preferences (Stage All, Ada) otherwise default to All.
+                                    let examBoard = stage === STAGE.ALL ? EXAM_BOARD.ADA : EXAM_BOARD.ALL;
+                                    const possibleExamBoards =
+                                        getFilteredExamBoardOptions({byUser: user, byStages: [stage], includeNullOptions: true})
+                                            .map(eb => eb.value);
+                                    // If we have possible valid exam board options but All is not one of them, use one of those.
+                                    if (possibleExamBoards.length > 0 && !possibleExamBoards.includes(EXAM_BOARD.ALL)) {
+                                        examBoard = possibleExamBoards[0];
+                                    }
+                                    // If we only have one possible exam board besides All, use that.
+                                    else if (possibleExamBoards.length === 2 && possibleExamBoards.includes(EXAM_BOARD.ALL)) {
+                                        examBoard = possibleExamBoards.filter(eb => eb !== EXAM_BOARD.ALL)[0];
+                                    }
+                                    newParams.examBoard = examBoard;
+                                    dispatch(transientUserContextSlice.actions.setExamBoard(examBoard));
                                 }
-                                // If we only have one possible exam board besides All, use that.
-                                else if (possibleExamBoards.length === 2 && possibleExamBoards.includes(EXAM_BOARD.ALL)) {
-                                    examBoard = possibleExamBoards.filter(eb => eb !== EXAM_BOARD.ALL)[0];
-                                }
-                                newParams.examBoard = examBoard;
-                                dispatch(transientUserContextSlice.actions.setExamBoard(examBoard));
+                                dispatch(transientUserContextSlice.actions.setStage(stage));
+                            }}
+                        >
+                            {filteredStages.map(item => <option key={item.value} value={item.value}>{item.label}</option>)}
+                            {/* If the userContext.stage is not in the user's normal list of options (following link with q. params) add it */}
+                            {!filteredStages.map(s => s.value).includes(userContext.stage) &&
+                                <option key={userContext.stage} value={userContext.stage}>
+                                    {"*"}
+                                    {getFilteredStageOptions().filter(o => o.value === userContext.stage)[0]?.label}
+                                    {"*"}
+                                </option>
                             }
-                            dispatch(transientUserContextSlice.actions.setStage(stage));
-                        }}
-                    >
-                        {filteredStages.map(item => <option key={item.value} value={item.value}>{item.label}</option>)}
-                        {/* If the userContext.stage is not in the user's normal list of options (following link with q. params) add it */}
-                        {!filteredStages.map(s => s.value).includes(userContext.stage) &&
-                            <option key={userContext.stage} value={userContext.stage}>
-                                {"*"}
-                                {getFilteredStageOptions().filter(o => o.value === userContext.stage)[0]?.label}
-                                {"*"}
-                            </option>
-                        }
-                    </Input>
-                </>}
+                        </Input>
+                    </>}
 
-                {/* Exam Board Selector */}
-                {showExamBoardSelector && <>
-                    {!hideLabels && <Label className="d-inline-block pe-2" htmlFor="uc-exam-board-select">Exam Board</Label>}
+                    {/* Exam Board Selector */}
+                    {showExamBoardSelector && <>
+                        {!hideLabels && <Label className="d-inline-block pe-2" htmlFor="uc-exam-board-select">Exam Board</Label>}
+                        <Input
+                            className={`flex-grow-1 d-inline-block ps-2 pe-0 mb-2 ${showStageSelector ? "ms-1" : ""}`} type="select" id="uc-exam-board-select"
+                            aria-label={hideLabels ? "Exam Board" : undefined}
+                            value={userContext.examBoard}
+                            onChange={e => {
+                                dispatch(transientUserContextSlice.actions.setExamBoard(e.target.value as EXAM_BOARD));
+                            }}
+                        >
+                            {onlyOneBoard 
+                                ? <option value={onlyOneBoard.value}>{onlyOneBoard.label}</option> 
+                                : filteredExamBoardOptions.map(item => <option key={item.value} value={item.value}>{item.label}</option>)
+                            }
+                            {/* If the userContext.examBoard is not in the user's normal list of options (following link with q. params) add it */}
+                            {!filteredExamBoardOptions.map(s => s.value).includes(userContext.examBoard) &&
+                                <option key={userContext.examBoard} value={userContext.examBoard}>
+                                    {"*"}
+                                    {getFilteredExamBoardOptions().filter(o => o.value === userContext.examBoard)[0]?.label}
+                                    {"*"}
+                                </option>
+                            }
+                        </Input>
+                    </>}
+                    
+                    {showUnusualContextMessage && <div className="mt-2 ms-1">
+                        <span id={`unusual-viewing-context-explanation`} className="icon-help mx-1" />
+                        <RS.UncontrolledTooltip placement="bottom" target={`unusual-viewing-context-explanation`}>
+                            You are seeing {stageLabelMap[userContext.stage]} {isAda ? examBoardLabelMap[userContext.examBoard] : ""}{" "}
+                            content, which is different to your account settings. <br />
+                            {unusual.stage && unusual.examBoard && <>
+                                {userContext.explanation.stage === userContext.explanation.examBoard ?
+                                    `The stage and exam board were specified by ${userContext.explanation.stage}.` :
+                                    `The stage was specified by ${userContext.explanation.stage} and the exam board by ${userContext.explanation.examBoard}.`}
+                            </>}
+                            {unusual.stage && !unusual.examBoard && `The stage was specified by ${userContext.explanation.stage}.`}
+                            {unusual.examBoard && !unusual.stage && `The exam board was specified by ${userContext.explanation.examBoard}.`}
+                        </RS.UncontrolledTooltip>
+                    </div>}
+                </FormGroup>
+            </RS.Row>
+            
+
+            {/* "Show other content" selector */}
+            {isAda && <RS.Row className="w-100 px-0 m-0 pb-2 justify-content-end">
+                <FormGroup className="form-group w-auto m-0">
+                    <Label className="d-inline-block m-0" htmlFor="uc-show-other-content-check">Show other content? </Label>
                     <Input
-                        className={`flex-grow-1 d-inline-block ps-2 pe-0 mb-2 ${showStageSelector ? "ms-1" : ""}`} type="select" id="uc-exam-board-select"
-                        aria-label={hideLabels ? "Exam Board" : undefined}
-                        value={userContext.examBoard}
-                        onChange={e => {
-                            dispatch(transientUserContextSlice.actions.setExamBoard(e.target.value as EXAM_BOARD));
-                        }}
-                    >
-                        {onlyOneBoard 
-                            ? <option value={onlyOneBoard.value}>{onlyOneBoard.label}</option> 
-                            : filteredExamBoardOptions.map(item => <option key={item.value} value={item.value}>{item.label}</option>)
-                        }
-                        {/* If the userContext.examBoard is not in the user's normal list of options (following link with q. params) add it */}
-                        {!filteredExamBoardOptions.map(s => s.value).includes(userContext.examBoard) &&
-                            <option key={userContext.examBoard} value={userContext.examBoard}>
-                                {"*"}
-                                {getFilteredExamBoardOptions().filter(o => o.value === userContext.examBoard)[0]?.label}
-                                {"*"}
-                            </option>
-                        }
-                    </Input>
-                </>}
-                
-                {showUnusualContextMessage && <div className="mt-2 ms-1">
-                    <span id={`unusual-viewing-context-explanation`} className="icon-help mx-1" />
-                    <RS.UncontrolledTooltip placement="bottom" target={`unusual-viewing-context-explanation`}>
-                        You are seeing {stageLabelMap[userContext.stage]} {isAda ? examBoardLabelMap[userContext.examBoard] : ""}{" "}
-                        content, which is different to your account settings. <br />
-                        {unusual.stage && unusual.examBoard && <>
-                            {userContext.explanation.stage === userContext.explanation.examBoard ?
-                                `The stage and exam board were specified by ${userContext.explanation.stage}.` :
-                                `The stage was specified by ${userContext.explanation.stage} and the exam board by ${userContext.explanation.examBoard}.`}
-                        </>}
-                        {unusual.stage && !unusual.examBoard && `The stage was specified by ${userContext.explanation.stage}.`}
-                        {unusual.examBoard && !unusual.stage && `The exam board was specified by ${userContext.explanation.examBoard}.`}
-                    </RS.UncontrolledTooltip>
-                </div>}
-            </FormGroup>
-        </RS.Row>
-        
-
-        {/* "Show other content" selector */}
-        {isAda && <RS.Row className="w-100 px-0 m-0 pb-2 justify-content-end">
-            <FormGroup className="form-group w-auto m-0">
-                <Label className="d-inline-block m-0" htmlFor="uc-show-other-content-check">Show other content? </Label>
-                <Input
-                    className="d-inline-block ms-2 pe-0 mt-1" type="checkbox" id="uc-show-other-content-check"
-                    checked={userContext.showOtherContent}
-                    onChange={e => dispatch(transientUserContextSlice.actions.setShowOtherContent(e.target.checked))}
-                />
-            </FormGroup>
-        </RS.Row>}
-    </RS.Col>;
+                        className="d-inline-block ms-2 pe-0 mt-1" type="checkbox" id="uc-show-other-content-check"
+                        checked={userContext.showOtherContent}
+                        onChange={e => dispatch(transientUserContextSlice.actions.setShowOtherContent(e.target.checked))}
+                    />
+                </FormGroup>
+            </RS.Row>}
+        </RS.Col>;
+    }
 };


### PR DESCRIPTION
For non-staff users: hide context picker.
For staff users: show all stage/exam boards options on context picker.