### PR TITLE
Convert to slices – page fetch

### DIFF
--- a/src/app/components/content/AnvilApp.tsx
+++ b/src/app/components/content/AnvilApp.tsx
@@ -1,6 +1,6 @@
 import React, {RefObject, useContext, useEffect} from 'react';
 import {AnvilAppDTO} from "../../../IsaacApiTypes";
-import {AppState, selectors, useAppSelector} from "../../state";
+import {selectors, useAppSelector} from "../../state";
 import {AccordionSectionContext, QuestionContext} from "../../../IsaacAppTypes";
 import {selectQuestionPart} from "../../services";
 import { AnvilCookieHandler } from '../handlers/InterstitialCookieHandler';
@@ -14,7 +14,7 @@ const sessionIdentifier = Math.random();
 export const AnvilApp = ({doc}: AnvilAppProps) => {
     const baseURL = `https://${doc.appId}.anvil.app/${doc.appAccessKey}?s=new${sessionIdentifier}`;
     const title = doc.value || "Anvil app";
-    const page = useAppSelector((state: AppState) => (state && state.doc) || null);
+    const page = useAppSelector(selectors.doc.get);
     const user = useAppSelector(selectors.user.orNull);
 
     const iframeRef = React.useRef() as RefObject<HTMLIFrameElement>;

--- a/src/app/components/content/IsaacAccordion.tsx
+++ b/src/app/components/content/IsaacAccordion.tsx
@@ -28,7 +28,7 @@ interface SectionWithDisplaySettings extends ContentDTO {
     hidden?: boolean;
 }
 export const IsaacAccordion = ({doc}: {doc: ContentDTO}) => {
-    const page = useAppSelector((state: AppState) => (state && state.doc) || null);
+    const page = useAppSelector(selectors.doc.get);
     const user = useAppSelector(selectors.user.orNull);
     const userContext = useUserViewingContext();
 

--- a/src/app/components/elements/Accordion.tsx
+++ b/src/app/components/elements/Accordion.tsx
@@ -42,7 +42,7 @@ let nextClientId = 0;
 export const Accordion = withRouter(({id, trustedTitle, index, children, startOpen, deEmphasised, disabled, audienceString, location: {hash}}: AccordionsProps) => {
     const dispatch = useAppDispatch();
     const componentId = useRef(uuid_v4().slice(0, 4)).current;
-    const page = useAppSelector((state: AppState) => (state && state.doc) || null);
+    const page = useAppSelector(selectors.doc.get);
 
     const deviceSize = useDeviceSize();
 

--- a/src/app/components/handlers/ShowLoadingQuery.tsx
+++ b/src/app/components/handlers/ShowLoadingQuery.tsx
@@ -28,6 +28,7 @@ export const DefaultQueryError = ({error, title}: {error?: FetchBaseQueryError |
 interface ShowLoadingQueryInfo<T> {
     data?: T | NOT_FOUND_TYPE;
     isLoading: boolean;
+    isFetching: boolean;
     isError: boolean;
     error?: FetchBaseQueryError | SerializedError;
 }
@@ -36,6 +37,7 @@ export function combineQueries<T, R, S>(firstQuery: ShowLoadingQueryInfo<T>, sec
     return {
         data: isFound<T>(firstQuery.data) && isFound<R>(secondQuery.data) ? combineResult(firstQuery.data, secondQuery.data) : undefined,
         isLoading: firstQuery.isLoading || secondQuery.isLoading,
+        isFetching: firstQuery.isFetching || secondQuery.isFetching,
         isError: firstQuery.isError || secondQuery.isError,
         error: firstQuery.error ?? secondQuery.error,
     };
@@ -71,12 +73,12 @@ type ShowLoadingQueryProps<T> = ShowLoadingQueryErrorProps<T> & ({
 //  - `placeholder` (React element to show while loading)
 //  - `query` (the object returned by a RTKQ useQuery hook)
 export function ShowLoadingQuery<T>({query, thenRender, children, placeholder, ifError, ifNotFound, defaultErrorTitle}: ShowLoadingQueryProps<T>) {
-    const {data, isLoading, isError, error} = query;
+    const {data, isLoading, isFetching, isError, error} = query;
     const renderError = () => ifError ? <>{ifError(error)}</> : <DefaultQueryError error={error} title={defaultErrorTitle}/>;
     if (isError && error) {
         return "status" in error && typeof error.status === "number" && [NOT_FOUND, NO_CONTENT].includes(error.status) && ifNotFound ? <>{ifNotFound}</> : renderError();
     }
-    if (isLoading) {
+    if (isLoading || isFetching) {
         return placeholder ? <>{placeholder}</> : loadingPlaceholder;
     }
     return isDefined(data)

--- a/src/app/components/pages/Concept.tsx
+++ b/src/app/components/pages/Concept.tsx
@@ -1,11 +1,11 @@
-import React, {useEffect} from "react";
+import React from "react";
 import {withRouter} from "react-router-dom";
-import {AppState, fetchDoc, selectors, useAppDispatch, useAppSelector} from "../../state";
+import {selectors, useAppSelector} from "../../state";
 import {Col, Container, Row} from "reactstrap";
 import {ShowLoading} from "../handlers/ShowLoading";
 import {IsaacContent} from "../content/IsaacContent";
 import {IsaacConceptPageDTO} from "../../../IsaacApiTypes";
-import {DOCUMENT_TYPE, Subject, above, below, usePreviousPageContext, isAda, isPhy, useDeviceSize, useNavigation, siteSpecific} from "../../services";
+import {Subject, above, below, usePreviousPageContext, isAda, isPhy, useDeviceSize, useNavigation, siteSpecific} from "../../services";
 import {DocumentSubject, GameboardContext} from "../../../IsaacAppTypes";
 import {RelatedContent} from "../elements/RelatedContent";
 import {WithFigureNumbering} from "../elements/WithFigureNumbering";
@@ -24,6 +24,7 @@ import {ReportButton} from "../elements/ReportButton";
 import classNames from "classnames";
 import { ConceptSidebar, MainContent, SidebarLayout } from "../elements/layout/SidebarLayout";
 import { TeacherNotes } from "../elements/TeacherNotes";
+import { useGetConceptQuery } from "../../state/slices/api/conceptsApi";
 
 interface ConceptPageProps {
     conceptIdOverride?: string;
@@ -33,15 +34,13 @@ interface ConceptPageProps {
 }
 
 export const Concept = withRouter(({match: {params}, location: {search}, conceptIdOverride, preview}: ConceptPageProps) => {
-    const dispatch = useAppDispatch();
     const conceptId = conceptIdOverride || params.conceptId;
     const user = useAppSelector(selectors.user.orNull);
-    useEffect(() => {dispatch(fetchDoc(DOCUMENT_TYPE.CONCEPT, conceptId));}, [conceptId]);
-    const doc = useAppSelector((state: AppState) => state?.doc || null);
-    const navigation = useNavigation(doc);
+    const {data: doc, isLoading} = useGetConceptQuery(conceptId);
+    const navigation = useNavigation(doc ?? null);
     const deviceSize = useDeviceSize();
 
-    const pageContext = usePreviousPageContext(user && user.loggedIn && user.registeredContexts || undefined, doc && doc !== 404 ? doc : undefined);
+    const pageContext = usePreviousPageContext(user && user.loggedIn && user.registeredContexts || undefined, doc && !isLoading ? doc : undefined);
 
     const ManageButtons = () => <div className={classNames("no-print d-flex justify-content-end mt-1 ms-2", {"gap-2": isPhy})}>
         <div className="question-actions">

--- a/src/app/components/pages/Concepts.tsx
+++ b/src/app/components/pages/Concepts.tsx
@@ -1,9 +1,8 @@
 import React, {FormEvent, MutableRefObject, useEffect, useRef, useState} from "react";
 import {RouteComponentProps, withRouter} from "react-router-dom";
-import {AppState, fetchConcepts, selectors, useAppDispatch, useAppSelector} from "../../state";
+import {selectors, useAppSelector} from "../../state";
 import {Badge, Card, CardBody, CardHeader, Container} from "reactstrap";
 import queryString from "query-string";
-import {ShowLoading} from "../handlers/ShowLoading";
 import {isAda, isPhy, matchesAllWordsInAnyOrder, pushConceptsToHistory, searchResultIsPublic, shortcuts, TAG_ID, tags} from "../../services";
 import {generateSubjectLandingPageCrumbFromContext, TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
 import {ShortcutResponse, Tag} from "../../../IsaacAppTypes";
@@ -12,14 +11,17 @@ import { ListView } from "../elements/list-groups/ListView";
 import { ContentTypeVisibility, LinkToContentSummaryList } from "../elements/list-groups/ContentSummaryListGroupItem";
 import { SubjectSpecificConceptListSidebar, MainContent, SidebarLayout, GenericConceptsSidebar } from "../elements/layout/SidebarLayout";
 import { isFullyDefinedContext, useUrlPageTheme } from "../../services/pageContext";
+import { useListConceptsQuery } from "../../state/slices/api/conceptsApi";
+import { ShowLoadingQuery } from "../handlers/ShowLoadingQuery";
+import { ContentSummaryDTO } from "../../../IsaacApiTypes";
 
 // This component is Isaac Physics only (currently)
 export const Concepts = withRouter((props: RouteComponentProps) => {
     const {location, history} = props;
-    const dispatch = useAppDispatch();
     const user = useAppSelector(selectors.user.orNull);
-    const concepts = useAppSelector((state: AppState) => state?.concepts?.results || null);
     const pageContext = useUrlPageTheme();
+
+    const listConceptsQuery = useListConceptsQuery({conceptIds: undefined, tagIds: pageContext?.subject});
 
     const subjectToTagMap = {
         physics: TAG_ID.physics,
@@ -29,13 +31,8 @@ export const Concepts = withRouter((props: RouteComponentProps) => {
     };
     
     const applicableTags = pageContext?.subject ? tags.getDirectDescendents(subjectToTagMap[pageContext.subject]) : tags.allFieldTags;
-    const tagCounts : Record<string, number> = [...applicableTags, ...(pageContext?.subject ? [tags.getById(pageContext?.subject as TAG_ID)] : [])].reduce((acc, t) => ({...acc, [t.id]: concepts?.filter(c => c.tags?.includes(t.id)).length || 0}), {});
-
-    useEffect(() => {
-        if (pageContext) {
-            dispatch(fetchConcepts(undefined, pageContext?.subject));
-        }
-    }, [dispatch, pageContext]);
+    
+    const tagCounts : Record<string, number> = [...applicableTags, ...(pageContext?.subject ? [tags.getById(pageContext?.subject as TAG_ID)] : [])].reduce((acc, t) => ({...acc, [t.id]: listConceptsQuery?.data?.results?.filter(c => c.tags?.includes(t.id)).length || 0}), {});
 
     const searchParsed = queryString.parse(location.search);
 
@@ -76,17 +73,21 @@ export const Concepts = withRouter((props: RouteComponentProps) => {
 
     useEffect(() => {doSearch();}, [conceptFilters]);
 
-    const searchResults = concepts
-        ?.filter(c =>
-            matchesAllWordsInAnyOrder(c.title, searchText || "") ||
-            matchesAllWordsInAnyOrder(c.summary, searchText || "")
-        );
+    const shortcutAndFilter = (concepts?: ContentSummaryDTO[]) => {
+        const searchResults = concepts
+            ?.filter(c =>
+                matchesAllWordsInAnyOrder(c.title, searchText || "") ||
+                matchesAllWordsInAnyOrder(c.summary, searchText || "")
+            );
+    
+        const filteredSearchResults = searchResults
+            ?.filter((result) => result?.tags?.some(t => filters.includes(t)))
+            .filter((result) => searchResultIsPublic(result, user));
+    
+        const shortcutAndFilteredSearchResults = (shortcutResponse || []).concat(filteredSearchResults || []);
 
-    const filteredSearchResults = searchResults
-        ?.filter((result) => result?.tags?.some(t => filters.includes(t)))
-        .filter((result) => searchResultIsPublic(result, user));
-
-    const shortcutAndFilteredSearchResults = (shortcutResponse || []).concat(filteredSearchResults || []);
+        return shortcutAndFilteredSearchResults;
+    };
 
     const crumb = isPhy && isFullyDefinedContext(pageContext) && generateSubjectLandingPageCrumbFromContext(pageContext);
 
@@ -106,14 +107,25 @@ export const Concepts = withRouter((props: RouteComponentProps) => {
                 }
                 <MainContent>
                     {isPhy && <div className="list-results-container p-2 my-4">
-                        {shortcutAndFilteredSearchResults && <div className="p-2 py-3">
-                            Showing <b>{shortcutAndFilteredSearchResults.length}</b> results
-                        </div>}
+                        <ShowLoadingQuery
+                            query={listConceptsQuery}
+                            thenRender={({results: concepts}) => {
 
-                        {shortcutAndFilteredSearchResults
-                            ? <ListView items={shortcutAndFilteredSearchResults}/>
-                            : <em>No results found</em>
-                        }
+                                const shortcutAndFilteredSearchResults = shortcutAndFilter(concepts);
+
+                                return <>
+                                    {!!shortcutAndFilteredSearchResults.length && <div className="p-2 py-3">
+                                        Showing <b>{shortcutAndFilteredSearchResults.length}</b> results
+                                    </div>}
+            
+                                    {shortcutAndFilteredSearchResults.length
+                                        ? <ListView items={shortcutAndFilteredSearchResults}/>
+                                        : <em>No results found</em>
+                                    }
+                                </>;
+                            }}
+                            defaultErrorTitle="Error fetching concepts"
+                        />
                     </div>
                     }
                     
@@ -122,22 +134,31 @@ export const Concepts = withRouter((props: RouteComponentProps) => {
                             <h3>
                                 <span className="d-none d-sm-inline-block">Search&nbsp;</span>Results 
                                 {query !== "" 
-                                    ? shortcutAndFilteredSearchResults 
-                                        ? <Badge color="primary">{shortcutAndFilteredSearchResults.length}</Badge> 
+                                    ? (listConceptsQuery?.data?.totalResults) 
+                                        ? <Badge color="primary">{listConceptsQuery?.data?.totalResults}</Badge> 
                                         : <IsaacSpinner /> 
                                     : null
                                 }
                             </h3>
                         </CardHeader>
                         <CardBody className="px-2">
-                            <ShowLoading until={shortcutAndFilteredSearchResults}>
-                                {shortcutAndFilteredSearchResults ?
-                                    <LinkToContentSummaryList 
-                                        items={shortcutAndFilteredSearchResults} showBreadcrumb={false} 
-                                        contentTypeVisibility={ContentTypeVisibility.ICON_ONLY}
-                                    />
-                                    : <em>No results found</em>}
-                            </ShowLoading>
+                            <ShowLoadingQuery
+                                query={listConceptsQuery}
+                                thenRender={({results: concepts}) => {
+
+                                    const shortcutAndFilteredSearchResults = shortcutAndFilter(concepts);
+
+                                    return <>
+                                        {shortcutAndFilteredSearchResults ?
+                                            <LinkToContentSummaryList 
+                                                items={shortcutAndFilteredSearchResults} showBreadcrumb={false} 
+                                                contentTypeVisibility={ContentTypeVisibility.ICON_ONLY}
+                                            />
+                                            : <em>No results found</em>}
+                                    </>;
+                                }}
+                                defaultErrorTitle="Error fetching concepts"
+                            />
                         </CardBody>
                     </Card>}
                 </MainContent>

--- a/src/app/components/pages/Generic.tsx
+++ b/src/app/components/pages/Generic.tsx
@@ -1,10 +1,8 @@
 import React, {useEffect} from "react";
 import {Col, Container, Row} from "reactstrap";
-import {AppState, fetchDoc, useAppDispatch, useAppSelector} from "../../state";
 import {IsaacQuestionPageDTO} from "../../../IsaacApiTypes";
-import {ShowLoading} from "../handlers/ShowLoading";
 import {IsaacContent} from "../content/IsaacContent";
-import {DOCUMENT_TYPE, isAda, isPhy, useUrlHashValue} from "../../services";
+import {isAda, isPhy, useUrlHashValue} from "../../services";
 import {withRouter} from "react-router-dom";
 import {RelatedContent} from "../elements/RelatedContent";
 import {DocumentSubject} from "../../../IsaacAppTypes";
@@ -18,6 +16,9 @@ import classNames from "classnames";
 import { useUntilFound } from "./Glossary";
 import { MainContent, SidebarLayout, GenericPageSidebar, PolicyPageSidebar } from "../elements/layout/SidebarLayout";
 import { TeacherNotes } from "../elements/TeacherNotes";
+import { useGetGenericPageQuery } from "../../state/slices/api/genericApi";
+import { ShowLoadingQuery } from "../handlers/ShowLoadingQuery";
+import { NotFound } from "./NotFound";
 
 interface GenericPageComponentProps {
     pageIdOverride?: string;
@@ -44,11 +45,11 @@ const PHY_SIDEBAR = new Map<string, () => React.JSX.Element>([
 export const Generic = withRouter(({pageIdOverride, match: {params}}: GenericPageComponentProps) => {
     const pageId = pageIdOverride || params.pageId;
 
-    const dispatch = useAppDispatch();
-    useEffect(() => {dispatch(fetchDoc(DOCUMENT_TYPE.GENERIC, pageId));}, [dispatch, pageId]);
-    const doc = useAppSelector((state: AppState) => state?.doc || null);
+    const pageQuery = useGetGenericPageQuery(pageId);
 
-    const hash = useUntilFound(doc, useUrlHashValue());
+    console.log(pageQuery);
+
+    const hash = useUntilFound(pageQuery.currentData, useUrlHashValue());
 
     useEffect(() => {
         if (hash) {
@@ -60,38 +61,43 @@ export const Generic = withRouter(({pageIdOverride, match: {params}}: GenericPag
         }
     }, [hash]);
 
-    return <ShowLoading until={doc} thenRender={supertypedDoc => {
-        const doc = supertypedDoc as IsaacQuestionPageDTO & DocumentSubject;
-        
-        return <Container data-bs-theme={doc.subjectId}>
-            <TitleAndBreadcrumb currentPageTitle={doc.title as string} subTitle={doc.subtitle} /> {/* TODO add page icon, replace main title with "General"?? */}
-            <MetaDescription description={doc.summary} />
-            <SidebarLayout>
-                {PHY_SIDEBAR.has(pageId) ? PHY_SIDEBAR.get(pageId)!() : <GenericPageSidebar/>}
-                <MainContent>
-                    <div className="no-print d-flex align-items-center">
-                        <EditContentButton doc={doc} />
-                        <div className={classNames("question-actions question-actions-leftmost mt-3", {"gap-2": isPhy})}>
-                            <ShareLink linkUrl={`/pages/${doc.id}`}/>
+    return <ShowLoadingQuery 
+        query={pageQuery}
+        defaultErrorTitle="Unable to load page"
+        ifNotFound={<NotFound />}
+        thenRender={supertypedDoc => {
+            const doc = supertypedDoc as IsaacQuestionPageDTO & DocumentSubject;
+            
+            return <Container data-bs-theme={doc.subjectId}>
+                <TitleAndBreadcrumb currentPageTitle={doc.title as string} subTitle={doc.subtitle} /> {/* TODO add page icon, replace main title with "General"?? */}
+                <MetaDescription description={doc.summary} />
+                <SidebarLayout>
+                    {PHY_SIDEBAR.has(pageId) ? PHY_SIDEBAR.get(pageId)!() : <GenericPageSidebar/>}
+                    <MainContent>
+                        <div className="no-print d-flex align-items-center">
+                            <EditContentButton doc={doc} />
+                            <div className={classNames("question-actions question-actions-leftmost mt-3", {"gap-2": isPhy})}>
+                                <ShareLink linkUrl={`/pages/${doc.id}`}/>
+                            </div>
+                            <div className="question-actions mt-3 not-mobile">
+                                <PrintButton/>
+                            </div>
                         </div>
-                        <div className="question-actions mt-3 not-mobile">
-                            <PrintButton/>
-                        </div>
-                    </div>
-                    
-                    <TeacherNotes notes={doc.teacherNotes} />
+                        
+                        <TeacherNotes notes={doc.teacherNotes} />
 
-                    <Row className="generic-content-container">
-                        <Col className={classNames("py-4 generic-panel", {"mw-760": isAda && !CS_FULL_WIDTH_OVERRIDE[pageId]})}>
-                            <WithFigureNumbering doc={doc}>
-                                <IsaacContent doc={doc} />
-                            </WithFigureNumbering>
-                        </Col>
-                    </Row>
-                </MainContent>
-            </SidebarLayout>
+                        <Row className="generic-content-container">
+                            <Col className={classNames("py-4 generic-panel", {"mw-760": isAda && !CS_FULL_WIDTH_OVERRIDE[pageId]})}>
+                                <WithFigureNumbering doc={doc}>
+                                    <IsaacContent doc={doc} />
+                                </WithFigureNumbering>
+                            </Col>
+                        </Row>
+                    </MainContent>
+                </SidebarLayout>
 
-            {doc.relatedContent && <RelatedContent content={doc.relatedContent} parentPage={doc} />}
-        </Container>;
-    }}/>;
+                {doc.relatedContent && <RelatedContent content={doc.relatedContent} parentPage={doc} />}
+            </Container>;
+        }}
+    />;
 });

--- a/src/app/components/pages/Question.tsx
+++ b/src/app/components/pages/Question.tsx
@@ -1,8 +1,7 @@
-import React, {useEffect} from "react";
+import React from "react";
 import {Button, Col, Container, Row} from "reactstrap";
 import {match, RouteComponentProps, withRouter} from "react-router-dom";
-import {fetchDoc, goToSupersededByQuestion, selectors, useAppDispatch, useAppSelector, useGetGameboardByIdQuery} from "../../state";
-import {ShowLoading} from "../handlers/ShowLoading";
+import {goToSupersededByQuestion, selectors, useAppDispatch, useAppSelector, useGetGameboardByIdQuery, useGetQuestionQuery} from "../../state";
 import {IsaacQuestionPageDTO} from "../../../IsaacApiTypes";
 import {
     determineAudienceViews,
@@ -44,6 +43,8 @@ import { GameboardQuestionSidebar, MainContent, QuestionSidebar, SidebarLayout }
 import { StageAndDifficultySummaryIcons } from "../elements/StageAndDifficultySummaryIcons";
 import { TeacherNotes } from "../elements/TeacherNotes";
 import { skipToken } from "@reduxjs/toolkit/query";
+import { ShowLoadingQuery } from "../handlers/ShowLoadingQuery";
+import { NotFound } from "./NotFound";
 
 interface QuestionPageProps extends RouteComponentProps<{questionId: string}> {
     questionIdOverride?: string;
@@ -65,135 +66,137 @@ function getTags(docTags?: string[]) {
 
 export const Question = withRouter(({questionIdOverride, match, location, preview}: QuestionPageProps) => {
     const questionId = questionIdOverride || match.params.questionId;
-    const doc = useAppSelector(selectors.doc.get);
+    const questionQuery = useGetQuestionQuery(questionId);
+    const {data: doc, isLoading} = questionQuery;
     const user = useAppSelector(selectors.user.orNull);
-    const prevPageContext = useAppSelector(selectors.pageContext.context);
     const allQuestionsCorrect = useAppSelector(selectors.questions.allQuestionsCorrect);
     const anyQuestionAttempted = useAppSelector(selectors.questions.anyQuestionPreviouslyAttempted);
-    const navigation = useNavigation(doc);
+    const navigation = useNavigation(doc ?? null);
     const pageContainsLLMFreeTextQuestion = useAppSelector(selectors.questions.includesLLMFreeTextQuestion);
     const query = queryString.parse(location.search);
     const gameboardId = query.board instanceof Array ? query.board[0] : query.board;
 
     const dispatch = useAppDispatch();
-    useEffect(() => {
-        dispatch(fetchDoc(DOCUMENT_TYPE.QUESTION, questionId));
-    }, [dispatch, questionId]);
 
-    const pageContext = usePreviousPageContext(user && user.loggedIn && user.registeredContexts || undefined, doc && doc !== 404 ? doc : undefined);
+    const pageContext = usePreviousPageContext(user && user.loggedIn && user.registeredContexts || undefined, doc && !isLoading ? doc : undefined);
     const {data: gameboard} = useGetGameboardByIdQuery(gameboardId || skipToken);
 
-    return <ShowLoading until={doc} thenRender={supertypedDoc => {
-        const doc = supertypedDoc as IsaacQuestionPageDTO & DocumentSubject;
-        const isFastTrack = doc && doc.type === DOCUMENT_TYPE.FAST_TRACK_QUESTION;
+    return <ShowLoadingQuery
+        query={questionQuery}
+        defaultErrorTitle="Unable to load question"
+        ifNotFound={<NotFound />}
+        thenRender={supertypedDoc => {
+            const doc = supertypedDoc as IsaacQuestionPageDTO & DocumentSubject;
+            const isFastTrack = doc && doc.type === DOCUMENT_TYPE.FAST_TRACK_QUESTION;
 
-        return <GameboardContext.Provider value={navigation.currentGameboard}>
-            <Container className={classNames("no-shadow")} data-bs-theme={pageContext?.subject ?? doc.subjectId}>
-                <TitleAndBreadcrumb
-                    currentPageTitle={siteSpecific("Question", generateQuestionTitle(doc))}
-                    subTitle={siteSpecific(undefined, doc.subtitle)}
-                    intermediateCrumbs={navigation.breadcrumbHistory}
-                    collectionType={navigation.collectionType}
-                    audienceViews={siteSpecific(undefined, determineAudienceViews(doc.audience, navigation.creationContext))}
-                    preview={preview} icon={{type: "hex", subject: doc.subjectId as Subject, icon: "icon-question"}}
-                />
-                {isFastTrack && fastTrackProgressEnabledBoards.includes(gameboardId || "") && <FastTrackProgress doc={doc} search={location.search} />}
-                <SidebarLayout>
-                    {isDefined(gameboardId) ? <GameboardQuestionSidebar id={gameboardId} title={gameboard?.title || ""} questions={gameboard?.contents || []} currentQuestionId={questionId}/>
-                        : <QuestionSidebar relatedContent={doc.relatedContent} />}
-                    <MainContent>
-                        {!preview && <CanonicalHrefElement />}
+            return <GameboardContext.Provider value={navigation.currentGameboard}>
+                <Container className={classNames("no-shadow")} data-bs-theme={pageContext?.subject ?? doc.subjectId}>
+                    <TitleAndBreadcrumb
+                        currentPageTitle={siteSpecific("Question", generateQuestionTitle(doc))}
+                        subTitle={siteSpecific(undefined, doc.subtitle)}
+                        intermediateCrumbs={navigation.breadcrumbHistory}
+                        collectionType={navigation.collectionType}
+                        audienceViews={siteSpecific(undefined, determineAudienceViews(doc.audience, navigation.creationContext))}
+                        preview={preview} icon={{type: "hex", subject: doc.subjectId as Subject, icon: "icon-question"}}
+                    />
+                    {isFastTrack && fastTrackProgressEnabledBoards.includes(gameboardId || "") && <FastTrackProgress doc={doc} search={location.search} />}
+                    <SidebarLayout>
+                        {isDefined(gameboardId) ? <GameboardQuestionSidebar id={gameboardId} title={gameboard?.title || ""} questions={gameboard?.contents || []} currentQuestionId={questionId}/>
+                            : <QuestionSidebar relatedContent={doc.relatedContent} />}
+                        <MainContent>
+                            {!preview && <CanonicalHrefElement />}
 
-                        <TeacherNotes notes={doc.teacherNotes} />
+                            <TeacherNotes notes={doc.teacherNotes} />
 
-                        <div className={classNames("no-print d-flex align-items-center", siteSpecific("my-3", "mt-3"))}>
-                            {isAda && <>
-                                {pageContainsLLMFreeTextQuestion && <span className="me-2"><LLMFreeTextQuestionIndicator /></span>}
-                                <EditContentButton doc={doc} />
-                                <div className="d-flex ms-auto">
-                                    <ShareLink linkUrl={`/questions/${questionId}${location.search || ""}`} clickAwayClose />
-                                    <PrintButton questionPage />
-                                    <ReportButton pageId={questionId}/>
-                                </div>
-                            </>}
-                            {isPhy && <>
-                                <div>
-                                    <h2 className="text-theme-dark"><Markup encoding="latex">{generateQuestionTitle(doc)}</Markup></h2>
-                                    {doc.subtitle && <h5 className="text-theme-dark">{doc.subtitle}</h5>}
-                                </div>
-                                <div className="d-flex gap-2 ms-auto">
-                                    <ShareLink linkUrl={`/questions/${questionId}${location.search || ""}`} clickAwayClose />
-                                    <PrintButton questionPage />
-                                    <ReportButton pageId={questionId}/>
-                                </div>
-                            </>}
-                        </div>
-                        
-                        {isPhy && <Row className="question-metadata d-flex">
-                            <Col xs={12} md={"auto"} className="d-flex flex-column flex-grow-1 px-3 pb-3 pb-md-0">
-                                <span>Subject & topics</span>
-                                <div className="d-flex align-items-center">
-                                    <i className="icon icon-hexagon me-2"/>
-                                    {getTags(doc.tags).map((tag, index, arr) => <>
-                                        <span key={tag.title} className="text-theme">{tag.title}</span>
-                                        {index !== arr.length - 1 && <span className="mx-2">|</span>}
-                                    </>)}
-                                </div>
-                            </Col>
-                            <Col xs={12} sm={6} md={"auto"} className="d-flex flex-column flex-grow-0 px-3 mt-3 pb-3 mt-md-0 pb-sm-0">
-                                <span>Stage & difficulty</span>
-                                <StageAndDifficultySummaryIcons audienceViews={determineAudienceViews(doc.audience, navigation.creationContext)} iconClassName="ps-2" stack/> 
-                            </Col>
-                            <Col xs={12} sm={6} md={"auto"} className="d-flex flex-column flex-grow-0 px-3 mt-3 mt-md-0">
-                                <span>Status</span>
-                                {allQuestionsCorrect 
-                                    ? <div className="d-flex align-items-center"><span className="icon-correct me-2"/> Correct</div>
-                                    : anyQuestionAttempted
-                                        ? <div className="d-flex align-items-center"><span className="icon-in-progress me-2"/> In Progress</div>
-                                        : <div className="d-flex align-items-center"><span className="icon-not-started me-2"/> Not Started</div>
-                                }
-                            </Col>
-                        </Row>}
+                            <div className={classNames("no-print d-flex align-items-center", siteSpecific("my-3", "mt-3"))}>
+                                {isAda && <>
+                                    {pageContainsLLMFreeTextQuestion && <span className="me-2"><LLMFreeTextQuestionIndicator /></span>}
+                                    <EditContentButton doc={doc} />
+                                    <div className="d-flex ms-auto">
+                                        <ShareLink linkUrl={`/questions/${questionId}${location.search || ""}`} clickAwayClose />
+                                        <PrintButton questionPage />
+                                        <ReportButton pageId={questionId}/>
+                                    </div>
+                                </>}
+                                {isPhy && <>
+                                    <div>
+                                        <h2 className="text-theme-dark"><Markup encoding="latex">{generateQuestionTitle(doc)}</Markup></h2>
+                                        {doc.subtitle && <h5 className="text-theme-dark">{doc.subtitle}</h5>}
+                                    </div>
+                                    <div className="d-flex gap-2 ms-auto">
+                                        <ShareLink linkUrl={`/questions/${questionId}${location.search || ""}`} clickAwayClose />
+                                        <PrintButton questionPage />
+                                        <ReportButton pageId={questionId}/>
+                                    </div>
+                                </>}
+                            </div>
+                            
+                            {isPhy && <Row className="question-metadata d-flex">
+                                <Col xs={12} md={"auto"} className="d-flex flex-column flex-grow-1 px-3 pb-3 pb-md-0">
+                                    <span>Subject & topics</span>
+                                    <div className="d-flex align-items-center">
+                                        <i className="icon icon-hexagon me-2"/>
+                                        {getTags(doc.tags).map((tag, index, arr) => <>
+                                            <span key={tag.title} className="text-theme">{tag.title}</span>
+                                            {index !== arr.length - 1 && <span className="mx-2">|</span>}
+                                        </>)}
+                                    </div>
+                                </Col>
+                                <Col xs={12} sm={6} md={"auto"} className="d-flex flex-column flex-grow-0 px-3 mt-3 pb-3 mt-md-0 pb-sm-0">
+                                    <span>Stage & difficulty</span>
+                                    <StageAndDifficultySummaryIcons audienceViews={determineAudienceViews(doc.audience, navigation.creationContext)} iconClassName="ps-2" stack/> 
+                                </Col>
+                                <Col xs={12} sm={6} md={"auto"} className="d-flex flex-column flex-grow-0 px-3 mt-3 mt-md-0">
+                                    <span>Status</span>
+                                    {allQuestionsCorrect 
+                                        ? <div className="d-flex align-items-center"><span className="icon-correct me-2"/> Correct</div>
+                                        : anyQuestionAttempted
+                                            ? <div className="d-flex align-items-center"><span className="icon-in-progress me-2"/> In Progress</div>
+                                            : <div className="d-flex align-items-center"><span className="icon-not-started me-2"/> Not Started</div>
+                                    }
+                                </Col>
+                            </Row>}
 
-                        {isPhy && <EditContentButton doc={doc} />}
+                            {isPhy && <EditContentButton doc={doc} />}
 
-                        <Row className="question-content-container">
-                            <Col className={classNames("py-4 question-panel", {"mw-760": isAda})}>
+                            <Row className="question-content-container">
+                                <Col className={classNames("py-4 question-panel", {"mw-760": isAda})}>
 
-                                <SupersededDeprecatedWarningBanner doc={doc} />
+                                    <SupersededDeprecatedWarningBanner doc={doc} />
 
-                                {isAda && <IntendedAudienceWarningBanner doc={doc} />}
+                                    {isAda && <IntendedAudienceWarningBanner doc={doc} />}
 
-                                {pageContainsLLMFreeTextQuestion && <LLMFreeTextQuestionInfoBanner doc={doc} />}
+                                    {pageContainsLLMFreeTextQuestion && <LLMFreeTextQuestionInfoBanner doc={doc} />}
 
-                                <RevisionWarningBanner />
+                                    <RevisionWarningBanner />
 
-                                <WithFigureNumbering doc={doc}>
-                                    <IsaacContent doc={doc}/>
-                                </WithFigureNumbering>
+                                    <WithFigureNumbering doc={doc}>
+                                        <IsaacContent doc={doc}/>
+                                    </WithFigureNumbering>
 
-                                {doc.supersededBy && isStudent(user) && <div className="alert alert-warning">
-                                    This question {" "}
-                                    <Button color="link" className="align-baseline" onClick={() => dispatch(goToSupersededByQuestion(doc))}>
-                                        has been replaced
-                                    </Button>.<br />
-                                    However, if you were assigned this version, you should complete it.
-                                </div>}
+                                    {doc.supersededBy && isStudent(user) && <div className="alert alert-warning">
+                                        This question {" "}
+                                        <Button color="link" className="align-baseline" onClick={() => dispatch(goToSupersededByQuestion(doc))}>
+                                            has been replaced
+                                        </Button>.<br />
+                                        However, if you were assigned this version, you should complete it.
+                                    </div>}
 
-                                {doc.attribution && <p className="text-muted">
-                                    <Markup trusted-markup-encoding={"markdown"}>
-                                        {doc.attribution}
-                                    </Markup>
-                                </p>}
+                                    {doc.attribution && <p className="text-muted">
+                                        <Markup trusted-markup-encoding={"markdown"}>
+                                            {doc.attribution}
+                                        </Markup>
+                                    </p>}
 
-                                <NavigationLinks navigation={navigation}/>
+                                    <NavigationLinks navigation={navigation}/>
 
-                                {isAda && doc.relatedContent && !isFastTrack && <RelatedContent content={doc.relatedContent} parentPage={doc} />}
-                            </Col>
-                        </Row>
-                    </MainContent>
-                </SidebarLayout>
-            </Container>
-        </GameboardContext.Provider>;}
-    } />;
+                                    {isAda && doc.relatedContent && !isFastTrack && <RelatedContent content={doc.relatedContent} parentPage={doc} />}
+                                </Col>
+                            </Row>
+                        </MainContent>
+                    </SidebarLayout>
+                </Container>
+            </GameboardContext.Provider>;}
+        } 
+    />;
 });

--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -153,9 +153,6 @@ export const api = {
         }
     },
     questions: {
-        get: (id: string): AxiosPromise<ApiTypes.IsaacQuestionPageDTO> => {
-            return endpoint.get(`/pages/questions/${id}`);
-        },
         search: (query: QuestionSearchQuery): AxiosPromise<ApiTypes.SearchResultsWrapper<ApiTypes.ContentSummaryDTO>> => {
             return endpoint.get(`/pages/questions/`, {
                 params: query,
@@ -176,11 +173,6 @@ export const api = {
         testFreeTextQuestion: (userDefinedChoices: Choice[], testCases: TestCaseDTO[]) => {
             return endpoint.post("/questions/test?type=isaacFreeTextQuestion", {userDefinedChoices, testCases});
         }
-    },
-    pages: {
-        get: (id: string): AxiosPromise<ApiTypes.IsaacConceptPageDTO> => {
-            return endpoint.get(`/pages/${id}`);
-        },
     },
     topics: {
         get: (topicName: TAG_ID): AxiosPromise<ApiTypes.IsaacTopicSummaryPageDTO> => {

--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -177,16 +177,6 @@ export const api = {
             return endpoint.post("/questions/test?type=isaacFreeTextQuestion", {userDefinedChoices, testCases});
         }
     },
-    concepts: {
-        list: (conceptIds?: string, tagIds?: string): AxiosPromise<Concepts> => {
-            return endpoint.get('/pages/concepts', {
-                params: { limit: 999 , ids: conceptIds, tags: tagIds }
-            });
-        },
-        get: (id: string): AxiosPromise<ApiTypes.IsaacConceptPageDTO> => {
-            return endpoint.get(`/pages/concepts/${id}`);
-        },
-    },
     pages: {
         get: (id: string): AxiosPromise<ApiTypes.IsaacConceptPageDTO> => {
             return endpoint.get(`/pages/${id}`);

--- a/src/app/services/fastTrack.ts
+++ b/src/app/services/fastTrack.ts
@@ -117,7 +117,7 @@ interface FastTrackPageProperties {
     isFastTrackPage: boolean;
     doc: QuestionDTO;
     correct: boolean;
-    page: ContentDTO | undefined;
+    page: ContentDTO | null;
     pageCompleted: boolean;
     questionHistory: string[];
     board: string | undefined;
@@ -133,7 +133,7 @@ export function useFastTrackInformation(
     const {board, questionHistory: questionHistoryUrl}: {board?: string; questionHistory?: string} = queryString.parse(location.search);
     const questionHistory = questionHistoryUrl?.split(",") || [];
 
-    const page = useAppSelector((state: AppState) => state?.doc && state.doc !== NOT_FOUND ? state.doc : undefined);
+    const page = useAppSelector(selectors.doc.getWithout404);
     const isFastTrackPage = page?.type === DOCUMENT_TYPE.FAST_TRACK_QUESTION;
     const pageCompleted = useAppSelector((state: AppState) => state?.questions ? state.questions.pageCompleted : false);
     const userContext = useUserViewingContext();

--- a/src/app/state/actions/index.tsx
+++ b/src/app/state/actions/index.tsx
@@ -519,7 +519,6 @@ export const fetchDoc = (documentType: DOCUMENT_TYPE, pageId: string) => async (
     dispatch({type: ACTION_TYPE.DOCUMENT_REQUEST, documentType: documentType, documentId: pageId});
     let apiEndpoint;
     switch (documentType) {
-        case DOCUMENT_TYPE.CONCEPT: apiEndpoint = api.concepts; break;
         case DOCUMENT_TYPE.QUESTION: apiEndpoint = api.questions; break;
         case DOCUMENT_TYPE.GENERIC: default: apiEndpoint = api.pages; break;
     }
@@ -764,15 +763,15 @@ export const resetMemberPassword = (member: AppGroupMembership) => async (dispat
 };
 
 // Concepts
-export const fetchConcepts = (conceptIds?: string, tagIds?: string) => async (dispatch: Dispatch<Action>) => {
-    dispatch({type: ACTION_TYPE.CONCEPTS_REQUEST});
-    try {
-        const concepts = await api.concepts.list(conceptIds, tagIds);
-        dispatch({type: ACTION_TYPE.CONCEPTS_RESPONSE_SUCCESS, concepts: concepts.data});
-    } catch (e) {
-        dispatch({type: ACTION_TYPE.CONCEPTS_RESPONSE_FAILURE});
-        dispatch(showAxiosErrorToastIfNeeded("Loading Concepts Failed", e));
-    }};
+// export const fetchConcepts = (conceptIds?: string, tagIds?: string) => async (dispatch: Dispatch<Action>) => {
+//     dispatch({type: ACTION_TYPE.CONCEPTS_REQUEST});
+//     try {
+//         const concepts = await api.concepts.list(conceptIds, tagIds);
+//         dispatch({type: ACTION_TYPE.CONCEPTS_RESPONSE_SUCCESS, concepts: concepts.data});
+//     } catch (e) {
+//         dispatch({type: ACTION_TYPE.CONCEPTS_RESPONSE_FAILURE});
+//         dispatch(showAxiosErrorToastIfNeeded("Loading Concepts Failed", e));
+//     }};
 
 // SERVICE ACTIONS (w/o dispatch)
 

--- a/src/app/state/actions/index.tsx
+++ b/src/app/state/actions/index.tsx
@@ -514,22 +514,6 @@ export const requestNotifications = () => async (dispatch: Dispatch<Action>) => 
     }
 };
 
-// Document & topic fetch
-export const fetchDoc = (documentType: DOCUMENT_TYPE, pageId: string) => async (dispatch: Dispatch<Action>) => {
-    dispatch({type: ACTION_TYPE.DOCUMENT_REQUEST, documentType: documentType, documentId: pageId});
-    let apiEndpoint;
-    switch (documentType) {
-        case DOCUMENT_TYPE.QUESTION: apiEndpoint = api.questions; break;
-        case DOCUMENT_TYPE.GENERIC: default: apiEndpoint = api.pages; break;
-    }
-    try {
-        const response = await apiEndpoint.get(pageId);
-        dispatch({type: ACTION_TYPE.DOCUMENT_RESPONSE_SUCCESS, doc: response.data});
-    } catch (e) {
-        dispatch({type: ACTION_TYPE.DOCUMENT_RESPONSE_FAILURE});
-    }
-};
-
 export const fetchTopicSummary = (topicName: TAG_ID) => async (dispatch: Dispatch<Action>) => {
     dispatch({type: ACTION_TYPE.TOPIC_REQUEST, topicName});
     try {

--- a/src/app/state/index.ts
+++ b/src/app/state/index.ts
@@ -14,6 +14,7 @@ export * from "./reducers/contentState";
 export * from "./slices/internalAppState";
 export * from "./slices/cookies";
 export * from "./slices/context";
+export * from "./slices/doc";
 export * from "./slices/linkableSetting";
 export * from "./actions/logging";
 export * from "./reducers/staticState";

--- a/src/app/state/reducers/contentState.ts
+++ b/src/app/state/reducers/contentState.ts
@@ -1,24 +1,5 @@
-import {ContentDTO} from "../../../IsaacApiTypes";
-import {Action, Concepts, NOT_FOUND_TYPE} from "../../../IsaacAppTypes";
-import {ACTION_TYPE, NOT_FOUND, tags} from "../../services";
-import {routerPageChange} from "../index";
-
-type DocState = ContentDTO | NOT_FOUND_TYPE | null;
-export const doc = (doc: DocState = null, action: Action) => {
-    if (routerPageChange.match(action)) {
-        return null;
-    }
-    switch (action.type) {
-        case ACTION_TYPE.DOCUMENT_REQUEST:
-            return null;
-        case ACTION_TYPE.DOCUMENT_RESPONSE_SUCCESS:
-            return {...tags.augmentDocWithSubject(action.doc)};
-        case ACTION_TYPE.DOCUMENT_RESPONSE_FAILURE:
-            return NOT_FOUND;
-        default:
-            return doc;
-    }
-};
+import {Action, Concepts} from "../../../IsaacAppTypes";
+import {ACTION_TYPE} from "../../services";
 
 export type ConceptsState = Concepts | null;
 export const concepts = (concepts: ConceptsState = null, action: Action) => {

--- a/src/app/state/reducers/index.ts
+++ b/src/app/state/reducers/index.ts
@@ -9,7 +9,7 @@ import {
     transientUserContextSlice,
     glossaryTerms,
     concepts,
-    doc,
+    docSlice,
     questions,
     activeModals,
     notifications,
@@ -58,7 +58,7 @@ export const rootReducer = combineReducers({
     glossaryTerms,
 
     // Content
-    doc,
+    page: docSlice.reducer,
     concepts,
 
     // Question

--- a/src/app/state/selectors.tsx
+++ b/src/app/state/selectors.tsx
@@ -18,7 +18,10 @@ export const selectors = {
     },
 
     doc: {
-        get: (state: AppState) => state?.doc || null,
+        get: (state: AppState) => state?.page?.doc || null,
+        getWithout404: (state: AppState) => {
+            return state?.page?.doc === NOT_FOUND ? null : state?.page?.doc ?? null;
+        }
     },
 
     questions: {

--- a/src/app/state/slices/api/conceptsApi.ts
+++ b/src/app/state/slices/api/conceptsApi.ts
@@ -1,6 +1,9 @@
 import { IsaacConceptPageDTO } from "../../../../IsaacApiTypes";
 import { Concepts } from "../../../../IsaacAppTypes";
+import { tags } from "../../../services";
+import { docSlice } from "../doc";
 import { isaacApi } from "./baseApi";
+import { onQueryLifecycleEvents } from "./utils";
 
 export const conceptsApi = isaacApi.injectEndpoints({
     endpoints: (build) => ({
@@ -9,11 +12,27 @@ export const conceptsApi = isaacApi.injectEndpoints({
                 url: '/pages/concepts',
                 params: { limit: 999, ids: conceptIds, tags: tagIds }
             }),
+            
+            onQueryStarted: onQueryLifecycleEvents({
+                errorTitle: "Unable to load concepts",
+            }),
         }),
         getConcept: build.query<IsaacConceptPageDTO, string>({
             query: (id) => ({
                 url: `/pages/concepts/${id}`
-            })
+            }),
+            transformResponse: (response: IsaacConceptPageDTO) => {
+                return tags.augmentDocWithSubject(response);
+            },
+            onQueryStarted: onQueryLifecycleEvents({
+                errorTitle: "Unable to load concept",
+                onQueryStart: (_args, {dispatch}) => {
+                    dispatch(docSlice.actions.resetPage());
+                },
+                onQuerySuccess: (_args, response, {dispatch}) => {
+                    dispatch(docSlice.actions.updatePage({ doc: response }));
+                }
+            }),
         }),
     }),
 });

--- a/src/app/state/slices/api/conceptsApi.ts
+++ b/src/app/state/slices/api/conceptsApi.ts
@@ -1,0 +1,24 @@
+import { IsaacConceptPageDTO } from "../../../../IsaacApiTypes";
+import { Concepts } from "../../../../IsaacAppTypes";
+import { isaacApi } from "./baseApi";
+
+export const conceptsApi = isaacApi.injectEndpoints({
+    endpoints: (build) => ({
+        listConcepts: build.query<Concepts, { conceptIds?: string; tagIds?: string }>({
+            query: ({ conceptIds, tagIds }) => ({
+                url: '/pages/concepts',
+                params: { limit: 999, ids: conceptIds, tags: tagIds }
+            }),
+        }),
+        getConcept: build.query<IsaacConceptPageDTO, string>({
+            query: (id) => ({
+                url: `/pages/concepts/${id}`
+            })
+        }),
+    }),
+});
+
+export const {
+    useListConceptsQuery,
+    useGetConceptQuery,
+} = conceptsApi;

--- a/src/app/state/slices/api/genericApi.ts
+++ b/src/app/state/slices/api/genericApi.ts
@@ -1,0 +1,32 @@
+import { SeguePageDTO } from "../../../../IsaacApiTypes";
+import { tags } from "../../../services";
+import { docSlice } from "../doc";
+import { isaacApi } from "./baseApi";
+import { onQueryLifecycleEvents } from "./utils";
+
+export const genericApi = isaacApi.injectEndpoints({
+    endpoints: (build) => ({
+        getGenericPage: build.query<SeguePageDTO, string>({
+            query: (id) => ({
+                url: `/pages/${id}`
+            }),
+            transformResponse: (response: SeguePageDTO) => {
+                return tags.augmentDocWithSubject(response);
+            },
+            onQueryStarted: onQueryLifecycleEvents({
+                errorTitle: "Unable to load question",
+                onQueryStart: (_args, {dispatch}) => {
+                    dispatch(docSlice.actions.resetPage());
+                },
+                onQuerySuccess: (_args, response, {dispatch}) => {
+                    dispatch(docSlice.actions.updatePage({ doc: response }));
+                }
+            }),
+            keepUnusedDataFor: 0,
+        }),
+    })
+});
+
+export const {
+    useGetGenericPageQuery,
+} = genericApi;

--- a/src/app/state/slices/api/questionsApi.ts
+++ b/src/app/state/slices/api/questionsApi.ts
@@ -1,9 +1,30 @@
+import { IsaacQuestionPageDTO } from "../../../../IsaacApiTypes";
 import { CanAttemptQuestionTypeDTO } from "../../../../IsaacAppTypes";
+import { tags } from "../../../services";
+import { docSlice } from "../doc";
 import { isaacApi } from "./baseApi";
+import { onQueryLifecycleEvents } from "./utils";
 
 
 export const questionsApi = isaacApi.enhanceEndpoints({addTagTypes: ["CanAttemptQuestionType"]}).injectEndpoints({
     endpoints: (build) => ({
+        getQuestion: build.query<IsaacQuestionPageDTO, string>({
+            query: (id) => ({
+                url: `/pages/questions/${id}`
+            }),
+            transformResponse: (response: IsaacQuestionPageDTO) => {
+                return tags.augmentDocWithSubject(response);
+            },
+            onQueryStarted: onQueryLifecycleEvents({
+                errorTitle: "Unable to load question",
+                onQueryStart: (_args, {dispatch}) => {
+                    dispatch(docSlice.actions.resetPage());
+                },
+                onQuerySuccess: (_args, response, {dispatch}) => {
+                    dispatch(docSlice.actions.updatePage({ doc: response }));
+                }
+            }),
+        }),
         canAttemptQuestionType: build.query<CanAttemptQuestionTypeDTO, string>({
             query: (questionType) => `/questions/${questionType}/can_attempt`,
             providesTags: (_result, _error, questionType) => [{ type: 'CanAttemptQuestionType', id: questionType }]
@@ -12,6 +33,7 @@ export const questionsApi = isaacApi.enhanceEndpoints({addTagTypes: ["CanAttempt
 });
 
 export const {
+    useGetQuestionQuery,
     useCanAttemptQuestionTypeQuery,
 } = questionsApi;
 

--- a/src/app/state/slices/doc.ts
+++ b/src/app/state/slices/doc.ts
@@ -1,0 +1,27 @@
+import { createSlice } from "@reduxjs/toolkit";
+import { ContentDTO } from "../../../IsaacApiTypes";
+import { NOT_FOUND_TYPE } from "../../../IsaacAppTypes";
+
+type DocState = {
+    doc: ContentDTO | NOT_FOUND_TYPE | null;
+} | null;
+
+interface actionType {
+    payload: DocState;
+    type: string;
+}
+
+export const docSlice = createSlice({
+    name: 'docSlice',
+    initialState: null as DocState,
+    reducers: {
+        updatePage: (state, action: actionType) => ({
+            ...state,
+            doc: action.payload?.doc ?? null,
+        }),
+        resetPage: (state) => ({
+            ...state,
+            doc: null,
+        }),
+    },
+});


### PR DESCRIPTION
Continuing a big piece of tech debt we inherited, this continues the move to slices from action/reducers. This was brought on since this automatically fixes issues with newer requests storing stale state before completion.

A previous iteration of this PR did not account for other components checking the page type through redux, so a new `docSlice` was built to allow this functionality.