### PR TITLE
Inequality producing empty canvases at root level on resize

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "html-to-text": "^9.0.5",
     "identity-obj-proxy": "3.0.0",
     "immer": "^9.0.21",
-    "inequality": "1.1.4",
+    "inequality": "1.1.5",
     "inequality-grammar": "1.3.5",
     "isaac-graph-sketcher": "0.13.7",
     "js-cookie": "^3.0.5",

--- a/src/app/components/content/IsaacSymbolicChemistryQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicChemistryQuestion.tsx
@@ -162,6 +162,10 @@ const IsaacSymbolicChemistryQuestion = ({doc, questionId, readonly}: IsaacQuesti
     const sketchRef = useRef<Inequality | null | undefined>();
 
     useLayoutEffect(() => {
+        if (!isDefined(hiddenEditorRef.current)) {
+            throw new Error("Unable to initialise inequality; target element not found.");
+        }
+        
         const {sketch, p} = makeInequality(
             hiddenEditorRef.current,
             100,

--- a/src/app/components/content/IsaacSymbolicChemistryQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicChemistryQuestion.tsx
@@ -161,11 +161,15 @@ const IsaacSymbolicChemistryQuestion = ({doc, questionId, readonly}: IsaacQuesti
     const hiddenEditorRef = useRef<HTMLDivElement | null>(null);
     const sketchRef = useRef<Inequality | null | undefined>();
 
+    const showTextEntry = !readonly && isStaff(user);
+
     useLayoutEffect(() => {
+        if (!showTextEntry) return; // as the ref will not be defined
+
         if (!isDefined(hiddenEditorRef.current)) {
             throw new Error("Unable to initialise inequality; target element not found.");
         }
-        
+
         const {sketch, p} = makeInequality(
             hiddenEditorRef.current,
             100,
@@ -246,7 +250,7 @@ const IsaacSymbolicChemistryQuestion = ({doc, questionId, readonly}: IsaacQuesti
                     {doc.children}
                 </IsaacContentValueOrChildren>
             </div>
-            {!readonly && isStaff(user) && <div className="eqn-editor-input">
+            {showTextEntry && <div className="eqn-editor-input">
                 <div ref={hiddenEditorRef} className="equation-editor-text-entry" style={{height: 0, overflow: "hidden", visibility: "hidden"}} />
                 <InputGroup className="my-2 separate-input-group">
                     <Input type="text" onChange={updateEquation} value={textInput}

--- a/src/app/components/content/IsaacSymbolicLogicQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicLogicQuestion.tsx
@@ -137,6 +137,10 @@ const IsaacSymbolicLogicQuestion = ({doc, questionId, readonly}: IsaacQuestionPr
     const sketchRef = useRef<Inequality | null | undefined>();
 
     useLayoutEffect(() => {
+        if (!isDefined(hiddenEditorRef.current)) {
+            throw new Error("Unable to initialise inequality; target element not found.");
+        }
+        
         const { sketch, p } = makeInequality(
             hiddenEditorRef.current,
             100,

--- a/src/app/components/content/IsaacSymbolicLogicQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicLogicQuestion.tsx
@@ -136,11 +136,13 @@ const IsaacSymbolicLogicQuestion = ({doc, questionId, readonly}: IsaacQuestionPr
     const hiddenEditorRef = useRef<HTMLDivElement | null>(null);
     const sketchRef = useRef<Inequality | null | undefined>();
 
-    useLayoutEffect(() => {
+    useLayoutEffect(() => {        
+        if (readonly) return; // as the ref won't be defined
+
         if (!isDefined(hiddenEditorRef.current)) {
             throw new Error("Unable to initialise inequality; target element not found.");
         }
-        
+
         const { sketch, p } = makeInequality(
             hiddenEditorRef.current,
             100,

--- a/src/app/components/content/IsaacSymbolicQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicQuestion.tsx
@@ -166,10 +166,12 @@ const IsaacSymbolicQuestion = ({doc, questionId, readonly}: IsaacQuestionProps<I
     const sketchRef = useRef<Inequality | null | undefined>();
 
     useLayoutEffect(() => {
+        if (readonly) return; // as the ref won't be defined
+
         if (!isDefined(hiddenEditorRef.current)) {
             throw new Error("Unable to initialise inequality; target element not found.");
         }
-        
+
         const {sketch, p} = makeInequality(
             hiddenEditorRef.current,
             100,

--- a/src/app/components/content/IsaacSymbolicQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicQuestion.tsx
@@ -166,6 +166,10 @@ const IsaacSymbolicQuestion = ({doc, questionId, readonly}: IsaacQuestionProps<I
     const sketchRef = useRef<Inequality | null | undefined>();
 
     useLayoutEffect(() => {
+        if (!isDefined(hiddenEditorRef.current)) {
+            throw new Error("Unable to initialise inequality; target element not found.");
+        }
+        
         const {sketch, p} = makeInequality(
             hiddenEditorRef.current,
             100,

--- a/src/app/components/elements/modals/inequality/InequalityModal.tsx
+++ b/src/app/components/elements/modals/inequality/InequalityModal.tsx
@@ -331,6 +331,7 @@ const InequalityModal = ({availableSymbols, logicSyntax, editorMode, close, onEd
     const sketch = useRef<Nullable<Inequality>>(null);
     const [editorState, setEditorState] = useState<any>({});
     useLayoutEffect(() => {
+        if (!inequalityModalRef) return;
         return prepareInequality({
             sketch,
             inequalityModalRef,

--- a/src/app/components/elements/modals/inequality/utils.ts
+++ b/src/app/components/elements/modals/inequality/utils.ts
@@ -690,6 +690,10 @@ interface PrepareInequalityArgs {
     setEditorState: (state: any) => void;
 }
 export function prepareInequality({editorMode, inequalityModalRef, initialEditorSymbols, isTrashActive, sketch, logicSyntax, setEditorState, onEditorStateChange}: PrepareInequalityArgs) {
+    if (!isDefined(inequalityModalRef.current)) {
+        throw new Error("Unable to initialise inequality; target element not found.");
+    }
+    
     const { sketch: newSketch, p } = makeInequality(
         inequalityModalRef.current,
         window.innerWidth,

--- a/src/app/components/pages/Equality.tsx
+++ b/src/app/components/pages/Equality.tsx
@@ -183,6 +183,8 @@ const Equality = withRouter(({location}: RouteComponentProps<{}, {}, {board?: st
     }, [editorSyntax]);
 
     useLayoutEffect(() => {
+        if (!allowTextInput) return; // as the ref won't be defined
+
         if (!isDefined(hiddenEditorRef.current)) {
             throw new Error("Unable to initialise inequality; target element not found.");
         }

--- a/src/app/components/pages/Equality.tsx
+++ b/src/app/components/pages/Equality.tsx
@@ -183,6 +183,10 @@ const Equality = withRouter(({location}: RouteComponentProps<{}, {}, {board?: st
     }, [editorSyntax]);
 
     useLayoutEffect(() => {
+        if (!isDefined(hiddenEditorRef.current)) {
+            throw new Error("Unable to initialise inequality; target element not found.");
+        }
+
         const {sketch, p} = makeInequality(
             hiddenEditorRef.current,
             100,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5941,10 +5941,10 @@ inequality-grammar@1.3.5:
     moo "^0.5.2"
     nearley "^2.20.1"
 
-inequality@1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/inequality/-/inequality-1.1.4.tgz#3614933d3c75d246cb30f7aff0c6d3d48bb1093f"
-  integrity sha512-Evyixxlw7X1hJtxovTphy7uMGz966p2mfRE0xzV3ffXOPCIZ9HFFF6s+8WPreO9KhgEzdhRG124VtCTKuH8oig==
+inequality@1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/inequality/-/inequality-1.1.5.tgz#b92b769bb5066006aa737eaeb081ce8ca4641264"
+  integrity sha512-J/MxmmfI+Wz01O6anvhUOhdKui8Z+Q89sHPSJ/VF+gikTKWdHhUHJY2Naqcow68s4gQPBdeWFIPElu437J04kw==
 
 inflight@^1.0.4:
   version "1.0.6"


### PR DESCRIPTION
If `makeInequality` is called with an undefined ref, p5 proceeds to generate a new canvas at root level with seemingly fullscreen sizing. With an adjacent change to [inequality](https://github.com/isaacphysics/inequality/pull/10), this forces the element to always be defined and will quietly cancel the setup in the known cases when this occurs.