### PR TITLE
Pod suggestions

### DIFF
--- a/src/app/components/elements/cards/EventCard.tsx
+++ b/src/app/components/elements/cards/EventCard.tsx
@@ -16,7 +16,7 @@ export const PhysicsEventCard = ({event}: {event: AugmentedEvent}) => {
 
     return <Card className="pod">
         {eventThumbnail &&
-            <div className={"pod-img event-pod-img"}>
+            <a className={"pod-img event-pod-img"} href={`/events/${id}`}>
                 <CardImg aria-hidden={true} top src={eventThumbnail.src} alt={"" /* Decorative image, should be hidden from screenreaders */} />
                 {isVirtualEvent &&
                     <div className={"event-pod-badge"}>
@@ -32,15 +32,13 @@ export const PhysicsEventCard = ({event}: {event: AugmentedEvent}) => {
                         <b>STUDENT EVENT</b>
                         <img src="/assets/phy/icons/redesign/student-event-hex.svg" alt={"student event icon"}/>
                     </div>}
-            </div>}
+            </a>}
         <CardBody className="d-flex flex-column ps-0">
             {title && <CardTitle tag="h4" className="mb-0">{title}</CardTitle>}
-            {subtitle && <CardText className="mb-0">
-                {subtitle}
-            </CardText>}
-            <Spacer/>
-            <div className="section-divider"/>
             <CardText>
+                {subtitle && <p className="m-0">{subtitle}</p>}
+                <Spacer/>
+                <div className="section-divider"/>
                 <b>When: </b>{formatEventCardDate(event)}
                 {location && location.address &&
                     <span className='d-block my-1'>

--- a/src/app/components/elements/cards/EventCard.tsx
+++ b/src/app/components/elements/cards/EventCard.tsx
@@ -5,6 +5,7 @@ import {AugmentedEvent} from "../../../../IsaacAppTypes";
 import {DateString} from "../DateString";
 import {formatEventCardDate, siteSpecific} from "../../../services";
 import { Card, CardImg, CardBody, CardTitle, Badge, CardText } from "reactstrap";
+import { Spacer } from "../Spacer";
 
 export const PhysicsEventCard = ({event}: {event: AugmentedEvent}) => {
     const {id, title, subtitle, eventThumbnail, location, date} = event;
@@ -32,15 +33,12 @@ export const PhysicsEventCard = ({event}: {event: AugmentedEvent}) => {
                         <img src="/assets/phy/icons/redesign/student-event-hex.svg" alt={"student event icon"}/>
                     </div>}
             </div>}
-        <CardBody className="pod-content mt-md-0 mt-3">
-            {title && 
-                <CardTitle tag="b">
-                    {title}
-                </CardTitle>}
-            {subtitle &&
-                <CardText>
-                    {subtitle}
-                </CardText>}
+        <CardBody className="d-flex flex-column ps-0">
+            {title && <CardTitle tag="h4" className="mb-0">{title}</CardTitle>}
+            {subtitle && <CardText className="mb-0">
+                {subtitle}
+            </CardText>}
+            <Spacer/>
             <div className="section-divider"/>
             <CardText>
                 <b>When: </b>{formatEventCardDate(event)}

--- a/src/app/components/elements/cards/EventCard.tsx
+++ b/src/app/components/elements/cards/EventCard.tsx
@@ -35,10 +35,12 @@ export const PhysicsEventCard = ({event}: {event: AugmentedEvent}) => {
             </a>}
         <CardBody className="d-flex flex-column ps-0">
             {title && <CardTitle tag="h4" className="mb-0">{title}</CardTitle>}
-            <CardText>
+            <CardText className="mb-0">
                 {subtitle && <p className="m-0">{subtitle}</p>}
-                <Spacer/>
-                <div className="section-divider"/>
+            </CardText>
+            <Spacer/>
+            <div className="section-divider"/>
+            <CardText>
                 <b>When: </b>{formatEventCardDate(event)}
                 {location && location.address &&
                     <span className='d-block my-1'>

--- a/src/app/components/elements/cards/NewsCard.tsx
+++ b/src/app/components/elements/cards/NewsCard.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import {Link} from "react-router-dom";
-import {Card, CardBody, CardImg, CardProps, CardText} from "reactstrap";
+import {Card, CardBody, CardImg, CardProps, CardText, CardTitle} from "reactstrap";
 import {IsaacPodDTO} from "../../../../IsaacApiTypes";
 import {apiHelper, siteSpecific} from "../../../services";
 import {AdaCard} from "./AdaCard";
+import { Spacer } from "../Spacer";
 
 interface NewsCardProps extends CardProps {
     newsItem: IsaacPodDTO;
@@ -19,17 +20,13 @@ const PhysicsNewsCard = ({newsItem, ...props}: NewsCardProps) => {
                 top
                 src={image.src && apiHelper.determineImageUrl(image.src)}
                 alt={image.altText || `Illustration for ${title}`}
-                className="pod-img"
             />
         </a>}
-        <CardBody className="pod-content">
-            <b className="pod-title">
-                {title}
-            </b>
-            <p>
-                {value}
-            </p>
+        <CardBody className="ps-0">
+            <CardTitle tag="h4" className="mb-0">{title}</CardTitle>
             <CardText>
+                {value && <p>{value}</p>}
+                <Spacer/>
                 {!url?.startsWith("http") ?
                     <Link aria-label={`${title} read more`} className="focus-target btn btn-keyline" to={`${url}`}>
                             Read more

--- a/src/app/components/pages/Events.tsx
+++ b/src/app/components/pages/Events.tsx
@@ -118,7 +118,7 @@ export const Events = withRouter(({history, location}: RouteComponentProps) => {
                         const numberOfLoadedEvents = events.length;
 
                         return <div className="my-4">
-                            <Row className="row-cols-1 row-cols-sm-2 row-cols-md-1">
+                            <Row className={`row-cols-1 row-cols-sm-2 ${siteSpecific("row-cols-md-1", "row-cols-lg-3")}`}>
                                 {events.map(event => <div key={event.id} className="my-3 px-3">
                                     <EventCard event={event} />
                                     {above["md"](deviceSize) && <div className="section-divider"/>}

--- a/src/app/components/pages/Events.tsx
+++ b/src/app/components/pages/Events.tsx
@@ -121,7 +121,7 @@ export const Events = withRouter(({history, location}: RouteComponentProps) => {
                             <Row className="row-cols-1 row-cols-sm-2 row-cols-md-1">
                                 {events.map(event => <div key={event.id} className="my-3 px-3">
                                     <EventCard event={event} />
-                                    {above["md"](deviceSize) && <><br/><div className="section-divider"/></>}
+                                    {above["md"](deviceSize) && <div className="section-divider"/>}
                                 </div>)}
                             </Row>
 

--- a/src/app/components/pages/News.tsx
+++ b/src/app/components/pages/News.tsx
@@ -5,8 +5,9 @@ import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
 import {MetaDescription} from "../elements/MetaDescription";
 import {useGetNewsPodListQuery} from "../../state";
 import {ShowLoadingQuery} from "../handlers/ShowLoadingQuery";
-import {above, NEWS_PODS_PER_PAGE, siteSpecific, useDeviceSize} from "../../services";
+import {above, isAda, isPhy, NEWS_PODS_PER_PAGE, siteSpecific, useDeviceSize} from "../../services";
 import { IsaacPodDTO } from "../../../IsaacApiTypes";
+import classNames from "classnames";
 
 export const News = () => {
     const [page, setPage] = React.useState(0);
@@ -41,10 +42,10 @@ export const News = () => {
                 defaultErrorTitle={"Error fetching news stories"}
             /> : 
             <>
-                <Row className="row-cols-1 row-cols-sm-2 row-cols-md-1">
-                    {allNews.map((n, i) => <Col key={i} className="my-3 px-3">
-                        <NewsCard key={n.id} newsItem={n} showTitle />
-                        {above["md"](deviceSize) && <div className="section-divider"/>}
+                <Row className={`row-cols-1 row-cols-sm-2 ${siteSpecific("row-cols-md-1", "row-cols-lg-3")}`}>
+                    {allNews.map((n, i) => <Col key={i} className={`my-3 ${siteSpecific("px-3", "px-0 justify-content-center")}`}>
+                        <NewsCard key={n.id} newsItem={n} className={classNames({"h-100": isAda})} showTitle />
+                        {isPhy && above["md"](deviceSize) && <div className="section-divider"/>}
                     </Col>)}
                 </Row>
                 <div className="w-100 d-flex justify-content-center mb-5">

--- a/src/app/components/pages/News.tsx
+++ b/src/app/components/pages/News.tsx
@@ -44,7 +44,7 @@ export const News = () => {
                 <Row className="row-cols-1 row-cols-sm-2 row-cols-md-1">
                     {allNews.map((n, i) => <Col key={i} className="my-3 px-3">
                         <NewsCard key={n.id} newsItem={n} showTitle />
-                        {above["md"](deviceSize) && <><br/><div className="section-divider"/></>}
+                        {above["md"](deviceSize) && <div className="section-divider"/>}
                     </Col>)}
                 </Row>
                 <div className="w-100 d-flex justify-content-center mb-5">

--- a/src/scss/phy/cards.scss
+++ b/src/scss/phy/cards.scss
@@ -4,10 +4,13 @@
     flex-direction: row;
     width: 100%;
     height: min-content;
-    padding-left: 1.5rem;
+    
+    a:has(> img) {
+      margin-right: 1.5rem;
 
-    .pod-img > img {
-      width: 200px;
+      > img {
+        width: 200px;
+      }
     }
 
     .card-body {
@@ -31,13 +34,14 @@ div:has(> .pod) {
     font-weight: 700;
   }
   
-  .pod-img {
-    border-radius: 8px;
-    
+  a:has(> img) {
+    height: min-content;
     > img {
       width: 100%;
       aspect-ratio: 16/9;
       object-fit: cover;
+      border: 1px solid $color-neutral-200;
+      border-radius: 8px;
     }
   }
 
@@ -53,8 +57,8 @@ div:has(> .pod) {
 
     .event-pod-hex {
       position: absolute;
-      top: 0;
-      right: 10%;
+      top: 1px;
+      right: 5%;
       color: white;
 
       > b {

--- a/src/scss/phy/cards.scss
+++ b/src/scss/phy/cards.scss
@@ -1,9 +1,18 @@
-@container pod-parent (min-width: 768px) {
+@container pod-parent (min-width: 736px) {
   .pod.card {
     display: flex;
     flex-direction: row;
     width: 100%;
-    padding-left: 20px;
+    height: min-content;
+    padding-left: 1.5rem;
+
+    .pod-img > img {
+      width: 200px;
+    }
+
+    .card-body {
+      padding-top: 0;
+    }
   }
 }
 
@@ -14,6 +23,7 @@ div:has(> .pod) {
 .pod {
   background-color: transparent;
   border: none;
+  height: 100%;
   width: 100%;
 
   .pod-title {
@@ -22,40 +32,29 @@ div:has(> .pod) {
   }
   
   .pod-img {
-    aspect-ratio: 16/9;
     border-radius: 8px;
-    width: 200px;
-    padding-right: 15px;
-
+    
     > img {
+      width: 100%;
+      aspect-ratio: 16/9;
       object-fit: cover;
     }
   }
 
-  .pod-content {
-    padding-left: 0;
-  }
-
   .event-pod-img {
     position: relative;
-    min-height: 100px;
+    height: min-content;
 
-    > img {
-      .event-pod-badge {
-        position: absolute;
-        bottom: 0;
-        width: 100%;
-        text-align: left;
-      }
+    .event-pod-badge {
+      position: absolute;
+      bottom: 3%;
+      left: 3%;
     }
 
     .event-pod-hex {
       position: absolute;
       top: 0;
       right: 10%;
-      min-height: 91px;
-      width: 100%;
-      text-align: right;
       color: white;
 
       > b {


### PR DESCRIPTION
Suggests some changes to the pods components.

- Make image sizes consistent between pods; increase size for vertically-stacked pod;
- Fix odd placement of `event-pod-badge`;
- Ensure the `@container` query lines up with `md` breakpoint when including padding;
- Aligns the structure of News pods and Event pods to be as similar as possible.
(On a related note, I'm tempted to make them the same component, or at least both inherit a common abstract structure so that changes to one would reflect in the other; the current way of doing it where we have two entirely separate components that generate almost the same thing is definitely redundant. Let's leave this for another time though, as it'll affect Ada too.)