### PR TITLE
Add support for inline regex questions

### DIFF
--- a/src/app/components/elements/markup/portals/InlineEntryZone.tsx
+++ b/src/app/components/elements/markup/portals/InlineEntryZone.tsx
@@ -7,7 +7,7 @@ import classNames from "classnames";
 import { InlineStringEntryZone } from "../../inputs/InlineStringEntryZone";
 import { InlineNumericEntryZone } from "../../inputs/InlineNumericEntryZone";
 import { InlineMultiChoiceEntryZone } from "../../inputs/InlineMultiChoiceEntryZone";
-import { IsaacMultiChoiceQuestionDTO, IsaacNumericQuestionDTO, IsaacStringMatchQuestionDTO, QuantityDTO } from "../../../../../IsaacApiTypes";
+import { IsaacMultiChoiceQuestionDTO, IsaacNumericQuestionDTO, IsaacRegexMatchQuestionDTO, IsaacStringMatchQuestionDTO, QuantityDTO } from "../../../../../IsaacApiTypes";
 import { InputProps } from "reactstrap";
 
 export function correctnessClass(correctness: QuestionCorrectness) {
@@ -61,6 +61,7 @@ const InlineEntryZoneBase = ({inlineSpanId, className: contentClasses, widthPx, 
                 return questionDTO?.currentAttempt?.value === undefined && (questionDTO?.currentAttempt as QuantityDTO)?.units === undefined;  
             case "isaacStringMatchQuestion":
             case "isaacMultiChoiceQuestion":
+            case "isaacRegexMatchQuestion":
             default:
                 return questionDTO?.currentAttempt?.value === undefined;
         }  
@@ -178,6 +179,18 @@ const InlineEntryZoneBase = ({inlineSpanId, className: contentClasses, widthPx, 
                 return <InlineMultiChoiceEntryZone
                     correctness={correctness}
                     questionDTO={questionDTO as IsaacMultiChoiceQuestionDTO & AppQuestionDTO} 
+                    className={classNames(correctnessClass(correctness), {"selected-feedback": isSelectedFeedback})}
+                    contentClasses={contentClasses}
+                    contentStyle={{width: widthPx, height: heightPx}}
+                    setModified={setModified}
+                    onFocus={() => inlineContext?.feedbackIndex !== undefined && inlineContext?.setFeedbackIndex(elementIndex)}
+                    focusRef={focusRef}
+                />;
+            }
+            case "isaacRegexMatchQuestion": {
+                return <InlineStringEntryZone 
+                    correctness={correctness}
+                    questionDTO={questionDTO as IsaacRegexMatchQuestionDTO & AppQuestionDTO} 
                     className={classNames(correctnessClass(correctness), {"selected-feedback": isSelectedFeedback})}
                     contentClasses={contentClasses}
                     contentStyle={{width: widthPx, height: heightPx}}

--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -1044,7 +1044,7 @@ export const NULL_CLOZE_ITEM: ItemDTO = {
 // Matches: all legacy, [inline-question:questionId class="{classes}"]
 export const inlineQuestionRegex = /\[inline-question:(?<id>[a-zA-Z0-9_-]+)(?<params> *\| *(?<width>w-\d+)?(?<height>h-\d+)?| +class=(?:["']|&apos;|&[rl]?quot;)(?<classes>[a-zA-Z0-9 _-]+?)(?:["']|&apos;|&[rl]?quot;))?\]/g;
 
-export type InlineQuestionType = "isaacStringMatchQuestion" | "isaacNumericQuestion" | "isaacMultiChoiceQuestion";
+export type InlineQuestionType = "isaacStringMatchQuestion" | "isaacNumericQuestion" | "isaacMultiChoiceQuestion" | "isaacRegexMatchQuestion";
 
 export const AUTHENTICATOR_FRIENDLY_NAMES_MAP: {[key: string]: string} = {
     "RASPBERRYPI": "Raspberry Pi Foundation",


### PR DESCRIPTION
Enables regex as a question type to be marked inline. Uses the same entry field as string match; some typing is technically incorrect because of this (i.e. TS assumes the question is a StringMatchQ as opposed to a RegexMatchQ), but only base class props are used so this is not an issue. Might genericise in future if necessary.