### PR TITLE
Use alt text and not MathML inside button elements

### DIFF
--- a/src/app/components/content/IsaacNumericQuestion.tsx
+++ b/src/app/components/content/IsaacNumericQuestion.tsx
@@ -150,7 +150,9 @@ const IsaacNumericQuestion = ({doc, questionId, validationResponse, readonly}: I
                                             data-unit={unit || 'None'}
                                             className={unit === currentAttemptUnits ? "btn bg-grey selected" : ""}
                                             onClick={(e: FormEvent) => {updateUnits(unit); e.preventDefault();}}>
-                                            <Markup encoding={"latex"}>
+                                            {/* Buttons cannot contain semantic children in the accessibility tree;
+                                                so we must use alt text here! */}
+                                            <Markup encoding={"latex"} forceMathsAltText={true}>
                                                 {wrapUnitForSelect(unit)}
                                             </Markup>
                                         </DropdownItem>

--- a/src/app/components/elements/markup/index.tsx
+++ b/src/app/components/elements/markup/index.tsx
@@ -53,6 +53,7 @@ type StringNot<X extends string, Y> =
 interface BaseMarkupProps {
     className?: string;
     children: string | undefined;
+    forceMathsAltText?: boolean;
 }
 
 type MarkupProps<T extends string> = {
@@ -74,8 +75,8 @@ type TrustedMarkupProps = {
 //  - `unknown`:   HTML is escaped, and markup is rendered alongside a warning that the encoding is unknown.
 //
 // You can pass in an encoding other than these, and the encoding will be treated the same as as `unknown`.
-export function Markup<T extends string>({encoding, "trusted-markup-encoding": trustedMarkupEncoding, className, children}: MarkupProps<T> | TrustedMarkupProps) {
-    const renderKaTeX = useRenderKatex();
+export function Markup<T extends string>({encoding, "trusted-markup-encoding": trustedMarkupEncoding, forceMathsAltText, className, children}: MarkupProps<T> | TrustedMarkupProps) {
+    const renderKaTeX = useRenderKatex(forceMathsAltText);
 
     if (!isDefined(children)) return null;
 

--- a/src/app/components/elements/markup/latexRendering.ts
+++ b/src/app/components/elements/markup/latexRendering.ts
@@ -337,10 +337,12 @@ export function katexify(
 }
 
 // A hook wrapper around katexify that gets its required parameters from the current redux state and existing figure numbering context
-export const useRenderKatex = () => {
+export const useRenderKatex = (forceAltText?: boolean) => {
     const {data: segueEnvironment} = useGetSegueEnvironmentQuery();
     const {preferredBooleanNotation, preferMathML} = useUserPreferences();
     const figureNumbers = useContext(FigureNumberingContext);
 
-    return (markup: string) => katexify(markup, preferredBooleanNotation && BOOLEAN_NOTATION[preferredBooleanNotation], segueEnvironment === "DEV", preferMathML ?? false, figureNumbers);
+    const useMathML = (!forceAltText && preferMathML) ?? false;
+
+    return (markup: string) => katexify(markup, preferredBooleanNotation && BOOLEAN_NOTATION[preferredBooleanNotation], segueEnvironment === "DEV", useMathML, figureNumbers);
 };


### PR DESCRIPTION
Button elements are only allowed to contain presentational content for the accessibility tree; but <math> elements are semantic and will not be used by the screenreader. So the MathML is unhelpful here and every button was read out the same way, leaving questions unanswerable.