### PR TITLE
Distinguish Practice Tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isaac-react-app",
-  "version": "3.14.8",
+  "version": "3.14.9-SNAPSHOT",
   "private": true,
   "engines": {
     "node": ">=18",

--- a/src/IsaacAppTypes.tsx
+++ b/src/IsaacAppTypes.tsx
@@ -322,7 +322,9 @@ export interface ActiveModal {
     overflowVisible?: boolean;
 }
 
-export enum BoardOrder {
+export type ProgressSortOrder = number | "name" | "totalQuestionPartPercentage" | "totalQuestionPercentage";
+
+export enum AssignmentBoardOrder {
     "created" = "created",
     "-created" = "-created",
     "visited" = "visited",

--- a/src/IsaacAppTypes.tsx
+++ b/src/IsaacAppTypes.tsx
@@ -324,6 +324,19 @@ export interface ActiveModal {
 
 export type ProgressSortOrder = number | "name" | "totalQuestionPartPercentage" | "totalQuestionPercentage";
 
+export enum QuizzesBoardOrder {
+    "title" = "title",
+    "-title" = "-title",
+    "setBy" = "setBy",
+    "-setBy" = "-setBy",
+    "dueDate" = "dueDate",
+    "-dueDate" = "-dueDate",
+    "setDate" = "setDate",
+    "-setDate" = "-setDate",
+    "startDate" = "startDate",
+    "-startDate" = "-startDate",
+}
+
 export enum AssignmentBoardOrder {
     "created" = "created",
     "-created" = "-created",

--- a/src/app/components/elements/CardGrid.tsx
+++ b/src/app/components/elements/CardGrid.tsx
@@ -4,12 +4,12 @@ import { below, useDeviceSize } from '../../services';
 
 export const CardGrid = (props: ContainerProps) => {
     const deviceSize = useDeviceSize();
-    const width = deviceSize === 'xs' ? 1 : below['lg'](deviceSize) ? 2 : 3;
+    const width = deviceSize === 'xs' ? 1 : below['md'](deviceSize) ? 2 : 3;
     if (!props.children || !Array.isArray(props.children)) return null;
     const rows = [];
 
     for (let i = 0; i < Math.ceil(props.children.length / width); i++) {
-        rows.push(<Row className={`w-100 card-grid-${deviceSize}`}>
+        rows.push(<Row className={`card-grid-${deviceSize}`}>
             {props.children.slice(i * width, (i + 1) * width)}
         </Row>);
     }

--- a/src/app/components/elements/CollapsibleContainer.tsx
+++ b/src/app/components/elements/CollapsibleContainer.tsx
@@ -1,0 +1,28 @@
+import classNames from "classnames";
+import React, { useLayoutEffect, useRef, useState } from "react";
+
+export interface CollapsibleContainerProps extends React.HTMLAttributes<HTMLDivElement> {
+    expanded: boolean;
+}
+
+export const CollapsibleContainer = (props: CollapsibleContainerProps) => {
+    const {expanded, ...rest} = props;
+    const [expandedHeight, setExpandedHeight] = useState(0);
+
+    const divRef = useRef<HTMLDivElement>(null);
+
+    useLayoutEffect(() => {
+        if (expanded) {
+            setExpandedHeight(divRef?.current ? [...divRef.current.children].map(c => 
+                c.getAttribute("data-targetHeight") ? parseInt(c.getAttribute("data-targetHeight") as string) : c.clientHeight
+            ).reduce((a, b) => a + b, 0) : 0);
+        }
+    }, [expanded, props.children]);
+
+    return <div {...rest} 
+        className={classNames("collapsible-body", rest.className)} 
+        style={{height: expanded ? expandedHeight : 0, maxHeight: expanded ? expandedHeight : 0, ...rest.style}}
+        data-targetHeight={expandedHeight}
+        ref={divRef} 
+    />;
+};

--- a/src/app/components/elements/CollapsibleList.tsx
+++ b/src/app/components/elements/CollapsibleList.tsx
@@ -41,7 +41,7 @@ export const CollapsibleList = (props: CollapsibleListProps) => {
                 {title && <span>{title}</span>}
                 <Spacer/>
                 {(props.numberSelected ?? 0) > 0
-                    && <FilterCount count={props.numberSelected ?? 0} />}
+                    && <FilterCount count={props.numberSelected ?? 0} className="me-2" />}
                 <img className={classNames("icon-dropdown-90", {"active": expanded})} src={"/assets/common/icons/chevron_right.svg"} alt="" />
             </button>
         </div>

--- a/src/app/components/elements/Gameboards.tsx
+++ b/src/app/components/elements/Gameboards.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Card, CardBody, Button, Row, Col, Table, UncontrolledTooltip, Spinner } from "reactstrap";
-import { BoardOrder, Boards } from "../../../IsaacAppTypes";
+import { AssignmentBoardOrder, Boards } from "../../../IsaacAppTypes";
 import { isPhy, siteSpecific, difficultiesOrdered, difficultyShortLabelMap, isAda, BoardViews, BoardCreators, BoardCompletions, matchesAllWordsInAnyOrder, formatBoardOwner, boardCompletionSelection } from "../../services";
 import { SortItemHeader } from "./SortableItemHeader";
 import { BoardCard } from "./cards/BoardCard";
@@ -21,8 +21,8 @@ export interface GameboardsTableProps {
     setBoardCreator: (creator: BoardCreators) => void;
     boardCompletion: BoardCompletions;
     setBoardCompletion: (boardCompletion: BoardCompletions) => void;
-    boardOrder: BoardOrder;
-    setBoardOrder: (boardOrder: BoardOrder) => void;
+    boardOrder: AssignmentBoardOrder;
+    setBoardOrder: (boardOrder: AssignmentBoardOrder) => void;
 }
 
 export interface GameboardsCardsProps {
@@ -55,7 +55,7 @@ const CSTable = (props: GameboardsTableProps) => {
     } = props;
 
     const tableHeader = <tr className="my-gameboard-table-header">
-        <SortItemHeader colSpan={isPhy ? 1 : 4} className={siteSpecific("", "w-100")} defaultOrder={BoardOrder.title} reverseOrder={BoardOrder["-title"]} currentOrder={boardOrder} setOrder={setBoardOrder} alignment="start">
+        <SortItemHeader<AssignmentBoardOrder> colSpan={isPhy ? 1 : 4} className={siteSpecific("", "w-100")} defaultOrder={AssignmentBoardOrder.title} reverseOrder={AssignmentBoardOrder["-title"]} currentOrder={boardOrder} setOrder={setBoardOrder} alignment="start">
             {siteSpecific("Board name", "Quiz name")}
         </SortItemHeader>
         <th colSpan={2} className={classNames("long-titled-col", {"align-middle" : isPhy})}>
@@ -66,13 +66,13 @@ const CSTable = (props: GameboardsTableProps) => {
             </UncontrolledTooltip>
         </th>
         {isAda && <th>Creator</th>}
-        <SortItemHeader defaultOrder={BoardOrder.created} reverseOrder={BoardOrder["-created"]} currentOrder={boardOrder} setOrder={setBoardOrder}>
+        <SortItemHeader<AssignmentBoardOrder> defaultOrder={AssignmentBoardOrder.created} reverseOrder={AssignmentBoardOrder["-created"]} currentOrder={boardOrder} setOrder={setBoardOrder}>
             Created
         </SortItemHeader>
-        <SortItemHeader defaultOrder={BoardOrder.attempted} reverseOrder={BoardOrder["-attempted"]} currentOrder={boardOrder} setOrder={setBoardOrder}>
+        <SortItemHeader<AssignmentBoardOrder> defaultOrder={AssignmentBoardOrder.attempted} reverseOrder={AssignmentBoardOrder["-attempted"]} currentOrder={boardOrder} setOrder={setBoardOrder}>
             Attempted
         </SortItemHeader>
-        <SortItemHeader defaultOrder={BoardOrder.correct} reverseOrder={BoardOrder["-correct"]} currentOrder={boardOrder} setOrder={setBoardOrder}>
+        <SortItemHeader<AssignmentBoardOrder> defaultOrder={AssignmentBoardOrder.correct} reverseOrder={AssignmentBoardOrder["-correct"]} currentOrder={boardOrder} setOrder={setBoardOrder}>
             Correct
         </SortItemHeader>
         {siteSpecific(

--- a/src/app/components/elements/SortableItemHeader.tsx
+++ b/src/app/components/elements/SortableItemHeader.tsx
@@ -2,6 +2,7 @@ import React, { ComponentProps } from "react";
 import { isDefined, siteSpecific } from "../../services";
 import { Spacer } from "./Spacer";
 import { NonUndefined } from "@reduxjs/toolkit/dist/query/tsHelpers";
+import classNames from "classnames";
 
 function toggleSort<T>(
         defaultOrder: T,
@@ -65,7 +66,10 @@ export const SortItemHeader = <T,>(props: SortItemHeaderProps<NonUndefined<T>>) 
         <span className="down">▼</span>
     </button>;
 
-    return <th {...rest} className={props.className + sortClass(defaultOrder, reverseOrder, currentOrder, reversed)} onClick={clickToSelect}>
+    return <th {...rest}
+        className={classNames(props.className, "user-select-none", sortClass(defaultOrder, reverseOrder, currentOrder, reversed))}
+        onClick={clickToSelect ?? (() => toggleSort(defaultOrder, reverseOrder, currentOrder, setOrder))}
+    >
         <div className={`d-flex ${justify} align-items-center`}>
             {props.children}
             {justify === "justify-content-start" && <Spacer/>}

--- a/src/app/components/elements/SortableItemHeader.tsx
+++ b/src/app/components/elements/SortableItemHeader.tsx
@@ -1,12 +1,9 @@
 import React, { ComponentProps } from "react";
-import { BoardOrder } from "../../../IsaacAppTypes";
-import { isDefined, siteSpecific, SortOrder } from "../../services";
+import { isDefined, siteSpecific } from "../../services";
 import { Spacer } from "./Spacer";
+import { NonUndefined } from "@reduxjs/toolkit/dist/query/tsHelpers";
 
-export type ProgressSortOrder = number | "name" | "totalQuestionPartPercentage" | "totalQuestionPercentage";
-type Order = BoardOrder | SortOrder | ProgressSortOrder;
-
-function toggleSort<T extends Order>(
+function toggleSort<T>(
         defaultOrder: T,
         reverseOrder: T,
         currentOrder: T,
@@ -18,7 +15,7 @@ function toggleSort<T extends Order>(
     }
 }
 
-function sortClass<T extends Order>(
+function sortClass<T>(
     defaultOrder: T,
     reverseOrder: T,
     currentOrder: T,
@@ -35,7 +32,7 @@ function sortClass<T extends Order>(
     }
 }
 
-export interface SortItemHeaderProps<T extends Order> extends ComponentProps<"th"> {
+export interface SortItemHeaderProps<T> extends ComponentProps<"th"> {
     defaultOrder: T,
     reverseOrder: T,
     currentOrder: T,
@@ -46,7 +43,7 @@ export interface SortItemHeaderProps<T extends Order> extends ComponentProps<"th
     alignment?: "start" | "center" | "end",
 }
 
-export const SortItemHeader = <T extends Order>(props: SortItemHeaderProps<T>) => {
+export const SortItemHeader = <T,>(props: SortItemHeaderProps<NonUndefined<T>>) => {
     const {
         defaultOrder,
         reverseOrder,

--- a/src/app/components/elements/modals/QuestionSearchModal.tsx
+++ b/src/app/components/elements/modals/QuestionSearchModal.tsx
@@ -255,10 +255,10 @@ export const QuestionSearchModal = (
                 <thead>
                     <tr className="search-modal-table-header">
                         <th className="w-5"> </th>
-                        <SortItemHeader
+                        <SortItemHeader<SortOrder>
                             className={siteSpecific("w-40", "w-30")}
                             setOrder={sortableTableHeaderUpdateState(questionsSort, setQuestionsSort, "title")}
-                            defaultOrder={SortOrder.ASC as SortOrder}
+                            defaultOrder={SortOrder.ASC}
                             reverseOrder={SortOrder.DESC}
                             currentOrder={questionsSort['title']}
                             alignment="start"

--- a/src/app/components/elements/quiz/QuizProgressCommon.tsx
+++ b/src/app/components/elements/quiz/QuizProgressCommon.tsx
@@ -1,12 +1,12 @@
 import React, {useContext, useLayoutEffect, useMemo, useRef, useState} from "react";
 import {Button} from "reactstrap";
-import {AssignmentProgressPageSettingsContext} from "../../../../IsaacAppTypes";
+import {AssignmentProgressPageSettingsContext, ProgressSortOrder} from "../../../../IsaacAppTypes";
 import {isAuthorisedFullAccess, siteSpecific, TODAY} from "../../../services";
 import {Link} from "react-router-dom";
 import orderBy from "lodash/orderBy";
 import { IsaacSpinner } from "../../handlers/IsaacSpinner";
 import { closeActiveModal, openActiveModal, useAppDispatch, useReturnQuizToStudentMutation } from "../../../state";
-import { ProgressSortOrder, SortItemHeader } from "../SortableItemHeader";
+import { SortItemHeader } from "../SortableItemHeader";
 import { AssignmentProgressDTO } from "../../../../IsaacApiTypes";
 
 export const ICON = siteSpecific(
@@ -133,9 +133,9 @@ export function ResultsTable<Q extends QuestionType>({assignmentId,
     , [semiSortedProgress, reverseOrder, sortOrder]);
 
     const tableHeaderFooter = <tr className="progress-table-header-footer">
-        <SortItemHeader className="student-name" defaultOrder={"name"} reverseOrder={"name"} currentOrder={sortOrder} setOrder={toggleSort} reversed={reverseOrder}/>
+        <SortItemHeader<ProgressSortOrder> className="student-name" defaultOrder={"name"} reverseOrder={"name"} currentOrder={sortOrder} setOrder={toggleSort} reversed={reverseOrder}/>
         {questions.map((q, index) =>
-            <SortItemHeader
+            <SortItemHeader<ProgressSortOrder>
                 key={q.id} className={`${isSelected(q)}`}
                 defaultOrder={index} reverseOrder={index} currentOrder={sortOrder}
                 setOrder={toggleSort}
@@ -147,14 +147,14 @@ export function ResultsTable<Q extends QuestionType>({assignmentId,
             </SortItemHeader>
         )}
         {isAssignment ? <>
-            <SortItemHeader
+            <SortItemHeader<ProgressSortOrder>
                 className="total-column left"
                 defaultOrder={"totalQuestionPartPercentage"}
                 reverseOrder={"totalQuestionPartPercentage"}
                 currentOrder={sortOrder} setOrder={toggleSort} reversed={reverseOrder}>
                 Total Parts
             </SortItemHeader>
-            <SortItemHeader
+            <SortItemHeader<ProgressSortOrder>
                 className="total-column right"
                 defaultOrder={"totalQuestionPercentage"}
                 reverseOrder={"totalQuestionPercentage"}
@@ -162,7 +162,7 @@ export function ResultsTable<Q extends QuestionType>({assignmentId,
                 Total Qs
             </SortItemHeader>
         </> :
-        <SortItemHeader
+        <SortItemHeader<ProgressSortOrder>
             defaultOrder={"totalQuestionPartPercentage"}
             reverseOrder={"totalQuestionPartPercentage"}
             currentOrder={sortOrder} setOrder={toggleSort} reversed={reverseOrder}

--- a/src/app/components/elements/svg/FilterCount.tsx
+++ b/src/app/components/elements/svg/FilterCount.tsx
@@ -3,14 +3,14 @@ import {Circle} from "./Circle";
 import { siteSpecific } from "../../../services";
 import { Hexagon } from "./Hexagon";
 
-const filterIconWidth = 25;
-
 export interface FilterCountProps extends React.SVGProps<SVGSVGElement> {
     count: number;
+    widthPx?: number;
 }
 
 export const FilterCount = (props: FilterCountProps) => {
-    const {count, ...rest} = props;
+    const {count, widthPx, ...rest} = props;
+    const filterIconWidth = widthPx || 25;
 
     return <svg
         {...rest}

--- a/src/app/components/elements/svg/FilterCount.tsx
+++ b/src/app/components/elements/svg/FilterCount.tsx
@@ -5,11 +5,17 @@ import { Hexagon } from "./Hexagon";
 
 const filterIconWidth = 25;
 
-export const FilterCount = ({count}: {count: number}) => {
+export interface FilterCountProps extends React.SVGProps<SVGSVGElement> {
+    count: number;
+}
+
+export const FilterCount = (props: FilterCountProps) => {
+    const {count, ...rest} = props;
+
     return <svg
+        {...rest}
         width={`${filterIconWidth}px`}
         height={`${filterIconWidth}px`}
-        className="me-2"
     >
         <title>{`${count} filters selected`}</title>
         <g>

--- a/src/app/components/elements/tables/TableLinks.tsx
+++ b/src/app/components/elements/tables/TableLinks.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import classNames from "classnames";
+
+interface TdLinkProps extends React.HTMLAttributes<HTMLTableCellElement> {
+    to: string | undefined;
+}
+
+interface TrLinkProps extends React.HTMLAttributes<HTMLTableRowElement> {
+    to: string | undefined;
+}
+
+// an <a/> anywhere between a <table/> and a <td/> is illegal, so a row can't be wrapped in a <Link/>. instead, each <td/> contains a link.
+export const TdLink = ({to, children, ...rest}: TdLinkProps) => {
+    return <td {...rest} className={classNames(rest.className, "td-link")}>{to ? <Link to={to}>{children}</Link> : <>{children}</>}</td>;
+};
+
+// this wrapper exists such that you only need specify the link prop once per row.
+// just drop <TrLink to={...}> in place of a <tr/>.
+export const TrLink = ({to, children, ...rest}: TrLinkProps) => {
+    return <tr {...rest}>
+        {React.Children.map(children, child => React.isValidElement(child) && child.type === "td" ? <TdLink to={to} {...child.props}/> : child)}
+    </tr>;
+};

--- a/src/app/components/pages/AssignmentSchedule.tsx
+++ b/src/app/components/pages/AssignmentSchedule.tsx
@@ -46,7 +46,7 @@ import {
     TODAY,
     useDeviceSize
 } from "../../services";
-import {AppGroup, AssignmentScheduleContext, BoardOrder, ValidAssignmentWithListingDate} from "../../../IsaacAppTypes";
+import {AppGroup, AssignmentScheduleContext, AssignmentBoardOrder, ValidAssignmentWithListingDate} from "../../../IsaacAppTypes";
 import {calculateHexagonProportions, Hexagon} from "../elements/svg/Hexagon";
 import classNames from "classnames";
 import {currentYear, DateInput} from "../elements/inputs/DateInput";
@@ -522,7 +522,7 @@ type AssignmentsGroupedByDate = [number, [number, [number, ValidAssignmentWithLi
 export const AssignmentSchedule = ({user}: {user: RegisteredUserDTO}) => {
     const assignmentsSetByMeQuery = useGetMySetAssignmentsQuery(undefined);
     const { data: assignmentsSetByMe } = assignmentsSetByMeQuery;
-    const { data: gameboards } = useGetGameboardsQuery({startIndex: 0, limit: BoardLimit.All, sort: BoardOrder.created});
+    const { data: gameboards } = useGetGameboardsQuery({startIndex: 0, limit: BoardLimit.All, sort: AssignmentBoardOrder.created});
     const { data: groups } = useGetGroupsQuery(false);
 
     const [viewBy, setViewBy] = useState<"startDate" | "dueDate">("startDate");

--- a/src/app/components/pages/MyGameboards.tsx
+++ b/src/app/components/pages/MyGameboards.tsx
@@ -8,7 +8,7 @@ import {
     Input,
     Label,
     Row} from 'reactstrap';
-import {BoardOrder} from "../../../IsaacAppTypes";
+import {AssignmentBoardOrder} from "../../../IsaacAppTypes";
 import {GameboardDTO, RegisteredUserDTO} from "../../../IsaacApiTypes";
 import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
 import {
@@ -33,8 +33,8 @@ export interface GameboardsDisplaySettingsProps {
     switchViewAndClearSelected: (e: React.ChangeEvent<HTMLInputElement>) => void,
     boardLimit: BoardLimit,
     setBoardLimit: (limit: BoardLimit) => void,
-    boardOrder: BoardOrder,
-    setBoardOrder: (order: BoardOrder) => void,
+    boardOrder: AssignmentBoardOrder,
+    setBoardOrder: (order: AssignmentBoardOrder) => void,
     showFilters: boolean,
     setShowFilters: React.Dispatch<React.SetStateAction<boolean>>,
 }
@@ -57,8 +57,8 @@ const GameboardsDisplaySettings = ({boardView, switchViewAndClearSelected, board
         </Col>
         <Col xs={9} md={5} lg={{size: 4, offset: 2}}>
             <Label className="w-100">
-                Sort by <Input type="select" value={boardOrder} onChange={e => setBoardOrder(e.target.value as BoardOrder)}>
-                    {Object.values(BoardOrder).map(order => <option key={order} value={order}>{BOARD_ORDER_NAMES[order]}</option>)}
+                Sort by <Input type="select" value={boardOrder} onChange={e => setBoardOrder(e.target.value as AssignmentBoardOrder)}>
+                    {Object.values(AssignmentBoardOrder).map(order => <option key={order} value={order}>{BOARD_ORDER_NAMES[order]}</option>)}
                 </Input>
             </Label>
         </Col>

--- a/src/app/components/pages/SetAssignments.tsx
+++ b/src/app/components/pages/SetAssignments.tsx
@@ -63,7 +63,7 @@ import {
 } from "../../services";
 import {IsaacSpinner, Loading} from "../handlers/IsaacSpinner";
 import {GameboardDTO, RegisteredUserDTO, UserGroupDTO} from "../../../IsaacApiTypes";
-import {BoardAssignee, BoardOrder, Boards} from "../../../IsaacAppTypes";
+import {BoardAssignee, AssignmentBoardOrder, Boards} from "../../../IsaacAppTypes";
 import {BoardCard} from "../elements/cards/BoardCard";
 import classNames from "classnames";
 import {StyledSelect} from "../elements/inputs/StyledSelect";
@@ -246,8 +246,8 @@ interface SetAssignmentsTableProps {
     setBoardTitleFilter: (title: string) => void;
     boardCreator: BoardCreators;
     setBoardCreator: (creator: BoardCreators) => void;
-    boardOrder: BoardOrder;
-    setBoardOrder: (boardOrder: BoardOrder) => void;
+    boardOrder: AssignmentBoardOrder;
+    setBoardOrder: (boardOrder: AssignmentBoardOrder) => void;
     groupsByGameboard: {[p: string]: BoardAssignee[]};
     openAssignModal: (board: GameboardDTO) => void;
 }
@@ -263,7 +263,7 @@ const PhyTable = (props: SetAssignmentsTableProps) => {
 
     const tableHeader = <tr className="my-gameboard-table-header">
         <th className="text-center align-middle"><span className="ps-2 pe-2">Groups</span></th>
-        <SortItemHeader defaultOrder={BoardOrder.title} reverseOrder={BoardOrder["-title"]} currentOrder={boardOrder} setOrder={setBoardOrder} alignment="start">
+        <SortItemHeader<AssignmentBoardOrder> defaultOrder={AssignmentBoardOrder.title} reverseOrder={AssignmentBoardOrder["-title"]} currentOrder={boardOrder} setOrder={setBoardOrder} alignment="start">
             Board name
         </SortItemHeader>
         <th colSpan={2} className="text-center align-middle">
@@ -274,7 +274,7 @@ const PhyTable = (props: SetAssignmentsTableProps) => {
                 Challenge: {difficultiesOrdered.slice(2).map(d => difficultyShortLabelMap[d]).join(", ")}
             </RS.UncontrolledTooltip>
         </th>
-        <SortItemHeader defaultOrder={BoardOrder.visited} reverseOrder={BoardOrder["-visited"]} currentOrder={boardOrder} setOrder={setBoardOrder}>
+        <SortItemHeader<AssignmentBoardOrder> defaultOrder={AssignmentBoardOrder.visited} reverseOrder={AssignmentBoardOrder["-visited"]} currentOrder={boardOrder} setOrder={setBoardOrder}>
             Last viewed
         </SortItemHeader>
         <th className="text-center align-middle">Manage</th>
@@ -348,7 +348,7 @@ const CSTable = (props: SetAssignmentsTableProps) => {
 
     const tableHeader = <tr className="my-gameboard-table-header">
         <th>Groups</th>
-        <SortItemHeader colSpan={2} defaultOrder={BoardOrder.title} reverseOrder={BoardOrder["-title"]} currentOrder={boardOrder} setOrder={setBoardOrder}>
+        <SortItemHeader<AssignmentBoardOrder> colSpan={2} defaultOrder={AssignmentBoardOrder.title} reverseOrder={AssignmentBoardOrder["-title"]} currentOrder={boardOrder} setOrder={setBoardOrder}>
             Quiz name
         </SortItemHeader>
         <th colSpan={2} className="long-titled-col">
@@ -359,7 +359,7 @@ const CSTable = (props: SetAssignmentsTableProps) => {
             </RS.UncontrolledTooltip>
         </th>
         <th>Creator</th>
-        <SortItemHeader defaultOrder={BoardOrder.visited} reverseOrder={BoardOrder["-visited"]} currentOrder={boardOrder} setOrder={setBoardOrder}>
+        <SortItemHeader<AssignmentBoardOrder> defaultOrder={AssignmentBoardOrder.visited} reverseOrder={AssignmentBoardOrder["-visited"]} currentOrder={boardOrder} setOrder={setBoardOrder}>
             Last viewed
         </SortItemHeader>
         <th>Manage</th>
@@ -575,8 +575,8 @@ export const SetAssignments = () => {
                         </Col>
                         <Col xs={6} lg={4}>
                             <Label className="w-100">
-                                Sort by <Input type="select" value={boardOrder} onChange={e => setBoardOrder(e.target.value as BoardOrder)}>
-                                    {Object.values(BoardOrder).map(order => <option key={order} value={order}>{BOARD_ORDER_NAMES[order]}</option>)}
+                                Sort by <Input type="select" value={boardOrder} onChange={e => setBoardOrder(e.target.value as AssignmentBoardOrder)}>
+                                    {Object.values(AssignmentBoardOrder).map(order => <option key={order} value={order}>{BOARD_ORDER_NAMES[order]}</option>)}
                                 </Input>
                             </Label>
                         </Col>

--- a/src/app/components/pages/quizzes/MyQuizzes.tsx
+++ b/src/app/components/pages/quizzes/MyQuizzes.tsx
@@ -117,7 +117,7 @@ function QuizGrid({quizzes, emptyMessage}: AssignmentGridProps) {
 // To avoid the chaos of QuizProgressCommon, this and PracticeQuizTable are **separate components**. Despite this repeating some code, please don't try to merge them.
 const AssignedQuizTable = ({quizzes, boardOrder, setBoardOrder, emptyMessage}: {quizzes: DisplayableQuiz[], boardOrder: QuizzesBoardOrder, setBoardOrder: (order: QuizzesBoardOrder) => void, emptyMessage: ReactNode}) => {
 
-    return <Table className="my-quizzes-table mb-0">
+    return <Table className="my-quizzes-table mb-0" responsive>
         <colgroup>
             <col className={"col-md-5"}/>
             <col className={"col-md-2"}/>
@@ -165,7 +165,7 @@ const AssignedQuizTable = ({quizzes, boardOrder, setBoardOrder, emptyMessage}: {
 };
 
 const PracticeQuizTable = ({quizzes, boardOrder, setBoardOrder, emptyMessage}: {quizzes: DisplayableQuiz[], boardOrder: QuizzesBoardOrder, setBoardOrder: (order: QuizzesBoardOrder) => void, emptyMessage: ReactNode}) => {
-    return <Table className="my-quizzes-table mb-0">
+    return <Table className="my-quizzes-table mb-0" responsive>
         <colgroup>
             <col className={"col-md-9"}/>
             <col className={"col-md-2"}/>

--- a/src/app/components/pages/quizzes/MyQuizzes.tsx
+++ b/src/app/components/pages/quizzes/MyQuizzes.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { ReactNode, useCallback, useEffect, useState } from "react";
 import {
     useGetAttemptedFreelyByMeQuery,
     useGetQuizAssignmentsAssignedToMeQuery
@@ -102,12 +102,12 @@ function QuizItem({quiz}: QuizAssignmentProps) {
 
 interface AssignmentGridProps {
     quizzes: DisplayableQuiz[];
-    empty: string;
+    emptyMessage: ReactNode;
 }
 
-function QuizGrid({quizzes, empty}: AssignmentGridProps) {
+function QuizGrid({quizzes, emptyMessage}: AssignmentGridProps) {
     return <>
-        {quizzes.length === 0 && <p>{empty}</p>}
+        {quizzes.length === 0 && <p>{emptyMessage}</p>}
         {quizzes.length > 0 && <CardGrid>
             {quizzes.map(quiz => <QuizItem key={(quiz.isAssigned ? 'as' : 'at') + quiz.id} quiz={quiz}/>)}
         </CardGrid>}
@@ -115,7 +115,7 @@ function QuizGrid({quizzes, empty}: AssignmentGridProps) {
 }
 
 // To avoid the chaos of QuizProgressCommon, this and PracticeQuizTable are **separate components**. Despite this repeating some code, please don't try to merge them.
-const AssignedQuizTable = ({quizzes, boardOrder, setBoardOrder}: {quizzes: DisplayableQuiz[], boardOrder: QuizzesBoardOrder, setBoardOrder: (order: QuizzesBoardOrder) => void}) => {
+const AssignedQuizTable = ({quizzes, boardOrder, setBoardOrder, emptyMessage}: {quizzes: DisplayableQuiz[], boardOrder: QuizzesBoardOrder, setBoardOrder: (order: QuizzesBoardOrder) => void, emptyMessage: ReactNode}) => {
 
     return <Table className="my-quizzes-table mb-0">
         <colgroup>
@@ -157,11 +157,14 @@ const AssignedQuizTable = ({quizzes, boardOrder, setBoardOrder}: {quizzes: Displ
                     <td className="text-center"><img className="icon-dropdown-90" src={"/assets/common/icons/chevron_right.svg"} alt="" /></td>
                 </TrLink>;
             })}
+            {quizzes.length === 0 && <tr>
+                <td colSpan={5} className="text-center">{emptyMessage}</td>
+            </tr>}
         </tbody>
     </Table>;
 };
 
-const PracticeQuizTable = ({quizzes, boardOrder, setBoardOrder}: {quizzes: DisplayableQuiz[], boardOrder: QuizzesBoardOrder, setBoardOrder: (order: QuizzesBoardOrder) => void}) => {
+const PracticeQuizTable = ({quizzes, boardOrder, setBoardOrder, emptyMessage}: {quizzes: DisplayableQuiz[], boardOrder: QuizzesBoardOrder, setBoardOrder: (order: QuizzesBoardOrder) => void, emptyMessage: ReactNode}) => {
     return <Table className="my-quizzes-table mb-0">
         <colgroup>
             <col className={"col-md-9"}/>
@@ -188,6 +191,9 @@ const PracticeQuizTable = ({quizzes, boardOrder, setBoardOrder}: {quizzes: Displ
                     <td className="text-center"><img className="icon-dropdown-90" src={"/assets/common/icons/chevron_right.svg"} alt="" /></td>
                 </TrLink>;
             })}
+            {quizzes.length === 0 && <tr>
+                <td colSpan={3} className="text-center">{emptyMessage}</td>
+            </tr>}
         </tbody>
     </Table>;
 };
@@ -266,6 +272,16 @@ const MyQuizzesPageComponent = ({user}: QuizzesPageProps) => {
         />
     </div>;
 
+    const emptyAssignedMessage = <span className="text-muted">{showCompleted
+        ? "You have not completed any tests."
+        : "You have no tests in progress."
+    }</span>;
+
+    const emptyPracticeMessage = <span className="text-muted">{showCompleted
+        ? "You have not completed any practice tests."
+        : "You have no practice tests in progress."
+    } Find some <Link to="/practice_tests">here</Link>!</span>;
+
     return <Container>
         <TitleAndBreadcrumb currentPageTitle={siteSpecific("My Tests", "My tests")} help={pageHelp} />
         <PageFragment fragmentId={`tests_help_${isTutorOrAbove(user) ? "teacher" : "student"}`} ifNotFound={<div className={"mt-5"}/>} />
@@ -285,8 +301,11 @@ const MyQuizzesPageComponent = ({user}: QuizzesPageProps) => {
                                 {pastTestsToggle}
                             </div>
                             {displayMode === "table" ? <Card>
-                                <AssignedQuizTable quizzes={sortedAssignedQuizzes} boardOrder={boardOrder} setBoardOrder={setBoardOrder}/>
-                            </Card> : <QuizGrid quizzes={sortedAssignedQuizzes} empty="No assigned tests found"/>}
+                                <AssignedQuizTable 
+                                    quizzes={sortedAssignedQuizzes} boardOrder={boardOrder} setBoardOrder={setBoardOrder}
+                                    emptyMessage={emptyAssignedMessage}
+                                />
+                            </Card> : <QuizGrid quizzes={sortedAssignedQuizzes} emptyMessage={emptyAssignedMessage}/>}
                         </div>
                     </ShowLoading>,
                 [siteSpecific("My Practice Tests", "My practice tests")]:
@@ -300,8 +319,11 @@ const MyQuizzesPageComponent = ({user}: QuizzesPageProps) => {
                                 {pastTestsToggle}
                             </div>
                             {displayMode === "table" ? <Card>
-                                <PracticeQuizTable quizzes={sortedPracticeQuizzes} boardOrder={boardOrder} setBoardOrder={setBoardOrder}/>
-                            </Card> : <QuizGrid quizzes={sortedPracticeQuizzes} empty="No practice tests found"/>}
+                                <PracticeQuizTable 
+                                    quizzes={sortedPracticeQuizzes} boardOrder={boardOrder} setBoardOrder={setBoardOrder}
+                                    emptyMessage={emptyPracticeMessage}
+                                />
+                            </Card> : <QuizGrid quizzes={sortedPracticeQuizzes} emptyMessage={emptyPracticeMessage}/>}
                         </div>
                     </ShowLoading>,
             }}

--- a/src/app/components/pages/quizzes/MyQuizzes.tsx
+++ b/src/app/components/pages/quizzes/MyQuizzes.tsx
@@ -30,6 +30,7 @@ import orderBy from "lodash/orderBy";
 import partition from "lodash/partition";
 import classNames from "classnames";
 import StyledToggle from "../../elements/inputs/StyledToggle";
+import { TrLink } from "../../elements/tables/TableLinks";
 
 export interface QuizzesPageProps extends RouteComponentProps {
     user: RegisteredUserDTO;
@@ -113,15 +114,6 @@ function QuizGrid({quizzes, empty}: AssignmentGridProps) {
     </>;
 }
 
-interface TdLinkProps extends React.HTMLAttributes<HTMLTableCellElement> {
-    to: string | undefined;
-}
-
-// an <a/> anywhere between a <table/> and a <td/> is illegal, so we can't wrap the row in a <Link/>. instead, we make each <td/> contain a link.
-const TdLink = ({to, ...props}: TdLinkProps) => {
-    return <td {...props} className={classNames(props.className, "td-link")}>{to ? <Link to={to}>{props.children}</Link> : <>{props.children}</>}</td>;
-};
-
 // To avoid the chaos of QuizProgressCommon, this and PracticeQuizTable are **separate components**. Despite this repeating some code, please don't try to merge them.
 const AssignedQuizTable = ({quizzes, boardOrder, setBoardOrder}: {quizzes: DisplayableQuiz[], boardOrder: QuizzesBoardOrder, setBoardOrder: (order: QuizzesBoardOrder) => void}) => {
 
@@ -144,9 +136,8 @@ const AssignedQuizTable = ({quizzes, boardOrder, setBoardOrder}: {quizzes: Displ
         </thead>
         <tbody>
             {quizzes.map(quiz => {
-                return <tr key={quiz.id} className={classNames("align-middle", {"completed": quiz.status === QuizStatus.Complete}, {"overdue": quiz.status === QuizStatus.Overdue})}>
-                    {/* TODO: replace TdLinks with one TrLink? */}
-                    <TdLink to={quiz.link}>
+                return <TrLink to={quiz.link} key={quiz.id} className={classNames("align-middle", {"completed": quiz.status === QuizStatus.Complete}, {"overdue": quiz.status === QuizStatus.Overdue})}>
+                    <td>
                         <div>
                             {quiz.title || quiz.id}<br/>
                             {quiz.status === QuizStatus.Overdue && <span className="small text-muted mt-1">Overdue</span>}
@@ -159,12 +150,12 @@ const AssignedQuizTable = ({quizzes, boardOrder, setBoardOrder}: {quizzes: Displ
                                 }
                             </>}
                         </div>
-                    </TdLink>
-                    <TdLink to={quiz.link}>{quiz.assignerSummary && extractTeacherName(quiz.assignerSummary)}</TdLink>
-                    <TdLink to={quiz.link}>{quiz.dueDate && formatDate(quiz.dueDate)}</TdLink>
-                    <TdLink to={quiz.link}>{quiz.setDate && formatDate(quiz.setDate)}</TdLink>
-                    <TdLink to={quiz.link} className="text-center"><img className="icon-dropdown-90" src={"/assets/common/icons/chevron_right.svg"} alt="" /></TdLink>
-                </tr>;
+                    </td>
+                    <td>{quiz.assignerSummary && extractTeacherName(quiz.assignerSummary)}</td>
+                    <td>{quiz.dueDate && formatDate(quiz.dueDate)}</td>
+                    <td>{quiz.setDate && formatDate(quiz.setDate)}</td>
+                    <td className="text-center"><img className="icon-dropdown-90" src={"/assets/common/icons/chevron_right.svg"} alt="" /></td>
+                </TrLink>;
             })}
         </tbody>
     </Table>;
@@ -186,16 +177,16 @@ const PracticeQuizTable = ({quizzes, boardOrder, setBoardOrder}: {quizzes: Displ
         </thead>
         <tbody>
             {quizzes.map(quiz => {
-                return <tr key={quiz.id} tabIndex={0} className={classNames("align-middle", {"completed": quiz.status === QuizStatus.Complete})}>
-                    <TdLink to={quiz.link}>
+                return <TrLink to={quiz.link} key={quiz.id} tabIndex={0} className={classNames("align-middle", {"completed": quiz.status === QuizStatus.Complete})}>
+                    <td>
                         <div className="d-flex flex-column align-items-start">
                             {quiz.title || quiz.id}
                             {quiz.status === QuizStatus.Complete && <span className="small text-muted mt-1">Completed</span>}
                         </div>
-                    </TdLink>
-                    <TdLink to={quiz.link}>{formatDate(quiz.startDate)}</TdLink>
-                    <TdLink to={quiz.link} className="text-center"><img className="icon-dropdown-90" src={"/assets/common/icons/chevron_right.svg"} alt="" /></TdLink>
-                </tr>;
+                    </td>
+                    <td>{formatDate(quiz.startDate)}</td>
+                    <td className="text-center"><img className="icon-dropdown-90" src={"/assets/common/icons/chevron_right.svg"} alt="" /></td>
+                </TrLink>;
             })}
         </tbody>
     </Table>;

--- a/src/app/components/pages/quizzes/MyQuizzes.tsx
+++ b/src/app/components/pages/quizzes/MyQuizzes.tsx
@@ -35,6 +35,7 @@ import { TrLink } from "../../elements/tables/TableLinks";
 import { StyledDropdown } from "../../elements/inputs/DropdownInput";
 import { StyledSelect } from "../../elements/inputs/StyledSelect";
 import { CollapsibleContainer } from "../../elements/CollapsibleContainer";
+import { FilterCount } from "../../elements/svg/FilterCount";
 
 export interface QuizzesPageProps extends RouteComponentProps {
     user: RegisteredUserDTO;
@@ -348,11 +349,19 @@ const MyQuizzesPageComponent = ({user}: QuizzesPageProps) => {
         </div>
     </div>;
 
-    const filtersToggle = <div className="d-flex flex-column align-items-center justify-content-between w-max-content pb-3 ms-3">
-        <span>Filters</span>
-        <Button color="secondary" className={classNames("gameboards-filter-dropdown align-self-center", {"selected": showFilters})}
-            onClick={() => setShowFilters(s => !s)} data-testid="filter-dropdown"/>
-    </div>;
+    // +!! converts a string to 0 if null or empty and 1 otherwise
+    const filterCount = +!!quizTitleFilter + +!!quizCreatorFilter + quizStatusFilter.length;
+
+    const filtersToggle = <Col xs={3} sm={2} md={1} className="pb-3 ms-3">
+        <Label className="w-100 d-flex flex-column align-items-center mb-0">
+            <span className="text-nowrap">
+                Filters
+                {<FilterCount count={filterCount ?? 0} className="ms-2 mb-1" />}
+            </span>
+            <Button color="secondary" className={classNames("w-100 gameboards-filter-dropdown align-self-center", {"selected": showFilters})}
+                onClick={() => setShowFilters(s => !s)} data-testid="filter-dropdown"/>
+        </Label>
+    </Col>;
 
     const tabTopContent = <>
         <div className="d-flex">

--- a/src/app/components/pages/quizzes/MyQuizzes.tsx
+++ b/src/app/components/pages/quizzes/MyQuizzes.tsx
@@ -16,6 +16,7 @@ import {
     convertAttemptToQuiz,
     DisplayableQuiz,
     extractTeacherName,
+    isPhy,
     isTutorOrAbove,
     QuizStatus,
     selectOnChange,
@@ -356,7 +357,7 @@ const MyQuizzesPageComponent = ({user}: QuizzesPageProps) => {
         <Label className="w-100 d-flex flex-column align-items-center mb-0">
             <span className="text-nowrap">
                 Filters
-                {<FilterCount count={filterCount ?? 0} className="ms-2 mb-1" />}
+                {<FilterCount count={filterCount ?? 0} widthPx={siteSpecific(25, 20)} className={classNames("ms-2", {"mb-1" : isPhy})}/>}
             </span>
             <Button color="secondary" className={classNames("w-100 gameboards-filter-dropdown align-self-center", {"selected": showFilters})}
                 onClick={() => setShowFilters(s => !s)} data-testid="filter-dropdown"/>

--- a/src/app/components/pages/quizzes/MyQuizzes.tsx
+++ b/src/app/components/pages/quizzes/MyQuizzes.tsx
@@ -374,7 +374,7 @@ const MyQuizzesPageComponent = ({user}: QuizzesPageProps) => {
             quizStatuses={quizStatusFilter} setQuizStatuses={setQuizStatuses} showFilters={showFilters}/>
     </>;
 
-    const emptyAssignedMessage = <span className="text-muted">{assignedQuizzes.filter(q => q.status && [QuizStatus.Started, QuizStatus.NotStarted].includes(q.status)).length === 0
+    const emptyAssignedMessage = <span className="text-muted">{!quizAssignments || quizAssignments.length === 0
         ? "You have no tests in progress."
         : "No tests match your filters."
     }</span>;

--- a/src/app/components/pages/quizzes/MyQuizzes.tsx
+++ b/src/app/components/pages/quizzes/MyQuizzes.tsx
@@ -34,6 +34,7 @@ import StyledToggle from "../../elements/inputs/StyledToggle";
 import { TrLink } from "../../elements/tables/TableLinks";
 import { StyledDropdown } from "../../elements/inputs/DropdownInput";
 import { StyledSelect } from "../../elements/inputs/StyledSelect";
+import { CollapsibleContainer } from "../../elements/CollapsibleContainer";
 
 export interface QuizzesPageProps extends RouteComponentProps {
     user: RegisteredUserDTO;
@@ -211,8 +212,8 @@ interface QuizFiltersProps {
 }
 
 const QuizFilters = ({setShowCompleted, setQuizTitleFilter, setQuizCreator, quizStatuses, setQuizStatuses, showFilters}: QuizFiltersProps) => {
-    return <div>
-        <Row className={classNames("my-gameboards-filters", {"shown": showFilters})}>
+    return <CollapsibleContainer expanded={showFilters}>
+        <Row>
             <Col xs={6}>
                 <Label className="w-100">
                     <span className={"text-nowrap"}>Filter by quiz title</span>
@@ -225,6 +226,8 @@ const QuizFilters = ({setShowCompleted, setQuizTitleFilter, setQuizCreator, quiz
                     <Input type="text" data-testid="title-filter" onChange={(e) => setQuizCreator(e.target.value)} />
                 </Label>
             </Col>
+        </Row>
+        <Row className="pb-3">
             <Col xs={12}>
                 <Label className="w-100">
                     <span className={"text-nowrap"}>Filter by status</span>
@@ -242,7 +245,7 @@ const QuizFilters = ({setShowCompleted, setQuizTitleFilter, setQuizCreator, quiz
                 </Label>
             </Col>
         </Row>
-    </div>;
+    </CollapsibleContainer>;
 };
 
 const MyQuizzesPageComponent = ({user}: QuizzesPageProps) => {

--- a/src/app/components/pages/quizzes/MyQuizzes.tsx
+++ b/src/app/components/pages/quizzes/MyQuizzes.tsx
@@ -379,9 +379,10 @@ const MyQuizzesPageComponent = ({user}: QuizzesPageProps) => {
         : "No tests match your filters."
     }</span>;
 
-    const emptyPracticeMessage = <span className="text-muted">
-        No practice tests match your filters. Take some new tests <Link to="/practice_tests">here</Link>!
-    </span>;
+    const emptyPracticeMessage = <span className="text-muted">{!freeAttempts || freeAttempts.length === 0
+        ? <>You have no practice tests. Take some new tests <Link to="/practice_tests">here</Link>!</>
+        : "No practice tests match your filters."
+    }</span>;
 
     return <Container>
         <TitleAndBreadcrumb currentPageTitle={siteSpecific("My Tests", "My tests")} help={pageHelp} />

--- a/src/app/components/pages/quizzes/MyQuizzes.tsx
+++ b/src/app/components/pages/quizzes/MyQuizzes.tsx
@@ -154,7 +154,7 @@ const AssignedQuizTable = ({quizzes, boardOrder, setBoardOrder, emptyMessage}: {
                     <td>{quiz.assignerSummary && extractTeacherName(quiz.assignerSummary)}</td>
                     <td>{quiz.dueDate && formatDate(quiz.dueDate)}</td>
                     <td>{quiz.setDate && formatDate(quiz.setDate)}</td>
-                    <td className="text-center"><img className="icon-dropdown-90" src={"/assets/common/icons/chevron_right.svg"} alt="" /></td>
+                    <td className="text-center"><img className="icon-dropdown-90" aria-disabled={!quiz.link} src={"/assets/common/icons/chevron_right.svg"} alt="" /></td>
                 </TrLink>;
             })}
             {quizzes.length === 0 && <tr>

--- a/src/app/components/pages/quizzes/PracticeQuizzes.tsx
+++ b/src/app/components/pages/quizzes/PracticeQuizzes.tsx
@@ -1,0 +1,91 @@
+import { withRouter } from "react-router-dom";
+import React, { useEffect, useState } from "react";
+import { Button, Container, ListGroupItem, Input, ListGroup, Col } from "reactstrap";
+import { TitleAndBreadcrumb } from "../../elements/TitleAndBreadcrumb";
+import { isEventLeaderOrStaff, isTutorOrAbove, siteSpecific } from "../../../services";
+import { QuizSummaryDTO } from "../../../../IsaacApiTypes";
+import { ShowLoading } from "../../handlers/ShowLoading";
+import { useGetAvailableQuizzesQuery } from "../../../state/slices/api/quizApi";
+import { QuizzesPageProps } from "./MyQuizzes";
+import { Spacer } from "../../elements/Spacer";
+import { Link } from "react-router-dom";
+import { PageFragment } from "../../elements/PageFragment";
+
+const PracticeQuizzesComponent = ({user}: QuizzesPageProps) => {
+    const {data: quizzes} = useGetAvailableQuizzesQuery(0);
+    const [filterText, setFilterText] = useState<string>("");
+    const [copied, setCopied] = useState(false);
+
+    useEffect(() => {
+        if (location.search.includes("filter")) {
+            setFilterText(new URLSearchParams(location.search).get("filter") || "");
+        }
+    }, []);
+
+    if (!user) {
+        return <p>You must be logged in to view practice tests.</p>;
+    }
+
+    const showQuiz = (quiz: QuizSummaryDTO) => {
+        switch (user.role) {
+            case "STUDENT":
+            // Tutors should see the same tests as students can
+            // eslint-disable-next-line no-fallthrough
+            case "TUTOR":
+                return (quiz.hiddenFromRoles && !quiz.hiddenFromRoles?.includes("STUDENT")) || quiz.visibleToStudents;
+            case "TEACHER":
+                return (quiz.hiddenFromRoles && !quiz.hiddenFromRoles?.includes("TEACHER")) ?? true;
+            default:
+                return true;
+        }
+    };
+
+    // If the user is event admin or above, and the quiz is hidden from teachers, then show that
+    // If the user is teacher or above, show if the quiz is visible to students
+    const roleVisibilitySummary = (quiz: QuizSummaryDTO) => <>
+        {isEventLeaderOrStaff(user) && quiz.hiddenFromRoles && quiz.hiddenFromRoles?.includes("TEACHER") && <div className="small text-muted d-block ms-2">hidden from teachers</div>}
+        {isTutorOrAbove(user) && ((quiz.hiddenFromRoles && !quiz.hiddenFromRoles?.includes("STUDENT")) || quiz.visibleToStudents) && <div className="small text-muted d-block ms-2">visible to students</div>}
+    </>;
+
+    return <Container>
+        <TitleAndBreadcrumb currentPageTitle={siteSpecific("Practice Tests", "Practice tests")} />
+        <PageFragment fragmentId="help_toptext_practice_tests" />
+        <ShowLoading until={quizzes}>
+            {quizzes && <>
+                <h3>Available</h3>
+                {quizzes.length === 0 && <p><em>There are no practice tests currently available.</em></p>}
+                <Col xs={12} className="mb-4">
+                    <Input type="text" placeholder="Filter tests by name..." value={filterText} onChange={(e) => setFilterText(e.target.value)} />
+                    <button className={`copy-test-filter-link m-0 ${copied ? "clicked" : ""}`} tabIndex={-1} onClick={() => {
+                        if (filterText.trim()) {
+                            navigator.clipboard.writeText(`${window.location.host}${window.location.pathname}?filter=${filterText.trim()}#practice`);
+                        }
+                        setCopied(true);
+                    }} onMouseLeave={() => setCopied(false)} />
+                </Col>
+                <ListGroup className="mb-3 quiz-list">
+                    {quizzes.filter((quiz) => showQuiz(quiz) && quiz.title?.toLowerCase().includes(filterText.toLowerCase())).map(quiz => <ListGroupItem className="p-0 bg-transparent" key={quiz.id}>
+                        <div className="d-flex flex-grow-1 flex-column flex-sm-row align-items-center p-3">
+                            <div>
+                                <span className="mb-2 mb-sm-0 pe-2">{quiz.title}</span>
+                                {roleVisibilitySummary(quiz)}
+                                {quiz.summary && <div className="small text-muted d-none d-md-block">{quiz.summary}</div>}
+                            </div>
+                            <Spacer />
+                            {isTutorOrAbove(user) && <div className="d-none d-md-flex align-items-center me-4">
+                                <Link to={{pathname: `/test/preview/${quiz.id}`}}>
+                                    <span>Preview</span>
+                                </Link>
+                            </div>}
+                            <Button tag={Link} to={{pathname: `/test/attempt/${quiz.id}`}}>
+                                {siteSpecific("Take Test", "Take test")}
+                            </Button>
+                        </div>
+                    </ListGroupItem>)}
+                </ListGroup>
+            </>}
+        </ShowLoading>
+    </Container>;
+};
+
+export const PracticeQuizzes = withRouter(PracticeQuizzesComponent);

--- a/src/app/components/pages/quizzes/PracticeQuizzes.tsx
+++ b/src/app/components/pages/quizzes/PracticeQuizzes.tsx
@@ -52,7 +52,6 @@ const PracticeQuizzesComponent = ({user}: QuizzesPageProps) => {
         <PageFragment fragmentId="help_toptext_practice_tests" />
         <ShowLoading until={quizzes}>
             {quizzes && <>
-                <h3>Available</h3>
                 {quizzes.length === 0 && <p><em>There are no practice tests currently available.</em></p>}
                 <Col xs={12} className="mb-4">
                     <Input type="text" placeholder="Filter tests by name..." value={filterText} onChange={(e) => setFilterText(e.target.value)} />

--- a/src/app/components/site/cs/RoutesCS.tsx
+++ b/src/app/components/site/cs/RoutesCS.tsx
@@ -33,6 +33,7 @@ import {ExamSpecificationsDirectory} from "../../pages/ExamSpecificationsDirecto
 import { StudentResources } from "../../pages/StudentResources";
 import { TeacherResources } from "../../pages/TeacherResources";
 import { CSProjects } from "../../pages/CSProjects";
+import { PracticeQuizzes } from "../../pages/quizzes/PracticeQuizzes";
 
 const Equality = lazy(() => import('../../pages/Equality'));
 const EventDetails = lazy(() => import('../../pages/EventDetails'));
@@ -66,6 +67,8 @@ export const RoutesCS = [
     <TrackedRoute key={key++} exact path="/set_tests" ifUser={isTeacherOrAbove} component={SetQuizzes} />,
     // Student test pages
     <TrackedRoute key={key++} exact path="/tests" ifUser={isLoggedIn} component={MyQuizzes} />,
+
+    <TrackedRoute key={key++} exact path="/practice_tests" ifUser={isLoggedIn} component={PracticeQuizzes} />,
 
     // Quiz (test) pages
     <TrackedRoute key={key++} exact path="/test/assignment/:quizAssignmentId" ifUser={isLoggedIn} component={QuizDoAssignment} />,

--- a/src/app/components/site/phy/NavigationBarPhy.tsx
+++ b/src/app/components/site/phy/NavigationBarPhy.tsx
@@ -47,6 +47,7 @@ export const NavigationBarPhy = () => {
             <LinkItem to="/gcse">GCSE Resources</LinkItem>
             <LinkItem to="/alevel">A Level Resources</LinkItem>
             <LinkItem to={PATHS.QUESTION_FINDER}>Question Finder</LinkItem>
+            <LinkItem to="/practice_tests">Practice Tests</LinkItem>
             <LinkItem to="/concepts">Concepts</LinkItem>
             <LinkItem to="/glossary">Glossary</LinkItem>
         </NavigationSection>

--- a/src/app/components/site/phy/RoutesPhy.tsx
+++ b/src/app/components/site/phy/RoutesPhy.tsx
@@ -33,7 +33,6 @@ import {TeacherRequest} from "../../pages/TeacherRequest";
 import { RegistrationStart } from "../../pages/RegistrationStart";
 import {EmailAlterHandler} from "../../handlers/EmailAlterHandler";
 import {News} from "../../pages/News";
-import {QuestionFinder} from "../../pages/QuestionFinder";
 import { RegistrationAgeCheck } from "../../pages/RegistrationAgeCheck";
 import { RegistrationAgeCheckFailed } from "../../pages/RegistrationAgeCheckFailed";
 import { RegistrationAgeCheckParentalConsent } from "../../pages/RegistrationAgeCheckParentalConsent";
@@ -42,6 +41,7 @@ import { RegistrationTeacherConnect } from "../../pages/RegistrationTeacherConne
 import { RegistrationSuccess } from "../../pages/RegistrationSuccess";
 import { RegistrationSetPreferences } from "../../pages/RegistrationSetPreferences";
 import { RegistrationGroupInvite } from "../../pages/RegistrationGroupInvite";
+import { PracticeQuizzes } from "../../pages/quizzes/PracticeQuizzes";
 
 const Equality = lazy(() => import('../../pages/Equality'));
 const EventDetails = lazy(() => import('../../pages/EventDetails'));
@@ -71,6 +71,7 @@ export const RoutesPhy = [
     // Student test pages
     <TrackedRoute key={key++} exact path="/tests" ifUser={isLoggedIn} component={MyQuizzes} />,
     <Redirect key={key++} from="/quizzes" to="/tests" />,
+    <TrackedRoute key={key++} exact path="/practice_tests" ifUser={isLoggedIn} component={PracticeQuizzes} />,
 
     // Quiz (test) pages
     <TrackedRoute key={key++} exact path="/test/assignment/:quizAssignmentId" ifUser={isLoggedIn} component={QuizDoAssignment} />,

--- a/src/app/services/gameboards.tsx
+++ b/src/app/services/gameboards.tsx
@@ -13,7 +13,7 @@ import {
     siteSpecific,
     stagesOrdered
 } from "./";
-import {BoardOrder, Boards, NOT_FOUND_TYPE, NumberOfBoards} from "../../IsaacAppTypes";
+import {AssignmentBoardOrder, Boards, NOT_FOUND_TYPE, NumberOfBoards} from "../../IsaacAppTypes";
 import {
     selectors,
     useAppDispatch,
@@ -204,7 +204,7 @@ export enum BoardLimit {
     "All" = "ALL"
 }
 
-export const BOARD_ORDER_NAMES: {[key in BoardOrder]: string} = {
+export const BOARD_ORDER_NAMES: {[key in AssignmentBoardOrder]: string} = {
     "created": "Date Created Ascending",
     "-created": "Date Created Descending",
     "visited": "Date Visited Ascending",
@@ -218,11 +218,11 @@ export const BOARD_ORDER_NAMES: {[key in BoardOrder]: string} = {
 };
 
 const BOARD_SORT_FUNCTIONS = {
-    [BoardOrder.visited]: (b: GameboardDTO) => b.lastVisited?.valueOf(),
-    [BoardOrder.created]: (b: GameboardDTO) => b.creationDate?.valueOf(),
-    [BoardOrder.title]: (b: GameboardDTO) => b.title,
-    [BoardOrder.attempted]: (b: GameboardDTO) => b.percentageAttempted,
-    [BoardOrder.correct]: (b: GameboardDTO) => b.percentageCorrect
+    [AssignmentBoardOrder.visited]: (b: GameboardDTO) => b.lastVisited?.valueOf(),
+    [AssignmentBoardOrder.created]: (b: GameboardDTO) => b.creationDate?.valueOf(),
+    [AssignmentBoardOrder.title]: (b: GameboardDTO) => b.title,
+    [AssignmentBoardOrder.attempted]: (b: GameboardDTO) => b.percentageAttempted,
+    [AssignmentBoardOrder.correct]: (b: GameboardDTO) => b.percentageCorrect
 };
 
 const parseBoardLimitAsNumber: (limit: BoardLimit) => NumberOfBoards = (limit: BoardLimit) =>
@@ -235,7 +235,7 @@ export const useGameboards = (initialView: BoardViews, initialLimit: BoardLimit)
     const [ loadGameboards ] = useLazyGetGameboardsQuery();
     const boards = useAppSelector(selectors.boards.boards);
 
-    const [boardOrder, setBoardOrder] = useState<BoardOrder>(BoardOrder.visited);
+    const [boardOrder, setBoardOrder] = useState<AssignmentBoardOrder>(AssignmentBoardOrder.visited);
     const [boardView, setBoardView] = useState<BoardViews>(initialView);
     const [boardLimit, setBoardLimit] = useState<BoardLimit>(initialLimit);
     const [boardTitleFilter, setBoardTitleFilter] = useState<string>("");

--- a/src/app/services/gameboards.tsx
+++ b/src/app/services/gameboards.tsx
@@ -321,4 +321,4 @@ export const useGameboards = (initialView: BoardViews, initialLimit: BoardLimit)
         boardLimit, setBoardLimit,
         boardTitleFilter, setBoardTitleFilter
     };
-}
+};

--- a/src/app/services/quiz.ts
+++ b/src/app/services/quiz.ts
@@ -325,7 +325,9 @@ export function convertAssignmentToQuiz(assignment: QuizAssignmentDTO): Displaya
         title: assignment.quizSummary?.title,
         creationDate: assignment.creationDate,
         setDate: assignment.scheduledStartDate,
+        startDate: assignment.attempt?.startDate,
         dueDate: assignment.dueDate,
+        completedDate: assignment.attempt?.completedDate,
         attempt: assignment.attempt,
         quizFeedbackMode: assignment.quizFeedbackMode,
         assignerSummary: assignment.assignerSummary,
@@ -348,7 +350,7 @@ export function convertAttemptToQuiz(attempt: QuizAttemptDTO): DisplayableQuiz |
         completedDate: attempt.completedDate,
         attempt: attempt,
         quizFeedbackMode: attempt.feedbackMode,
-        link: attempt.completedDate ? `/test/attempt/${attempt.id}/feedback` : `/test/attempt/${attempt.quizId}`,
+        link: attempt.completedDate ? `/test/attempt/${attempt.id}/feedback` : `/test/attempt/${attempt.id}`,
         status: attempt.completedDate ? QuizStatus.Complete : QuizStatus.Started,
     };
 }

--- a/src/app/services/quiz.ts
+++ b/src/app/services/quiz.ts
@@ -288,7 +288,10 @@ export function partitionCompleteAndIncompleteQuizzes(assignmentsAndAttempts: Qu
 }
 
 export enum QuizStatus {
-    Overdue, NotStarted, Started, Complete
+    Overdue = "Overdue", 
+    NotStarted = "Not started", 
+    Started = "Started", 
+    Complete = "Complete",
 }
 
 const todaysDate = new Date(new Date().setHours(0, 0, 0, 0));

--- a/src/app/state/slices/api/gameboardApi.ts
+++ b/src/app/state/slices/api/gameboardApi.ts
@@ -1,5 +1,5 @@
 import {isaacApi} from "./baseApi";
-import {BoardOrder, Boards, NumberOfBoards} from "../../../../IsaacAppTypes";
+import {AssignmentBoardOrder, Boards, NumberOfBoards} from "../../../../IsaacAppTypes";
 import {GameboardDTO, GameboardListDTO, IsaacWildcard} from "../../../../IsaacApiTypes";
 import {onQueryLifecycleEvents} from "./utils";
 import {isPhy, QUESTION_CATEGORY, siteSpecific} from "../../../services";
@@ -8,7 +8,7 @@ import {logAction} from "../../actions/logging";
 export const gameboardApi = isaacApi.injectEndpoints({
     endpoints: (build) => ({
 
-        getGameboards: build.query<Boards, {startIndex: number, limit: NumberOfBoards, sort: BoardOrder}>({
+        getGameboards: build.query<Boards, {startIndex: number, limit: NumberOfBoards, sort: AssignmentBoardOrder}>({
             query: ({startIndex, limit, sort}) => ({
                 url: "/gameboards/user_gameboards",
                 params: {"start_index": startIndex, limit, sort}

--- a/src/scss/common/elements.scss
+++ b/src/scss/common/elements.scss
@@ -296,6 +296,8 @@ iframe.email-html {
 
 .collapsible-body {
   transition: max-height 0.3s ease-in-out, height 0.3s ease-in-out;
+  // https://stackoverflow.com/q/6421966; x-overflow must be visible (for e.g. box shadows), y-overflow would preferably be entirely hidden but can't be.
+  overflow: visible clip;
   // height must be animated alongside max-height to prevent jumping if the inner content changes height during the animation
   max-height: 0;
 }

--- a/src/scss/common/gameboard.scss
+++ b/src/scss/common/gameboard.scss
@@ -146,6 +146,7 @@
     content: url(/assets/common/icons/chevron_down.svg);
     filter: invert(1);
     transform: rotate(-90deg);
+    transition: transform 0.2s ease-in-out;
     display: block;
     width: 100%;
     height: 100%;

--- a/src/scss/common/icons.scss
+++ b/src/scss/common/icons.scss
@@ -46,3 +46,7 @@ polygon.fill-secondary {
     @include icon-dropdown(90deg);
   }
 }
+
+img[aria-disabled="true"] {
+  opacity: 0.5;
+}

--- a/src/scss/common/quiz.scss
+++ b/src/scss/common/quiz.scss
@@ -210,6 +210,7 @@
 
 .my-quizzes-table {
   @extend .my-gameboard-table;
+  min-width: 694px;
   thead > tr {
     @extend .my-gameboard-table-header;
     > th {
@@ -230,6 +231,10 @@
     }
     &.completed {
       background: rgba(map-get($theme-colors, "success"), 0.09);
+    }
+
+    > td {
+      background: transparent;
     }
   }
 }

--- a/src/scss/common/quiz.scss
+++ b/src/scss/common/quiz.scss
@@ -220,6 +220,8 @@
     }
   }
   tbody > tr {
+    @include td-link-padding(0.8rem 1rem);
+
     &:not(.overdue) {
       cursor: pointer;
     }
@@ -229,18 +231,5 @@
     &.completed {
       background: rgba(map-get($theme-colors, "success"), 0.09);
     }
-    > td:not(.td-link), > td.td-link > a, td.td-link:not(:has(> a)) {
-      padding: 0.8rem 1rem;
-    }
-    > td.td-link:has(> a) {
-      padding: 0;
-    }
-  }
-}
-
-.td-link {
-  a {
-    display: block;
-    text-decoration: none;
   }
 }

--- a/src/scss/common/quiz.scss
+++ b/src/scss/common/quiz.scss
@@ -207,3 +207,40 @@
     transform: none;
   }
 }
+
+.my-quizzes-table {
+  @extend .my-gameboard-table;
+  thead > tr {
+    @extend .my-gameboard-table-header;
+    > th {
+      padding: 0.5rem 1rem;
+    }
+    > th:not(:last-child) {
+      cursor: pointer;
+    }
+  }
+  tbody > tr {
+    &:not(.overdue) {
+      cursor: pointer;
+    }
+    &.overdue {
+      background: rgba($gray-160, 0.09);
+    }
+    &.completed {
+      background: rgba(map-get($theme-colors, "success"), 0.09);
+    }
+    > td:not(.td-link), > td.td-link > a, td.td-link:not(:has(> a)) {
+      padding: 0.8rem 1rem;
+    }
+    > td.td-link:has(> a) {
+      padding: 0;
+    }
+  }
+}
+
+.td-link {
+  a {
+    display: block;
+    text-decoration: none;
+  }
+}

--- a/src/scss/common/table.scss
+++ b/src/scss/common/table.scss
@@ -1,3 +1,22 @@
 .table-row-dragging {
-    display: table;
+  display: table;
+}
+
+.td-link {
+  height: 1px; // gives cells a set height, so height: 100% can be applied to links and it will reference the td's height. the actual height a td-link ends up taking will be determined by the content.
+  a {
+    display: block;
+    align-content: center;
+    height: 100%;
+    text-decoration: none;
+  }
+}
+
+@mixin td-link-padding ($padding: 0.8rem 1rem) {
+  > td:not(.td-link), > td.td-link > a, td.td-link:not(:has(> a)) {
+    padding: $padding;
+  }
+  > td.td-link:has(> a) {
+    padding: 0;
+  }
 }

--- a/src/scss/common/table.scss
+++ b/src/scss/common/table.scss
@@ -8,7 +8,7 @@
     display: block;
     align-content: center;
     height: 100%;
-    text-decoration: none;
+    text-decoration: none !important;
   }
 }
 

--- a/src/scss/common/table.scss
+++ b/src/scss/common/table.scss
@@ -3,12 +3,17 @@
 }
 
 .td-link {
-  height: 1px; // gives cells a set height, so height: 100% can be applied to links and it will reference the td's height. the actual height a td-link ends up taking will be determined by the content.
-  a {
-    display: block;
-    align-content: center;
-    height: 100%;
-    text-decoration: none !important;
+  vertical-align: middle;
+
+  &:has(> a) {
+    display: contents;
+
+    > a {
+      @extend td;
+      display: table-cell;
+      vertical-align: middle;
+      text-decoration: none !important;
+    }
   }
 }
 


### PR DESCRIPTION
- Splits the listing of available practice tests into its own page, `/practice_tests`, accessible via the Learn nav;
- Creates a new default table view for `/tests` (though the original card view is still accessible), which displays the title, assigner and relevant dates;
- Splits assigned tests from practice tests into separate tabs at the topmost level of `/tests`; further filtering inside these categories (for started, not yet started, overdue and completed) can be achieved via the filters menu
