### PR TITLE
Remove non-attemptable practice tests for teachers

### DIFF
--- a/src/app/components/pages/quizzes/PracticeQuizzes.tsx
+++ b/src/app/components/pages/quizzes/PracticeQuizzes.tsx
@@ -32,9 +32,9 @@ const PracticeQuizzesComponent = ({user}: QuizzesPageProps) => {
             // Tutors should see the same tests as students can
             // eslint-disable-next-line no-fallthrough
             case "TUTOR":
-                return (quiz.hiddenFromRoles && !quiz.hiddenFromRoles?.includes("STUDENT")) || quiz.visibleToStudents;
             case "TEACHER":
-                return (quiz.hiddenFromRoles && !quiz.hiddenFromRoles?.includes("TEACHER")) ?? true;
+                return (quiz.hiddenFromRoles && !quiz.hiddenFromRoles?.includes("STUDENT")) || quiz.visibleToStudents;
+                // return (quiz.hiddenFromRoles && !quiz.hiddenFromRoles?.includes("TEACHER")) ?? true;
             default:
                 return true;
         }

--- a/src/app/components/pages/quizzes/PracticeQuizzes.tsx
+++ b/src/app/components/pages/quizzes/PracticeQuizzes.tsx
@@ -29,12 +29,11 @@ const PracticeQuizzesComponent = ({user}: QuizzesPageProps) => {
     const showQuiz = (quiz: QuizSummaryDTO) => {
         switch (user.role) {
             case "STUDENT":
-            // Tutors should see the same tests as students can
-            // eslint-disable-next-line no-fallthrough
             case "TUTOR":
             case "TEACHER":
+                // Practice attempts are only possible on quizzes that are visible to students
+                // (most quizzes that are hidden from students may be previewed by teachers, but may not be practised)
                 return (quiz.hiddenFromRoles && !quiz.hiddenFromRoles?.includes("STUDENT")) || quiz.visibleToStudents;
-                // return (quiz.hiddenFromRoles && !quiz.hiddenFromRoles?.includes("TEACHER")) ?? true;
             default:
                 return true;
         }


### PR DESCRIPTION
This is a temporary stopgap solution so teachers cannot see practice tests that can't be attempted (and which lead to an error page) on the new dedicated "Practice Tests" page.

These tests can still be previewed on the "Set Tests" page as normal, and we'll likely allow them to be attempted in another change soon - at which point this can be reverted.