### PR TITLE
Allow loading of old-style coordinate answers

### DIFF
--- a/src/IsaacApiTypes.tsx
+++ b/src/IsaacApiTypes.tsx
@@ -44,7 +44,7 @@ export interface AssignmentStatusDTO {
     errorMessage?: string;
 }
 
-export interface AssignmentProgressDTO { 
+export interface AssignmentProgressDTO {
     user?: UserSummaryDTO;
     correctPartResults?: number[];
     incorrectPartResults?: number[];
@@ -514,6 +514,8 @@ export interface ParsonsItemDTO extends ItemDTO {
 
 export interface CoordinateItemDTO extends ItemDTO {
     coordinates?: string[];
+    x?: string;  // deprecated
+    y?: string;  // deprecated
 }
 
 export interface QuantityDTO extends ChoiceDTO {


### PR DESCRIPTION
Moving to using an array means we don't load the x and y values from existing answers. This supports doing that, whilst cleaning the updated choice so that if it is submitted again there is no sign of the old-style properties.