### PR TITLE
Fix back button on consistency error using stale data

### DIFF
--- a/src/app/state/middleware/userConsistencyChecker.tsx
+++ b/src/app/state/middleware/userConsistencyChecker.tsx
@@ -1,7 +1,7 @@
 import {Dispatch, Middleware, MiddlewareAPI} from "redux";
 import {RegisteredUserDTO} from "../../../IsaacApiTypes";
 import {ACTION_TYPE, isDefined} from "../../services";
-import {redirectTo, getUserId, logAction, setUserId, AppDispatch} from "../index";
+import {redirectTo, getUserId, logAction, setUserId, AppDispatch, changePage} from "../index";
 
 let timeoutHandle: number | undefined;
 
@@ -63,6 +63,9 @@ export const userConsistencyCheckerMiddleware: Middleware = (api: MiddlewareAPI)
         case ACTION_TYPE.USER_CONSISTENCY_ERROR:
             redirect = "/consistency-error";
             clearCurrentUser();
+            // Pushing this history item here causes the page to reload before the redirect below, but this prevents the
+            // back button from using stale data:
+            changePage(redirect);
             break;
         case ACTION_TYPE.USER_SESSION_EXPIRED:
             redirect = "/error_expired";


### PR DESCRIPTION
If you log out in another tab, a consistency error page is shown that should clear the local Redux state and make you logged out in these other tabs too. However we had issues with the browser back button, which for obscure reasons from the HTTP 1.1 specification, will ignore cache headers and use stale data to reload the previous page.

We could fix this by disabling caching for the current user data, but the back button does not misbehave on the tab where you actually log out. This suggests a fix; add an extra history entry for the error page and then hard-navigate to it. Then the back button takes you to the page from before the error, but without loading stale data.