### PR TITLE
Add inline multiple choice questions

### DIFF
--- a/src/app/components/elements/inputs/InlineMultiChoiceEntryZone.tsx
+++ b/src/app/components/elements/inputs/InlineMultiChoiceEntryZone.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from "react";
+import { ChoiceQuestionDTO, IsaacMultiChoiceQuestionDTO } from "../../../../IsaacApiTypes";
+import { InlineEntryZoneProps, correctnessClass } from "../markup/portals/InlineEntryZone";
+import classNames from "classnames";
+import { DropdownItem, Dropdown, DropdownMenu, DropdownToggle } from "reactstrap";
+import { useCurrentQuestionAttempt } from "../../../services";
+import { Markup } from "../markup";
+
+export const InlineMultiChoiceEntryZone = ({questionDTO, focusRef, setModified, correctness, contentClasses, contentStyle, ...rest} : InlineEntryZoneProps<IsaacMultiChoiceQuestionDTO>) => {
+
+    const { currentAttempt, dispatchSetCurrentAttempt } = useCurrentQuestionAttempt<ChoiceQuestionDTO>(questionDTO.id as string);
+    const [isOpen, setIsOpen] = useState(false);
+    
+    function updateCurrentAttempt({newValue} : {newValue?: string}) {
+        const attempt = {
+            type: "stringChoice",
+            value: newValue,
+        };
+        dispatchSetCurrentAttempt(attempt);
+        setModified(true);
+    }
+    
+    return <div {...rest} className={classNames("inline-multi-choice-container w-100 h-100", rest.className)}>
+        <Dropdown
+            isOpen={isOpen}
+            toggle={() => {setIsOpen(!isOpen);}}
+            className={classNames("d-flex feedback-wrapper", contentClasses)}
+            style={contentStyle}
+        >
+            <DropdownToggle innerRef={focusRef} className={classNames("w-100 h-100 d-flex ps-2 pe-4 p-0", correctnessClass(correctness))} color="white">
+                <span aria-hidden>
+                    <Markup trusted-markup-encoding={"html"}>
+                        {currentAttempt?.value ?? ""}
+                    </Markup>
+                </span>
+                <img className={classNames("dropzone-dropdown", {"active": isOpen})} src="/assets/common/icons/chevron_down.svg" alt="expand dropdown"/>
+            </DropdownToggle>
+            <DropdownMenu container={focusRef.current?.closest(".question-content") as HTMLElement || "body"} end> 
+                {/* Dummy option added to clear selection */}
+                <DropdownItem
+                    data-unit={'None'}
+                    onClick={() => {updateCurrentAttempt({newValue: undefined});}}
+                >
+                    <span className="fst-italic text-muted">(clear)</span>
+                </DropdownItem>
+                {questionDTO.choices?.map((item, i) => {
+                    return <DropdownItem key={i}
+                        data-unit={item}
+                        onClick={() => {updateCurrentAttempt({newValue: item.value});}}
+                    >
+                        <Markup trusted-markup-encoding={"html"}>
+                            {item.value ?? ""}
+                        </Markup>
+                    </DropdownItem>;
+                })}
+            </DropdownMenu>
+        </Dropdown>
+    </div>;
+};

