### PR TITLE
Use slices for API interaction in concepts

### DIFF
--- a/src/app/components/pages/Concept.tsx
+++ b/src/app/components/pages/Concept.tsx
@@ -1,11 +1,11 @@
-import React, {useEffect} from "react";
+import React from "react";
 import {withRouter} from "react-router-dom";
-import {AppState, fetchDoc, selectors, useAppDispatch, useAppSelector} from "../../state";
+import {selectors, useAppSelector} from "../../state";
 import {Col, Container, Row} from "reactstrap";
 import {ShowLoading} from "../handlers/ShowLoading";
 import {IsaacContent} from "../content/IsaacContent";
 import {IsaacConceptPageDTO} from "../../../IsaacApiTypes";
-import {DOCUMENT_TYPE, Subject, above, below, usePreviousPageContext, isAda, isPhy, useDeviceSize, useNavigation, siteSpecific} from "../../services";
+import {Subject, above, below, usePreviousPageContext, isAda, isPhy, useDeviceSize, useNavigation, siteSpecific} from "../../services";
 import {DocumentSubject, GameboardContext} from "../../../IsaacAppTypes";
 import {RelatedContent} from "../elements/RelatedContent";
 import {WithFigureNumbering} from "../elements/WithFigureNumbering";
@@ -24,6 +24,7 @@ import {ReportButton} from "../elements/ReportButton";
 import classNames from "classnames";
 import { ConceptSidebar, MainContent, SidebarLayout } from "../elements/layout/SidebarLayout";
 import { TeacherNotes } from "../elements/TeacherNotes";
