### PR TITLE
Redesign concept pages

### DIFF
--- a/src/app/components/elements/PrintButton.tsx
+++ b/src/app/components/elements/PrintButton.tsx
@@ -14,8 +14,8 @@ export const PrintButton = ({questionPage}: PrintProps ) => {
     const dispatch = useAppDispatch();
 
     return questionPage ?
-        <>
-            {questionPrintOpen && <div className="question-actions-link-box not-mobile">
+        <div className="position-relative">
+            {questionPrintOpen && <div className="action-buttons-popup-container not-mobile">
                 <div className="question-actions-link text-nowrap">
                     <Button
                         size={"sm"}
@@ -58,7 +58,7 @@ export const PrintButton = ({questionPage}: PrintProps ) => {
                     aria-label="Print page"
                 />
             )}
-        </>
+        </div>
         :
         siteSpecific(
             <IconButton

--- a/src/app/components/elements/ShareLink.tsx
+++ b/src/app/components/elements/ShareLink.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useRef, useState} from "react";
-import {isMobile, isPhy, isTutorOrAbove, PATHS, siteSpecific, useOutsideCallback} from "../../services";
+import {isAda, isMobile, isPhy, isTutorOrAbove, PATHS, siteSpecific, useOutsideCallback} from "../../services";
 import {selectors, useAppSelector} from "../../state";
 import classNames from "classnames";
 import { IconButton } from "./AffixButton";
@@ -40,9 +40,17 @@ export const ShareLink = ({linkUrl, reducedWidthLink, gameboardId, clickAwayClos
     useOutsideCallback(shareLinkDivRef, () => clickAwayClose && setShowShareLink(false), [setShowShareLink]);
 
     const buttonAriaLabel = showShareLink ? "Hide share link" : "Get share link";
-    const linkWidth = isMobile() || reducedWidthLink ? 192 : (shareUrl.length * siteSpecific(9, 6));
+    const linkWidth = isMobile() || reducedWidthLink ? siteSpecific(256, 192) : (shareUrl.length * siteSpecific(9, 6));
     const showDuplicateAndEdit = gameboardId && isTutorOrAbove(user);
-    return <div ref={shareLinkDivRef} className={classNames(className, "share-link-icon", {"w-max-content d-inline-flex": isPhy})}>
+    return <div ref={shareLinkDivRef} className={classNames(className, "position-relative share-link-icon", {"w-max-content d-inline-flex": isPhy})}>
+        <div className={`action-buttons-popup-container ${showShareLink ? "" : "d-none"} ${showDuplicateAndEdit ? "double-height" : ""}`} style={{width: linkWidth}}>
+            <input type="text" readOnly ref={shareLink} value={shareUrl} onClick={(e) => e.preventDefault()} aria-label="Share URL" />
+        </div>
+        {showShareLink && showDuplicateAndEdit && <div className="duplicate-and-edit" style={{width: linkWidth}}>
+            <a href={`${PATHS.GAMEBOARD_BUILDER}?base=${gameboardId}`} className={isPhy ? "px-1" : ""}>
+                {siteSpecific("Duplicate and Edit", "Duplicate and edit")}
+            </a>
+        </div>}
         {siteSpecific(
             <IconButton
                 icon="icon-share"
@@ -54,16 +62,7 @@ export const ShareLink = ({linkUrl, reducedWidthLink, gameboardId, clickAwayClos
                 data-bs-theme="neutral"
                 onClick={(e) => { e.preventDefault(); toggleShareLink(); }}
             />,
-            <button className={siteSpecific("btn-action", classNames({"outline": outline}))} onClick={(e) => {e.preventDefault(); toggleShareLink();}} aria-label={buttonAriaLabel} />
+            <button className={siteSpecific("btn-action", classNames("btn btn-primary", {"outline": outline}))} onClick={(e) => {e.preventDefault(); toggleShareLink();}} aria-label={buttonAriaLabel} />
         )}
-        <div className={`share-link ${showShareLink ? "d-block" : ""} ${showDuplicateAndEdit ? "double-height" : ""}`} style={{width: linkWidth}}>
-            <input type="text" readOnly ref={shareLink} value={shareUrl} onClick={(e) => e.preventDefault()} aria-label="Share URL" />
-            {showDuplicateAndEdit && <React.Fragment>
-                {isPhy && <hr className="text-center mt-4" />}
-                <a href={`${PATHS.GAMEBOARD_BUILDER}?base=${gameboardId}`} className={isPhy ? "px-1" : ""}>
-                    {siteSpecific("Duplicate and Edit", "Duplicate and edit")}
-                </a>
-            </React.Fragment>}
-        </div>
     </div>;
 };

--- a/src/app/components/elements/inputs/UserContextPicker.tsx
+++ b/src/app/components/elements/inputs/UserContextPicker.tsx
@@ -17,6 +17,7 @@ import {
     useUserViewingContext
 } from "../../../services";
 import {selectors, transientUserContextSlice, useAppDispatch, useAppSelector,} from "../../../state";
+import classNames from "classnames";
 
 const contextExplanationMap: {[key in CONTEXT_SOURCE]: string} = {
     [CONTEXT_SOURCE.TRANSIENT]: "these context picker settings",
@@ -62,7 +63,7 @@ export const UserContextPicker = ({className, hideLabels = true}: {className?: s
         return <Col className={`d-flex flex-column w-100 px-0 mt-2 context-picker-container no-print ${className}`}>
             <Row sm={12} md={7} lg={siteSpecific(7, 8)} xl={siteSpecific(7, 9)} className={`d-flex m-0 p-0 justify-content-md-end`}>
                 {/* Stage Selector */}
-                <FormGroup className={`form-group w-100 d-flex justify-content-end m-0`}>
+                <div className={classNames("form-group w-100 d-flex justify-content-end m-0", {"mb-3": isAda})}>
                     {!hideLabels && <Label className="d-inline-block pe-2" htmlFor="uc-stage-select">Stage</Label>}
                     {!userContext.hasDefaultPreferences && (userContext.explanation.stage == CONTEXT_SOURCE.TRANSIENT || userContext.explanation.examBoard == CONTEXT_SOURCE.TRANSIENT) &&
                         <button className={"icon-reset mt-2"} aria-label={"Reset viewing context"} onClick={() => {
@@ -71,7 +72,7 @@ export const UserContextPicker = ({className, hideLabels = true}: {className?: s
                         }}/>
                     }
                     <Input
-                        className={`flex-grow-1 d-inline-block ps-2 pe-0 mb-2 ${isAda ? "me-1" : ""}`}
+                        className={classNames("flex-grow-1 d-inline-block ps-2 pe-0", { "mb-2 me-1": isAda })}
                         type="select" id="uc-stage-select"
                         aria-label={hideLabels ? "Stage" : undefined}
                         value={userContext.stage}
@@ -134,7 +135,7 @@ export const UserContextPicker = ({className, hideLabels = true}: {className?: s
                             }
                         </UncontrolledTooltip>
                     </div>
-                </FormGroup>
+                </div>
             </Row>
         </Col>;
     }

--- a/src/app/components/elements/layout/SidebarLayout.tsx
+++ b/src/app/components/elements/layout/SidebarLayout.tsx
@@ -67,7 +67,7 @@ const NavigationSidebar = (props: SidebarProps) => {
     if (isAda) return <></>;
 
     const { className, ...rest } = props;
-    return <Col lg={4} xl={3} {...rest} className={classNames("sidebar p-4 order-1 order-lg-0", className)} />;
+    return <Col lg={4} xl={3} {...rest} className={classNames("sidebar no-print p-4 order-1 order-lg-0", className)} />;
 };
 
 interface ContentSidebarProps extends SidebarProps {
@@ -86,9 +86,9 @@ const ContentSidebar = (props: ContentSidebarProps) => {
     const { className, buttonTitle, ...rest } = props;
     return <>
         {above['lg'](deviceSize) 
-            ? <Col lg={4} xl={3} {...rest} className={classNames("d-none d-lg-flex flex-column sidebar p-4 order-0", className)} />
+            ? <Col lg={4} xl={3} {...rest} className={classNames("d-none d-lg-flex flex-column sidebar no-print p-4 order-0", className)} />
             : <>
-                <div className="d-flex align-items-center flex-wrap py-3 gap-3">
+                <div className="d-flex align-items-center no-print flex-wrap py-3 gap-3">
                     <AffixButton color="keyline" size="lg" onClick={toggleMenu} affix={{
                         affix: "icon-sidebar", 
                         position: "prefix", 

--- a/src/app/components/elements/layout/SidebarLayout.tsx
+++ b/src/app/components/elements/layout/SidebarLayout.tsx
@@ -33,8 +33,6 @@ const QuestionLink = (props: React.HTMLAttributes<HTMLLIElement> & {question: Qu
     const { question, ...rest } = props;
     const subject = useAppSelector(selectors.pageContext.subject);
     const audienceFields = filterAudienceViewsByProperties(determineAudienceViews(question.audience), AUDIENCE_DISPLAY_FIELDS);
-
-    console.log(question.bestAttempt?.correct);
                         
     return <li key={question.id} {...rest} data-bs-theme={getThemeFromContextAndTags(subject, question.tags ?? [])}>
         <Link to={`/questions/${question.id}`} className="py-2">

--- a/src/app/components/elements/markup/markdownRendering.ts
+++ b/src/app/components/elements/markup/markdownRendering.ts
@@ -6,8 +6,9 @@ MARKDOWN_RENDERER.renderer.rules.link_open = function(tokens: Remarkable.LinkOpe
     const href = utils.escapeHtml(tokens[idx].href || "");
     const localLink = href.startsWith(window.location.origin) || href.startsWith("/") || href.startsWith("mailto:") || href.startsWith("#");
     const title = tokens[idx].title ? (' title="' + utils.escapeHtml(utils.replaceEntities(tokens[idx].title || "")) + '"') : '';
+    const conceptIcon = "<i class=\"icon icon-lightbulb\"></i>";
     if (localLink) {
-        return `<a class="a-link" href="${href}" ${title}>`;
+        return `<a class="a-link" href="${href}" ${title}>${isPhy && href.includes("/concepts/") ? conceptIcon : ""}`;
     } else {
         return `<a class="a-link" href="${href}" ${title} target="_blank" rel="noopener nofollow">`;
     }

--- a/src/app/components/pages/Concept.tsx
+++ b/src/app/components/pages/Concept.tsx
@@ -102,8 +102,6 @@ export const Concept = withRouter(({match: {params}, location: {search}, concept
                                 {isAda && doc.relatedContent && <RelatedContent conceptId={conceptId} content={doc.relatedContent} parentPage={doc} />}
 
                                 <NavigationLinks navigation={navigation} />
-
-                                {isPhy && doc.relatedContent && <RelatedContent conceptId={conceptId} content={doc.relatedContent} parentPage={doc} />}
                             </Col>
                         </Row>
                     </MainContent>

--- a/src/app/components/pages/Concept.tsx
+++ b/src/app/components/pages/Concept.tsx
@@ -5,7 +5,7 @@ import {Col, Container, Row} from "reactstrap";
 import {ShowLoading} from "../handlers/ShowLoading";
 import {IsaacContent} from "../content/IsaacContent";
 import {IsaacConceptPageDTO} from "../../../IsaacApiTypes";
-import {DOCUMENT_TYPE, Subject, above, below, usePreviousPageContext, isAda, isPhy, useDeviceSize, useNavigation} from "../../services";
+import {DOCUMENT_TYPE, Subject, above, below, usePreviousPageContext, isAda, isPhy, useDeviceSize, useNavigation, siteSpecific} from "../../services";
 import {DocumentSubject, GameboardContext} from "../../../IsaacAppTypes";
 import {RelatedContent} from "../elements/RelatedContent";
 import {WithFigureNumbering} from "../elements/WithFigureNumbering";
@@ -60,9 +60,9 @@ export const Concept = withRouter(({match: {params}, location: {search}, concept
             <Container data-bs-theme={doc.subjectId ?? pageContext?.subject}>
                 <TitleAndBreadcrumb
                     intermediateCrumbs={navigation.breadcrumbHistory}
-                    currentPageTitle={doc.title as string}
+                    currentPageTitle={siteSpecific("Concept", doc.title as string)}
                     collectionType={navigation.collectionType}
-                    subTitle={doc.subtitle as string}
+                    subTitle={siteSpecific(undefined, doc.subtitle as string)}
                     preview={preview} 
                     icon={{type: "hex", subject: doc.subjectId as Subject, icon: "page-icon-concept"}}
                 />
@@ -73,14 +73,35 @@ export const Concept = withRouter(({match: {params}, location: {search}, concept
                 <SidebarLayout>
                     <ConceptSidebar relatedContent={doc.relatedContent} />
                     <MainContent>
-                        <EditContentButton doc={doc} />
+                        {isPhy && <>
+                            <div className="no-print d-flex align-items-center mt-3">
+                                <div>
+                                    <h2 className="text-theme-dark mb-4"><Markup encoding="latex">{doc.title as string}</Markup></h2>
+                                    {doc.subtitle && <h5 className="text-theme-dark">{doc.subtitle}</h5>}
+                                </div>
+                                <div className="d-flex gap-2 ms-auto">
+                                    <ShareLink linkUrl={`/concepts/${conceptId}${search || ""}`} />
+                                    <PrintButton questionPage />
+                                    <ReportButton pageId={conceptId}/>
+                                </div>
+                            </div>
 
-                        {below["sm"](deviceSize) && <ManageButtons />}
+                            <div className="section-divider"/>
 
-                        <div className="d-flex justify-content-end align-items-center me-sm-1 flex-grow-1">
-                            <UserContextPicker />
-                            {above["md"](deviceSize) && <ManageButtons />}
-                        </div>
+                            <div className="d-flex justify-content-end align-items-center me-sm-1 flex-grow-1">
+                                <EditContentButton doc={doc} />
+                                <UserContextPicker />
+                            </div>
+                        </>}
+
+                        {isAda && <>
+                            {below["sm"](deviceSize) && <ManageButtons />}
+
+                            <div className="d-flex justify-content-end align-items-center me-sm-1 flex-grow-1">
+                                <UserContextPicker />
+                                {above["md"](deviceSize) && <ManageButtons />}
+                            </div>
+                        </>}
 
                         <Row className="concept-content-container">
                             <Col className={classNames("py-4 concept-panel", {"mw-760": isAda})}>

--- a/src/app/components/pages/Concept.tsx
+++ b/src/app/components/pages/Concept.tsx
@@ -81,7 +81,7 @@ export const Concept = withRouter(({match: {params}, location: {search}, concept
                                 </div>
                                 <div className="d-flex gap-2 ms-auto">
                                     <ShareLink linkUrl={`/concepts/${conceptId}${search || ""}`} />
-                                    <PrintButton questionPage />
+                                    <PrintButton />
                                     <ReportButton pageId={conceptId}/>
                                 </div>
                             </div>

--- a/src/app/components/pages/Concepts.tsx
+++ b/src/app/components/pages/Concepts.tsx
@@ -29,7 +29,7 @@ export const Concepts = withRouter((props: RouteComponentProps) => {
     };
     
     const applicableTags = pageContext?.subject ? tags.getDirectDescendents(subjectToTagMap[pageContext.subject]) : tags.allFieldTags;
-    const tagCounts : Record<string, number> = applicableTags.reduce((acc, t) => ({...acc, [t.id]: concepts?.filter(c => c.tags?.includes(t.id)).length || 0}), {});
+    const tagCounts : Record<string, number> = [...applicableTags, ...(pageContext?.subject ? [tags.getById(pageContext?.subject as TAG_ID)] : [])].reduce((acc, t) => ({...acc, [t.id]: concepts?.filter(c => c.tags?.includes(t.id)).length || 0}), {});
 
     useEffect(() => {
         if (pageContext) {
@@ -105,7 +105,7 @@ export const Concepts = withRouter((props: RouteComponentProps) => {
                     : <GenericConceptsSidebar {...sidebarProps}/>
                 }
                 <MainContent>
-                    {isPhy && <div className="list-results-container p-2 mt-4">
+                    {isPhy && <div className="list-results-container p-2 my-4">
                         {shortcutAndFilteredSearchResults && <div className="p-2 py-3">
                             Showing <b>{shortcutAndFilteredSearchResults.length}</b> results
                         </div>}

--- a/src/scss/common/scroll-button.scss
+++ b/src/scss/common/scroll-button.scss
@@ -1,5 +1,6 @@
-button.btn.scroll-btn {
+button.scroll-btn.scroll-btn {
   position: fixed;
+  display: flex;
   opacity: 0;
   height: 45px;
   width: 45px;
@@ -15,8 +16,6 @@ button.btn.scroll-btn {
 
   &.is-sticky {
     opacity: 1;
-    display: flex;
-    // TODO: animate opacity on destruction
   }
   
   > img {

--- a/src/scss/cs/button.scss
+++ b/src/scss/cs/button.scss
@@ -178,42 +178,6 @@
     position: relative;
     z-index: 2;
   }
-  .share-link {
-    z-index: 1;
-    top: 3px;
-    font-family: $secondary-font !important;
-    display: none;
-    position: absolute;
-    border: 1px solid gray;
-    transform: translate(calc(30px - 100%));
-    height: 42px;
-    width: 70%;
-
-    input {
-      z-index: 1;
-      padding-right: 40px;
-      padding-left: 10px;
-      white-space: nowrap;
-      text-overflow: ellipsis;
-      user-select: all;
-      -webkit-user-select: all;
-      -moz-user-select: all;
-      -ms-user-select: all;
-      width: 100%;
-      height: 100%;
-    }
-
-    &.double-height {
-      height: auto;
-      padding-bottom: 10px;
-      background: #fff;
-      text-align: center;
-      input {
-        height: 42px;
-        margin-bottom: 8px;
-      }
-    }
-  }
 }
 
 .print-icon {

--- a/src/scss/cs/questions.scss
+++ b/src/scss/cs/questions.scss
@@ -1,19 +1,18 @@
 @import "../common/questions";
 
-.question-actions-link-box {
-  $x-translation: 24px;
-  margin-left: -$x-translation;
-  float: left;
-  transform: translateX(7.5px + $x-translation);
-  height: 48px; // height of an icon button, should be a variable probably
+.action-buttons-popup-container {
+  position: absolute;
+  height: 100%;
+  right: 30px;
   display: flex;
   flex-direction: column;
   justify-content: center;
   border: 3px solid $secondary;
-  padding-left: 15px;
-  padding-right: 32px;
+  padding-left: 1.5rem;
+  padding-right: 2rem;
   border-top-left-radius: 50px;
   border-bottom-left-radius: 50px;
+  z-index: 2;
   .question-actions-link {
     margin-top: 2px; // Just to vertically center the links nicely
     color: $secondary;
@@ -21,6 +20,53 @@
       margin-left: 7px;
       margin-right: 7px;
     }
+  }
+
+  &:has(> input + a) {
+    flex-direction: row;
+
+    input {
+      width: auto;
+    }
+  }
+
+  a {
+    flex-grow: 1;
+    align-self: center;
+  }
+
+  input {
+    flex-grow: 1;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    user-select: all;
+    -webkit-user-select: all;
+    -moz-user-select: all;
+    -ms-user-select: all;
+    width: 100%;
+    height: 100%;
+    background: none;
+    border: none;
+    outline: none;
+  }
+
+  & ~ .duplicate-and-edit {
+    position: absolute;
+    right: 30px;
+    padding: 24px 24px 0;
+    top: 24px;
+    text-align: center;
+    background: white;
+    border: 1px solid $gray-118;
+    border-radius: 8px;
+    border-top-left-radius: 0;
+    font-size: small;
+    z-index: 1;
+  }
+
+  &.double-height {
+    background: #fff;
+    text-align: center;
   }
 }
 

--- a/src/scss/phy/button.scss
+++ b/src/scss/phy/button.scss
@@ -376,43 +376,41 @@ a.btn {
   background-color: transparent;
 }
 
-.share-link-icon {
+.action-buttons-popup-container {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  width: max-content;
+  height: 100%;
+  right: 50%;
+  align-items: center;
+  border: 1px solid $color-neutral-200;
+  border-radius: 0.5rem;
+  padding: 0 1.5rem 0 1rem;
+  z-index: 15;
+  background: white;
 
-  button {
+  & ~ button {
     position: relative;
-    z-index: 12;
+    z-index: 15;
   }
 
-  .share-link {
-    z-index: 11;
-    font-family: $secondary-font !important;
-    display: none;
-    position: absolute;
-    padding: 4px 32px 4px 8px;
-    transform: translate(calc(25px - 100%), -3px);
-    border: 1px solid $color-neutral-300;
-    background: #fff;
-    height: 58px;
-    width: 70%;
+  input {
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    user-select: all;
+    -webkit-user-select: all;
+    -moz-user-select: all;
+    -ms-user-select: all;
+    width: 100%;
+    height: max-content;
+    border: none;
+    border-bottom: 2px solid $color-neutral-200;
+  }
 
-    input {
-      position: relative;
-      top: 9px;
-      white-space: nowrap;
-      text-overflow: ellipsis;
-      user-select: all;
-      -webkit-user-select: all;
-      -moz-user-select: all;
-      -ms-user-select: all;
-      width: 100%;
-      padding-left: 2px;
-      border: none;
-      border-bottom: 2px solid $color-neutral-200;
-    }
-
-    &.double-height {
-      height: 118px;
-    }
+  &.double-height {
+    height: calc(100% + 38px);
   }
 }
 

--- a/src/scss/phy/questions.scss
+++ b/src/scss/phy/questions.scss
@@ -1,33 +1,5 @@
 @import "../common/questions";
 
-.question-actions {
-  .question-actions-icon {
-    height: 3rem;
-    &:focus {
-      outline: none;
-    }
-  }
-  .question-actions-link-box {
-    float:right;
-    border: 1px solid gray;
-    height: 3.6rem;
-    border-right: none;
-    padding-right: 2.5rem;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    margin-right: -1.9rem;
-    background: white;
-
-    .question-actions-link {
-      padding-left: 3px;
-      padding-right: 3px;
-      margin-left: 1rem;
-      font-style: italic;
-    }
-  }
-}
-
 .question-panel > .content-chunk > .content-value,
 .question-component .question-content {
   font-family: $primary-font;

--- a/src/scss/phy/typography.scss
+++ b/src/scss/phy/typography.scss
@@ -246,5 +246,16 @@ a {
     clear: left;
     text-decoration: none;
   }
+
+  &.a-link:has(> i.icon) {
+    display: inline-flex;
+    align-items: center;
+    font-weight: bold;
+    gap: 4px;
+    > i.icon {
+      order: 1;
+      margin-top: 1px;
+    }
+  }
 }
 


### PR DESCRIPTION
Applies design changes to concept pages.

Note that some changes to concept pages have already been merged owing to the [context overhaul](https://github.com/isaacphysics/isaac-react-app/pull/1341) PR being based off the first half of this commit. The changes here are an extension of these, cleaning up odd bits on the page.

Note that the `a-link` lightbulb icons do not all work in dev, as links to content pages are not seen as local if they start `https://isaacphysics.org/`, as some do. `cp_ang_eq_of_motion` has correct links if you need a page to test.