--- a/src/app/components/elements/markup/portals/InlineDropZones.tsx
+++ b/src/app/components/elements/markup/portals/InlineDropZones.tsx
@@ -103,7 +103,7 @@ function InlineDropRegion({id, index, emptyWidth, emptyHeight, rootElement}: {id
         toggle={() => {setIsOpen(!isOpen);}}
         className="cloze-dropdown"
     >
-        <DropdownToggle className={classNames("toggle", {"empty": !item, "px-1 py-0": isPhy, "p-2": isAda})} style={{minHeight: height, width: width}} innerRef={zoneRef}>
+        <DropdownToggle className={classNames({"empty": !item, "px-1 py-0": isPhy, "p-2": isAda})} style={{minHeight: height, width: width}} innerRef={zoneRef}>
             <div className={classNames("d-flex cloze-item feedback-zone", {"feedback-showing": isDefined(isCorrect), "p-2": isAda && !!item})}>
                 <span className={"visually-hidden"}>{item?.altText ?? item?.value ?? "cloze item without a description"}</span>
                 <span aria-hidden={true}>

--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -1045,19 +1045,7 @@ export const NULL_CLOZE_ITEM: ItemDTO = {
 // Matches: all legacy, [inline-question:questionId class="{classes}"]
 export const inlineQuestionRegex = /\[inline-question:(?<id>[a-zA-Z0-9_-]+)(?<params> *\| *(?<width>w-\d+)?(?<height>h-\d+)?| +class=(?:["']|&apos;|&[rl]?quot;)(?<classes>[a-zA-Z0-9 _-]+?)(?:["']|&apos;|&[rl]?quot;))?\]/g;
 
-interface inlineQuestionType<T extends ChoiceDTO> {
-    choice: {
-        type: string,
-        dto: T, // since types can't be variables, we make an empty object of type T then use typeof
-    }
-}
-
-type inlineDTOTypes = StringChoiceDTO | QuantityDTO;
-
-export const inlineQuestionTypes : {[key: string]: inlineQuestionType<inlineDTOTypes>} = {
-    "isaacStringMatchQuestion": {choice: { type: "stringMatch", dto: {} as StringChoiceDTO}},
-    "isaacNumericQuestion": {choice: { type: "quantity", dto: {} as QuantityDTO}},
-};
+export type InlineQuestionType = "isaacStringMatchQuestion" | "isaacNumericQuestion" | "isaacMultiChoiceQuestion";
 
 export const AUTHENTICATOR_FRIENDLY_NAMES_MAP: {[key: string]: string} = {
     "RASPBERRYPI": "Raspberry Pi Foundation",

--- a/src/scss/common/icons.scss
+++ b/src/scss/common/icons.scss
@@ -27,6 +27,8 @@ polygon.fill-secondary {
   align-self: center;
   right: 5px;
   @extend .icon-dropdown-180;
+  transition: transform 0.15s ease-in-out;
+  opacity: 0.3;
 }
 
 @mixin icon-dropdown($deg) {

--- a/src/scss/common/questions.scss
+++ b/src/scss/common/questions.scss
@@ -145,6 +145,21 @@ $inline-feedback-padding: 2px;
     }
   }
 
+  input.is-valid, button.is-valid {
+    border: solid 1px map-get($theme-colors, "success");
+    @include border-radius($input-border-radius, 0);
+  }
+
+  input.is-invalid, button.is-invalid {
+    border: solid 1px map-get($theme-colors, "failed");
+    @include border-radius($input-border-radius, 0);
+  }
+
+  input.is-unanswered, button.is-unanswered {
+    border: solid 1px map-get($theme-colors, "in-progress");
+    @include border-radius($input-border-radius, 0);
+  }
+
   $shadow-size: 2px;
   &.selected-feedback {
     box-shadow: 0 0 0 $shadow-size #000;
@@ -197,6 +212,26 @@ $inline-feedback-padding: 2px;
       button.btn {
         border: 1px solid black;
       }
+    }
+  }
+}
+
+.inline-multi-choice-container {
+  @extend .inline-container;
+
+  
+  button.btn {
+    min-width: unset;
+    font-family: $primary-font !important;
+    background-color: transparent;
+    border-radius: 0.35rem;
+
+    &:not(.is-valid):not(.is-invalid):not(.is-unanswered) {
+      border: $gray-136 solid 1px;
+    }
+
+    > div {
+      margin-top: -1px; // equal to the border width above, re-centres contents
     }
   }
 }
@@ -454,7 +489,7 @@ $inline-feedback-padding: 2px;
   }
 }
 
-.cloze-dropdown .toggle {
+.cloze-dropdown > button {
   min-width: unset !important; // Bootstrap thinks its important
   &.empty.empty {
     &, &:hover, &:active, &:focus { // Apply regardless of hover

--- a/src/scss/cs/questions.scss
+++ b/src/scss/cs/questions.scss
@@ -40,11 +40,6 @@
   }
 }
 
-input.form-control.is-unanswered {
-  border: solid 1px $yellow-200;
-  @include border-radius($input-border-radius, 0);
-}
-
 // Quick questions
 .quick-question-title {
   display: flex;

--- a/src/scss/phy/questions.scss
+++ b/src/scss/phy/questions.scss
@@ -118,8 +118,3 @@
     border: solid 1px $black;
   }
 }
-
-input.form-control.is-unanswered {
-  border: solid 1px map-get($theme-colors, "in-progress");
-  @include border-radius($input-border-radius, 0);
-}


### PR DESCRIPTION
Adds a new type of inline question, multiple choice, that creates a dropdown similar to (but slightly distinct from in structure) cloze questions in mobile view.

Also adds some type checking to `InlineEntryZone` such that adding further new inline questions is even easier, and collates all border / shadow colouring into the same place.