+import { useGetConceptQuery } from "../../state/slices/api/conceptsApi";
 
 interface ConceptPageProps {
     conceptIdOverride?: string;
@@ -33,15 +34,13 @@ interface ConceptPageProps {
 }
 
 export const Concept = withRouter(({match: {params}, location: {search}, conceptIdOverride, preview}: ConceptPageProps) => {
-    const dispatch = useAppDispatch();
     const conceptId = conceptIdOverride || params.conceptId;
     const user = useAppSelector(selectors.user.orNull);
-    useEffect(() => {dispatch(fetchDoc(DOCUMENT_TYPE.CONCEPT, conceptId));}, [conceptId]);
-    const doc = useAppSelector((state: AppState) => state?.doc || null);
-    const navigation = useNavigation(doc);
+    const {data: doc, isLoading} = useGetConceptQuery(conceptId);
+    const navigation = useNavigation(doc ?? null);
     const deviceSize = useDeviceSize();
 
-    const pageContext = usePreviousPageContext(user && user.loggedIn && user.registeredContexts || undefined, doc && doc !== 404 ? doc : undefined);
+    const pageContext = usePreviousPageContext(user && user.loggedIn && user.registeredContexts || undefined, doc && !isLoading ? doc : undefined);
 
     const ManageButtons = () => <div className={classNames("no-print d-flex justify-content-end mt-1 ms-2", {"gap-2": isPhy})}>
         <div className="question-actions">

--- a/src/app/components/pages/Concepts.tsx
+++ b/src/app/components/pages/Concepts.tsx
@@ -1,9 +1,8 @@
 import React, {FormEvent, MutableRefObject, useEffect, useRef, useState} from "react";
 import {RouteComponentProps, withRouter} from "react-router-dom";
-import {AppState, fetchConcepts, selectors, useAppDispatch, useAppSelector} from "../../state";
+import {selectors, useAppSelector} from "../../state";
 import {Badge, Card, CardBody, CardHeader, Container} from "reactstrap";
 import queryString from "query-string";
-import {ShowLoading} from "../handlers/ShowLoading";
 import {isAda, isPhy, matchesAllWordsInAnyOrder, pushConceptsToHistory, searchResultIsPublic, shortcuts, TAG_ID, tags} from "../../services";
 import {generateSubjectLandingPageCrumbFromContext, TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
 import {ShortcutResponse, Tag} from "../../../IsaacAppTypes";
@@ -12,14 +11,17 @@ import { ListView } from "../elements/list-groups/ListView";
 import { ContentTypeVisibility, LinkToContentSummaryList } from "../elements/list-groups/ContentSummaryListGroupItem";
 import { SubjectSpecificConceptListSidebar, MainContent, SidebarLayout, GenericConceptsSidebar } from "../elements/layout/SidebarLayout";
 import { isFullyDefinedContext, useUrlPageTheme } from "../../services/pageContext";
+import { useListConceptsQuery } from "../../state/slices/api/conceptsApi";
+import { ShowLoadingQuery } from "../handlers/ShowLoadingQuery";
+import { ContentSummaryDTO } from "../../../IsaacApiTypes";
 
 // This component is Isaac Physics only (currently)
 export const Concepts = withRouter((props: RouteComponentProps) => {
     const {location, history} = props;
-    const dispatch = useAppDispatch();
     const user = useAppSelector(selectors.user.orNull);
-    const concepts = useAppSelector((state: AppState) => state?.concepts?.results || null);
     const pageContext = useUrlPageTheme();
+
+    const listConceptsQuery = useListConceptsQuery({conceptIds: undefined, tagIds: pageContext?.subject});
 
     const subjectToTagMap = {
         physics: TAG_ID.physics,
@@ -29,13 +31,8 @@ export const Concepts = withRouter((props: RouteComponentProps) => {
     };
     
     const applicableTags = pageContext?.subject ? tags.getDirectDescendents(subjectToTagMap[pageContext.subject]) : tags.allFieldTags;
-    const tagCounts : Record<string, number> = [...applicableTags, ...(pageContext?.subject ? [tags.getById(pageContext?.subject as TAG_ID)] : [])].reduce((acc, t) => ({...acc, [t.id]: concepts?.filter(c => c.tags?.includes(t.id)).length || 0}), {});
-
-    useEffect(() => {
-        if (pageContext) {
-            dispatch(fetchConcepts(undefined, pageContext?.subject));
-        }
-    }, [dispatch, pageContext]);
+    
+    const tagCounts : Record<string, number> = [...applicableTags, ...(pageContext?.subject ? [tags.getById(pageContext?.subject as TAG_ID)] : [])].reduce((acc, t) => ({...acc, [t.id]: listConceptsQuery?.data?.results?.filter(c => c.tags?.includes(t.id)).length || 0}), {});
 
     const searchParsed = queryString.parse(location.search);
 
@@ -76,17 +73,21 @@ export const Concepts = withRouter((props: RouteComponentProps) => {
 
     useEffect(() => {doSearch();}, [conceptFilters]);
 
-    const searchResults = concepts
-        ?.filter(c =>
-            matchesAllWordsInAnyOrder(c.title, searchText || "") ||
-            matchesAllWordsInAnyOrder(c.summary, searchText || "")
-        );
+    const shortcutAndFilter = (concepts?: ContentSummaryDTO[]) => {
+        const searchResults = concepts
+            ?.filter(c =>
+                matchesAllWordsInAnyOrder(c.title, searchText || "") ||
+                matchesAllWordsInAnyOrder(c.summary, searchText || "")
+            );
+    
+        const filteredSearchResults = searchResults
+            ?.filter((result) => result?.tags?.some(t => filters.includes(t)))
+            .filter((result) => searchResultIsPublic(result, user));
+    
+        const shortcutAndFilteredSearchResults = (shortcutResponse || []).concat(filteredSearchResults || []);
 
-    const filteredSearchResults = searchResults
-        ?.filter((result) => result?.tags?.some(t => filters.includes(t)))
-        .filter((result) => searchResultIsPublic(result, user));
-
-    const shortcutAndFilteredSearchResults = (shortcutResponse || []).concat(filteredSearchResults || []);
+        return shortcutAndFilteredSearchResults;
+    };
 
     const crumb = isPhy && isFullyDefinedContext(pageContext) && generateSubjectLandingPageCrumbFromContext(pageContext);
 
@@ -106,14 +107,25 @@ export const Concepts = withRouter((props: RouteComponentProps) => {
                 }
                 <MainContent>
                     {isPhy && <div className="list-results-container p-2 my-4">
-                        {shortcutAndFilteredSearchResults && <div className="p-2 py-3">
-                            Showing <b>{shortcutAndFilteredSearchResults.length}</b> results
-                        </div>}
+                        <ShowLoadingQuery
+                            query={listConceptsQuery}
+                            thenRender={({results: concepts}) => {
 
-                        {shortcutAndFilteredSearchResults
-                            ? <ListView items={shortcutAndFilteredSearchResults}/>
-                            : <em>No results found</em>
-                        }
+                                const shortcutAndFilteredSearchResults = shortcutAndFilter(concepts);
+
+                                return <>
+                                    {!!shortcutAndFilteredSearchResults.length && <div className="p-2 py-3">
+                                        Showing <b>{shortcutAndFilteredSearchResults.length}</b> results
+                                    </div>}
+            
+                                    {shortcutAndFilteredSearchResults.length
+                                        ? <ListView items={shortcutAndFilteredSearchResults}/>
+                                        : <em>No results found</em>
+                                    }
+                                </>;
+                            }}
+                            defaultErrorTitle="Error fetching concepts"
+                        />
                     </div>
                     }
                     
@@ -122,22 +134,31 @@ export const Concepts = withRouter((props: RouteComponentProps) => {
                             <h3>
                                 <span className="d-none d-sm-inline-block">Search&nbsp;</span>Results 
                                 {query !== "" 
-                                    ? shortcutAndFilteredSearchResults 
-                                        ? <Badge color="primary">{shortcutAndFilteredSearchResults.length}</Badge> 
+                                    ? (listConceptsQuery?.data?.totalResults) 
+                                        ? <Badge color="primary">{listConceptsQuery?.data?.totalResults}</Badge> 
                                         : <IsaacSpinner /> 
                                     : null
                                 }
                             </h3>
                         </CardHeader>
                         <CardBody className="px-2">
-                            <ShowLoading until={shortcutAndFilteredSearchResults}>
-                                {shortcutAndFilteredSearchResults ?
-                                    <LinkToContentSummaryList 
-                                        items={shortcutAndFilteredSearchResults} showBreadcrumb={false} 
-                                        contentTypeVisibility={ContentTypeVisibility.ICON_ONLY}
-                                    />
-                                    : <em>No results found</em>}
-                            </ShowLoading>
+                            <ShowLoadingQuery
+                                query={listConceptsQuery}
+                                thenRender={({results: concepts}) => {
+
+                                    const shortcutAndFilteredSearchResults = shortcutAndFilter(concepts);
+
+                                    return <>
+                                        {shortcutAndFilteredSearchResults ?
+                                            <LinkToContentSummaryList 
+                                                items={shortcutAndFilteredSearchResults} showBreadcrumb={false} 
+                                                contentTypeVisibility={ContentTypeVisibility.ICON_ONLY}
+                                            />
+                                            : <em>No results found</em>}
+                                    </>;
+                                }}
+                                defaultErrorTitle="Error fetching concepts"
+                            />
                         </CardBody>
                     </Card>}
                 </MainContent>

--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -177,16 +177,6 @@ export const api = {
             return endpoint.post("/questions/test?type=isaacFreeTextQuestion", {userDefinedChoices, testCases});
         }
     },
-    concepts: {
-        list: (conceptIds?: string, tagIds?: string): AxiosPromise<Concepts> => {
-            return endpoint.get('/pages/concepts', {
-                params: { limit: 999 , ids: conceptIds, tags: tagIds }
-            });
-        },
-        get: (id: string): AxiosPromise<ApiTypes.IsaacConceptPageDTO> => {
-            return endpoint.get(`/pages/concepts/${id}`);
-        },
-    },
     pages: {
         get: (id: string): AxiosPromise<ApiTypes.IsaacConceptPageDTO> => {
             return endpoint.get(`/pages/${id}`);

--- a/src/app/state/actions/index.tsx
+++ b/src/app/state/actions/index.tsx
@@ -519,7 +519,6 @@ export const fetchDoc = (documentType: DOCUMENT_TYPE, pageId: string) => async (
     dispatch({type: ACTION_TYPE.DOCUMENT_REQUEST, documentType: documentType, documentId: pageId});
     let apiEndpoint;
     switch (documentType) {
-        case DOCUMENT_TYPE.CONCEPT: apiEndpoint = api.concepts; break;
         case DOCUMENT_TYPE.QUESTION: apiEndpoint = api.questions; break;
         case DOCUMENT_TYPE.GENERIC: default: apiEndpoint = api.pages; break;
     }
@@ -764,15 +763,15 @@ export const resetMemberPassword = (member: AppGroupMembership) => async (dispat
 };
 
 // Concepts
-export const fetchConcepts = (conceptIds?: string, tagIds?: string) => async (dispatch: Dispatch<Action>) => {
-    dispatch({type: ACTION_TYPE.CONCEPTS_REQUEST});
-    try {
-        const concepts = await api.concepts.list(conceptIds, tagIds);
-        dispatch({type: ACTION_TYPE.CONCEPTS_RESPONSE_SUCCESS, concepts: concepts.data});
-    } catch (e) {
-        dispatch({type: ACTION_TYPE.CONCEPTS_RESPONSE_FAILURE});
-        dispatch(showAxiosErrorToastIfNeeded("Loading Concepts Failed", e));
-    }};
+// export const fetchConcepts = (conceptIds?: string, tagIds?: string) => async (dispatch: Dispatch<Action>) => {
+//     dispatch({type: ACTION_TYPE.CONCEPTS_REQUEST});
+//     try {
+//         const concepts = await api.concepts.list(conceptIds, tagIds);
+//         dispatch({type: ACTION_TYPE.CONCEPTS_RESPONSE_SUCCESS, concepts: concepts.data});
+//     } catch (e) {
+//         dispatch({type: ACTION_TYPE.CONCEPTS_RESPONSE_FAILURE});
+//         dispatch(showAxiosErrorToastIfNeeded("Loading Concepts Failed", e));
+//     }};
 
 // SERVICE ACTIONS (w/o dispatch)
 

--- a/src/app/state/slices/api/conceptsApi.ts
+++ b/src/app/state/slices/api/conceptsApi.ts
@@ -1,0 +1,24 @@
+import { IsaacConceptPageDTO } from "../../../../IsaacApiTypes";
+import { Concepts } from "../../../../IsaacAppTypes";
+import { isaacApi } from "./baseApi";
+
+export const conceptsApi = isaacApi.injectEndpoints({
+    endpoints: (build) => ({
+        listConcepts: build.query<Concepts, { conceptIds?: string; tagIds?: string }>({
+            query: ({ conceptIds, tagIds }) => ({
+                url: '/pages/concepts',
+                params: { limit: 999, ids: conceptIds, tags: tagIds }
+            }),
+        }),
+        getConcept: build.query<IsaacConceptPageDTO, string>({
+            query: (id) => ({
+                url: `/pages/concepts/${id}`
+            })
+        }),
+    }),
+});
+
+export const {
+    useListConceptsQuery,
+    useGetConceptQuery,
+} = conceptsApi;


### PR DESCRIPTION
Continuing a big piece of tech debt we inherited, this continues the move to slices from action/reducers. This was brought on since this automatically fixes issues with newer requests storing stale state before completion.