### PR TITLE
Fix assignment modal bug

### DIFF
--- a/src/app/services/gameboards.tsx
+++ b/src/app/services/gameboards.tsx
@@ -205,10 +205,10 @@ export enum BoardLimit {
 }
 
 export const BOARD_ORDER_NAMES: {[key in AssignmentBoardOrder]: string} = {
-    "created": "Date created (oldest first)",
-    "-created": "Date created (recent first)",
-    "visited": "Date visited (oldest first)",
-    "-visited": "Date visited (recent first)",
+    "created": "Date created (recent first)",
+    "-created": "Date created (oldest first)",
+    "visited": "Date visited (recent first)",
+    "-visited": "Date visited (oldest first)",
     "title": "Title (A-Z)",
     "-title": "Title (Z-A)",
     "attempted": "Attempted (lowest first)",
@@ -235,7 +235,7 @@ export const useGameboards = (initialView: BoardViews, initialLimit: BoardLimit)
     const [ loadGameboards ] = useLazyGetGameboardsQuery();
     const boards = useAppSelector(selectors.boards.boards);
 
-    const [boardOrder, setBoardOrder] = useState<AssignmentBoardOrder>(AssignmentBoardOrder["-visited"]);
+    const [boardOrder, setBoardOrder] = useState<AssignmentBoardOrder>(AssignmentBoardOrder.visited);
     const [boardView, setBoardView] = useState<BoardViews>((boards && boards.boards.length > 6) ? BoardViews.table : initialView);
     const [boardLimit, setBoardLimit] = useState<BoardLimit>(initialLimit);
     const [boardTitleFilter, setBoardTitleFilter] = useState<string>("");
@@ -309,7 +309,7 @@ export const useGameboards = (initialView: BoardViews, initialLimit: BoardLimit)
         const boardOrderNegative = boardOrder.at(0) == "-";
         const boardOrderKind = (boardOrderNegative ? boardOrder.slice(1) : boardOrder) as "created" | "visited" | "attempted" | "correct" | "title";
         const orderedBoards = sortBy(boards?.boards, BOARD_SORT_FUNCTIONS[boardOrderKind]);
-        if (["-visited", "-created", "-attempted", "-correct", "-title"].includes(boardOrder)) orderedBoards.reverse();
+        if (["visited", "created", "-attempted", "-correct", "-title"].includes(boardOrder)) orderedBoards.reverse();
         return {
             totalResults: boards?.totalResults ?? 0,
             boards: orderedBoards


### PR DESCRIPTION
Context: After creating a new gameboard and clicking "set as assignment", the assignment setting modal was not opening.

Explanation: When "set as assignment" is clicked, the ID of the new gameboard is stored in a hash anchor. The modal then works by taking the first 6 gameboards from the `useGameboards` hook and checking their IDs against the hash anchor to determine which gameboard to use. This previously worked because `useGameboards` returned gameboards sorted most-recent-first, so the just-created gameboard is always among the 6 returned. A previous change on the redesign branch reversed the order in which gameboards are returned, so the ID in the hash anchor was not found if the user had > 6 gameboards and no modal appeared.

The solution proposed here is just to revert the sorting changes to how it works on master. If we want to keep the new sorting logic, we could alternatively remove the 6-gameboard limit and search all of a user's gameboards for the hash anchor ID, but for users with many gameboards this would be lots of extra requests.