### PR TITLE
Set Inequality text editor mode strictly

### DIFF
--- a/src/app/components/content/IsaacSymbolicChemistryQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicChemistryQuestion.tsx
@@ -176,6 +176,7 @@ const IsaacSymbolicChemistryQuestion = ({doc, questionId, readonly}: IsaacQuesti
             0,
             _flattenDeep((currentAttemptValue || { symbols: [] }).symbols),
             {
+                editorMode: doc.isNuclear ? "nuclear" : "chemistry",
                 textEntry: true,
                 fontItalicPath: '/assets/common/fonts/STIXGeneral-Italic.ttf',
                 fontRegularPath: '/assets/common/fonts/STIXGeneral-Regular.ttf',

--- a/src/app/components/content/IsaacSymbolicLogicQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicLogicQuestion.tsx
@@ -149,6 +149,7 @@ const IsaacSymbolicLogicQuestion = ({doc, questionId, readonly}: IsaacQuestionPr
             0,
             _flattenDeep((currentAttemptValue || { symbols: [] }).symbols),
             {
+                editorMode: "logic",
                 textEntry: true,
                 fontItalicPath: '/assets/common/fonts/STIXGeneral-Italic.ttf',
                 fontRegularPath: '/assets/common/fonts/STIXGeneral-Regular.ttf',

--- a/src/app/components/content/IsaacSymbolicQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicQuestion.tsx
@@ -178,6 +178,7 @@ const IsaacSymbolicQuestion = ({doc, questionId, readonly}: IsaacQuestionProps<I
             0,
             _flattenDeep((currentAttemptValue || { symbols: [] }).symbols),
             {
+                editorMode: "maths",
                 textEntry: true,
                 fontItalicPath: '/assets/common/fonts/STIXGeneral-Italic.ttf',
                 fontRegularPath: '/assets/common/fonts/STIXGeneral-Regular.ttf',


### PR DESCRIPTION
Currently, `editorMode` is not always instantiated for inequality’s text input. Often this doesn't matter, but when each mode has a different valid input (e.g. the exponent docking point being removed for Chemistry but kept in Maths) and `editorMode` has not been instantiated, it defaults to the less expressive input.

Text entry normally copies parameters from symbolic entry, but this causes a race condition. `editorMode` can simply be hard-coded into each editor’s text entry box to avoid this.