### PR TITLE
Improvement/autofill assignment due

### DIFF
--- a/config/jest/jest.config.common.js
+++ b/config/jest/jest.config.common.js
@@ -4,6 +4,7 @@ module.exports = {
         "!src/**/*.d.ts"
     ],
     "resolver": "jest-pnp-resolver",
+    globalSetup: "<rootDir>/src/test/globalSetup.ts",
     setupFiles: [
         "<rootDir>/config/jest/jest.polyfills.js"
     ],

--- a/src/app/components/elements/inputs/DateInput.tsx
+++ b/src/app/components/elements/inputs/DateInput.tsx
@@ -260,6 +260,6 @@ export const DateInput = (props: DateInputProps) => {
             </div>
             {(props.noClear === undefined || !props.noClear) && <Button close {...controlPropsWithValidationStripped} className="mx-1" aria-label={`Clear date${props.labelSuffix ? props.labelSuffix : ""}`} onClick={clear} />}
         </InputGroup>
-        <Input innerRef={hiddenRef} type="hidden" name={props.name} value={calculateHiddenValue()} {...controlProps} />
+        <Input data-testid='date-input' innerRef={hiddenRef} type="hidden" name={props.name} value={calculateHiddenValue()} {...controlProps} />
     </React.Fragment>;
 };

--- a/src/app/components/pages/AssignmentSchedule.tsx
+++ b/src/app/components/pages/AssignmentSchedule.tsx
@@ -53,7 +53,8 @@ import {
     TAG_LEVEL,
     tags,
     TODAY,
-    useDeviceSize
+    useDeviceSize,
+    UTC_MIDNIGHT_IN_SIX_DAYS
 } from "../../services";
 import {
     AppGroup,
@@ -415,7 +416,7 @@ const AssignmentModal = ({user, showSetAssignmentUI, toggleSetAssignmentUI, assi
             // Create from scratch
             setSelectedGameboard(undefined);
             setScheduledStartDate(undefined);
-            setDueDate(undefined);
+            setDueDate(UTC_MIDNIGHT_IN_SIX_DAYS);
             setAssignmentNotes(undefined);
         }
     }, [assignmentToCopy]);
