### PR TITLE
Pass editorMode into text entry's Inequality reference on the equality demo page

### DIFF
--- a/src/app/components/pages/Equality.tsx
+++ b/src/app/components/pages/Equality.tsx
@@ -195,6 +195,7 @@ const Equality = withRouter(({location}: RouteComponentProps<{}, {}, {board?: st
             0,
             [],
             {
+                editorMode: editorMode,
                 textEntry: true,
                 fontItalicPath: '/assets/common/fonts/STIXGeneral-Italic.ttf',
                 fontRegularPath: '/assets/common/fonts/STIXGeneral-Regular.ttf',


### PR DESCRIPTION
The bug is that text entry sometimes doesn't work on switching modes on the demo page. To recreate:

1. Go to [staging.isaacphysics.org/equality](http://staging.isaacphysics.org/equality) (logged into an admin account)
2. Choose ‘Nuclear Physics’ from the dropdown
3. Type “H”
4. Click to enter Inequality modal
5. Submit
6. Try to edit the text input prescripts (e.g. "{}^{2}_{}H")


This is broken (only for the demo page) due to the `editorMode` for inequality text entry (`hiddenEditorRef`) only being set when the main inequality `editorMode` changes, but the page reload forcing text entry to be generated again. This regenerated `hiddenEditorRef` therefore doesn’t have `editorMode` set, so it is set to the default of “logic”.

The solution is simply to pass the main `editorMode` into `hiddenEditorRef`’s `editorMode` when it is generated.