### PR TITLE
Redesign - start implementing general page sidebars

### DIFF
--- a/src/app/components/elements/layout/SidebarLayout.tsx
+++ b/src/app/components/elements/layout/SidebarLayout.tsx
@@ -1217,21 +1217,14 @@ export const PolicyPageSidebar = () => {
     const history = useHistory();
     const path = useLocation().pathname;
 
-    const pageIdMap: {[path: string]: string} = {
-        "/accessibility": "accessibility_statement",
-        "/privacy": "privacy_policy",
-        "/cookies": "cookie_policy",
-        "/terms": "terms_of_use"
-    };
-
     return <NavigationSidebar>
         <div className="section-divider"/>
         <h5>Select a page</h5>
         <ul>
-            <li><StyledTabPicker checkboxTitle="Accessibility Statement" checked={pageIdMap[path] === "accessibility_statement"} onClick={() => history.push("/accessibility")}/></li>
-            <li><StyledTabPicker checkboxTitle="Privacy Policy" checked={pageIdMap[path] === "privacy_policy"} onClick={() => history.push("/privacy")}/></li>
-            <li><StyledTabPicker checkboxTitle="Cookie Policy" checked={pageIdMap[path] === "cookie_policy"} onClick={() => history.push("/cookies")}/></li>
-            <li><StyledTabPicker checkboxTitle="Terms of Use" checked={pageIdMap[path] === "terms_of_use"} onClick={() => history.push("/terms")}/></li>
+            <li><StyledTabPicker checkboxTitle="Accessibility Statement" checked={path === "/accessibility"} onClick={() => history.push("/accessibility")}/></li>
+            <li><StyledTabPicker checkboxTitle="Privacy Policy" checked={path === "/privacy"} onClick={() => history.push("/privacy")}/></li>
+            <li><StyledTabPicker checkboxTitle="Cookie Policy" checked={path === "/cookies"} onClick={() => history.push("/cookies")}/></li>
+            <li><StyledTabPicker checkboxTitle="Terms of Use" checked={path === "/terms"} onClick={() => history.push("/terms")}/></li>
         </ul>
     </NavigationSidebar>;
 };

--- a/src/app/components/elements/layout/SidebarLayout.tsx
+++ b/src/app/components/elements/layout/SidebarLayout.tsx
@@ -1217,7 +1217,7 @@ export const PolicyPageSidebar = () => {
     const history = useHistory();
     const path = useLocation().pathname;
 
-    return <NavigationSidebar>
+    return <ContentSidebar buttontitle="Select a page">
         <div className="section-divider"/>
         <h5>Select a page</h5>
         <ul>
@@ -1226,5 +1226,5 @@ export const PolicyPageSidebar = () => {
             <li><StyledTabPicker checkboxTitle="Cookie Policy" checked={path === "/cookies"} onClick={() => history.push("/cookies")}/></li>
             <li><StyledTabPicker checkboxTitle="Terms of Use" checked={path === "/terms"} onClick={() => history.push("/terms")}/></li>
         </ul>
-    </NavigationSidebar>;
+    </ContentSidebar>;
 };

--- a/src/app/components/elements/layout/SidebarLayout.tsx
+++ b/src/app/components/elements/layout/SidebarLayout.tsx
@@ -1201,3 +1201,17 @@ export const GlossarySidebar = (props: GlossarySidebarProps) => {
         </>}
     </ContentSidebar>;
 };
+
+export interface PolicyPageSidebarProps extends SidebarProps {
+    currentPageId: string;
+}
+
+export const PolicyPageSidebar = (props: PolicyPageSidebarProps) => {
+    const history = useHistory();
+    return <NavigationSidebar>
+        <StyledTabPicker checkboxTitle="Accessibility Statement" checked={props.currentPageId === "accessibility_statement"} onClick={() => history.push("/accessibility")}/>
+        <StyledTabPicker checkboxTitle="Privacy Policy" checked={props.currentPageId === "privacy_policy"} onClick={() => history.push("/privacy")}/>
+        <StyledTabPicker checkboxTitle="Cookie Policy" checked={props.currentPageId === "cookie_policy"} onClick={() => history.push("/cookies")}/>
+        <StyledTabPicker checkboxTitle="Terms of Use" checked={props.currentPageId === "terms_of_use"} onClick={() => history.push("/terms")}/>
+    </NavigationSidebar>;
+};

