### PR TITLE
Redesign: change dashboard due date logic

### DIFF
--- a/src/app/components/elements/Assignments.tsx
+++ b/src/app/components/elements/Assignments.tsx
@@ -5,17 +5,12 @@ import {Link} from "react-router-dom";
 import {
     extractTeacherName,
     isDefined,
+    isOverdue,
     PATHS,
     siteSpecific} from "../../services";
 import {formatDate, getFriendlyDaysUntil} from "./DateString";
 import {Circle} from "./svg/Circle";
 import { GameboardCard, GameboardLinkLocation } from "./cards/GameboardCard";
-
-const midnightOf = (date: Date | number) => {
-    const d = new Date(date);
-    d.setHours(23, 59, 59, 999);
-    return d;
-};
 
 const CSCircle = ({label, percentage}: {percentage: number | unknown, label: string}) => {
     return <Label>
@@ -30,7 +25,6 @@ const CSCircle = ({label, percentage}: {percentage: number | unknown, label: str
 };
 
 const PhyAssignmentCard = ({assignment}: {assignment: AssignmentDTO}) => {
-    const now = new Date();
     const assignmentStartDate = assignment.scheduledStartDate ?? assignment.creationDate;
 
     return <GameboardCard gameboard={assignment.gameboard} linkLocation={GameboardLinkLocation.Card}>
@@ -41,7 +35,7 @@ const PhyAssignmentCard = ({assignment}: {assignment: AssignmentDTO}) => {
                         Assigned <strong>{getFriendlyDaysUntil(assignmentStartDate)}</strong>
                     </p>
                 }
-                {isDefined(assignment.dueDate) && isDefined(assignment.gameboard) && now > midnightOf(assignment.dueDate) && assignment.gameboard.percentageAttempted !== 100
+                {isDefined(assignment.dueDate) && isDefined(assignment.gameboard) && isOverdue(assignment) && assignment.gameboard.percentageAttempted !== 100
                     ? <p className="mb-0"><strong className="overdue">Overdue</strong> <span className="small text-muted">(due {formatDate(assignment.dueDate)})</span></p>
                     : <>{assignment.dueDate && <p className="mb-0">Due <strong>{getFriendlyDaysUntil(assignment.dueDate)}</strong></p>}</>
                 }
@@ -61,7 +55,6 @@ const PhyAssignmentCard = ({assignment}: {assignment: AssignmentDTO}) => {
 };
 
 const CSAssignmentCard = ({assignment}: {assignment: AssignmentDTO}) => {
-    const now = new Date();
     const assignmentStartDate = assignment.scheduledStartDate ?? assignment.creationDate;
     return <Row data-testid={"my-assignment"} className={"pt-3 mb-3 border-top"}>
         <Col xs={8} sm={9} md={7} lg={8}>
@@ -69,7 +62,7 @@ const CSAssignmentCard = ({assignment}: {assignment: AssignmentDTO}) => {
                 <h4>{isDefined(assignment.gameboard) && assignment.gameboard.title}</h4>
             </Link>
             {isDefined(assignmentStartDate) && <p className="mb-0" data-testid={"gameboard-assigned"}><strong>Assigned:</strong> {formatDate(assignmentStartDate)}</p>}
-            {isDefined(assignment.dueDate) && isDefined(assignment.gameboard) && now > midnightOf(assignment.dueDate) && assignment.gameboard.percentageAttempted !== 100
+            {isDefined(assignment.dueDate) && isDefined(assignment.gameboard) && isOverdue(assignment) && assignment.gameboard.percentageAttempted !== 100
                 ? <p className="mb-0"><strong className="overdue">Overdue:</strong> {formatDate(assignment.dueDate)}</p>
                 : <>{assignment.dueDate && <p className="mb-0"><strong>Due:</strong> {formatDate(assignment.dueDate)}</p>}</>
             }

--- a/src/app/components/elements/StudentDashboard.tsx
+++ b/src/app/components/elements/StudentDashboard.tsx
@@ -10,6 +10,7 @@ import { Spacer } from './Spacer';
 import classNames from 'classnames';
 import { AppGroup, UserSnapshot } from '../../../IsaacAppTypes';
 import { authenticateWithTokenAfterPrompt } from './panels/TeacherConnections';
+import { getFriendlyDaysUntil } from './DateString';
 
 const GroupJoinPanel = () => {
     const user = useAppSelector(selectors.user.orNull);
@@ -87,9 +88,7 @@ interface AssignmentCardProps {
 
 export const AssignmentCard = (props: AssignmentCardProps) => {
     const { assignment, isTeacherDashboard, groups } = props;
-    const today = new Date();
     const dueDate = assignment.dueDate ? new Date(assignment.dueDate) : undefined;
-    const daysUntilDue = dueDate ? Math.ceil((dueDate.getTime() - today.getTime()) / 86400000) : undefined; // 1000*60*60*24
 
     // QuizAssignmentDTOs don't have group names
     const groupIdToName = useMemo<{[id: number]: string | undefined}>(() => groups?.reduce((acc, group) => group?.id ? {...acc, [group.id]: group.groupName} : acc, {} as {[id: number]: string | undefined}) ?? {}, [groups]);
@@ -118,7 +117,7 @@ export const AssignmentCard = (props: AssignmentCardProps) => {
             </h5>
             <Spacer/>
             <div className="d-flex text-nowrap">
-                {dueDate && (isOverdue(assignment) ? <span className="overdue me-3">Overdue</span> : <span className="me-3">Due in {daysUntilDue} day{daysUntilDue !== 1 && "s"}</span>)}
+                {dueDate && (isOverdue(assignment) ? <span className="overdue me-3">Overdue</span> : <span className="me-3">Due {getFriendlyDaysUntil(dueDate)}</span>)}
                 <span className="group-name">{groupName}</span>
             </div>
         </Card>

--- a/src/app/components/elements/TeacherDashboard.tsx
+++ b/src/app/components/elements/TeacherDashboard.tsx
@@ -2,7 +2,7 @@ import React, { ChangeEvent, useState } from 'react';
 import { selectors, useAppSelector } from '../../state';
 import { Button, Card, Col, Row } from 'reactstrap';
 import { Link } from 'react-router-dom';
-import { BookInfo, extractTeacherName, ISAAC_BOOKS, isDefined, isTutor, sortUpcomingAssignments, Subject, useDeviceSize } from '../../services';
+import { BookInfo, extractTeacherName, ISAAC_BOOKS, isDefined, isOverdue, isTutor, sortUpcomingAssignments, Subject, useDeviceSize } from '../../services';
 import { AssignmentDTO, QuizAssignmentDTO, UserSummaryDTO } from '../../../IsaacApiTypes';
 import StyledToggle from './inputs/StyledToggle';
 import { AssignmentCard, StudentDashboard } from './StudentDashboard';
@@ -49,10 +49,10 @@ const AssignmentsPanel = ({ assignments, quizzes, groups }: AssignmentsPanelProp
         return <div className="dashboard-panel"/>;
     }
     
-    const upcomingAssignments = assignments?.filter(a => a.dueDate ? a.dueDate >= new Date() : false); // Filter out past assignments
+    const upcomingAssignments = assignments?.filter(a => !isOverdue(a)); // Filter out past assignments
     const sortedAssignments = upcomingAssignments ? sortUpcomingAssignments(upcomingAssignments) : [];
 
-    const upcomingQuizAssignments = quizzes?.filter(a => a.dueDate ? a.dueDate >= new Date() : false); // Filter out past quizzes
+    const upcomingQuizAssignments = quizzes?.filter(a => !isOverdue(a)); // Filter out past quizzes
     const sortedQuizAssignments = upcomingQuizAssignments ? sortUpcomingAssignments(upcomingQuizAssignments) : [];
 
     // Get the 3 most urgent due dates from assignments & quizzes combined

--- a/src/app/services/assignments.ts
+++ b/src/app/services/assignments.ts
@@ -15,13 +15,13 @@ function createAssignmentWithStartDate(assignment: AssignmentDTO): AssignmentDTO
     return {...assignment, startDate: assignmentStartDate};
 }
 
+const now = new Date();
+const midnightLastNight = new Date(now);
+midnightLastNight.setHours(0, 0, 0, 0);
+
 type AssignmentStatus = "inProgressRecent" | "inProgressOld" | "allAttempted" | "allCorrect";
 export const filterAssignmentsByStatus = (assignments: AssignmentDTO[] | undefined | null) => {
-    const now = new Date();
     const fourWeeksAgo = new Date(now.valueOf() - (4 * 7 * 24 * 60 * 60 * 1000));
-    // Midnight last night:
-    const midnightLastNight = new Date(now);
-    midnightLastNight.setHours(0, 0, 0, 0);
 
     const myAssignments: Record<AssignmentStatus, (AssignmentDTO & {startDate: Date | number})[]> = {
         inProgressRecent: [],
@@ -118,4 +118,4 @@ export const getAssignmentStartDate = (a: AssignmentDTO): number => (a.scheduled
 
 export const hasAssignmentStarted = (a: AssignmentDTO): boolean => getAssignmentStartDate(a) <= Date.now();
 
-export const isOverdue = (a: IAssignmentLike) =>  a.dueDate && a.dueDate < new Date();
+export const isOverdue = (a: IAssignmentLike) =>  a.dueDate && a.dueDate < midnightLastNight;


### PR DESCRIPTION
The homepage dashboards weren't showing assignments/quizzes due today because they were considered overdue. This was inconsistent with My Assignments, which doesn't consider an assignment overdue until midnight at the _end_ of the due date. Both places now use the same `isOverdue` function which maintains the current My Assignments behaviour.

(This also fixes some edge cases for the student dashboard where having assignments due today prevented the next-soonest assignments from being shown).
