### PR TITLE
Update Inequality to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "html-to-text": "^9.0.5",
     "identity-obj-proxy": "3.0.0",
     "immer": "^9.0.21",
-    "inequality": "1.1.5",
+    "inequality": "^1.2.0",
     "inequality-grammar": "1.3.5",
     "isaac-graph-sketcher": "0.13.7",
     "js-cookie": "^3.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5941,10 +5941,10 @@ inequality-grammar@1.3.5:
     moo "^0.5.2"
     nearley "^2.20.1"
 
-inequality@1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/inequality/-/inequality-1.1.5.tgz#b92b769bb5066006aa737eaeb081ce8ca4641264"
-  integrity sha512-J/MxmmfI+Wz01O6anvhUOhdKui8Z+Q89sHPSJ/VF+gikTKWdHhUHJY2Naqcow68s4gQPBdeWFIPElu437J04kw==
+inequality@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/inequality/-/inequality-1.2.0.tgz#dc140b4da86f033aca5c7bd7821e70ac0e5427fa"
+  integrity sha512-dtOK6lRaIKITf2jAIJJPp3iyAQsI8loPJI8HC03cNiBpwJhGxf9Tvj51tApL/Ki3jc7lWlzFT/G6LxbWzcU/Cg==
 
 inflight@^1.0.4:
   version "1.0.6"


### PR DESCRIPTION
This change to Inequality disables various docking points (the circular points that each widget attaches to) depending on Inequality's `editorMode` being `'chemistry'`/`'nuclear'`. This includes:

- Anything docking to the Exponent of Numbers
- BinaryOperation (plus/minus) docking to Relations (reaction arrows) or to the right of Operators (numbers)
- Brackets docking to Exponent/Subscript slots or to the right of Operators (numbers)
- Numbers docking to the right of Brackets
- (Nuclear only) Anything docking the Exponent/Subscripts of Elements
- (Nuclear only) Anything docking to Subscripts of Particles (Exponents are needed for e.g. positrons)
