### PR TITLE
Limit multiple-digit numbers in Inequality

### DIFF
--- a/src/app/components/content/IsaacSymbolicChemistryQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicChemistryQuestion.tsx
@@ -65,7 +65,9 @@ const IsaacSymbolicChemistryQuestion = ({doc, questionId, readonly}: IsaacQuesti
         currentAttemptValue = jsonHelper.parseOrDefault(currentAttempt.value, {result: {tex: '\\textrm{PLACEHOLDER HERE}'}});
     }
 
-    const hasMetaSymbols = !doc.availableSymbols?.every(symbol => CHEMICAL_ELEMENTS.includes(symbol.trim()) || CHEMICAL_PARTICLES.hasOwnProperty(symbol.trim()));
+    const hasMetaSymbols = doc.availableSymbols ? doc.availableSymbols.length > 0 && !doc.availableSymbols.every(
+        symbol => CHEMICAL_ELEMENTS.includes(symbol.trim()) || CHEMICAL_PARTICLES.hasOwnProperty(symbol.trim())
+    ) : false;
 
     const symbolicInputValidator = (input: string) => {
         const openRoundBracketsCount = input.split("(").length - 1;

--- a/src/app/components/elements/modals/inequality/InequalityModal.tsx
+++ b/src/app/components/elements/modals/inequality/InequalityModal.tsx
@@ -179,9 +179,19 @@ const InequalityMenu = React.forwardRef<HTMLDivElement, InequalityMenuProps>(({o
     const updateNumberInputValue = (n: number) => {
         if (!isDefined(numberInputValue) || numberInputValue === 0) return setNumberInputValue(n);
         // Past this point, we know that `numberInputValue` is defined and non-zero
-        setNumberInputValue(numberInputValue * 10 + (Math.sign(numberInputValue) * n));
+        if (numberInputValue > -100 && numberInputValue < 1000) {
+            // Multiple-digit numbers should be limited to 4 characters to fit in the Inequality menu
+            setNumberInputValue(numberInputValue * 10 + (Math.sign(numberInputValue) * n));
+        }
     };
-    const flipNumberInputValueSign = () => setNumberInputValue(-(numberInputValue ?? 0));
+    const flipNumberInputValueSign = () => {
+        if (!isDefined(numberInputValue) || numberInputValue === 0) return setNumberInputValue(0);
+        if (numberInputValue >= 1000) {
+            setNumberInputValue(-Math.floor(numberInputValue / 10));
+        } else {
+            setNumberInputValue(-numberInputValue);
+        }  
+    };
     const clearNumberInputValue = () => setNumberInputValue(undefined);
 
     // Logic for parsing chemical elements from the chemical element input box and turning them into menu items

--- a/src/app/components/pages/Equality.tsx
+++ b/src/app/components/pages/Equality.tsx
@@ -234,7 +234,7 @@ const Equality = withRouter(({location}: RouteComponentProps<{}, {}, {board?: st
     };
 
     const previewText = currentAttemptValue && currentAttemptValue.result && currentAttemptValue.result.tex;
-    const allowTextInput = editorMode === 'maths'  || (isStaff(user) && ['chemistry', 'nuclear', 'logic'].includes(editorMode));
+    const allowTextInput = editorMode === 'maths' || (isStaff(user) && ['chemistry', 'nuclear', 'logic'].includes(editorMode));
 
     return <div>
         <Container>


### PR DESCRIPTION
Forming a multiple-digit `numberInputValue` in the Inequality Modal was unlimited, which led to bad behaviour (e.g. overflowing from its menu container, large numbers facing integer limit issues, larger numbers being converted to scientific notation).

I've run a script to check all symbolic questions on the site and found 10 total questions with answers containing 4 or more digits:
- 7 of them would be fine with 4 positive digits
- The other 3 are just a single number and so can be answered very easily with just the existing text input (and don't even really need to be symbolic questions anyway!) [e.g. [Part A](https://isaacphysics.org/questions/iodate?stage=a_level)]

4 characters is also the amount that fit cleanly in the menu hexagon, so 4 positive digits / 3 negative digits is the safest answer.

--- 

Also to get in simultaneously for the Chemistry Checker, the `hasMetaSymbols` check now also tests for empty lists. This has already been tested by Content so shouldn't need too much checking. 