@@ -432,8 +433,8 @@ const AssignmentModal = ({user, showSetAssignmentUI, toggleSetAssignmentUI, assi
         })).then((result) => {
             if (assignGameboard.fulfilled.match(result)) {
                 setSelectedGroups([]);
-                setDueDate(undefined);
                 setScheduledStartDate(undefined);
+                setDueDate(UTC_MIDNIGHT_IN_SIX_DAYS);
                 setAssignmentNotes('');
             }
             // Fails silently if assignGameboard throws an error - we let it handle opening toasts for errors
@@ -506,11 +507,9 @@ const AssignmentModal = ({user, showSetAssignmentUI, toggleSetAssignmentUI, assi
             <DateInput value={dueDate} placeholder="Select your due date..." yearRange={yearRange}
                 onChange={(e: ChangeEvent<HTMLInputElement>) => setDueDate(e.target.valueAsDate as Date)}
             />
+            {!dueDate && <small className={"pt-2 text-danger"}>Since January 2025, due dates are required for assignments.</small>}
             {dueDateInvalid && <small className={"pt-2 text-danger"}>Due date must be on or after start date.</small>}
         </Label>
-        <Alert color={siteSpecific("warning", "info")} className="py-1">
-            Since January 2025, due dates are required for assignments.
-        </Alert>
         {isStaff(user) && <Label className="w-100 pb-2">Notes (optional):
             <Input type="textarea"
                 spellCheck={true}

--- a/src/app/components/pages/SetAssignments.tsx
+++ b/src/app/components/pages/SetAssignments.tsx
@@ -179,10 +179,10 @@ const SetAssignmentsModal = (props: SetAssignmentsModalProps) => {
         }
     }
 
-    const description = siteSpecific(
-        "Manage assignment of groups to the selected gameboard",
-        "Select a group to which to assign the quiz"
-    );
+    const description = `${siteSpecific(
+        "Manage assignment of groups to the selected gameboard.",
+        "Select a group to which to assign the quiz."
+    )} Scheduled assignments appear to students on the morning of the day chosen. If no start date is selected, assignments appear immediately. Assignments are due by the end of the day indicated.`;
 
     return <Modal isOpen={isOpen} data-testid={"set-assignment-modal"} toggle={toggle}>
         <ModalHeader data-testid={"modal-header"} role={"heading"} className={"text-break d-flex justify-content-between"} close={
@@ -211,7 +211,7 @@ const SetAssignmentsModal = (props: SetAssignmentsModalProps) => {
             <div className="py-2">
                 <Label>Pending {siteSpecific("assignments", "quiz assignments")}: <span className="icon-help mx-1" id={`pending-assignments-help-${board?.id}`}/></Label>
                 <UncontrolledTooltip placement="left" autohide={false} target={`pending-assignments-help-${board?.id}`}>
-                    {siteSpecific("Assignments", "Quizzes")} that are scheduled to begin at a future date. Once the start date passes, students
+                    {siteSpecific("Assignments", "Quizzes")} that are scheduled to begin at a future date. On the morning of the start date, students
                     will be able to see the {siteSpecific("assignment", "quiz")}, and will receive a notification email.
                 </UncontrolledTooltip>
                 {scheduledAssignees.length > 0

--- a/src/app/components/pages/SetAssignments.tsx
+++ b/src/app/components/pages/SetAssignments.tsx
@@ -90,7 +90,7 @@ const AssignGroup = ({groups, board}: AssignGroupProps) => {
         dispatch(assignGameboard({boardId: board?.id as string, groups: selectedGroups, dueDate, scheduledStartDate, notes: assignmentNotes, userId: user?.id})).then(success => {
             if (success) {
                 setSelectedGroups([]);
-                setDueDate(undefined);
+                setDueDate(UTC_MIDNIGHT_IN_SIX_DAYS);
                 setScheduledStartDate(undefined);
                 setAssignmentNotes('');
             }

--- a/src/app/components/pages/SetAssignments.tsx
+++ b/src/app/components/pages/SetAssignments.tsx
@@ -179,10 +179,8 @@ const SetAssignmentsModal = (props: SetAssignmentsModalProps) => {
         }
     }
 
-    const description = `${siteSpecific(
-        "Manage assignment of groups to the selected gameboard.",
-        "Select a group to which to assign the quiz."
-    )} Scheduled assignments appear to students on the morning of the day chosen. If no start date is selected, assignments appear immediately. Assignments are due by the end of the day indicated.`;
+    const description = "Scheduled assignments appear to students on the morning of the day chosen, otherwise assignments appear immediately. " +
+        "Assignments are due by the end of the day indicated.";
 
     return <Modal isOpen={isOpen} data-testid={"set-assignment-modal"} toggle={toggle}>
         <ModalHeader data-testid={"modal-header"} role={"heading"} className={"text-break d-flex justify-content-between"} close={
@@ -211,7 +209,7 @@ const SetAssignmentsModal = (props: SetAssignmentsModalProps) => {
             <div className="py-2">
                 <Label>Pending {siteSpecific("assignments", "quiz assignments")}: <span className="icon-help mx-1" id={`pending-assignments-help-${board?.id}`}/></Label>
                 <UncontrolledTooltip placement="left" autohide={false} target={`pending-assignments-help-${board?.id}`}>
-                    {siteSpecific("Assignments", "Quizzes")} that are scheduled to begin at a future date. On the morning of the start date, students
+                    These {siteSpecific("assignments", "quizzes")} are scheduled to begin at a future date. On the morning of the scheduled date, students
                     will be able to see the {siteSpecific("assignment", "quiz")}, and will receive a notification email.
                 </UncontrolledTooltip>
                 {scheduledAssignees.length > 0

--- a/src/app/components/pages/SetAssignments.tsx
+++ b/src/app/components/pages/SetAssignments.tsx
@@ -74,9 +74,16 @@ interface AssignGroupProps {
     groups: UserGroupDTO[];
     board: GameboardDTO | undefined;
 }
+
+const weekFromNow = () => {
+    const now = new Date(Date.now());
+    now.setDate(now.getDate() + 6);
+    return now;
+};
+
 const AssignGroup = ({groups, board}: AssignGroupProps) => {
     const [selectedGroups, setSelectedGroups] = useState<Item<number>[]>([]);
-    const [dueDate, setDueDate] = useState<Date>();
+    const [dueDate, setDueDate] = useState<Date | undefined>(weekFromNow);
     const [scheduledStartDate, setScheduledStartDate] = useState<Date>();
     const [assignmentNotes, setAssignmentNotes] = useState<string>();
     const user = useAppSelector(selectors.user.loggedInOrNull);
@@ -111,7 +118,7 @@ const AssignGroup = ({groups, board}: AssignGroupProps) => {
     }
 
     return <Container className="py-2">
-        <Label className="w-100 pb-2">Group(s):
+        <Label data-testid="modal-groups-selector" className="w-100 pb-2">Group(s):
             <StyledSelect inputId="groups-to-assign" isMulti isClearable placeholder="None"
                 value={selectedGroups}
                 closeMenuOnSelect={false}

--- a/src/app/components/pages/SetAssignments.tsx
+++ b/src/app/components/pages/SetAssignments.tsx
@@ -58,7 +58,8 @@ import {
     siteSpecific,
     useDeviceSize,
     useGameboards,
-    TODAY
+    TODAY,
+    UTC_MIDNIGHT_IN_SIX_DAYS
 } from "../../services";
 import {IsaacSpinner, Loading} from "../handlers/IsaacSpinner";
 import {GameboardDTO, RegisteredUserDTO, UserGroupDTO} from "../../../IsaacApiTypes";
@@ -75,15 +76,9 @@ interface AssignGroupProps {
     board: GameboardDTO | undefined;
 }
 
-const weekFromNow = () => {
-    const now = new Date(Date.now());
-    now.setDate(now.getDate() + 6);
-    return now;
-};
-
 const AssignGroup = ({groups, board}: AssignGroupProps) => {
     const [selectedGroups, setSelectedGroups] = useState<Item<number>[]>([]);
-    const [dueDate, setDueDate] = useState<Date | undefined>(weekFromNow);
+    const [dueDate, setDueDate] = useState<Date | undefined>(UTC_MIDNIGHT_IN_SIX_DAYS);
     const [scheduledStartDate, setScheduledStartDate] = useState<Date>();
     const [assignmentNotes, setAssignmentNotes] = useState<string>();
     const user = useAppSelector(selectors.user.loggedInOrNull);

--- a/src/app/components/pages/SetAssignments.tsx
+++ b/src/app/components/pages/SetAssignments.tsx
@@ -129,12 +129,9 @@ const AssignGroup = ({groups, board}: AssignGroupProps) => {
         <Label className="w-100 pb-2">Due date reminder
             <DateInput value={dueDate} placeholder="Select your due date..." yearRange={yearRange}
                 onChange={(e: ChangeEvent<HTMLInputElement>) => setDueDate(e.target.valueAsDate as Date)} /> {/* DANGER here with force-casting Date|null to Date */}
+            {!dueDate && <small className={"pt-2 text-danger"}>Since {siteSpecific("Jan", "January")} 2025, due dates are required for assignments.</small>}
             {dueDateInvalid && <small className={"pt-2 text-danger"}>Due date must be on or after start date and in the future.</small>}
-            {dueDateInvalid && startDateInvalid && <br/>}
         </Label>
-        <Alert color={siteSpecific("warning", "info")} className="py-1 px-2">
-            Since {siteSpecific("Jan", "January")} 2025, due dates are required for assignments.
-        </Alert>
         {isEventLeaderOrStaff(user) && <Label className="w-100 pb-2">Notes (optional):
             <Input type="textarea"
                 spellCheck={true}

--- a/src/app/services/dates.ts
+++ b/src/app/services/dates.ts
@@ -9,7 +9,7 @@ export const TODAY = () => {
 };
 
 export const UTC_MIDNIGHT_IN_SIX_DAYS = () => {
-    return addUtcDays(6, nthUtcHourOf(0, new Date(Date.now())));
+    return addDays(6, nthUtcHourOf(0, new Date(Date.now())));
 };
 
 export const MONTH_NAMES = [ "January", "February", "March", "April", "May", "June",
@@ -21,8 +21,8 @@ export const nthUtcHourOf = (n: number, d: Date | number) => {
     return newDate;
 };
 
-const addUtcDays = (days: number, date: Date, ) => {
+const addDays = (days: number, date: Date, ) => {
     const newDate = new Date(date.valueOf());
-    newDate.setUTCDate(date.getUTCDate() + days);
+    newDate.setDate(date.getDate() + days);
     return newDate;
 };

--- a/src/app/services/dates.ts
+++ b/src/app/services/dates.ts
@@ -5,8 +5,24 @@ export const nthHourOf = (n: number, d: Date | number) => {
 };
 
 export const TODAY = () => {
-    return nthHourOf(0, new Date());
+    return nthHourOf(0, new Date(Date.now()));
+};
+
+export const UTC_MIDNIGHT_IN_SIX_DAYS = () => {
+    return addUtcDays(6, nthUtcHourOf(0, new Date(Date.now())));
 };
 
 export const MONTH_NAMES = [ "January", "February", "March", "April", "May", "June",
     "July", "August", "September", "October", "November", "December" ];
+
+export const nthUtcHourOf = (n: number, d: Date | number) => {
+    const newDate = new Date(d.valueOf());
+    newDate.setUTCHours(n, 0, 0, 0);
+    return newDate;
+};
+
+const addUtcDays = (days: number, date: Date, ) => {
+    const newDate = new Date(date.valueOf());
+    newDate.setUTCDate(date.getUTCDate() + days);
+    return newDate;
+};

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -255,3 +255,9 @@ export const buildFunctionHandler = <T extends string, V extends JsonBodyType>(p
         return HttpResponse.json(fn(params), { status: 200, });
     });
 };
+export const buildPostHandler = <T, V extends JsonBodyType>(path: string, fn: (p: T) => V) => {
+    return http.post(API_PATH + path, async ({ request }) => {
+        const body = await request.json() as T;
+        return HttpResponse.json(fn(body), { status: 200, });
+    });
+};

--- a/src/test/environment.test.ts
+++ b/src/test/environment.test.ts
@@ -1,0 +1,5 @@
+describe('Testing environment', () => {
+    it('is set to the Europe/London timezone', () => {
+        expect(new Date("2025-04-01").getTimezoneOffset()).toEqual(-60);
+    });
+});

--- a/src/test/globalSetup.ts
+++ b/src/test/globalSetup.ts
@@ -1,0 +1,3 @@
+module.exports = () => {
+    process.env.TZ = 'Europe/London';
+};

--- a/src/test/pages/SetAssignments.test.tsx
+++ b/src/test/pages/SetAssignments.test.tsx
@@ -234,6 +234,13 @@ describe("SetAssignments", () => {
             });
         });
 
+        it('due date is displayed in UTC', async () => {
+            await withMockedDate(Date.parse("2025-04-28T23:30:00.000Z"), async () => { // Monday in UTC, already Tuesday in UTC+1.
+                renderModal();
+                expect(await dateInput("Due date reminder")).toHaveValue('2025-05-04'); // Sunday in UTC (would be Monday if we showed UTC+1)
+            });
+        });
+
         const testPostedDueDate = ({ currentTime, expectedDueDatePosted } : { currentTime: string, expectedDueDatePosted: string}) => async () => {
             await withMockedDate(Date.parse(currentTime), async () => { // Monday
                 const observer = parameterObserver<AssignmentDTO[]>();
@@ -256,7 +263,7 @@ describe("SetAssignments", () => {
             { currentTime: "2025-01-30T09:00:00.000Z" /* Monday */, expectedDueDatePosted: "2025-02-05T00:00:00.000Z" /* Sunday */ }
         ));
 
-        it('posts the default due date as UTC midnight, even when the current time zone offset is non-zero', testPostedDueDate(
+        it('posts the default due date as UTC midnight, even when local representation does not equal UTC', testPostedDueDate(
             { currentTime: "2025-04-28" /* Monday */, expectedDueDatePosted: "2025-05-04T00:00:00.000Z" /* Sunday */ }
         ));
     });

--- a/src/test/pages/SetAssignments.test.tsx
+++ b/src/test/pages/SetAssignments.test.tsx
@@ -3,10 +3,12 @@ import userEvent from "@testing-library/user-event";
 import {SetAssignments} from "../../app/components/pages/SetAssignments";
 import {mockActiveGroups, mockGameboards, mockSetAssignments} from "../../mocks/data";
 import {dayMonthYearStringToDate, DDMMYYYY_REGEX, ONE_DAY_IN_MS, SOME_FIXED_FUTURE_DATE} from "../dateUtils";
-import {renderTestEnvironment, withMockedDate} from "../testUtils";
+import {clickButton, renderTestEnvironment, withMockedDate} from "../testUtils";
 
 import {API_PATH, isAda, isPhy, PATHS, siteSpecific} from "../../app/services";
-import {DefaultRequestMultipartBody, http, HttpResponse} from "msw";
+import { http, HttpHandler, HttpResponse } from "msw";
+import { AssignmentDTO } from "../../IsaacApiTypes";
+import { buildPostHandler } from "../../mocks/handlers";
 
 const expectedPhysicsTopLinks = {
     "our books": null,
@@ -16,10 +18,11 @@ const expectedPhysicsTopLinks = {
 
 describe("SetAssignments", () => {
 
-    const renderSetAssignments = (path = PATHS.SET_ASSIGNMENTS) => {
+    const renderSetAssignments = ({path = PATHS.SET_ASSIGNMENTS, endpoints = []}: { endpoints?: HttpHandler[], path?: string } = {}) => {
         renderTestEnvironment({
             PageComponent: SetAssignments,
-            initalRouteEntries: [path]
+            initalRouteEntries: [path],
+            extraEndpoints: endpoints
         });
     };
 
@@ -124,20 +127,16 @@ describe("SetAssignments", () => {
     });
 
     it('should let you assign a gameboard in card view (using the modal)', async () => {
-        let requestGroupIds: string[];
-        let requestAssignment: {gameboardId: string, scheduledStartDate?: any, dueDate?: any, notes?: string};
-        renderTestEnvironment({
-            PageComponent: SetAssignments,
-            initalRouteEntries: [PATHS.MY_ASSIGNMENTS],
-            extraEndpoints: [
-                http.post(API_PATH + "/assignments/assign_bulk", async ({request}) => {
-                    const json = await request.json() as Record<string, any> | DefaultRequestMultipartBody;
-                    requestGroupIds = json?.map((x: any) => x.groupId);
-                    requestAssignment = json[0];
-                    return HttpResponse.json(json.map((x: any) => ({groupId: x.groupId, assignmentId: x.groupId * 2})), {
-                        status: 200,
-                    });
-                })
+        const requestGroupIds = (body: AssignmentDTO[]) => body?.map((x) => x.groupId!);
+        const requestAssignment = (body: AssignmentDTO[]) => body[0];
+        const observer = parameterObserver<AssignmentDTO[]>();
+
+        renderSetAssignments({
+            endpoints: [
+                buildPostHandler(
+                    "/assignments/assign_bulk",
+                    observer.attach(body => body.map(x => ({ groupId: x.groupId, assignmentId: x.groupId! * 2 })))
+                ), 
             ]
         });
         if (!isPhy) {
@@ -156,15 +155,12 @@ describe("SetAssignments", () => {
         const modal = await screen.findByTestId("set-assignment-modal");
         expect(modal).toHaveModalTitle(mockGameboard.title);
         // Ensure all active groups are selectable in the drop-down
-        const selectContainer = within(modal).getByText(/Group(\(s\))?:/);
-        const selectBox = within(modal).getByLabelText(/Group(\(s\))?:/);
-        await userEvent.click(selectBox);
+        const groupSelector = await toggleGroupSelect();
         mockActiveGroups.forEach(g => {
-            expect(selectContainer.textContent).toContain(g.groupName);
+            expect(groupSelector.textContent).toContain(g.groupName);
         });
         // Pick the second active group
-        const group1Choice = within(selectContainer).getByText(mockActiveGroups[1].groupName);
-        await userEvent.click(group1Choice);
+        await selectGroup(mockActiveGroups[1].groupName);
 
         // Check scheduled start date and due date are there
         within(modal).getByLabelText("Schedule an assignment start date", {exact: false});
@@ -186,16 +182,15 @@ describe("SetAssignments", () => {
         expect(allAssignments[0].textContent).toContain(mockActiveGroups[0].groupName);
 
         // Click button
-        const assignButton = within(modal).getByRole("button", {name: "Assign to group"});
-        await userEvent.click(assignButton);
+        await clickButton('Assign to group', Promise.resolve(modal));
 
         // Expect request to be sent off with expected parameters
         await waitFor(() => {
-            expect(requestGroupIds).toEqual([mockActiveGroups[1].id]);
-            expect(requestAssignment.gameboardId).toEqual(mockGameboard.id);
-            expect(requestAssignment.notes).toEqual(testNotes);
-            expect(requestAssignment.dueDate).toBeDefined();
-            expect(requestAssignment.scheduledStartDate).not.toBeDefined();
+            expect(requestGroupIds(observer.observedParams!)).toEqual([mockActiveGroups[1].id]);
+            expect(requestAssignment(observer.observedParams!).gameboardId).toEqual(mockGameboard.id);
+            expect(requestAssignment(observer.observedParams!).notes).toEqual(testNotes);
+            expect(requestAssignment(observer.observedParams!).dueDate).toBeDefined();
+            expect(requestAssignment(observer.observedParams!).scheduledStartDate).not.toBeDefined();
         });
 
         // Check that new assignment is displayed in the modal
@@ -219,32 +214,51 @@ describe("SetAssignments", () => {
 
     describe('modal', () => {
         const mockGameboard = mockGameboards.results[0];
-        const renderModal = () => renderSetAssignments(`${PATHS.SET_ASSIGNMENTS}#${mockGameboard.id}`); 
-        const modal = () => screen.findByTestId("set-assignment-modal");
-        const dateInput = async (labelText: string | RegExp) => {
-            const label = await within(await modal()).findByText(labelText);
-            return await within(label).findByTestId('date-input');
-        };
+        const renderModal = (endpoints: HttpHandler[] = []) => renderSetAssignments({ path: `${PATHS.SET_ASSIGNMENTS}#${mockGameboard.id}`, endpoints}); 
 
-        describe('default values', () => {
-            it('groups are empty', async () => {
-                renderModal();
-                const select = await within(await modal()).findByTestId('modal-groups-selector');
-                expect(select).toHaveTextContent('Group(s):None');
-            });
+        it('groups are empty', async () => {
+            renderModal();
+            const select = await within(await modal()).findByTestId('modal-groups-selector');
+            expect(select).toHaveTextContent('Group(s):None');
+        });
     
-            it('start date is empty', async () => {
-                renderModal();
-                expect(await dateInput(/Schedule an assignment start date/)).toHaveValue('');
-            });
+        it('start date is empty', async () => {
+            renderModal();
+            expect(await dateInput(/Schedule an assignment start date/)).toHaveValue('');
+        });
             
-            it('due date is a week from now', async() => {
-                await withMockedDate(Date.parse("2025-01-30"), async () => { // Monday
-                    renderModal();
-                    expect(await dateInput("Due date reminder")).toHaveValue('2025-02-05'); // Sunday
-                });
+        it('due date is a week from now', async() => {
+            await withMockedDate(Date.parse("2025-01-30"), async () => { // Monday
+                renderModal();
+                expect(await dateInput("Due date reminder")).toHaveValue('2025-02-05'); // Sunday
             });
         });
+
+        const testPostedDueDate = ({ currentTime, expectedDueDatePosted } : { currentTime: string, expectedDueDatePosted: string}) => async () => {
+            await withMockedDate(Date.parse(currentTime), async () => { // Monday
+                const observer = parameterObserver<AssignmentDTO[]>();
+                renderModal([
+                    buildPostHandler(
+                        "/assignments/assign_bulk",
+                        observer.attach(body => body.map(x => ({ groupId: x.groupId, assignmentId: x.groupId! * 2 })))
+                    )
+                ]);
+
+                await toggleGroupSelect();
+                await selectGroup(mockActiveGroups[1].groupName);
+                await clickButton('Assign to group', modal());
+
+                await waitFor(() => expect(observer.observedParams![0].dueDate).toEqual(expectedDueDatePosted)); // Sunday
+            });
+        };
+
+        it('posts the default due date as UTC midnight, even when that is not exactly 24 hours away', testPostedDueDate(
+            { currentTime: "2025-01-30T09:00:00.000Z" /* Monday */, expectedDueDatePosted: "2025-02-05T00:00:00.000Z" /* Sunday */ }
+        ));
+
+        it('posts the default due date as UTC midnight, even when the current time zone offset is non-zero', testPostedDueDate(
+            { currentTime: "2025-04-28" /* Monday */, expectedDueDatePosted: "2025-05-04T00:00:00.000Z" /* Sunday */ }
+        ));
     });
 
     it('should let you unassign a gameboard', async () => {
@@ -352,4 +366,33 @@ describe("SetAssignments", () => {
             expect(groupsAssignedHexagon.textContent?.replace(" ", "")).toEqual("1group");
         });
     });
+});
+
+const modal = () => screen.findByTestId("set-assignment-modal");
+
+const dateInput = async (labelText: string | RegExp) => {
+    const label = await within(await modal()).findByText(labelText);
+    return await within(label).findByTestId('date-input');
+};
+
+const toggleGroupSelect = async () => {
+    const selectBox = within(await modal()).getByLabelText(/Group(\(s\))?:/);
+    await userEvent.click(selectBox);
+    return within(await modal()).getByText(/Group(\(s\))?:/);;
+};
+
+const selectGroup = async (groupName: string) => {
+    const selectContainer = within(await modal()).getByText(/Group(\(s\))?:/);
+    const group1Choice = within(selectContainer).getByText(groupName);
+    await userEvent.click(group1Choice);
+};
+
+const parameterObserver = <T,>() => ({
+    observedParams: null as T | null,
+    attach<U>(fn: (p: T)=> U) {
+        return (p: T) => {
+            this.observedParams = p;
+            return fn(p);
+        }; 
+    }
 });

--- a/src/test/pages/SetAssignments.test.tsx
+++ b/src/test/pages/SetAssignments.test.tsx
@@ -167,7 +167,8 @@ describe("SetAssignments", () => {
         const dueDateContainer = within(modal).getByLabelText("Due date reminder", {exact: false});
         // TODO check setting scheduled start date and due date leads to correctly saved values,
         //  since this currently just checks any form of due date is set.
-        await userEvent.selectOptions(dueDateContainer, "1");
+        await clearDateInput("Due date reminder"); // get rid of default due date
+        await userEvent.selectOptions(dueDateContainer, "1"); // set some due date
 
         // Add some notes
         const testNotes = "Test notes to test groups for test assignments";
@@ -234,6 +235,7 @@ describe("SetAssignments", () => {
             });
         });
 
+        // assumes local time zone is Europe/London
         it('due date is displayed in UTC', async () => {
             await withMockedDate(Date.parse("2025-04-28T23:30:00.000Z"), async () => { // Monday in UTC, already Tuesday in UTC+1.
                 renderModal();
@@ -263,6 +265,7 @@ describe("SetAssignments", () => {
             { currentTime: "2025-01-30T09:00:00.000Z" /* Monday */, expectedDueDatePosted: "2025-02-05T00:00:00.000Z" /* Sunday */ }
         ));
 
+        // assumes local time zone is Europe/London
         it('posts the default due date as UTC midnight, even when local representation does not equal UTC', testPostedDueDate(
             { currentTime: "2025-04-28" /* Monday */, expectedDueDatePosted: "2025-05-04T00:00:00.000Z" /* Sunday */ }
         ));
@@ -380,6 +383,12 @@ const modal = () => screen.findByTestId("set-assignment-modal");
 const dateInput = async (labelText: string | RegExp) => {
     const label = await within(await modal()).findByText(labelText);
     return await within(label).findByTestId('date-input');
+};
+
+const clearDateInput = async (labelText: string) => {
+    const container = await within(await modal()).findByText(labelText);
+    const clearButton = await within(container).findByRole('button');
+    await userEvent.click(clearButton);
 };
 
 const toggleGroupSelect = async () => {

--- a/src/test/pages/SetAssignments.test.tsx
+++ b/src/test/pages/SetAssignments.test.tsx
@@ -287,6 +287,19 @@ describe("SetAssignments", () => {
                 expect(await dateInput("Due date reminder")).toHaveValue('2025-02-05'); // Sunday
             });
         });
+
+        describe('validation', () => {
+            it('shows an error message when the due date is missing', async () => {
+                renderModal();
+                await clearDateInput("Due date reminder");
+                expect(await findByText("Due date reminder")).toHaveTextContent(`Since ${siteSpecific("Jan", "Januaryt")} 2025, due dates are required for assignments`);
+            });
+
+            it('does not show an error when the due date is present', async () => {
+                renderModal();
+                expect(await findByText("Due date reminder")).not.toHaveTextContent(`due dates are required for assignments`);
+            });
+        });
     });
 
     it('should let you unassign a gameboard', async () => {
@@ -398,14 +411,12 @@ describe("SetAssignments", () => {
 
 const modal = () => screen.findByTestId("set-assignment-modal");
 
-const dateInput = async (labelText: string | RegExp) => {
-    const label = await within(await modal()).findByText(labelText);
-    return await within(label).findByTestId('date-input');
-};
+const findByText = async (labelText: string | RegExp) => await within(await modal()).findByText(labelText);
+
+const dateInput = async (labelText: string | RegExp) => await within(await findByText(labelText)).findByTestId('date-input');
 
 const clearDateInput = async (labelText: string) => {
-    const container = await within(await modal()).findByText(labelText);
-    const clearButton = await within(container).findByRole('button');
+    const clearButton = await within(await findByText(labelText)).findByRole('button');
     await userEvent.click(clearButton);
 };
 

--- a/src/test/pages/SetAssignments.test.tsx
+++ b/src/test/pages/SetAssignments.test.tsx
@@ -234,7 +234,7 @@ describe("SetAssignments", () => {
             });
         });
 
-        // local time zone should be Europe/London
+        // local time zone is Europe/London, as set in globalSetup.ts
         it('due date is displayed in UTC', async () => {
             await withMockedDate(Date.parse("2025-04-28T23:30:00.000Z"), async () => { // Monday in UTC, already Tuesday in UTC+1.
                 renderModal();
@@ -264,7 +264,7 @@ describe("SetAssignments", () => {
             { currentTime: "2025-01-30T09:00:00.000Z" /* Monday */, expectedDueDatePosted: "2025-02-05T00:00:00.000Z" /* Sunday */ }
         ));
 
-        // local time zone should be Europe/London
+        // local time zone is Europe/London, as set in globalSetup.ts
         it('posts the default due date as UTC midnight, even when local representation does not equal UTC', testPostedDueDate(
             { currentTime: "2025-04-28" /* Monday */, expectedDueDatePosted: "2025-05-04T00:00:00.000Z" /* Sunday */ }
         ));

--- a/src/test/pages/SetAssignments.test.tsx
+++ b/src/test/pages/SetAssignments.test.tsx
@@ -292,7 +292,7 @@ describe("SetAssignments", () => {
             it('shows an error message when the due date is missing', async () => {
                 renderModal();
                 await clearDateInput("Due date reminder");
-                expect(await findByText("Due date reminder")).toHaveTextContent(`Since ${siteSpecific("Jan", "Januaryt")} 2025, due dates are required for assignments`);
+                expect(await findByText("Due date reminder")).toHaveTextContent(`Since ${siteSpecific("Jan", "January")} 2025, due dates are required for assignments`);
             });
 
             it('does not show an error when the due date is present', async () => {

--- a/src/test/testUtils.tsx
+++ b/src/test/testUtils.tsx
@@ -181,3 +181,12 @@ export const withMockedRandom = async (fn: (randomSequence: (n: number[]) => voi
         jest.spyOn(miscUtils, 'nextRandom').mockRestore();
     }
 };
+
+export const withMockedDate = async (date: number, fn: () => Promise<void>) => {
+    try {
+        jest.spyOn(global.Date, 'now').mockImplementation(() => new Date(date).valueOf());
+        await fn();
+    } finally {
+        jest.spyOn(global.Date, 'now').mockRestore();
+    }
+};


### PR DESCRIPTION
On the `Set assignment` modal, the due date now has a default value, which is set to 6 days from now. This way, an assignment set on Monday will be due by the end of Sunday.

I've included new notice text on the modal to clarify when during the day an assignment becomes available and when it's due. I've also moved the notice about due date now being a required field. It is now a validation message that we only show when the due date is empty.

There is a different version of this page, available through the `Assignment schedule` page, just for Physics. That page populates the fields from an existing assignment. I did not overwrite these fields with the default, but introduced the default on this page also for when an assignment is successfully set and the option is presented to set a second assignment with defaults. This page has no user guidance and I did not introduce that text here. However, I did convert the warning about due date now being required to a validation error on this page as well.