--- a/src/app/components/elements/layout/SidebarLayout.tsx
+++ b/src/app/components/elements/layout/SidebarLayout.tsx
@@ -22,6 +22,7 @@ import queryString from "query-string";
 import { EventsPageQueryParams } from "../../pages/Events";
 import { StyledDropdown } from "../inputs/DropdownInput";
 import { StyledSelect } from "../inputs/StyledSelect";
+import { extendUrl } from "../../pages/subjectLandingPageComponents";
 
 export const SidebarLayout = (props: RowProps) => {
     const { className, ...rest } = props;
@@ -136,6 +137,7 @@ export const QuestionSidebar = (props: QuestionSidebarProps) => {
     const relatedConcepts = props.relatedContent?.filter(c => c.type === "isaacConceptPage") as IsaacConceptPageDTO[] | undefined;
     const relatedQuestions = props.relatedContent?.filter(c => c.type === "isaacQuestionPage") as QuestionDTO[] | undefined;
 
+    const pageContext = useAppSelector(selectors.pageContext.context);
     const pageContextStage = useAppSelector(selectors.pageContext.stage);
 
     const [relatedQuestionsForContextStage, relatedQuestionsForOtherStages] = partition(relatedQuestions, q => q.audience && determineAudienceViews(q.audience).some(v => v.stage === pageContextStage));
@@ -143,46 +145,58 @@ export const QuestionSidebar = (props: QuestionSidebarProps) => {
     const sidebarRef = useRef<HTMLDivElement>(null);
 
     return <NavigationSidebar ref={sidebarRef}>
-        {relatedConcepts && relatedConcepts.length > 0 && <>
-            <div className="section-divider"/>
-            <h5>Related concepts</h5>
-            <ul className="link-list">
+        <div className="section-divider"/>
+        <h5>Related concepts</h5>
+        {relatedConcepts && relatedConcepts.length > 0
+            ? <ul className="link-list">
                 {relatedConcepts.map((concept, i) => <ConceptLink key={i} concept={concept} />)}
             </ul>
-        </>}
-        {relatedQuestions && relatedQuestions.length > 0 && <>
-            {!pageContextStage || pageContextStage.length > 1 || relatedQuestionsForContextStage.length === 0 || relatedQuestionsForOtherStages.length === 0
-                ? <>
-                    <div className="section-divider"/>
-                    <h5>Related questions</h5>
-                    <ul className="link-list">
-                        {relatedQuestions.map((question, i) => <QuestionLink key={i} question={question} />)}
-                    </ul>
-                </>
-                : <>
-                    <div className="section-divider"/>
-                    <h5>Related {HUMAN_STAGES[pageContextStage[0]]} questions</h5>
-                    <ul className="link-list">
-                        {relatedQuestionsForContextStage.map((question, i) => <QuestionLink key={i} question={question} />)}
-                    </ul>
-                    <div className="section-divider"/>
-                    <h5>Related questions for other learning stages</h5>
-                    <ul className="link-list">
-                        {relatedQuestionsForOtherStages.map((question, i) => <QuestionLink key={i} question={question} />)}
-                    </ul>
-                </>
-            }
+            : <>
+                There are no related concepts for this question.
+                {isFullyDefinedContext(pageContext) && <AffixButton color="keyline" className="mt-3 w-100" tag={Link} to={extendUrl(pageContext, "concepts")} affix={{affix: "icon-right", position: "suffix", type: "icon"}}>
+                    See all concepts for {getHumanContext(pageContext)}
+                </AffixButton>}
+            </>
+        }
+        <div className="section-divider"/>
+        <h5>Related questions</h5>
+        {relatedQuestions && relatedQuestions.length > 0
+            ? <>
+                {!pageContextStage || pageContextStage.length > 1 || relatedQuestionsForContextStage.length === 0 || relatedQuestionsForOtherStages.length === 0
+                    ? <>
+                        <ul className="link-list">
+                            {relatedQuestions.map((question, i) => <QuestionLink key={i} question={question} />)}
+                        </ul>
+                    </>
+                    : <>
+                        <div className="section-divider"/>
+                        <h5>Related {HUMAN_STAGES[pageContextStage[0]]} questions</h5>
+                        <ul className="link-list">
+                            {relatedQuestionsForContextStage.map((question, i) => <QuestionLink key={i} question={question} />)}
+                        </ul>
+                        <div className="section-divider"/>
+                        <h5>Related questions for other learning stages</h5>
+                        <ul className="link-list">
+                            {relatedQuestionsForOtherStages.map((question, i) => <QuestionLink key={i} question={question} />)}
+                        </ul>
+                    </>
+                }
+                <div className="section-divider"/>
+                <div className="d-flex flex-column sidebar-key">
+                    Key
+                    <KeyItem icon="status-in-progress" text="Question in progress"/>
+                    <KeyItem icon="status-correct" text="Question completed correctly"/>
+                    <KeyItem icon="status-incorrect" text="Question completed incorrectly"/>
+                </div>
 
-            <div className="section-divider"/>
-
-            <div className="d-flex flex-column sidebar-key">
-                Key
-                <KeyItem icon="status-in-progress" text="Question in progress"/>
-                <KeyItem icon="status-correct" text="Question completed correctly"/>
-                <KeyItem icon="status-incorrect" text="Question completed incorrectly"/>
-            </div>
-
-        </>}
+            </>
+            : <>
+                There are no related questions for this question.
+                {isFullyDefinedContext(pageContext) && <AffixButton color="keyline" className="mt-3 w-100" tag={Link} to={extendUrl(pageContext, "questions")} affix={{affix: "icon-right", position: "suffix", type: "icon"}}>
+                    See all questions for {getHumanContext(pageContext)}
+                </AffixButton>}
+            </>
+        }
     </NavigationSidebar>;
 };
 

--- a/src/app/components/elements/layout/SidebarLayout.tsx
+++ b/src/app/components/elements/layout/SidebarLayout.tsx
@@ -1202,13 +1202,26 @@ export const GlossarySidebar = (props: GlossarySidebarProps) => {
     </ContentSidebar>;
 };
 
-export interface PolicyPageSidebarProps extends SidebarProps {
+
+export const GenericPageSidebar = () => {
+    // Default sidebar for general pages that don't have a custom sidebar
+    return <ContentSidebar buttonTitle="Options">
+        <div className="section-divider"/>
+        <AffixButton color="keyline" tag={Link} to={"/"} affix={{affix: "icon-right", position: "suffix", type: "icon"}}>
+            Go to homepage
+        </AffixButton>
+    </ContentSidebar>;
+};
+
+interface PolicyPageSidebarProps extends SidebarProps {
     currentPageId: string;
 }
 
 export const PolicyPageSidebar = (props: PolicyPageSidebarProps) => {
     const history = useHistory();
     return <NavigationSidebar>
+        <div className="section-divider"/>
+        <h5>Select a page</h5>
         <StyledTabPicker checkboxTitle="Accessibility Statement" checked={props.currentPageId === "accessibility_statement"} onClick={() => history.push("/accessibility")}/>
         <StyledTabPicker checkboxTitle="Privacy Policy" checked={props.currentPageId === "privacy_policy"} onClick={() => history.push("/privacy")}/>
         <StyledTabPicker checkboxTitle="Cookie Policy" checked={props.currentPageId === "cookie_policy"} onClick={() => history.push("/cookies")}/>

--- a/src/app/components/elements/layout/SidebarLayout.tsx
+++ b/src/app/components/elements/layout/SidebarLayout.tsx
@@ -1222,9 +1222,11 @@ export const PolicyPageSidebar = (props: PolicyPageSidebarProps) => {
     return <NavigationSidebar>
         <div className="section-divider"/>
         <h5>Select a page</h5>
-        <StyledTabPicker checkboxTitle="Accessibility Statement" checked={props.currentPageId === "accessibility_statement"} onClick={() => history.push("/accessibility")}/>
-        <StyledTabPicker checkboxTitle="Privacy Policy" checked={props.currentPageId === "privacy_policy"} onClick={() => history.push("/privacy")}/>
-        <StyledTabPicker checkboxTitle="Cookie Policy" checked={props.currentPageId === "cookie_policy"} onClick={() => history.push("/cookies")}/>
-        <StyledTabPicker checkboxTitle="Terms of Use" checked={props.currentPageId === "terms_of_use"} onClick={() => history.push("/terms")}/>
+        <ul>
+            <li><StyledTabPicker checkboxTitle="Accessibility Statement" checked={props.currentPageId === "accessibility_statement"} onClick={() => history.push("/accessibility")}/></li>
+            <li><StyledTabPicker checkboxTitle="Privacy Policy" checked={props.currentPageId === "privacy_policy"} onClick={() => history.push("/privacy")}/></li>
+            <li><StyledTabPicker checkboxTitle="Cookie Policy" checked={props.currentPageId === "cookie_policy"} onClick={() => history.push("/cookies")}/></li>
+            <li><StyledTabPicker checkboxTitle="Terms of Use" checked={props.currentPageId === "terms_of_use"} onClick={() => history.push("/terms")}/></li>
+        </ul>
     </NavigationSidebar>;
 };

--- a/src/app/components/elements/layout/SidebarLayout.tsx
+++ b/src/app/components/elements/layout/SidebarLayout.tsx
@@ -6,7 +6,7 @@ import { AssignmentDTO, ContentSummaryDTO, IsaacConceptPageDTO, QuestionDTO, Qui
 import { above, ACCOUNT_TAB, ACCOUNT_TABS, AUDIENCE_DISPLAY_FIELDS, below, BOARD_ORDER_NAMES, BoardCompletions, BoardCreators, BoardLimit, BoardSubjects, BoardViews, confirmThen, determineAudienceViews, EventStageMap, EventStatusFilter, EventTypeFilter, filterAssignmentsByStatus, filterAudienceViewsByProperties, getDistinctAssignmentGroups, getDistinctAssignmentSetters, getHumanContext, getThemeFromContextAndTags, HUMAN_STAGES, ifKeyIsEnter, isAda, isDefined, PHY_NAV_SUBJECTS, isTeacherOrAbove, QuizStatus, siteSpecific, TAG_ID, tags, STAGE, useDeviceSize, LearningStage, HUMAN_SUBJECTS, ArrayElement, isFullyDefinedContext, isSingleStageContext, Item, stageLabelMap } from "../../../services";
 import { StageAndDifficultySummaryIcons } from "../StageAndDifficultySummaryIcons";
 import { selectors, useAppSelector, useGetQuizAssignmentsAssignedToMeQuery } from "../../../state";
-import { Link, useHistory } from "react-router-dom";
+import { Link, useHistory, useLocation } from "react-router-dom";
 import { AppGroup, AssignmentBoardOrder, PageContextState, Tag } from "../../../../IsaacAppTypes";
 import { AffixButton } from "../AffixButton";
 import { QuestionFinderFilterPanel, QuestionFinderFilterPanelProps } from "../panels/QuestionFinderFilterPanel";
@@ -1213,20 +1213,25 @@ export const GenericPageSidebar = () => {
     </ContentSidebar>;
 };
 
-interface PolicyPageSidebarProps extends SidebarProps {
-    currentPageId: string;
-}
-
-export const PolicyPageSidebar = (props: PolicyPageSidebarProps) => {
+export const PolicyPageSidebar = () => {
     const history = useHistory();
+    const path = useLocation().pathname;
+
+    const pageIdMap: {[path: string]: string} = {
+        "/accessibility": "accessibility_statement",
+        "/privacy": "privacy_policy",
+        "/cookies": "cookie_policy",
+        "/terms": "terms_of_use"
+    };
+
     return <NavigationSidebar>
         <div className="section-divider"/>
         <h5>Select a page</h5>
         <ul>
-            <li><StyledTabPicker checkboxTitle="Accessibility Statement" checked={props.currentPageId === "accessibility_statement"} onClick={() => history.push("/accessibility")}/></li>
-            <li><StyledTabPicker checkboxTitle="Privacy Policy" checked={props.currentPageId === "privacy_policy"} onClick={() => history.push("/privacy")}/></li>
-            <li><StyledTabPicker checkboxTitle="Cookie Policy" checked={props.currentPageId === "cookie_policy"} onClick={() => history.push("/cookies")}/></li>
-            <li><StyledTabPicker checkboxTitle="Terms of Use" checked={props.currentPageId === "terms_of_use"} onClick={() => history.push("/terms")}/></li>
+            <li><StyledTabPicker checkboxTitle="Accessibility Statement" checked={pageIdMap[path] === "accessibility_statement"} onClick={() => history.push("/accessibility")}/></li>
+            <li><StyledTabPicker checkboxTitle="Privacy Policy" checked={pageIdMap[path] === "privacy_policy"} onClick={() => history.push("/privacy")}/></li>
+            <li><StyledTabPicker checkboxTitle="Cookie Policy" checked={pageIdMap[path] === "cookie_policy"} onClick={() => history.push("/cookies")}/></li>
+            <li><StyledTabPicker checkboxTitle="Terms of Use" checked={pageIdMap[path] === "terms_of_use"} onClick={() => history.push("/terms")}/></li>
         </ul>
     </NavigationSidebar>;
 };

--- a/src/app/components/pages/Generic.tsx
+++ b/src/app/components/pages/Generic.tsx
@@ -16,7 +16,7 @@ import {WithFigureNumbering} from "../elements/WithFigureNumbering";
 import {MetaDescription} from "../elements/MetaDescription";
 import classNames from "classnames";
 import { useUntilFound } from "./Glossary";
-import { MainContent, PolicyPageSidebar, PolicyPageSidebarProps, SidebarLayout } from "../elements/layout/SidebarLayout";
+import { MainContent, SidebarLayout, GenericPageSidebar, PolicyPageSidebar } from "../elements/layout/SidebarLayout";
 
 interface GenericPageComponentProps {
     pageIdOverride?: string;
@@ -31,7 +31,9 @@ const CS_FULL_WIDTH_OVERRIDE: {[pageId: string]: boolean | undefined} = {
     "computer_science_stories": true
 };
 
-const PHY_SIDEBAR: {[pageId: string]: ((props: PolicyPageSidebarProps) => React.JSX.Element)} = {
+// Overrides for physics pages which shouldn't use the default GenericPageSidebar
+// TODO this should also consider page tags (for events/news etc)
+const PHY_SIDEBAR: {[pageId: string]: ((props: any) => React.JSX.Element)} = {
     "privacy_policy": PolicyPageSidebar,
     "terms_of_use": PolicyPageSidebar,
     "cookie_policy": PolicyPageSidebar,
@@ -59,40 +61,32 @@ export const Generic = withRouter(({pageIdOverride, match: {params}}: GenericPag
 
     return <ShowLoading until={doc} thenRender={supertypedDoc => {
         const doc = supertypedDoc as IsaacQuestionPageDTO & DocumentSubject;
-
-        const PageContent = () => {
-            return <>
-                <div className="no-print d-flex align-items-center">
-                    <EditContentButton doc={doc} />
-                    <div className="question-actions question-actions-leftmost mt-3">
-                        <ShareLink linkUrl={`/pages/${doc.id}`}/>
-                    </div>
-                    <div className="question-actions mt-3 not-mobile">
-                        <PrintButton/>
-                    </div>
-                </div>
-
-                <Row className="generic-content-container">
-                    <Col className={classNames("py-4 generic-panel", {"mw-760": isAda && !CS_FULL_WIDTH_OVERRIDE[pageId]})}>
-                        <WithFigureNumbering doc={doc}>
-                            <IsaacContent doc={doc} />
-                        </WithFigureNumbering>
-                    </Col>
-                </Row>
-            </>;};
-
+        
         return <Container data-bs-theme={doc.subjectId}>
-            <TitleAndBreadcrumb currentPageTitle={doc.title as string} subTitle={doc.subtitle} />
+            <TitleAndBreadcrumb currentPageTitle={doc.title as string} subTitle={doc.subtitle} /> {/* TODO add page icon, replace main title with "General"?? */}
             <MetaDescription description={doc.summary} />
+            <SidebarLayout>
+                {PHY_SIDEBAR[pageId] ? PHY_SIDEBAR[pageId]({currentPageId: pageId}) : <GenericPageSidebar/>}
+                <MainContent>
+                    <div className="no-print d-flex align-items-center">
+                        <EditContentButton doc={doc} />
+                        <div className="question-actions question-actions-leftmost mt-3">
+                            <ShareLink linkUrl={`/pages/${doc.id}`}/>
+                        </div>
+                        <div className="question-actions mt-3 not-mobile">
+                            <PrintButton/>
+                        </div>
+                    </div>
 
-            {PHY_SIDEBAR[pageId]
-                ? <SidebarLayout>
-                    {PHY_SIDEBAR[pageId]({currentPageId: pageId})}
-                    <MainContent>
-                        <PageContent />
-                    </MainContent>
-                </SidebarLayout>
-                : <PageContent />}
+                    <Row className="generic-content-container">
+                        <Col className={classNames("py-4 generic-panel", {"mw-760": isAda && !CS_FULL_WIDTH_OVERRIDE[pageId]})}>
+                            <WithFigureNumbering doc={doc}>
+                                <IsaacContent doc={doc} />
+                            </WithFigureNumbering>
+                        </Col>
+                    </Row>
+                </MainContent>
+            </SidebarLayout>
 
             {doc.relatedContent && <RelatedContent content={doc.relatedContent} parentPage={doc} />}
         </Container>;

--- a/src/app/components/pages/Generic.tsx
+++ b/src/app/components/pages/Generic.tsx
@@ -4,7 +4,7 @@ import {AppState, fetchDoc, useAppDispatch, useAppSelector} from "../../state";
 import {IsaacQuestionPageDTO} from "../../../IsaacApiTypes";
 import {ShowLoading} from "../handlers/ShowLoading";
 import {IsaacContent} from "../content/IsaacContent";
-import {DOCUMENT_TYPE, isAda, useUrlHashValue} from "../../services";
+import {DOCUMENT_TYPE, isAda, isDefined, useUrlHashValue} from "../../services";
 import {withRouter} from "react-router-dom";
 import {RelatedContent} from "../elements/RelatedContent";
 import {DocumentSubject} from "../../../IsaacAppTypes";
@@ -33,12 +33,11 @@ const CS_FULL_WIDTH_OVERRIDE: {[pageId: string]: boolean | undefined} = {
 
 // Overrides for physics pages which shouldn't use the default GenericPageSidebar
 // TODO this should also consider page tags (for events/news etc)
-const PHY_SIDEBAR: {[pageId: string]: (() => React.JSX.Element)} = {
-    "privacy_policy": PolicyPageSidebar,
-    "terms_of_use": PolicyPageSidebar,
-    "cookie_policy": PolicyPageSidebar,
-    "accessibility_statement": PolicyPageSidebar
-};
+const PHY_SIDEBAR = new Map<string, () => React.JSX.Element>();
+PHY_SIDEBAR.set("privacy_policy", PolicyPageSidebar);
+PHY_SIDEBAR.set("terms_of_use", PolicyPageSidebar);
+PHY_SIDEBAR.set("cookie_policy", PolicyPageSidebar);
+PHY_SIDEBAR.set("accessibility_statement", PolicyPageSidebar);
 
 export const Generic = withRouter(({pageIdOverride, match: {params}}: GenericPageComponentProps) => {
     const pageId = pageIdOverride || params.pageId;
@@ -66,7 +65,7 @@ export const Generic = withRouter(({pageIdOverride, match: {params}}: GenericPag
             <TitleAndBreadcrumb currentPageTitle={doc.title as string} subTitle={doc.subtitle} /> {/* TODO add page icon, replace main title with "General"?? */}
             <MetaDescription description={doc.summary} />
             <SidebarLayout>
-                {PHY_SIDEBAR[pageId] ? PHY_SIDEBAR[pageId]() : <GenericPageSidebar/>}
+                {isDefined(PHY_SIDEBAR.get(pageId)) ? PHY_SIDEBAR.get(pageId)!() : <GenericPageSidebar/>}
                 <MainContent>
                     <div className="no-print d-flex align-items-center">
                         <EditContentButton doc={doc} />

--- a/src/app/components/pages/Generic.tsx
+++ b/src/app/components/pages/Generic.tsx
@@ -33,7 +33,7 @@ const CS_FULL_WIDTH_OVERRIDE: {[pageId: string]: boolean | undefined} = {
 
 // Overrides for physics pages which shouldn't use the default GenericPageSidebar
 // TODO this should also consider page tags (for events/news etc)
-const PHY_SIDEBAR: {[pageId: string]: ((props: any) => React.JSX.Element)} = {
+const PHY_SIDEBAR: {[pageId: string]: (() => React.JSX.Element)} = {
     "privacy_policy": PolicyPageSidebar,
     "terms_of_use": PolicyPageSidebar,
     "cookie_policy": PolicyPageSidebar,
@@ -66,7 +66,7 @@ export const Generic = withRouter(({pageIdOverride, match: {params}}: GenericPag
             <TitleAndBreadcrumb currentPageTitle={doc.title as string} subTitle={doc.subtitle} /> {/* TODO add page icon, replace main title with "General"?? */}
             <MetaDescription description={doc.summary} />
             <SidebarLayout>
-                {PHY_SIDEBAR[pageId] ? PHY_SIDEBAR[pageId]({currentPageId: pageId}) : <GenericPageSidebar/>}
+                {PHY_SIDEBAR[pageId] ? PHY_SIDEBAR[pageId]() : <GenericPageSidebar/>}
                 <MainContent>
                     <div className="no-print d-flex align-items-center">
                         <EditContentButton doc={doc} />

--- a/src/app/components/pages/Generic.tsx
+++ b/src/app/components/pages/Generic.tsx
@@ -33,12 +33,11 @@ const CS_FULL_WIDTH_OVERRIDE: {[pageId: string]: boolean | undefined} = {
 
 // Overrides for physics pages which shouldn't use the default GenericPageSidebar
 // TODO this should also consider page tags (for events/news etc)
-const PHY_SIDEBAR: {[pageId: string]: (() => React.JSX.Element)} = {
-    "privacy_policy": PolicyPageSidebar,
-    "terms_of_use": PolicyPageSidebar,
-    "cookie_policy": PolicyPageSidebar,
-    "accessibility_statement": PolicyPageSidebar
-};
+const PHY_SIDEBAR = new Map<string, () => React.JSX.Element>();
+PHY_SIDEBAR.set("privacy_policy", PolicyPageSidebar);
+PHY_SIDEBAR.set("terms_of_use", PolicyPageSidebar);
+PHY_SIDEBAR.set("cookie_policy", PolicyPageSidebar);
+PHY_SIDEBAR.set("accessibility_statement", PolicyPageSidebar);
 
 export const Generic = withRouter(({pageIdOverride, match: {params}}: GenericPageComponentProps) => {
     const pageId = pageIdOverride || params.pageId;
@@ -66,7 +65,7 @@ export const Generic = withRouter(({pageIdOverride, match: {params}}: GenericPag
             <TitleAndBreadcrumb currentPageTitle={doc.title as string} subTitle={doc.subtitle} /> {/* TODO add page icon, replace main title with "General"?? */}
             <MetaDescription description={doc.summary} />
             <SidebarLayout>
-                {PHY_SIDEBAR[pageId] ? PHY_SIDEBAR[pageId]() : <GenericPageSidebar/>}
+                {PHY_SIDEBAR.has(pageId) ? PHY_SIDEBAR.get(pageId)!() : <GenericPageSidebar/>}
                 <MainContent>
                     <div className="no-print d-flex align-items-center">
                         <EditContentButton doc={doc} />

--- a/src/app/components/pages/Generic.tsx
+++ b/src/app/components/pages/Generic.tsx
@@ -4,7 +4,7 @@ import {AppState, fetchDoc, useAppDispatch, useAppSelector} from "../../state";
 import {IsaacQuestionPageDTO} from "../../../IsaacApiTypes";
 import {ShowLoading} from "../handlers/ShowLoading";
 import {IsaacContent} from "../content/IsaacContent";
-import {DOCUMENT_TYPE, isAda, isDefined, useUrlHashValue} from "../../services";
+import {DOCUMENT_TYPE, isAda, useUrlHashValue} from "../../services";
 import {withRouter} from "react-router-dom";
 import {RelatedContent} from "../elements/RelatedContent";
 import {DocumentSubject} from "../../../IsaacAppTypes";
@@ -33,11 +33,12 @@ const CS_FULL_WIDTH_OVERRIDE: {[pageId: string]: boolean | undefined} = {
 
 // Overrides for physics pages which shouldn't use the default GenericPageSidebar
 // TODO this should also consider page tags (for events/news etc)
-const PHY_SIDEBAR = new Map<string, () => React.JSX.Element>();
-PHY_SIDEBAR.set("privacy_policy", PolicyPageSidebar);
-PHY_SIDEBAR.set("terms_of_use", PolicyPageSidebar);
-PHY_SIDEBAR.set("cookie_policy", PolicyPageSidebar);
-PHY_SIDEBAR.set("accessibility_statement", PolicyPageSidebar);
+const PHY_SIDEBAR: {[pageId: string]: (() => React.JSX.Element)} = {
+    "privacy_policy": PolicyPageSidebar,
+    "terms_of_use": PolicyPageSidebar,
+    "cookie_policy": PolicyPageSidebar,
+    "accessibility_statement": PolicyPageSidebar
+};
 
 export const Generic = withRouter(({pageIdOverride, match: {params}}: GenericPageComponentProps) => {
     const pageId = pageIdOverride || params.pageId;
@@ -65,7 +66,7 @@ export const Generic = withRouter(({pageIdOverride, match: {params}}: GenericPag
             <TitleAndBreadcrumb currentPageTitle={doc.title as string} subTitle={doc.subtitle} /> {/* TODO add page icon, replace main title with "General"?? */}
             <MetaDescription description={doc.summary} />
             <SidebarLayout>
-                {isDefined(PHY_SIDEBAR.get(pageId)) ? PHY_SIDEBAR.get(pageId)!() : <GenericPageSidebar/>}
+                {PHY_SIDEBAR[pageId] ? PHY_SIDEBAR[pageId]() : <GenericPageSidebar/>}
                 <MainContent>
                     <div className="no-print d-flex align-items-center">
                         <EditContentButton doc={doc} />

--- a/src/app/components/pages/Generic.tsx
+++ b/src/app/components/pages/Generic.tsx
@@ -33,11 +33,12 @@ const CS_FULL_WIDTH_OVERRIDE: {[pageId: string]: boolean | undefined} = {
 
 // Overrides for physics pages which shouldn't use the default GenericPageSidebar
 // TODO this should also consider page tags (for events/news etc)
-const PHY_SIDEBAR = new Map<string, () => React.JSX.Element>();
-PHY_SIDEBAR.set("privacy_policy", PolicyPageSidebar);
-PHY_SIDEBAR.set("terms_of_use", PolicyPageSidebar);
-PHY_SIDEBAR.set("cookie_policy", PolicyPageSidebar);
-PHY_SIDEBAR.set("accessibility_statement", PolicyPageSidebar);
+const PHY_SIDEBAR = new Map<string, () => React.JSX.Element>([
+    ["privacy_policy", PolicyPageSidebar],
+    ["terms_of_use", PolicyPageSidebar],
+    ["cookie_policy", PolicyPageSidebar],
+    ["accessibility_statement", PolicyPageSidebar]
+]);
 
 export const Generic = withRouter(({pageIdOverride, match: {params}}: GenericPageComponentProps) => {
     const pageId = pageIdOverride || params.pageId;

--- a/src/app/components/pages/subjectLandingPageComponents.ts
+++ b/src/app/components/pages/subjectLandingPageComponents.ts
@@ -3,7 +3,7 @@ import { BookInfo, getHumanContext, interleave, ISAAC_BOOKS, isFullyDefinedConte
 import { ListViewTagProps } from "../elements/list-groups/AbstractListViewItem";
 import { ListViewCardProps } from "../elements/list-groups/ListView";
 
-const extendUrl = (context: NonNullable<Required<PageContextState>>, page: string) => {
+export const extendUrl = (context: NonNullable<Required<PageContextState>>, page: string) => {
     return `/${context.subject}/${context.stage}/${page}`;
 };
 


### PR DESCRIPTION
- Add sidebars to general pages
    - For the accessibility/policy pages this is fully implemented
    - For all other general pages this is just a link to the homepage, pending a decision on what should go here
- Add "no related content" messages to question sidebars