### PR TITLE
Allow menu collapse on options with submenus

### DIFF
--- a/src/app/components/elements/modals/inequality/InequalityModal.tsx
+++ b/src/app/components/elements/modals/inequality/InequalityModal.tsx
@@ -68,8 +68,8 @@ const InequalityMenuTab = ({menu, latexTitle, subMenu, className, isSubMenu = fa
     if (!menuContext) return null;
     const {activeMenu: [activeMenu, activeSubMenu], openNewMenuTab} = menuContext;
 
-    const navigate = () => openNewMenuTab([menu, subMenu ?? null]);
     const active = activeMenu === menu && (isSubMenu ? activeSubMenu === subMenu : true);
+    const navigate = () => openNewMenuTab([menu, (!active || isSubMenu) && subMenu ? subMenu : null]);
 
     return <li className={classNames(active ? "active" : "inactive", className)} onClick={navigate} onKeyUp={navigate}>
         {isSubMenu ? <VShape/> : <TabShape/>}<Markup encoding={"latex"}>{`$${latexTitle}$`}</Markup>


### PR DESCRIPTION
Currently, Inequality menus with sub-menus (_Maths->Letters_, _Boolean->Letters_, _Maths->Other Functions_) don't have their main button collapse the menu, but those without sub-menus do.

This is essentially because the same logic is used for sub-menu buttons (at the very top of the screen) and the dropped down main menu buttons. `isSubMenu` can be used to differentiate between these, so adding a check for this to the `openNewMenuTab` call here fixes the problem.