### PR TITLE
Add admin search postcode validation

### DIFF
--- a/src/app/components/pages/AdminUserManager.tsx
+++ b/src/app/components/pages/AdminUserManager.tsx
@@ -111,8 +111,13 @@ export const AdminUserManager = () => {
 
     const search = (event: React.FormEvent<HTMLFormElement>) => {
         event.preventDefault();
-        adminSearchResultsRef.current?.scrollIntoView({behavior: "smooth"});
-        searchUsers(searchQuery);
+        if (searchQuery.postcode && !/^[A-Z]{1,2}[0-9]{1,2}[A-Z]{0,1} ?([0-9][A-Z]{2})?$/i.test(searchQuery.postcode)) {
+            alert("Postcode input invalid");
+        }
+        else {
+            adminSearchResultsRef.current?.scrollIntoView({behavior: "smooth"});
+            searchUsers(searchQuery);
+        }
     };
 
     const editUser = (userid: number | undefined) => {

--- a/src/app/components/pages/AdminUserManager.tsx
+++ b/src/app/components/pages/AdminUserManager.tsx
@@ -111,7 +111,7 @@ export const AdminUserManager = () => {
 
     const search = (event: React.FormEvent<HTMLFormElement>) => {
         event.preventDefault();
-        if (searchQuery.postcode && !/^[A-Z]{1,2}[0-9]{1,2}[A-Z]{0,1} ?([0-9][A-Z]{2})?$/i.test(searchQuery.postcode)) {
+        if (searchQuery.postcode && !/^[A-Z]{1,2}[0-9][A-Z|0-9]? ?([0-9][A-Z]{2})?$/i.test(searchQuery.postcode)) {
             alert("Postcode input invalid");
         }
         else {

--- a/src/app/components/pages/AdminUserManager.tsx
+++ b/src/app/components/pages/AdminUserManager.tsx
@@ -111,7 +111,7 @@ export const AdminUserManager = () => {
 
     const search = (event: React.FormEvent<HTMLFormElement>) => {
         event.preventDefault();
-        if (searchQuery.postcode && !/^[A-Z]{1,2}[0-9][A-Z|0-9]? ?([0-9][A-Z]{2})?$/i.test(searchQuery.postcode)) {
+        if (searchQuery.postcode && !/^[A-Z]{1,2}[0-9][A-Z0-9]? ?([0-9][A-Z]{2})?$/i.test(searchQuery.postcode)) {
             alert("Postcode input invalid");
         }
         else {


### PR DESCRIPTION
Add a regex to verify that a postcode is of a sensible format in admin user search before sending it to the API. The regex should match complete postcodes (e.g. CB3 0FD) and outcodes (e.g. CB3).

This check doesn't verify that a postcode actually exists, so a server error can still be thrown in some cases, but this should reduce the chances of this happening.