### PR TITLE
Fix intended audience logic for content where only a role is specified

### DIFF
--- a/src/app/services/userViewingContext.ts
+++ b/src/app/services/userViewingContext.ts
@@ -367,9 +367,6 @@ export function isIntendedAudience(intendedAudience: ContentBaseDTO['audience'],
             if (!satisfiesExamBoardCriteria) {
                 return false;
             }
-        } else if (isAda) {
-            // If no exam board specified treat as off specification (only for Ada)
-            return false;
         }
 
         // If a role is specified do we have any of those roles or greater


### PR DESCRIPTION
At the start of the year we added logic to `isIntendedAudience` that returns `false` early if the content's audience field does not include an exam board. I believe we did this to keep non spec-aligned content (such as the AI topics) from appearing as "on your specification" - at the time we didn't have Core and Advanced so these had no audience tags, and content without any audiences defined defaulted to on-spec.

This causes a problem for Teacher Resources accordion sections, which define their audience based on role only and have no exam board field, so by this logic are always hidden.

Now all content should be tagged Ada and either Core or Advanced, so this should be safe to remove.