### PR TITLE
Feature/quiz view redesign

### DIFF
--- a/src/IsaacApiTypes.tsx
+++ b/src/IsaacApiTypes.tsx
@@ -214,6 +214,14 @@ export interface IsaacQuizDTO extends SeguePageDTO, HasTitleOrId {
     individualFeedback?: QuizFeedbackDTO;
 }
 
+export interface IsaacRubricDTO extends HasTitleOrId{
+    rubric?: ContentDTO;
+    hiddenFromRoles: UserRole[];
+    tags: string[];
+    type: string;
+    url: string
+}
+
 export interface IsaacQuizSectionDTO extends SeguePageDTO {
 }
 
@@ -411,7 +419,7 @@ export interface ContentDTO extends ContentBaseDTO {
     encoding?: string;
     layout?: string;
     expandable?: boolean;
-    children?: ContentBaseDTO[];
+    children?: ContentDTO[];
     value?: string;
     attribution?: string;
     relatedContent?: ContentSummaryDTO[];

--- a/src/app/components/elements/layout/SidebarLayout.tsx
+++ b/src/app/components/elements/layout/SidebarLayout.tsx
@@ -850,6 +850,7 @@ export const QuizSidebar = (props: QuizSidebarProps) => {
                 <div className="d-flex flex-column sidebar-key">
                 Key
                     <ul>
+                        <KeyItem icon="status-not-started" text="Section not started"/>
                         <KeyItem icon="status-in-progress" text="Section in progress"/>
                         <KeyItem icon="status-correct" text="Section completed"/>
                     </ul>

--- a/src/app/components/elements/quiz/QuizAttemptComponent.tsx
+++ b/src/app/components/elements/quiz/QuizAttemptComponent.tsx
@@ -218,7 +218,7 @@ function QuizSection({attempt, page, studentUser, user, quizAssignmentId}: QuizA
 
 export const myQuizzesCrumbs = [{title: siteSpecific("My Tests", "My tests"), to: `/tests`}];
 export const teacherQuizzesCrumbs = [{title: siteSpecific("Set / Manage Tests", "Set tests"), to: `/set_tests`}];
-export const rubricCrumbs = [{title: "Practice Tests", to: "/practice_tests"}];
+export const rubricCrumbs = [{title: siteSpecific("Practice Tests", "Practice tests"), to: "/practice_tests"}];
 const getCrumbs = (preview: boolean | undefined, view: boolean | undefined, user: RegisteredUserDTO) => {
     if (preview && isTeacherOrAbove(user)) {
         return teacherQuizzesCrumbs;

--- a/src/app/components/elements/quiz/QuizAttemptComponent.tsx
+++ b/src/app/components/elements/quiz/QuizAttemptComponent.tsx
@@ -115,7 +115,7 @@ function QuizHeader({attempt, preview, view, user}: QuizAttemptProps) {
         return <>
             <EditContentButton doc={attempt.quiz} />
             <div data-testid="quiz-action" className="d-flex">
-                <span>{ preview ? "You are previewing this test." : "You are viewing the rubric for this test."}</span>
+                <p>{ preview ? "You are previewing this test." : "You are viewing the rubric for this test."}</p>
                 <Spacer />
                 {isTeacherOrAbove(user) && <Button onClick={() => dispatch(showQuizSettingModal(attempt.quiz as IsaacQuizDTO))}>Set Test</Button>}
             </div>

--- a/src/app/components/elements/quiz/QuizAttemptComponent.tsx
+++ b/src/app/components/elements/quiz/QuizAttemptComponent.tsx
@@ -87,7 +87,8 @@ function QuizContents({attempt, sections, questions, pageLink}: QuizAttemptProps
                 </table>;
     } else {
         const anyStarted = questions.some(q => q.bestAttempt !== undefined);
-        return <div>
+        const anySections = Object.keys(sections).length > 0;
+        return anySections && <div>
             <h4>Test sections</h4>
             <ul>
                 {Object.keys(sections).map((k, index) => {

--- a/src/app/components/elements/quiz/QuizAttemptComponent.tsx
+++ b/src/app/components/elements/quiz/QuizAttemptComponent.tsx
@@ -114,7 +114,7 @@ function QuizHeader({attempt, preview, view, user}: QuizAttemptProps) {
     if (preview || view) {
         return <>
             <EditContentButton doc={attempt.quiz} />
-            <div data-testId="quiz-action" className="d-flex">
+            <div data-testid="quiz-action" className="d-flex">
                 <span>{ preview ? "You are previewing this test." : "You are viewing the rubric for this test."}</span>
                 <Spacer />
                 {isTeacherOrAbove(user) && <Button onClick={() => dispatch(showQuizSettingModal(attempt.quiz as IsaacQuizDTO))}>Set Test</Button>}
@@ -143,7 +143,7 @@ function QuizHeader({attempt, preview, view, user}: QuizAttemptProps) {
             </Alert>}
         </>;
     } else {
-        return <p>You {attempt.completedDate ? "freely attempted" : "are freely attempting"} this test.</p>;
+        return <p data-testid="quiz-action">You {attempt.completedDate ? "freely attempted" : "are freely attempting"} this test.</p>;
     }
 }
 

--- a/src/app/components/elements/quiz/QuizAttemptComponent.tsx
+++ b/src/app/components/elements/quiz/QuizAttemptComponent.tsx
@@ -74,7 +74,7 @@ function QuizContents({attempt, sections, questions, pageLink}: QuizAttemptProps
                             const section = sections[k];
                             return <tr key={k}>
                                 {attempt.feedbackMode === 'DETAILED_FEEDBACK' ?
-                                    <td><Link replace to={pageLink(index + 1)}>{section.title}</Link></td> :
+                                    <td><Link to={pageLink(index + 1)}>{section.title}</Link></td> :
                                     <td>{section.title}</td>
                                 }
                                 <td>
@@ -98,7 +98,7 @@ function QuizContents({attempt, sections, questions, pageLink}: QuizAttemptProps
                     const answerCount = questionsInSection.filter(q => q.bestAttempt !== undefined).length;
                     const completed = questionsInSection.length === answerCount;
                     return <li key={k}>
-                        <Link replace to={pageLink(index + 1)}>{section.title}</Link>
+                        <Link to={pageLink(index + 1)}>{section.title}</Link>
                         {" "}
                         <small className="text-muted">{completed ? "Completed" : anyStarted ? `${answerCount} / ${questionsInSection.length}` : ""}</small>
                     </li>;
@@ -269,9 +269,9 @@ export function QuizPagination({page, sections, pageLink, finalLabel}: QuizAttem
     const nextLink = pageLink(!finalSection ? page + 1 : undefined);
 
     return <div className="d-flex w-100 justify-content-between align-items-center">
-        <Button color="primary" outline={isAda} size={below["sm"](deviceSize) ? "sm" : ""} className={classNames({"btn btn-keyline": isPhy})} tag={Link} replace to={backLink}>Back</Button>
+        <Button color="primary" outline={isAda} size={below["sm"](deviceSize) ? "sm" : ""} className={classNames({"btn btn-keyline": isPhy})} tag={Link} to={backLink}>Back</Button>
         <div className="d-none d-md-block">Section {page} / {sectionCount}</div>
-        <Button color="secondary" size={below["sm"](deviceSize) ? "sm" : ""} tag={Link} replace to={nextLink}>{finalSection ? finalLabel : "Next"}</Button>
+        <Button color="secondary" size={below["sm"](deviceSize) ? "sm" : ""} tag={Link} to={nextLink}>{finalSection ? finalLabel : "Next"}</Button>
     </div>;
 }
 

--- a/src/app/components/elements/quiz/QuizAttemptFooter.tsx
+++ b/src/app/components/elements/quiz/QuizAttemptFooter.tsx
@@ -62,8 +62,8 @@ export function QuizAttemptFooter(props: QuizAttemptProps & {feedbackLink: strin
             controls = <>
                 {
                     siteSpecific(
-                        <Button className="btn btn-keyline" tag={Link} replace to={pageLink(1)}>Review answers</Button>,
-                        <Button outline color="secondary" tag={Link} replace to={pageLink(1)}>Review answers</Button>
+                        <Button className="btn btn-keyline" tag={Link} to={pageLink(1)}>Review answers</Button>,
+                        <Button outline color="secondary" tag={Link} to={pageLink(1)}>Review answers</Button>
                     )
                 }
                 <Spacer/>
@@ -80,7 +80,7 @@ export function QuizAttemptFooter(props: QuizAttemptProps & {feedbackLink: strin
                     <Spacer/>
                     {totalCompleted} / {sectionCount} sections complete<br/>
                     <Spacer/>
-                    <Button color={siteSpecific("secondary", "primary")} tag={Link} replace to={pageLink(firstIncomplete + 1)}>Continue</Button>
+                    <Button color={siteSpecific("secondary", "primary")} tag={Link} to={pageLink(firstIncomplete + 1)}>Continue</Button>
                 </>;
             } else {
                 controls = <>

--- a/src/app/components/elements/quiz/QuizAttemptFooter.tsx
+++ b/src/app/components/elements/quiz/QuizAttemptFooter.tsx
@@ -12,6 +12,7 @@ import {IsaacSpinner} from "../../handlers/IsaacSpinner";
 import {Button} from "reactstrap";
 import {below, confirmThen, isAda, siteSpecific, useDeviceSize} from "../../../services";
 import { MainContent, SidebarLayout } from "../layout/SidebarLayout";
+import { QuizSidebarLayout } from "./QuizSidebarLayout";
 
 function extractSectionIdFromQuizQuestionId(questionId: string) {
     const ids = questionId.split("|", 3);
@@ -94,11 +95,7 @@ export function QuizAttemptFooter(props: QuizAttemptProps & {feedbackLink: strin
     }
 
     // Empty sidebar to match layout of quiz attempt component
-    return <SidebarLayout className="d-flex flex-column align-items-end">
-        <MainContent>
-            <div className="d-flex border-top pt-2 my-2 align-items-center">
-                {controls}
-            </div>
-        </MainContent>
-    </SidebarLayout>;
+    return <QuizSidebarLayout>
+        {controls}
+    </QuizSidebarLayout>;
 }

--- a/src/app/components/elements/quiz/QuizAttemptFooter.tsx
+++ b/src/app/components/elements/quiz/QuizAttemptFooter.tsx
@@ -39,7 +39,6 @@ export function QuizAttemptFooter(props: QuizAttemptProps & {feedbackLink: strin
     const sectionCount = Object.keys(sections).length;
 
     let controls;
-    let prequel = null;
     if (page === null) {
         let anyAnswered = false;
         const completedSections = Object.keys(sections).reduce((map, sectionId) => {
@@ -57,9 +56,6 @@ export function QuizAttemptFooter(props: QuizAttemptProps & {feedbackLink: strin
         const totalCompleted = Object.values(completedSections).reduce((sum, complete) => sum + (complete ? 1 : 0), 0);
         const firstIncomplete = Object.values(completedSections).indexOf(false);
         const allCompleted = totalCompleted === sectionCount;
-
-        const primaryButton = anyAnswered ? "Continue" : "Start";
-        const primaryDescription = anyAnswered ? "resume" : "begin";
         const submitButton = submitting ? <IsaacSpinner /> : allCompleted ? "Submit" : "Submit anyway";
 
         if (allCompleted) {
@@ -76,7 +72,6 @@ export function QuizAttemptFooter(props: QuizAttemptProps & {feedbackLink: strin
                 <Button color={siteSpecific("secondary", "primary")} onClick={submitQuiz}>{submitButton}</Button>
             </>;
         } else {
-            prequel = <p>Click &lsquo;{primaryButton}&rsquo; when you are ready to {primaryDescription} the test.</p>;
             if (anyAnswered) {
                 controls = <>
                     <div className="text-center">
@@ -85,12 +80,12 @@ export function QuizAttemptFooter(props: QuizAttemptProps & {feedbackLink: strin
                     <Spacer/>
                     {totalCompleted} / {sectionCount} sections complete<br/>
                     <Spacer/>
-                    <Button color={siteSpecific("secondary", "primary")} tag={Link} replace to={pageLink(firstIncomplete + 1)}>{primaryButton}</Button>
+                    <Button color={siteSpecific("secondary", "primary")} tag={Link} replace to={pageLink(firstIncomplete + 1)}>Continue</Button>
                 </>;
             } else {
                 controls = <>
                     <Spacer/>
-                    <Button color={siteSpecific("secondary", "primary")} tag={Link} replace to={pageLink(1)}>{primaryButton}</Button>
+                    <Button color={siteSpecific("secondary", "primary")} tag={Link} replace to={pageLink(1)}>Continue</Button>
                 </>;
             }
         }
@@ -101,7 +96,6 @@ export function QuizAttemptFooter(props: QuizAttemptProps & {feedbackLink: strin
     // Empty sidebar to match layout of quiz attempt component
     return <SidebarLayout className="d-flex flex-column align-items-end">
         <MainContent>
-            {(isAda || below["md"](deviceSize)) && prequel}
             <div className="d-flex border-top pt-2 my-2 align-items-center">
                 {controls}
             </div>

--- a/src/app/components/elements/quiz/QuizAttemptFooter.tsx
+++ b/src/app/components/elements/quiz/QuizAttemptFooter.tsx
@@ -85,7 +85,7 @@ export function QuizAttemptFooter(props: QuizAttemptProps & {feedbackLink: strin
             } else {
                 controls = <>
                     <Spacer/>
-                    <Button color={siteSpecific("secondary", "primary")} tag={Link} replace to={pageLink(1)}>Continue</Button>
+                    <Button color={siteSpecific("secondary", "primary")} tag={Link} to={pageLink(1)}>Continue</Button>
                 </>;
             }
         }

--- a/src/app/components/elements/quiz/QuizSidebarLayout.tsx
+++ b/src/app/components/elements/quiz/QuizSidebarLayout.tsx
@@ -1,0 +1,11 @@
+import React, { ReactNode } from "react";
+import { SidebarLayout, MainContent } from "../layout/SidebarLayout";
+
+export const QuizSidebarLayout = ({ children } : { children: ReactNode }) =>
+    <SidebarLayout className="d-flex flex-column align-items-end">
+        <MainContent>
+            <div className="d-flex border-top pt-2 my-2 align-items-center">
+                {children}
+            </div>
+        </MainContent>
+    </SidebarLayout>;

--- a/src/app/components/elements/quiz/builErrorComponent.tsx
+++ b/src/app/components/elements/quiz/builErrorComponent.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import {TitleAndBreadcrumb} from "../../elements/TitleAndBreadcrumb";
+import {myQuizzesCrumbs} from "./QuizAttemptComponent";
+import {Alert} from "reactstrap";
+import { getRTKQueryErrorMessage } from "../../../state";
+import type {FetchBaseQueryError} from "@reduxjs/toolkit/query";
+import type {SerializedError} from "@reduxjs/toolkit";
+
+type Error = FetchBaseQueryError | SerializedError | undefined;
+
+export const buildErrorComponent = (title: string, heading: string) => function ErrorComponent(error: Error){
+    return <>
+        <TitleAndBreadcrumb currentPageTitle={title} intermediateCrumbs={myQuizzesCrumbs} />
+        <Alert color="danger">
+            <h4 className="alert-heading">{heading}</h4>
+            <p data-testid="error-message">{getRTKQueryErrorMessage(error).message}</p>
+        </Alert>
+    </>;
+};

--- a/src/app/components/elements/quiz/builErrorComponent.tsx
+++ b/src/app/components/elements/quiz/builErrorComponent.tsx
@@ -1,16 +1,16 @@
 import React from "react";
 import {TitleAndBreadcrumb} from "../../elements/TitleAndBreadcrumb";
-import {myQuizzesCrumbs} from "./QuizAttemptComponent";
 import {Alert} from "reactstrap";
 import { getRTKQueryErrorMessage } from "../../../state";
 import type {FetchBaseQueryError} from "@reduxjs/toolkit/query";
 import type {SerializedError} from "@reduxjs/toolkit";
+import { LinkInfo } from "../../../services";
 
 type Error = FetchBaseQueryError | SerializedError | undefined;
 
-export const buildErrorComponent = (title: string, heading: string) => function ErrorComponent(error: Error){
+export const buildErrorComponent = (title: string, heading: string, breadcrumbs: LinkInfo[]) => function ErrorComponent(error: Error){
     return <>
-        <TitleAndBreadcrumb currentPageTitle={title} intermediateCrumbs={myQuizzesCrumbs} />
+        <TitleAndBreadcrumb currentPageTitle={title} intermediateCrumbs={breadcrumbs} />
         <Alert color="danger">
             <h4 className="alert-heading">{heading}</h4>
             <p data-testid="error-message">{getRTKQueryErrorMessage(error).message}</p>

--- a/src/app/components/pages/quizzes/PracticeQuizzes.tsx
+++ b/src/app/components/pages/quizzes/PracticeQuizzes.tsx
@@ -50,54 +50,38 @@ const PracticeQuizzesComponent = (props: QuizzesPageProps) => {
         {isTutorOrAbove(user) && ((quiz.hiddenFromRoles && !quiz.hiddenFromRoles?.includes("STUDENT")) || quiz.visibleToStudents) && <div className="small text-muted d-block ms-2">visible to students</div>}
     </>;
 
-    return <Container { ...(pageContext?.subject && { "data-bs-theme" : pageContext.subject })}>
-        <TitleAndBreadcrumb 
-            currentPageTitle={siteSpecific("Practice Tests", "Practice tests")} 
-            icon={{"type": "hex", "icon": "icon-tests"}}
-        />
-        <SidebarLayout>
-            <PracticeQuizzesSidebar />
-            <MainContent>
-                <PageFragment fragmentId="help_toptext_practice_tests" />
-                {!user 
-                    ? <b>You must be logged in to view practice tests.</b> 
-                    : <ShowLoading until={quizzes}>
-                        {quizzes && <>
-                            {quizzes.length === 0 && <p><em>There are no practice tests currently available.</em></p>}
-                            <Col xs={12} className="mb-4">
-                                <Input type="text" placeholder="Filter tests by name..." value={filterText} onChange={(e) => setFilterText(e.target.value)} />
-                                <button className={`copy-test-filter-link m-0 ${copied ? "clicked" : ""}`} tabIndex={-1} onClick={() => {
-                                    if (filterText.trim()) {
-                                        navigator.clipboard.writeText(`${window.location.host}${window.location.pathname}?filter=${filterText.trim()}#practice`);
-                                    }
-                                    setCopied(true);
-                                }} onMouseLeave={() => setCopied(false)} />
-                            </Col>
-                            <ListGroup className="mb-3 quiz-list">
-                                {quizzes.filter((quiz) => showQuiz(quiz) && quiz.title?.toLowerCase().includes(filterText.toLowerCase())).map(quiz => <ListGroupItem className="p-0 bg-transparent" key={quiz.id}>
-                                    <div className="d-flex flex-grow-1 flex-column flex-sm-row align-items-center p-3">
-                                        <div>
-                                            <span className="mb-2 mb-sm-0 pe-2">{quiz.title}</span>
-                                            {roleVisibilitySummary(quiz)}
-                                            {quiz.summary && <div className="small text-muted d-none d-md-block">{quiz.summary}</div>}
-                                        </div>
-                                        <Spacer />
-                                        {isTutorOrAbove(user) && <div className="d-none d-md-flex align-items-center me-4">
-                                            <Link to={{pathname: `/test/preview/${quiz.id}`}}>
-                                                <span>Preview</span>
-                                            </Link>
-                                        </div>}
-                                        <Button tag={Link} to={{pathname: `/test/attempt/${quiz.id}`}}>
-                                            {siteSpecific("Take Test", "Take test")}
-                                        </Button>
-                                    </div>
-                                </ListGroupItem>)}
-                            </ListGroup>
-                        </>}
-                    </ShowLoading>
-                }
-            </MainContent>
-        </SidebarLayout>
+    return <Container>
+        <TitleAndBreadcrumb currentPageTitle={siteSpecific("Practice Tests", "Practice tests")} />
+        <PageFragment fragmentId="help_toptext_practice_tests" />
+        <ShowLoading until={quizzes}>
+            {quizzes && <>
+                {quizzes.length === 0 && <p><em>There are no practice tests currently available.</em></p>}
+                <Col xs={12} className="mb-4">
+                    <Input type="text" placeholder="Filter tests by name..." value={filterText} onChange={(e) => setFilterText(e.target.value)} />
+                    <button className={`copy-test-filter-link m-0 ${copied ? "clicked" : ""}`} tabIndex={-1} onClick={() => {
+                        if (filterText.trim()) {
+                            navigator.clipboard.writeText(`${window.location.host}${window.location.pathname}?filter=${filterText.trim()}#practice`);
+                        }
+                        setCopied(true);
+                    }} onMouseLeave={() => setCopied(false)} />
+                </Col>
+                <ListGroup className="mb-3 quiz-list">
+                    {quizzes.filter((quiz) => showQuiz(quiz) && quiz.title?.toLowerCase().includes(filterText.toLowerCase())).map(quiz => <ListGroupItem className="p-0 bg-transparent" key={quiz.id}>
+                        <div className="d-flex flex-grow-1 flex-column flex-sm-row align-items-center p-3">
+                            <div>
+                                <span className="mb-2 mb-sm-0 pe-2">{quiz.title}</span>
+                                {roleVisibilitySummary(quiz)}
+                                {quiz.summary && <div className="small text-muted d-none d-md-block">{quiz.summary}</div>}
+                            </div>
+                            <Spacer />
+                            <Button tag={Link} to={{pathname: `/test/view/${quiz.id}`}}>
+                                {siteSpecific("View Test", "View test")}
+                            </Button>
+                        </div>
+                    </ListGroupItem>)}
+                </ListGroup>
+            </>}
+        </ShowLoading>
     </Container>;
 };
 

--- a/src/app/components/pages/quizzes/QuizAttemptFeedback.tsx
+++ b/src/app/components/pages/quizzes/QuizAttemptFeedback.tsx
@@ -23,7 +23,7 @@ function QuizAttemptFeedbackFooter(props: QuizAttemptProps) {
         prequel = <p className="mt-3">Click on a section title or click &lsquo;Next&rsquo; to look at {isDefined(studentUser) ? "their" : "your"} detailed feedback.</p>;
         controls = <>
             <Spacer/>
-            <Button tag={Link} replace to={pageLink(1)}>Next</Button>
+            <Button tag={Link} to={pageLink(1)}>Next</Button>
         </>;
     } else {
         controls = <QuizPagination {...props} page={page} finalLabel="Back to Overview" />;

--- a/src/app/components/pages/quizzes/QuizDoFreeAttempt.tsx
+++ b/src/app/components/pages/quizzes/QuizDoFreeAttempt.tsx
@@ -51,7 +51,7 @@ export const QuizDoFreeAttempt = ({user}: {user: RegisteredUserDTO}) => {
                 <TitleAndBreadcrumb currentPageTitle="Test" intermediateCrumbs={myQuizzesCrumbs} icon={{type: "hex", icon: "icon-error"}} />
                 <Alert color={assignedQuizError ? "warning" : "danger"} className="mt-4">
                     <h4 className="alert-heading">{assignedQuizError ? "You have been set this test" : "Error loading test!"}</h4>
-                    {!assignedQuizError && <p>{error}</p>}
+                    {!assignedQuizError && <p data-testId="error-message">{error}</p>}
                     {assignedQuizError && <>
                         <p>Your teacher has set this test to you.  You may not practise it in advance.<br/>
                             If you are ready to take the test, click on it in your <a href={"/tests"} target="_self" rel="noopener noreferrer">assigned tests</a> page.

--- a/src/app/components/pages/quizzes/QuizDoFreeAttempt.tsx
+++ b/src/app/components/pages/quizzes/QuizDoFreeAttempt.tsx
@@ -41,7 +41,7 @@ export const QuizDoFreeAttempt = ({user}: {user: RegisteredUserDTO}) => {
     // Importantly, these are only used if attempt is defined
     const subProps: QuizAttemptProps & {feedbackLink: string} = {attempt: attempt as QuizAttemptDTO, page: pageNumber, questions, sections, pageLink, pageHelp, user, feedbackLink};
 
-    return <Container className={`mb-5 ${attempt?.quiz?.subjectId}`} data-bs-theme={getThemeFromTags(attempt?.quiz?.tags)}>
+    return <Container data-testId="quiz-attempt" className={`mb-5 ${attempt?.quiz?.subjectId}`} data-bs-theme={getThemeFromTags(attempt?.quiz?.tags)}>
         <ShowLoading until={attempt || error}>
             {attempt && <>
                 <QuizAttemptComponent {...subProps} />

--- a/src/app/components/pages/quizzes/QuizPreview.tsx
+++ b/src/app/components/pages/quizzes/QuizPreview.tsx
@@ -15,7 +15,7 @@ const QuizFooter = ({page, pageLink, ...rest}: QuizAttemptProps) =>
             ? <QuizPagination {...rest} page={page} pageLink={pageLink} finalLabel="Back to Contents" />
             : <>
                 <Spacer/>
-                <Button color="secondary" tag={Link} replace to={pageLink(1)}>{"View questions"}</Button>
+                <Button color="secondary" tag={Link} to={pageLink(1)}>{"View questions"}</Button>
             </>}
     </div>;
 

--- a/src/app/components/pages/quizzes/QuizPreview.tsx
+++ b/src/app/components/pages/quizzes/QuizPreview.tsx
@@ -1,20 +1,13 @@
 import React, {useCallback, useMemo} from "react";
-import {getRTKQueryErrorMessage, useGetQuizPreviewQuery} from "../../../state";
+import {useGetQuizPreviewQuery} from "../../../state";
 import {Link, useParams} from "react-router-dom";
 import {getThemeFromTags, isDefined, tags, useQuizQuestions, useQuizSections} from "../../../services";
-import {
-    myQuizzesCrumbs,
-    QuizAttemptComponent,
-    QuizAttemptProps,
-    QuizPagination
-} from "../../elements/quiz/QuizAttemptComponent";
+import {QuizAttemptComponent, QuizAttemptProps, QuizPagination} from "../../elements/quiz/QuizAttemptComponent";
 import {QuizAttemptDTO, RegisteredUserDTO} from "../../../../IsaacApiTypes";
 import {Spacer} from "../../elements/Spacer";
-import {TitleAndBreadcrumb} from "../../elements/TitleAndBreadcrumb";
-import {Alert, Button, Container} from "reactstrap";
+import {Button, Container} from "reactstrap";
 import {ShowLoadingQuery} from "../../handlers/ShowLoadingQuery";
-import {FetchBaseQueryError} from "@reduxjs/toolkit/query";
-import {SerializedError} from "@reduxjs/toolkit";
+import {buildErrorComponent} from "../../elements/quiz/builErrorComponent";
 
 const QuizFooter = ({page, pageLink, ...rest}: QuizAttemptProps) =>
     <div className="d-flex border-top pt-2 my-2 align-items-center">
@@ -29,6 +22,8 @@ const QuizFooter = ({page, pageLink, ...rest}: QuizAttemptProps) =>
 const pageHelp = <span>
     Preview the questions on this test.
 </span>;
+
+const Error = buildErrorComponent("Test Preview", "Error loading test preview");
 
 export const QuizPreview = ({user}: {user: RegisteredUserDTO}) => {
 
@@ -56,16 +51,8 @@ export const QuizPreview = ({user}: {user: RegisteredUserDTO}) => {
 
     const subProps: QuizAttemptProps = {attempt: attempt as QuizAttemptDTO, page: pageNumber, questions, sections, pageLink, pageHelp, user};
 
-    const buildErrorComponent = (error: FetchBaseQueryError | SerializedError | undefined) => <>
-        <TitleAndBreadcrumb currentPageTitle="Test Preview" intermediateCrumbs={myQuizzesCrumbs} icon={{type: "hex", icon: "icon-error"}}/>
-        <Alert color="danger">
-            <h4 className="alert-heading">Error loading test preview</h4>
-            <p>{getRTKQueryErrorMessage(error).message}</p>
-        </Alert>
-    </>;
-
     return <Container className={`mb-5 ${attempt?.quiz?.subjectId}`} data-bs-theme={getThemeFromTags(quiz?.tags)}>
-        <ShowLoadingQuery query={quizPreviewQuery} ifError={buildErrorComponent}>
+        <ShowLoadingQuery query={quizPreviewQuery} ifError={Error}>
             <QuizAttemptComponent preview {...subProps} />
             <QuizFooter {...subProps} />
         </ShowLoadingQuery>

--- a/src/app/components/pages/quizzes/QuizPreview.tsx
+++ b/src/app/components/pages/quizzes/QuizPreview.tsx
@@ -51,7 +51,7 @@ export const QuizPreview = ({user}: {user: RegisteredUserDTO}) => {
 
     const subProps: QuizAttemptProps = {attempt: attempt as QuizAttemptDTO, page: pageNumber, questions, sections, pageLink, pageHelp, user};
 
-    return <Container className={`mb-5 ${attempt?.quiz?.subjectId}`} data-bs-theme={getThemeFromTags(quiz?.tags)}>
+    return <Container data-testId="quiz-preview" className={`mb-5 ${attempt?.quiz?.subjectId}`} data-bs-theme={getThemeFromTags(quiz?.tags)}>
         <ShowLoadingQuery query={quizPreviewQuery} ifError={Error}>
             <QuizAttemptComponent preview {...subProps} />
             <QuizFooter {...subProps} />

--- a/src/app/components/pages/quizzes/QuizPreview.tsx
+++ b/src/app/components/pages/quizzes/QuizPreview.tsx
@@ -8,16 +8,17 @@ import {Spacer} from "../../elements/Spacer";
 import {Button, Container} from "reactstrap";
 import {ShowLoadingQuery} from "../../handlers/ShowLoadingQuery";
 import {buildErrorComponent} from "../../elements/quiz/builErrorComponent";
+import { QuizSidebarLayout } from "../../elements/quiz/QuizSidebarLayout";
 
 const QuizFooter = ({page, pageLink, ...rest}: QuizAttemptProps) =>
-    <div className="d-flex border-top pt-2 my-2 align-items-center">
+    <QuizSidebarLayout>
         {isDefined(page)
             ? <QuizPagination {...rest} page={page} pageLink={pageLink} finalLabel="Back to Contents" />
             : <>
                 <Spacer/>
                 <Button color="secondary" tag={Link} to={pageLink(1)}>{"View questions"}</Button>
             </>}
-    </div>;
+    </QuizSidebarLayout>;
 
 const pageHelp = <span>
     Preview the questions on this test.

--- a/src/app/components/pages/quizzes/QuizPreview.tsx
+++ b/src/app/components/pages/quizzes/QuizPreview.tsx
@@ -2,7 +2,7 @@ import React, {useCallback, useMemo} from "react";
 import {useGetQuizPreviewQuery} from "../../../state";
 import {Link, useParams} from "react-router-dom";
 import {getThemeFromTags, isDefined, tags, useQuizQuestions, useQuizSections} from "../../../services";
-import {QuizAttemptComponent, QuizAttemptProps, QuizPagination} from "../../elements/quiz/QuizAttemptComponent";
+import {myQuizzesCrumbs, QuizAttemptComponent, QuizAttemptProps, QuizPagination} from "../../elements/quiz/QuizAttemptComponent";
 import {QuizAttemptDTO, RegisteredUserDTO} from "../../../../IsaacApiTypes";
 import {Spacer} from "../../elements/Spacer";
 import {Button, Container} from "reactstrap";
@@ -23,7 +23,7 @@ const pageHelp = <span>
     Preview the questions on this test.
 </span>;
 
-const Error = buildErrorComponent("Test Preview", "Error loading test preview");
+const Error = buildErrorComponent("Test Preview", "Error loading test preview", myQuizzesCrumbs);
 
 export const QuizPreview = ({user}: {user: RegisteredUserDTO}) => {
 

--- a/src/app/components/pages/quizzes/QuizView.tsx
+++ b/src/app/components/pages/quizzes/QuizView.tsx
@@ -18,7 +18,7 @@ const pageHelp = <span>
 const Error = buildErrorComponent("Unknown Test", "There was an error loading that test.", rubricCrumbs);
 
 const FooterButton = ({link, label}: {link: string, label: string}) => <Col className="d-flex">
-    <Button className="flex-fill d-flex align-items-center justify-content-center mb-3" color="secondary" tag={Link} to={link}>
+    <Button className="flex-fill d-flex text-nowrap align-items-center justify-content-center mb-3" color="secondary" tag={Link} to={link}>
         {label}
     </Button>
 </Col>; 

--- a/src/app/components/pages/quizzes/QuizView.tsx
+++ b/src/app/components/pages/quizzes/QuizView.tsx
@@ -12,7 +12,7 @@ import { Spacer } from "../../elements/Spacer";
 const pageLink = () => '';
 
 const pageHelp = <span>
-    View information about a test without adding it to "My Tests". This page page does not show any questions.
+    View information about a test without adding it to &quot;My Tests&quot;. This page page does not show any questions.
 </span>;
 
 const Error = buildErrorComponent("Unknown Test", "There was an error loading that test.", rubricCrumbs);
@@ -20,7 +20,7 @@ const Error = buildErrorComponent("Unknown Test", "There was an error loading th
 const QuizFooter = ({quizId}: {quizId: string}) =>
     <div className="d-flex border-top pt-2 my-2 align-items-center">
         <Spacer/>
-        <Button color="secondary" tag={Link} replace to={`/test/attempt/${quizId}`}>{"Take Test"}</Button>
+        <Button color="secondary" tag={Link} to={`/test/attempt/${quizId}`}>{"Take Test"}</Button>
     </div>;
 
 export const QuizView = ({user}: {user: RegisteredUserDTO}) => {

--- a/src/app/components/pages/quizzes/QuizView.tsx
+++ b/src/app/components/pages/quizzes/QuizView.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import {useGetQuizRubricQuery} from "../../../state";
 import {useParams} from "react-router-dom";
 import {tags} from "../../../services";
-import {QuizAttemptComponent} from "../../elements/quiz/QuizAttemptComponent";
+import {QuizAttemptComponent, rubricCrumbs} from "../../elements/quiz/QuizAttemptComponent";
 import {Container} from "reactstrap";
 import {ShowLoadingQuery} from "../../handlers/ShowLoadingQuery";
 import type { RegisteredUserDTO } from "../../../../IsaacApiTypes";
@@ -12,7 +12,7 @@ const pageLink = () => '';
 
 const pageHelp = <span> View information about this test. </span>;
 
-const Error = buildErrorComponent("Viewing Test", "There was an error loading that test.");
+const Error = buildErrorComponent("Unknown Test", "There was an error loading that test.", rubricCrumbs);
 
 export const QuizView = ({user}: {user: RegisteredUserDTO}) => {
     const {quizId} = useParams<{quizId: string}>();
@@ -24,7 +24,7 @@ export const QuizView = ({user}: {user: RegisteredUserDTO}) => {
 
     return <Container className={`mb-5 ${attempt?.quiz?.subjectId}`}>
         <ShowLoadingQuery query={quizRubricQuery} ifError={Error}>
-            <QuizAttemptComponent preview attempt={attempt} page={null} questions={[]} sections={{}} pageLink={pageLink} pageHelp={pageHelp} user={user} />
+            <QuizAttemptComponent view attempt={attempt} page={null} questions={[]} sections={{}} pageLink={pageLink} pageHelp={pageHelp} user={user} />
         </ShowLoadingQuery>
     </Container>;
 };

--- a/src/app/components/pages/quizzes/QuizView.tsx
+++ b/src/app/components/pages/quizzes/QuizView.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import {useGetQuizRubricQuery} from "../../../state";
+import {useParams} from "react-router-dom";
+import {tags} from "../../../services";
+import {QuizAttemptComponent} from "../../elements/quiz/QuizAttemptComponent";
+import {Container} from "reactstrap";
+import {ShowLoadingQuery} from "../../handlers/ShowLoadingQuery";
+import type { RegisteredUserDTO } from "../../../../IsaacApiTypes";
+import { buildErrorComponent } from "../../elements/quiz/builErrorComponent";
+
+const pageLink = () => '';
+
+const pageHelp = <span> View information about this test. </span>;
+
+const Error = buildErrorComponent("Viewing Test", "There was an error loading that test.");
+
+export const QuizView = ({user}: {user: RegisteredUserDTO}) => {
+    const {quizId} = useParams<{quizId: string}>();
+    const quizRubricQuery = useGetQuizRubricQuery(quizId);
+    const attempt = {
+        quiz: quizRubricQuery.data && tags.augmentDocWithSubject(quizRubricQuery.data),
+        quizId: quizRubricQuery.data?.id,
+    };
+
+    return <Container className={`mb-5 ${attempt?.quiz?.subjectId}`}>
+        <ShowLoadingQuery query={quizRubricQuery} ifError={Error}>
+            <QuizAttemptComponent preview attempt={attempt} page={null} questions={[]} sections={{}} pageLink={pageLink} pageHelp={pageHelp} user={user} />
+        </ShowLoadingQuery>
+    </Container>;
+};

--- a/src/app/components/pages/quizzes/QuizView.tsx
+++ b/src/app/components/pages/quizzes/QuizView.tsx
@@ -9,8 +9,6 @@ import type { RegisteredUserDTO } from "../../../../IsaacApiTypes";
 import { buildErrorComponent } from "../../elements/quiz/builErrorComponent";
 import { Spacer } from "../../elements/Spacer";
 
-const pageLink = () => '';
-
 const pageHelp = <span>
     View information about a test without adding it to &quot;My Tests&quot;. This page page does not show any questions.
 </span>;
@@ -42,7 +40,7 @@ export const QuizView = ({user}: {user: RegisteredUserDTO}) => {
 
     return <Container className={`mb-5 ${attempt?.quiz?.subjectId}`}>
         <ShowLoadingQuery query={quizRubricQuery} ifError={Error}>
-            <QuizAttemptComponent view attempt={attempt} page={null} questions={[]} sections={{}} pageLink={pageLink} pageHelp={pageHelp} user={user} />
+            <QuizAttemptComponent view attempt={attempt} page={null} questions={[]} sections={{}} pageLink={() => ''} pageHelp={pageHelp} user={user} />
             <QuizFooter quizId={quizId} user={user} />
         </ShowLoadingQuery>
     </Container>;

--- a/src/app/components/pages/quizzes/QuizView.tsx
+++ b/src/app/components/pages/quizzes/QuizView.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import {useGetQuizRubricQuery} from "../../../state";
 import {Link, useParams} from "react-router-dom";
-import {tags} from "../../../services";
+import {isTeacherOrAbove, tags} from "../../../services";
 import {QuizAttemptComponent, rubricCrumbs} from "../../elements/quiz/QuizAttemptComponent";
-import {Button, Container} from "reactstrap";
+import {Button, Col, Container, Row} from "reactstrap";
 import {ShowLoadingQuery} from "../../handlers/ShowLoadingQuery";
 import type { RegisteredUserDTO } from "../../../../IsaacApiTypes";
 import { buildErrorComponent } from "../../elements/quiz/builErrorComponent";
@@ -17,10 +17,19 @@ const pageHelp = <span>
 
 const Error = buildErrorComponent("Unknown Test", "There was an error loading that test.", rubricCrumbs);
 
-const QuizFooter = ({quizId}: {quizId: string}) =>
+const FooterButton = ({link, label}: {link: string, label: string}) => <Col className="d-flex">
+    <Button className="flex-fill d-flex align-items-center justify-content-center mb-3" color="secondary" tag={Link} to={link}>
+        {label}
+    </Button>
+</Col>; 
+
+const QuizFooter = ({quizId, user}: {quizId: string, user: RegisteredUserDTO}) =>
     <div className="d-flex border-top pt-2 my-2 align-items-center">
-        <Spacer/>
-        <Button color="secondary" tag={Link} to={`/test/attempt/${quizId}`}>{"Take Test"}</Button>
+        <Spacer />
+        <Row>
+            {isTeacherOrAbove(user) && <FooterButton link={`/test/preview/${quizId}`} label="Preview" />}
+            <FooterButton link={`/test/attempt/${quizId}`} label="Take Test" />
+        </Row>
     </div>;
 
 export const QuizView = ({user}: {user: RegisteredUserDTO}) => {
@@ -34,7 +43,7 @@ export const QuizView = ({user}: {user: RegisteredUserDTO}) => {
     return <Container className={`mb-5 ${attempt?.quiz?.subjectId}`}>
         <ShowLoadingQuery query={quizRubricQuery} ifError={Error}>
             <QuizAttemptComponent view attempt={attempt} page={null} questions={[]} sections={{}} pageLink={pageLink} pageHelp={pageHelp} user={user} />
-            <QuizFooter quizId={quizId} />
+            <QuizFooter quizId={quizId} user={user} />
         </ShowLoadingQuery>
     </Container>;
 };

--- a/src/app/components/pages/quizzes/QuizView.tsx
+++ b/src/app/components/pages/quizzes/QuizView.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import {useGetQuizRubricQuery} from "../../../state";
 import {Link, useParams} from "react-router-dom";
-import {isTeacherOrAbove, tags} from "../../../services";
+import {isTeacherOrAbove, siteSpecific, tags} from "../../../services";
 import {QuizAttemptComponent, rubricCrumbs} from "../../elements/quiz/QuizAttemptComponent";
 import {Button, Col, Container, Row} from "reactstrap";
 import {ShowLoadingQuery} from "../../handlers/ShowLoadingQuery";
@@ -10,7 +10,7 @@ import { buildErrorComponent } from "../../elements/quiz/builErrorComponent";
 import { Spacer } from "../../elements/Spacer";
 
 const pageHelp = <span>
-    View information about a test without adding it to &quot;My Tests&quot;. This page page does not show any questions.
+    View information about a test without adding it to {siteSpecific('"My Tests"', '"My tests"')}. This page page does not show any questions.
 </span>;
 
 const Error = buildErrorComponent("Unknown Test", "There was an error loading that test.", rubricCrumbs);

--- a/src/app/components/pages/quizzes/QuizView.tsx
+++ b/src/app/components/pages/quizzes/QuizView.tsx
@@ -1,18 +1,27 @@
 import React from "react";
 import {useGetQuizRubricQuery} from "../../../state";
-import {useParams} from "react-router-dom";
+import {Link, useParams} from "react-router-dom";
 import {tags} from "../../../services";
 import {QuizAttemptComponent, rubricCrumbs} from "../../elements/quiz/QuizAttemptComponent";
-import {Container} from "reactstrap";
+import {Button, Container} from "reactstrap";
 import {ShowLoadingQuery} from "../../handlers/ShowLoadingQuery";
 import type { RegisteredUserDTO } from "../../../../IsaacApiTypes";
 import { buildErrorComponent } from "../../elements/quiz/builErrorComponent";
+import { Spacer } from "../../elements/Spacer";
 
 const pageLink = () => '';
 
-const pageHelp = <span> View information about this test. </span>;
+const pageHelp = <span>
+    View information about a test without adding it to "My Tests". This page page does not show any questions.
+</span>;
 
 const Error = buildErrorComponent("Unknown Test", "There was an error loading that test.", rubricCrumbs);
+
+const QuizFooter = ({quizId}: {quizId: string}) =>
+    <div className="d-flex border-top pt-2 my-2 align-items-center">
+        <Spacer/>
+        <Button color="secondary" tag={Link} replace to={`/test/attempt/${quizId}`}>{"Take Test"}</Button>
+    </div>;
 
 export const QuizView = ({user}: {user: RegisteredUserDTO}) => {
     const {quizId} = useParams<{quizId: string}>();
@@ -25,6 +34,7 @@ export const QuizView = ({user}: {user: RegisteredUserDTO}) => {
     return <Container className={`mb-5 ${attempt?.quiz?.subjectId}`}>
         <ShowLoadingQuery query={quizRubricQuery} ifError={Error}>
             <QuizAttemptComponent view attempt={attempt} page={null} questions={[]} sections={{}} pageLink={pageLink} pageHelp={pageHelp} user={user} />
+            <QuizFooter quizId={quizId} />
         </ShowLoadingQuery>
     </Container>;
 };

--- a/src/app/components/pages/quizzes/QuizView.tsx
+++ b/src/app/components/pages/quizzes/QuizView.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import {useGetQuizRubricQuery} from "../../../state";
 import {Link, useParams} from "react-router-dom";
-import {isTeacherOrAbove, siteSpecific, tags} from "../../../services";
+import {getThemeFromTags, isTeacherOrAbove, siteSpecific, tags} from "../../../services";
 import {QuizAttemptComponent, rubricCrumbs} from "../../elements/quiz/QuizAttemptComponent";
 import {Button, Col, Container, Row} from "reactstrap";
 import {ShowLoadingQuery} from "../../handlers/ShowLoadingQuery";
@@ -38,7 +38,7 @@ export const QuizView = ({user}: {user: RegisteredUserDTO}) => {
         quizId: quizRubricQuery.data?.id,
     };
 
-    return <Container className={`mb-5 ${attempt?.quiz?.subjectId}`}>
+    return <Container data-testid="quiz-view" className={`mb-5 ${attempt?.quiz?.subjectId}`} data-bs-theme={getThemeFromTags(attempt.quiz?.tags)}>
         <ShowLoadingQuery query={quizRubricQuery} ifError={Error}>
             <QuizAttemptComponent view attempt={attempt} page={null} questions={[]} sections={{}} pageLink={() => ''} pageHelp={pageHelp} user={user} />
             <QuizFooter quizId={quizId} user={user} />

--- a/src/app/components/pages/quizzes/QuizView.tsx
+++ b/src/app/components/pages/quizzes/QuizView.tsx
@@ -8,6 +8,7 @@ import {ShowLoadingQuery} from "../../handlers/ShowLoadingQuery";
 import type { RegisteredUserDTO } from "../../../../IsaacApiTypes";
 import { buildErrorComponent } from "../../elements/quiz/builErrorComponent";
 import { Spacer } from "../../elements/Spacer";
+import { QuizSidebarLayout } from "../../elements/quiz/QuizSidebarLayout";
 
 const pageHelp = <span>
     View information about a test without adding it to {siteSpecific('"My Tests"', '"My tests"')}. This page page does not show any questions.
@@ -22,14 +23,14 @@ const FooterButton = ({link, label}: {link: string, label: string}) => <Col clas
 </Col>; 
 
 const QuizFooter = ({quizId, user}: {quizId: string, user: RegisteredUserDTO}) =>
-    <div className="d-flex border-top pt-2 my-2 align-items-center">
+    <QuizSidebarLayout>
         <Spacer />
         <Row>
             {isTeacherOrAbove(user) && <FooterButton link={`/test/preview/${quizId}`} label="Preview" />}
             <FooterButton link={`/test/attempt/${quizId}`} label="Take Test" />
         </Row>
-    </div>;
-
+    </QuizSidebarLayout>;
+    
 export const QuizView = ({user}: {user: RegisteredUserDTO}) => {
     const {quizId} = useParams<{quizId: string}>();
     const quizRubricQuery = useGetQuizRubricQuery(quizId);

--- a/src/app/components/site/cs/RoutesCS.tsx
+++ b/src/app/components/site/cs/RoutesCS.tsx
@@ -35,6 +35,7 @@ import { TeacherResources } from "../../pages/TeacherResources";
 import { CSProjects } from "../../pages/CSProjects";
 import { PracticeQuizzes } from "../../pages/quizzes/PracticeQuizzes";
 import {StudentChallenges} from "../../pages/StudentChallenges";
+import { QuizView } from "../../pages/quizzes/QuizView";
 
 const Equality = lazy(() => import('../../pages/Equality'));
 const EventDetails = lazy(() => import('../../pages/EventDetails'));
@@ -84,6 +85,8 @@ export const RoutesCS = [
     <TrackedRoute key={key++} exact path="/test/preview/:quizId/page/:page" ifUser={isTutorOrAbove} component={QuizPreview} />,
     <TrackedRoute key={key++} exact path="/test/attempt/:quizId" ifUser={isLoggedIn} component={QuizDoFreeAttempt} />,
     <TrackedRoute key={key++} exact path="/test/attempt/:quizId/page/:page" ifUser={isLoggedIn} component={QuizDoFreeAttempt} />,
+    <TrackedRoute key={key++} exact path="/test/view/:quizId" ifUser={isLoggedIn} component={QuizView} />,
+    
 
     // Topics and content
     <TrackedRoute key={key++} exact path="/topics" component={AllTopics} />,

--- a/src/app/components/site/phy/RoutesPhy.tsx
+++ b/src/app/components/site/phy/RoutesPhy.tsx
@@ -47,6 +47,7 @@ import { PhysBookYrNine } from "../../pages/books_old/phys_book_yr9";
 import { PreUniMaths } from "../../pages/books_old/pre_uni_maths";
 import { PreUniMaths2e } from "../../pages/books_old/pre_uni_maths_2e";
 import { StepUpPhys } from "../../pages/books_old/step_up_phys";
+import { QuizView } from "../../pages/quizzes/QuizView";
 
 const Equality = lazy(() => import('../../pages/Equality'));
 const EventDetails = lazy(() => import('../../pages/EventDetails'));
@@ -116,6 +117,8 @@ export const RoutesPhy = [
     <TrackedRoute key={key++} exact path="/test/preview/:quizId/page/:page" ifUser={isTutorOrAbove} component={QuizPreview} />,
     <TrackedRoute key={key++} exact path="/test/attempt/:quizId" ifUser={isLoggedIn} component={QuizDoFreeAttempt} />,
     <TrackedRoute key={key++} exact path="/test/attempt/:quizId/page/:page" ifUser={isLoggedIn} component={QuizDoFreeAttempt} />,
+    <TrackedRoute key={key++} exact path="/test/view/:quizId" ifUser={isLoggedIn} component={QuizView} />,
+
     // The order of these redirects matters to prevent substring replacement
     <Redirect key={key++} from="/quiz/assignment/:quizAssignmentId/feedback"   to="/test/assignment/:quizAssignmentId/feedback" />,
     <Redirect key={key++} from="/quiz/assignment/:quizAssignmentId/page/:page" to="/test/assignment/:quizAssignmentId/page/:page" />,

--- a/src/app/state/slices/api/quizApi.ts
+++ b/src/app/state/slices/api/quizApi.ts
@@ -3,6 +3,7 @@ import {
     AssignmentStatusDTO,
     ChoiceDTO,
     IsaacQuizDTO,
+    IsaacRubricDTO,
     QuestionValidationResponseDTO,
     QuizAssignmentDTO,
     QuizAttemptDTO,
@@ -85,6 +86,13 @@ export const quizApi = isaacApi.enhanceEndpoints({
             query: (quizId) => `/quiz/${quizId}/preview`,
             onQueryStarted: onQueryLifecycleEvents({
                 errorTitle: "Loading test preview failed",
+            })
+        }),
+
+        getQuizRubric: build.query<IsaacRubricDTO, string>({
+            query: (quizId) => `/quiz/${quizId}/rubric`,
+            onQueryStarted: onQueryLifecycleEvents({
+                errorTitle: "Loading test rubric failed",
             })
         }),
 
@@ -233,6 +241,7 @@ export const {
     useLazyGetQuizAssignmentsAssignedToMeQuery,
     useMarkQuizAttemptAsCompleteMutation,
     useGetQuizPreviewQuery,
+    useGetQuizRubricQuery,
     useLogQuizSectionViewMutation,
     useGetStudentQuizAttemptWithFeedbackQuery,
     useAssignQuizMutation,

--- a/src/app/state/store.tsx
+++ b/src/app/state/store.tsx
@@ -34,7 +34,7 @@ export const store = configureStore({
         // @ts-ignore
         if (process.env.NODE_ENV !== 'production' && !window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) {
             // newMiddleware.concat([reduxLogger]);
-            newMiddleware.push(reduxLogger as Middleware);
+            // newMiddleware.push(reduxLogger as Middleware);
         }
         return newMiddleware;
     },

--- a/src/app/state/store.tsx
+++ b/src/app/state/store.tsx
@@ -34,7 +34,7 @@ export const store = configureStore({
         // @ts-ignore
         if (process.env.NODE_ENV !== 'production' && !window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) {
             // newMiddleware.concat([reduxLogger]);
-            // newMiddleware.push(reduxLogger as Middleware);
+            newMiddleware.push(reduxLogger as Middleware);
         }
         return newMiddleware;
     },

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -6,6 +6,7 @@ import {
     EmailVerificationStatus,
     EventStatus,
     IsaacRubricDTO,
+    QuizAttemptDTO,
     USER_ROLES,
     UserRole,
     UserSummaryWithGroupMembershipDTO
@@ -2281,6 +2282,53 @@ export const mockRubrics: Record<string, IsaacRubricDTO> = {
                 }
             ],
             "tags":[]
+        }
+    }
+};
+
+export const mockAttempts: Record<string, QuizAttemptDTO> = {
+    a_level_1d_motion_test: {
+        id: 4,
+        userId: 1,
+        quizId: "a_level_1d_motion_test",
+        startDate: new Date(1744125060688),
+        quiz: {
+            id: "a_level_1d_motion_test",
+            title: "A Level 1-d Motion Test",
+            type: "isaacQuiz",
+            encoding: "markdown",
+            canonicalSourceFile: "content/questions/physics/tests/unpublished_tests/a_level_1d_motion_test.json",
+            children: [
+                {
+                    id: "a_level_1d_motion_test|6a5e50ef",
+                    title: "Velocity & Acceleration",
+                    type: "isaacQuizSection",
+                    encoding: "markdown",
+                    children: [],
+                    published: false,
+                    tags: []
+                }
+            ],
+            tags: [],
+            hiddenFromRoles: [
+                "STUDENT",
+                "TUTOR"
+            ],
+            rubric: {
+                type: "content",
+                encoding: "markdown",
+                children: [
+                    {
+                        type: "content",
+                        encoding: "markdown",
+                        children: [],
+                        value: "We recommend completing this test after studying the relevant concepts ([Equations of Motion](/concepts/cp_eq_of_motion)), either in school or by doing the appropriate sections in the [Essential Pre-Uni Physics book](/books/physics_skills_19).\n\nFor this test make sure to follow the Isaac Physics rules for [significant figures](/solving_problems#acc_solving_problems_sig_figs).",
+                        tags: []
+                    }
+                ],
+                tags: []
+            },
+            published: false
         }
     }
 };

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -5,6 +5,8 @@ import {
     BookingStatus,
     EmailVerificationStatus,
     EventStatus,
+    IsaacRubricDTO,
+    USER_ROLES,
     UserRole,
     UserSummaryWithGroupMembershipDTO
 } from "../IsaacApiTypes";
@@ -2256,6 +2258,31 @@ export const mockGameboards = {
     totalInProgress: 0,
     totalCompleted: 0,
     totalResults: 7
+};
+
+export const mockRubrics: Record<string, IsaacRubricDTO> = {
+    a_level_1d_motion_test: {
+        id: "a_level_1d_motion_test",
+        title: "A Level 1-d Motion Test",
+        type: "isaacQuiz",
+        tags: [],
+        url: "/isaac-api/api/quiz/a_level_1d_motion_test",
+        hiddenFromRoles: [USER_ROLES[0], USER_ROLES[1]],
+        rubric:{
+            type: "content",
+            encoding: "markdown",
+            children:[
+                {
+                    type:"content",
+                    encoding:"markdown",
+                    children:[],
+                    value:"We recommend completing this test after studying the relevant concepts Equations of Motion, either in school or by doing the appropriate sections in the Essential Pre-Uni Physics book.\\n\\nFor this test make sure to follow the Isaac Physics rules for significant figures.",
+                    tags:[]
+                }
+            ],
+            "tags":[]
+        }
+    }
 };
 
 export const mockMyAssignments = [

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -5,6 +5,7 @@ import {
     BookingStatus,
     EmailVerificationStatus,
     EventStatus,
+    IsaacQuizDTO,
     IsaacRubricDTO,
     QuizAttemptDTO,
     USER_ROLES,
@@ -2330,6 +2331,56 @@ export const mockAttempts: Record<string, QuizAttemptDTO> = {
             },
             published: false
         }
+    }
+};
+
+export const mockPreviews: Record<string, IsaacQuizDTO> = {
+    a_level_1d_motion_test: {
+        id: "a_level_1d_motion_test",
+        title: "A Level 1-d Motion Test",
+        type: "isaacQuiz",
+        encoding: "markdown",
+        canonicalSourceFile: "content/questions/physics/tests/unpublished_tests/a_level_1d_motion_test.json",
+        children: [
+            {
+                id: "a_level_1d_motion_test|6a5e50ef",
+                title: "Velocity & Acceleration",
+                type: "isaacQuizSection",
+                encoding: "markdown",
+                children: [],
+                published: false,
+                tags: []
+            },
+            {
+                id: "a_level_1d_motion_test|b76267ab",
+                title: "Problems involving Distance",
+                type: "isaacQuizSection",
+                encoding: "markdown",
+                children: [],
+                published: false,
+                tags: []
+            }
+        ],
+        tags: [],
+        hiddenFromRoles: [
+            "STUDENT",
+            "TUTOR"
+        ],
+        rubric: {
+            type: "content",
+            encoding: "markdown",
+            children: [
+                {
+                    type: "content",
+                    encoding: "markdown",
+                    children: [],
+                    value: "We recommend completing this test after studying the relevant concepts ([Equations of Motion](/concepts/cp_eq_of_motion)), either in school or by doing the appropriate sections in the [Essential Pre-Uni Physics book](/books/physics_skills_19).\n\nFor this test make sure to follow the Isaac Physics rules for [significant figures](/solving_problems#acc_solving_problems_sig_figs).",
+                    tags: []
+                }
+            ],
+            tags: []
+        },
+        published: false
     }
 };
 

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -2267,7 +2267,7 @@ export const mockRubrics: Record<string, IsaacRubricDTO> = {
         id: "a_level_1d_motion_test",
         title: "A Level 1-d Motion Test",
         type: "isaacQuiz",
-        tags: [],
+        tags: ["physics"],
         url: "/isaac-api/api/quiz/a_level_1d_motion_test",
         hiddenFromRoles: [USER_ROLES[0], USER_ROLES[1]],
         rubric:{
@@ -2330,7 +2330,7 @@ export const mockAttempts: Record<string, QuizAttemptDTO> = {
                 published:false,
                 tags:[]
             }],
-            tags: [],
+            tags: ["physics"],
             hiddenFromRoles: [
                 "STUDENT",
                 "TUTOR"
@@ -2392,7 +2392,7 @@ export const mockPreviews: Record<string, IsaacQuizDTO> = {
             published:false,
             tags:[]
         }],
-        tags: [],
+        tags: ["physics"],
         hiddenFromRoles: [
             "STUDENT",
             "TUTOR"

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -2299,17 +2299,37 @@ export const mockAttempts: Record<string, QuizAttemptDTO> = {
             type: "isaacQuiz",
             encoding: "markdown",
             canonicalSourceFile: "content/questions/physics/tests/unpublished_tests/a_level_1d_motion_test.json",
-            children: [
-                {
-                    id: "a_level_1d_motion_test|6a5e50ef",
-                    title: "Velocity & Acceleration",
-                    type: "isaacQuizSection",
+            children: [{
+                id: "a_level_1d_motion_test|6a5e50ef",
+                title: "Velocity & Acceleration",
+                type: "isaacQuizSection",
+                encoding: "markdown",
+                children: [{
+                    id:"a_level_1d_motion_test|6a5e50ef|a15b8ea9-603a-445c-b792-aa17430d578d",
+                    type: "isaacNumericQuestion",
                     encoding: "markdown",
                     children: [],
-                    published: false,
-                    tags: []
-                }
-            ],
+                    value: "If an object accelerates from rest at $\\\\quantity{2.5}{m\\\\\\\\,s^{-2}}$, what will be its speed after $\\\\quantity{8.0}{s}$?",
+                    published:false,
+                }],
+                published: false,
+                tags: []
+            }, {
+                id: "a_level_1d_motion_test|b76267ab",
+                title: "Problems involving Distance",
+                type: "isaacQuizSection",
+                encoding: "markdown",
+                children:[{
+                    id: "a_level_1d_motion_test|b76267ab|aa19154e-228a-4b94-b8e3-55fcbd708c5a",
+                    type: "isaacNumericQuestion",
+                    encoding: "markdown",
+                    children:[],
+                    value: "If an object accelerates from rest at $\\\\quantity{1.8}{m\\\\\\\\,s^{-2}}$, how far does it travel in the first $\\\\quantity{7.0}{s}$ of its motion?",
+                    published: false, 
+                }], 
+                published:false,
+                tags:[]
+            }],
             tags: [],
             hiddenFromRoles: [
                 "STUDENT",
@@ -2323,7 +2343,7 @@ export const mockAttempts: Record<string, QuizAttemptDTO> = {
                         type: "content",
                         encoding: "markdown",
                         children: [],
-                        value: "We recommend completing this test after studying the relevant concepts ([Equations of Motion](/concepts/cp_eq_of_motion)), either in school or by doing the appropriate sections in the [Essential Pre-Uni Physics book](/books/physics_skills_19).\n\nFor this test make sure to follow the Isaac Physics rules for [significant figures](/solving_problems#acc_solving_problems_sig_figs).",
+                        value: "We recommend completing this test after studying the relevant concepts (Equations of Motion), either in school or by doing the appropriate sections in the Essential Pre-Uni Physics book.",
                         tags: []
                     }
                 ],

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -2361,26 +2361,37 @@ export const mockPreviews: Record<string, IsaacQuizDTO> = {
         type: "isaacQuiz",
         encoding: "markdown",
         canonicalSourceFile: "content/questions/physics/tests/unpublished_tests/a_level_1d_motion_test.json",
-        children: [
-            {
-                id: "a_level_1d_motion_test|6a5e50ef",
-                title: "Velocity & Acceleration",
-                type: "isaacQuizSection",
+        children: [{
+            id: "a_level_1d_motion_test|6a5e50ef",
+            title: "Velocity & Acceleration",
+            type: "isaacQuizSection",
+            encoding: "markdown",
+            children: [{
+                id:"a_level_1d_motion_test|6a5e50ef|a15b8ea9-603a-445c-b792-aa17430d578d",
+                type: "isaacNumericQuestion",
                 encoding: "markdown",
                 children: [],
-                published: false,
-                tags: []
-            },
-            {
-                id: "a_level_1d_motion_test|b76267ab",
-                title: "Problems involving Distance",
-                type: "isaacQuizSection",
+                value: "If an object accelerates from rest at $\\\\quantity{2.5}{m\\\\\\\\,s^{-2}}$, what will be its speed after $\\\\quantity{8.0}{s}$?",
+                published:false,
+            }],
+            published: false,
+            tags: []
+        }, {
+            id: "a_level_1d_motion_test|b76267ab",
+            title: "Problems involving Distance",
+            type: "isaacQuizSection",
+            encoding: "markdown",
+            children:[{
+                id: "a_level_1d_motion_test|b76267ab|aa19154e-228a-4b94-b8e3-55fcbd708c5a",
+                type: "isaacNumericQuestion",
                 encoding: "markdown",
-                children: [],
-                published: false,
-                tags: []
-            }
-        ],
+                children:[],
+                value: "If an object accelerates from rest at $\\\\quantity{1.8}{m\\\\\\\\,s^{-2}}$, how far does it travel in the first $\\\\quantity{7.0}{s}$ of its motion?",
+                published: false, 
+            }], 
+            published:false,
+            tags:[]
+        }],
         tags: [],
         hiddenFromRoles: [
             "STUDENT",
@@ -2394,7 +2405,7 @@ export const mockPreviews: Record<string, IsaacQuizDTO> = {
                     type: "content",
                     encoding: "markdown",
                     children: [],
-                    value: "We recommend completing this test after studying the relevant concepts ([Equations of Motion](/concepts/cp_eq_of_motion)), either in school or by doing the appropriate sections in the [Essential Pre-Uni Physics book](/books/physics_skills_19).\n\nFor this test make sure to follow the Isaac Physics rules for [significant figures](/solving_problems#acc_solving_problems_sig_figs).",
+                    value: "We recommend completing this test after studying the relevant concepts (Equations of Motion), either in school or by doing the appropriate sections in the Essential Pre-Uni Physics book.",
                     tags: []
                 }
             ],

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -2267,7 +2267,7 @@ export const mockRubrics: Record<string, IsaacRubricDTO> = {
         id: "a_level_1d_motion_test",
         title: "A Level 1-d Motion Test",
         type: "isaacQuiz",
-        tags: ["physics"],
+        tags: ["physics", "mechanics"],
         url: "/isaac-api/api/quiz/a_level_1d_motion_test",
         hiddenFromRoles: [USER_ROLES[0], USER_ROLES[1]],
         rubric:{
@@ -2330,7 +2330,7 @@ export const mockAttempts: Record<string, QuizAttemptDTO> = {
                 published:false,
                 tags:[]
             }],
-            tags: ["physics"],
+            tags: ["physics", "mechanics"],
             hiddenFromRoles: [
                 "STUDENT",
                 "TUTOR"
@@ -2392,7 +2392,7 @@ export const mockPreviews: Record<string, IsaacQuizDTO> = {
             published:false,
             tags:[]
         }],
-        tags: ["physics"],
+        tags: ["physics", "mechanics"],
         hiddenFromRoles: [
             "STUDENT",
             "TUTOR"

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -22,6 +22,7 @@ import {
 import {API_PATH} from "../app/services";
 import {produce} from "immer";
 import {School} from "../IsaacAppTypes";
+import { errorResponses } from "../test/test-factory";
 
 export const handlers = [
     http.get(API_PATH + "/gameboards/user_gameboards", ({request}) => {
@@ -71,36 +72,21 @@ export const handlers = [
         if (quizId in mockRubrics) {
             return HttpResponse.json(mockRubrics[quizId], { status: 200 });
         } 
-        return HttpResponse.json({
-            bypassGenericSiteErrorPage: false,
-            errorMessage: "This test has become unavailable.",
-            responseCode: 404,
-            responseCodeType: "Not found"
-        },  { status: 404 });
+        return HttpResponse.json(errorResponses.testUnavailable404,  { status: 404 });
     }),
     http.get(API_PATH + "/quiz/:quizId/preview", ({ params }) => {
         const quizId = params.quizId as string;
         if (quizId in mockPreviews) {
             return HttpResponse.json(mockPreviews[quizId], { status: 200 });
         } 
-        return HttpResponse.json({
-            bypassGenericSiteErrorPage: false,
-            errorMessage: "This test has become unavailable.",
-            responseCode: 404,
-            responseCodeType: "Not found"
-        },  { status: 404 });
+        return HttpResponse.json(errorResponses.testUnavailable404,  { status: 404 });
     }),
     http.post(API_PATH + "/quiz/:quizId/attempt", ({ params }) => {
         const quizId = params.quizId as string;
         if (quizId in mockAttempts) {
             return HttpResponse.json(mockAttempts[quizId], { status: 200 });
         } 
-        return HttpResponse.json({
-            bypassGenericSiteErrorPage: false,
-            errorMessage: "This test has become unavailable.",
-            responseCode: 404,
-            responseCodeType: "Not found"
-        },  { status: 404 });
+        return HttpResponse.json(errorResponses.testUnavailable404,  { status: 404 });
     }),
     http.get(API_PATH + "/assignments/assign/:assignmentId", ({params}) => {
         const {assignmentId: _assignmentId} = params;

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -16,7 +16,8 @@ import {
     mockQuestionFinderResults,
     mockConceptPage,
     mockRubrics,
-    mockAttempts
+    mockAttempts,
+    mockPreviews
 } from "./data";
 import {API_PATH} from "../app/services";
 import {produce} from "immer";
@@ -69,6 +70,18 @@ export const handlers = [
         const quizId = params.quizId as string;
         if (quizId in mockRubrics) {
             return HttpResponse.json(mockRubrics[quizId], { status: 200 });
+        } 
+        return HttpResponse.json({
+            bypassGenericSiteErrorPage: false,
+            errorMessage: "This test has become unavailable.",
+            responseCode: 404,
+            responseCodeType: "Not found"
+        },  { status: 404 });
+    }),
+    http.get(API_PATH + "/quiz/:quizId/preview", ({ params }) => {
+        const quizId = params.quizId as string;
+        if (quizId in mockPreviews) {
+            return HttpResponse.json(mockPreviews[quizId], { status: 200 });
         } 
         return HttpResponse.json({
             bypassGenericSiteErrorPage: false,

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -15,7 +15,8 @@ import {
     mockRegressionTestQuestions,
     mockQuestionFinderResults,
     mockConceptPage,
-    mockRubrics
+    mockRubrics,
+    mockAttempts
 } from "./data";
 import {API_PATH} from "../app/services";
 import {produce} from "immer";
@@ -68,6 +69,18 @@ export const handlers = [
         const quizId = params.quizId as string;
         if (quizId in mockRubrics) {
             return HttpResponse.json(mockRubrics[quizId], { status: 200 });
+        } 
+        return HttpResponse.json({
+            bypassGenericSiteErrorPage: false,
+            errorMessage: "This test has become unavailable.",
+            responseCode: 404,
+            responseCodeType: "Not found"
+        },  { status: 404 });
+    }),
+    http.post(API_PATH + "/quiz/:quizId/attempt", ({ params }) => {
+        const quizId = params.quizId as string;
+        if (quizId in mockAttempts) {
+            return HttpResponse.json(mockAttempts[quizId], { status: 200 });
         } 
         return HttpResponse.json({
             bypassGenericSiteErrorPage: false,

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -14,7 +14,8 @@ import {
     mockUserPreferences,
     mockRegressionTestQuestions,
     mockQuestionFinderResults,
-    mockConceptPage
+    mockConceptPage,
+    mockRubrics
 } from "./data";
 import {API_PATH} from "../app/services";
 import {produce} from "immer";
@@ -62,6 +63,18 @@ export const handlers = [
         return HttpResponse.json(mockQuizAssignments, {
             status: 200,
         });
+    }),
+    http.get(API_PATH + "/quiz/:quizId/rubric", ({ params }) => {
+        const quizId = params.quizId as string;
+        if (quizId in mockRubrics) {
+            return HttpResponse.json(mockRubrics[quizId], { status: 200 });
+        } 
+        return HttpResponse.json({
+            bypassGenericSiteErrorPage: false,
+            errorMessage: "This test has become unavailable.",
+            responseCode: 404,
+            responseCodeType: "Not found"
+        },  { status: 404 });
     }),
     http.get(API_PATH + "/assignments/assign/:assignmentId", ({params}) => {
         const {assignmentId: _assignmentId} = params;

--- a/src/test/helpers/quiz.ts
+++ b/src/test/helpers/quiz.ts
@@ -1,0 +1,36 @@
+import {act, screen, within } from "@testing-library/react";
+import { expectTextInElementWithId, renderTestEnvironment, setUrl, waitForLoaded } from "../testUtils";
+import { UserRole } from "../../IsaacApiTypes";
+
+export const renderQuizPage = (baseUrl: string) => async ({role, quizId}: {role: UserRole | "ANONYMOUS", quizId: string}) => {
+    await act(async () => renderTestEnvironment({ role }));
+    await act(async () => setUrl({ pathname: `${baseUrl}/${quizId}` }));
+    await waitForLoaded();
+};
+
+export const expectErrorMessage = expectTextInElementWithId('error-message');
+
+export const expectActionMessage = expectTextInElementWithId('quiz-action');
+
+export const setTestButton = () => screen.queryByRole('button', {name: "Set Test"});
+
+export const editButton = () => screen.queryByRole('heading', {name: "Published ✎"});
+
+export const previewButton = () => screen.queryByRole('link', {name: "Preview"});
+
+export const testSectionsHeader = () => screen.queryByRole('heading', {name: "Test sections"});
+
+export const expectPhyBreadCrumbs = ({href, text}: {href: string, text: string}) => {
+    const breadcrumbs = within(screen.getByRole('navigation', { name: 'breadcrumb' })).getByRole('list');
+    expect(Array.from(breadcrumbs.children).map(e => e.innerHTML)).toEqual([
+        `<a href="${href}"><span>${text}</span></a>`,
+    ]);
+};
+export const expectAdaBreadCrumbs = ([first, second, third]: [{href: string, text: string}, {href: string, text: string}, string | undefined]) => {
+    const breadcrumbs = within(screen.getByRole('navigation', { name: 'breadcrumb' })).getByRole('list');
+    expect(Array.from(breadcrumbs.children).map(e => e.innerHTML)).toEqual([
+        `<a href="${first.href}"><span>${first.text}</span></a>`,
+        `<a href="${second.href}"><span>${second.text}</span></a>`,
+        `<span>${third}</span>`
+    ]);
+};

--- a/src/test/helpers/quiz.ts
+++ b/src/test/helpers/quiz.ts
@@ -1,11 +1,23 @@
 import {act, screen, within } from "@testing-library/react";
-import { expectTextInElementWithId, renderTestEnvironment, setUrl, waitForLoaded } from "../testUtils";
+import { expectTextInElementWithId, renderTestEnvironment, withSizedWindow, setUrl, waitForLoaded } from "../testUtils";
 import { UserRole } from "../../IsaacApiTypes";
 
 export const renderQuizPage = (baseUrl: string) => async ({role, quizId}: {role: UserRole | "ANONYMOUS", quizId: string}) => {
     await act(async () => renderTestEnvironment({ role }));
     await act(async () => setUrl({ pathname: `${baseUrl}/${quizId}` }));
     await waitForLoaded();
+};
+
+export const sideBarTestCases = (init: () => Promise<void>) => () => {
+    it('shows subject on sidebar', async () => {
+        await init();
+        expect(subject()).toHaveTextContent('Physics');
+    });
+
+    it('shows topics on sidebar', async () => {
+        await init();
+        expect(topic()).toHaveTextContent("Mechanics");
+    });
 };
 
 export const expectErrorMessage = expectTextInElementWithId('error-message');
@@ -35,3 +47,21 @@ export const expectAdaBreadCrumbs = ([first, second, third]: [{href: string, tex
         `<span>${third}</span>`
     ]);
 };
+
+const sidebar = () => screen.getByTestId('sidebar');
+
+const subject = () => within(
+    within(sidebar()).getByText(/Subject/)
+).getByRole('generic');
+
+const topic = () => within(
+    within(sidebar()).getByText(/Topic/)
+).getByRole('generic');
+
+const sidebarToggle = () => screen.getByTestId('sidebar-toggle');
+
+export const expectSidebarToggle = async (text: string) => {
+    await withSizedWindow(400, 400, () => {
+        expect(sidebarToggle()).toHaveTextContent(text);
+    });
+}; 

--- a/src/test/helpers/quiz.ts
+++ b/src/test/helpers/quiz.ts
@@ -26,6 +26,7 @@ export const expectPhyBreadCrumbs = ({href, text}: {href: string, text: string})
         `<a href="${href}"><span>${text}</span></a>`,
     ]);
 };
+
 export const expectAdaBreadCrumbs = ([first, second, third]: [{href: string, text: string}, {href: string, text: string}, string | undefined]) => {
     const breadcrumbs = within(screen.getByRole('navigation', { name: 'breadcrumb' })).getByRole('list');
     expect(Array.from(breadcrumbs.children).map(e => e.innerHTML)).toEqual([

--- a/src/test/pages/QuestionFinder.test.tsx
+++ b/src/test/pages/QuestionFinder.test.tsx
@@ -86,7 +86,7 @@ describe("QuestionFinder", () => {
                 // On Ada, clearing filters only has an affect after clicking the "Apply" button, so same case as above 
                 it('when clearing all filters', async () => {
                     await renderQuestionFinderPage({ questionsSearchResponse, queryParams: "?randomSeed=1&stages=gcse" });
-                    await clickButton(siteSpecific("Clear all filters", "Clear all"));
+                    await clickOn(siteSpecific("Clear all filters", "Clear all"));
                     await expectUrlParams('');
                 });
 

--- a/src/test/pages/QuestionFinder.test.tsx
+++ b/src/test/pages/QuestionFinder.test.tsx
@@ -1,5 +1,5 @@
 import {act, screen, waitFor, within} from "@testing-library/react";
-import { clickButton, enterInput, expectUrlParams, renderTestEnvironment, setUrl, withMockedRandom} from "../testUtils";
+import { clickOn, enterInput, expectUrlParams, renderTestEnvironment, setUrl, withMockedRandom} from "../testUtils";
 import { buildMockQuestionFinderResults, buildMockQuestions, mockQuestionFinderResults } from "../../mocks/data";
 import _ from "lodash";
 import { buildFunctionHandler } from "../../mocks/handlers";
@@ -51,7 +51,7 @@ describe("QuestionFinder", () => {
                 await setFilter("GCSE");
                 await expectQuestions(questions.slice(0, 30));
                     
-                await clickButton("Shuffle questions");
+                await clickOn("Shuffle questions");
                 await expectQuestions(shuffledQuestions.slice(0, 30));
             });
         });
@@ -62,7 +62,7 @@ describe("QuestionFinder", () => {
                    
                 await renderQuestionFinderPage({ questionsSearchResponse });
                 await setFilter("GCSE");
-                await clickButton("Shuffle questions");
+                await clickOn("Shuffle questions");
                 await expectUrlParams("?randomSeed=1&stages=gcse");
             });
         });
@@ -120,11 +120,11 @@ describe("QuestionFinder", () => {
                 await expectQuestions(questions.slice(0, 30));
                 await expectPageIndicator("Showing 30 of 40.");
                     
-                await clickButton("Shuffle questions");
+                await clickOn("Shuffle questions");
                 await expectQuestions(shuffledQuestions.slice(0, 30));
                 await expectPageIndicator("Showing 30 of 40.");
 
-                await clickButton("Load more");
+                await clickOn("Load more");
                 await expectQuestions(shuffledQuestions);
                 await expectPageIndicator("Showing 40 of 40.");
             });
@@ -164,9 +164,9 @@ const clearFilterTag = async (tagId: string) => {
 
 const setFilter = async (filter: string) => {
     if (isPhy) {
-        await clickButton(filter, mainContainer());
+        await clickOn(filter, mainContainer());
     } else {
-        await clickButton(filter);
-        await clickButton("Apply filters");
+        await clickOn(filter);
+        await clickOn("Apply filters");
     }
 };

--- a/src/test/pages/QuizAttempt.test.tsx
+++ b/src/test/pages/QuizAttempt.test.tsx
@@ -1,7 +1,8 @@
 import { expectLinkWithEnabledBackwardsNavigation, expectH1, expectH4, expectTitledSection, expectUrl } from "../testUtils";
 import {mockAttempts} from "../../mocks/data";
-import { siteSpecific } from "../../app/services";
+import { isPhy, siteSpecific } from "../../app/services";
 import { expectActionMessage, expectAdaBreadCrumbs, expectErrorMessage, expectPhyBreadCrumbs, renderQuizPage, testSectionsHeader } from "../helpers/quiz";
+import { screen } from "@testing-library/react";
 
 describe("QuizAttempt", () => {
     const quizId = Object.keys(mockAttempts)[0];
@@ -12,6 +13,12 @@ describe("QuizAttempt", () => {
     const studentAttemptsQuiz = () => renderQuizAttempt({ role: 'STUDENT', quizId });
 
     describe("overview", () => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+        isPhy && it('applies subject-specific theme', async () => {
+            await studentAttemptsQuiz();
+            expect(screen.getByTestId('quiz-attempt')).toHaveAttribute('data-bs-theme', 'physics');
+        });
+        
         it('shows quiz title on the breadcrumbs', async () => {
             await studentAttemptsQuiz();
             siteSpecific(

--- a/src/test/pages/QuizAttempt.test.tsx
+++ b/src/test/pages/QuizAttempt.test.tsx
@@ -1,0 +1,101 @@
+import {act, screen, within} from "@testing-library/react";
+import { expectButtonWithEnabledBackwardsNavigation, expectH1, expectH4, expectTextInElementWithId, expectTitledSection, expectUrl, renderTestEnvironment, setUrl, waitForLoaded } from "../testUtils";
+import {mockAttempts} from "../../mocks/data";
+import type {UserRole} from "../../IsaacApiTypes";
+import { siteSpecific } from "../../app/services";
+
+describe("QuizAttempt", () => {
+    const quizId = Object.keys(mockAttempts)[0];
+    const attempt = mockAttempts[quizId];
+
+    const renderQuizAttempt =  async ({role, quizId}: {role: UserRole | "ANONYMOUS", quizId: string}) => {
+        await act(async () => renderTestEnvironment({ role }));
+        await act(async () => setUrl({ pathname: `/test/attempt/${quizId}` }));
+        await waitForLoaded();
+    };
+
+    const studentAttemptsQuiz = () => renderQuizAttempt({ role: 'STUDENT', quizId });
+
+    describe("overview", () => {
+        it('shows quiz title on the breadcrumbs', async () => {
+            await studentAttemptsQuiz();
+            siteSpecific(
+                () => expectPhyBreadCrumbs({href: "/tests", text: "My Tests"}),
+                () => expectAdaBreadCrumbs([{href: '/', text: "Home"}, {href: "/tests", text: "My tests"}, attempt.quiz?.title])
+            )();
+        });
+
+        it('shows quiz title', async () => {
+            await studentAttemptsQuiz();
+            expectH1(attempt.quiz?.title);
+        });
+
+        it('shows message about this page', async () => {
+            await studentAttemptsQuiz();
+            expectActionMessage('You are freely attempting this test.');
+        });
+
+        it('shows quiz rubric', async () => {
+            await studentAttemptsQuiz();
+            expectTitledSection("Instructions", attempt.quiz?.rubric?.children?.[0].value);
+        });
+
+        // TODO: assert what the sections are
+        it("shows Test sections", async () => {
+            await studentAttemptsQuiz();
+            expect(testSectionsHeader()).toBeInTheDocument();
+        });
+
+        it('shows "Continue" button that loads the attempts page and allows navigating back', async () => {
+            await studentAttemptsQuiz();
+            await expectButtonWithEnabledBackwardsNavigation("Continue", `/test/attempt/${quizId}/page/1`, `/test/attempt/${quizId}`);
+        });
+    });
+
+
+    describe('for unregistered users', () => {
+        const anonymousAttemptsMissingQuiz = () => renderQuizAttempt({ role: 'ANONYMOUS', quizId: 'some_non_existent_test'}); 
+        
+        it('redirects to log in', async () => {
+            await anonymousAttemptsMissingQuiz();
+            await expectUrl('/login');
+        });
+    });
+
+    describe('when quiz does not exist', () => {
+        const studentAttemptsMissingQuiz = () => renderQuizAttempt({ role: 'STUDENT', quizId: 'some_non_existent_test'});
+
+        it ('shows Test on breadcrumbs', async () => {
+            await studentAttemptsMissingQuiz();
+            siteSpecific(
+                () => expectPhyBreadCrumbs({href: "/tests", text: "My Tests"}),
+                () => expectAdaBreadCrumbs([{href: '/', text: "Home"}, {href: "/tests", text: "My tests"}, "Test"])
+            )();
+        });
+        
+        it('shows error', async () => {
+            await studentAttemptsMissingQuiz();
+            expectH1('Test');
+            expectH4('Error loading test!');
+            expectErrorMessage('This test has become unavailable.');
+        });
+    });
+});
+
+const expectErrorMessage = expectTextInElementWithId('error-message');
+const expectActionMessage = expectTextInElementWithId('quiz-action');
+const testSectionsHeader = () => screen.queryByRole('heading', {name: "Test sections"});
+const expectPhyBreadCrumbs = ({href, text}: {href: string, text: string}) => {
+    const breadcrumbs = within(screen.getByRole('navigation', { name: 'breadcrumb' })).getByRole('list');
+    expect(Array.from(breadcrumbs.children).map(e => e.innerHTML)).toEqual([
+        `<a href="${href}"><span>${text}</span></a>`,
+    ]);
+};
+const expectAdaBreadCrumbs = ([first, second, third]: [{href: string, text: string}, {href: string, text: string}, string | undefined]) => {
+    const breadcrumbs = within(screen.getByRole('navigation', { name: 'breadcrumb' })).getByRole('list');
+    expect(Array.from(breadcrumbs.children).map(e => e.innerHTML)).toEqual([
+        `<a href="${first.href}"><span>${first.text}</span></a>`,
+        `<a href="${second.href}"><span>${second.text}</span></a>`,
+        `<span>${third}</span>`
+    ]);
+};

--- a/src/test/pages/QuizAttempt.test.tsx
+++ b/src/test/pages/QuizAttempt.test.tsx
@@ -1,20 +1,14 @@
-import {act, screen, within} from "@testing-library/react";
-import { expectLinkWithEnabledBackwardsNavigation, expectH1, expectH4, expectTextInElementWithId, expectTitledSection, expectUrl, renderTestEnvironment, setUrl, waitForLoaded } from "../testUtils";
+import { expectLinkWithEnabledBackwardsNavigation, expectH1, expectH4, expectTitledSection, expectUrl } from "../testUtils";
 import {mockAttempts} from "../../mocks/data";
-import type {UserRole} from "../../IsaacApiTypes";
 import { siteSpecific } from "../../app/services";
+import { expectActionMessage, expectAdaBreadCrumbs, expectErrorMessage, expectPhyBreadCrumbs, renderQuizPage, testSectionsHeader } from "../helpers/quiz";
 
 describe("QuizAttempt", () => {
     const quizId = Object.keys(mockAttempts)[0];
     const attempt = mockAttempts[quizId];
     const sections = attempt.quiz?.children;
 
-    const renderQuizAttempt =  async ({role, quizId}: {role: UserRole | "ANONYMOUS", quizId: string}) => {
-        await act(async () => renderTestEnvironment({ role }));
-        await act(async () => setUrl({ pathname: `/test/attempt/${quizId}` }));
-        await waitForLoaded();
-    };
-
+    const renderQuizAttempt = renderQuizPage('/test/attempt');
     const studentAttemptsQuiz = () => renderQuizAttempt({ role: 'STUDENT', quizId });
 
     describe("overview", () => {
@@ -103,21 +97,3 @@ describe("QuizAttempt", () => {
         });
     });
 });
-
-const expectErrorMessage = expectTextInElementWithId('error-message');
-const expectActionMessage = expectTextInElementWithId('quiz-action');
-const testSectionsHeader = () => screen.queryByRole('heading', {name: "Test sections"});
-const expectPhyBreadCrumbs = ({href, text}: {href: string, text: string}) => {
-    const breadcrumbs = within(screen.getByRole('navigation', { name: 'breadcrumb' })).getByRole('list');
-    expect(Array.from(breadcrumbs.children).map(e => e.innerHTML)).toEqual([
-        `<a href="${href}"><span>${text}</span></a>`,
-    ]);
-};
-const expectAdaBreadCrumbs = ([first, second, third]: [{href: string, text: string}, {href: string, text: string}, string | undefined]) => {
-    const breadcrumbs = within(screen.getByRole('navigation', { name: 'breadcrumb' })).getByRole('list');
-    expect(Array.from(breadcrumbs.children).map(e => e.innerHTML)).toEqual([
-        `<a href="${first.href}"><span>${first.text}</span></a>`,
-        `<a href="${second.href}"><span>${second.text}</span></a>`,
-        `<span>${third}</span>`
-    ]);
-};

--- a/src/test/pages/QuizAttempt.test.tsx
+++ b/src/test/pages/QuizAttempt.test.tsx
@@ -1,7 +1,7 @@
 import { expectLinkWithEnabledBackwardsNavigation, expectH1, expectH4, expectTitledSection, expectUrl } from "../testUtils";
 import {mockAttempts} from "../../mocks/data";
 import { isPhy, siteSpecific } from "../../app/services";
-import { expectActionMessage, expectAdaBreadCrumbs, expectErrorMessage, expectPhyBreadCrumbs, renderQuizPage, testSectionsHeader } from "../helpers/quiz";
+import { expectActionMessage, expectAdaBreadCrumbs, expectErrorMessage, expectPhyBreadCrumbs, expectSidebarToggle, renderQuizPage, sideBarTestCases, testSectionsHeader } from "../helpers/quiz";
 import { screen } from "@testing-library/react";
 
 describe("QuizAttempt", () => {
@@ -52,6 +52,15 @@ describe("QuizAttempt", () => {
         it('shows "Continue" button that loads first page and allows navigating back', async () => {
             await studentAttemptsQuiz();
             await expectLinkWithEnabledBackwardsNavigation("Continue", `/test/attempt/${quizId}/page/1`, `/test/attempt/${quizId}`);
+        });
+
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+        isPhy && describe('sidebar on redesigned Physics site', sideBarTestCases(studentAttemptsQuiz));
+       
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+        isPhy && it('sidebar toggle is called "Sections"', async () => {
+            await studentAttemptsQuiz();
+            await expectSidebarToggle("Sections");
         });
     });
 

--- a/src/test/pages/QuizAttempt.test.tsx
+++ b/src/test/pages/QuizAttempt.test.tsx
@@ -1,5 +1,5 @@
 import {act, screen, within} from "@testing-library/react";
-import { expectButtonWithEnabledBackwardsNavigation, expectH1, expectH4, expectTextInElementWithId, expectTitledSection, expectUrl, renderTestEnvironment, setUrl, waitForLoaded } from "../testUtils";
+import { expectLinkWithEnabledBackwardsNavigation, expectH1, expectH4, expectTextInElementWithId, expectTitledSection, expectUrl, renderTestEnvironment, setUrl, waitForLoaded } from "../testUtils";
 import {mockAttempts} from "../../mocks/data";
 import type {UserRole} from "../../IsaacApiTypes";
 import { siteSpecific } from "../../app/services";
@@ -7,6 +7,7 @@ import { siteSpecific } from "../../app/services";
 describe("QuizAttempt", () => {
     const quizId = Object.keys(mockAttempts)[0];
     const attempt = mockAttempts[quizId];
+    const sections = attempt.quiz?.children;
 
     const renderQuizAttempt =  async ({role, quizId}: {role: UserRole | "ANONYMOUS", quizId: string}) => {
         await act(async () => renderTestEnvironment({ role }));
@@ -40,18 +41,39 @@ describe("QuizAttempt", () => {
             expectTitledSection("Instructions", attempt.quiz?.rubric?.children?.[0].value);
         });
 
-        // TODO: assert what the sections are
-        it("shows Test sections", async () => {
+        it("shows Test sections that load section and allow navigating back", async () => {
             await studentAttemptsQuiz();
             expect(testSectionsHeader()).toBeInTheDocument();
+            await expectLinkWithEnabledBackwardsNavigation(sections?.[0].title, `/test/attempt/${quizId}/page/1`, `/test/attempt/${quizId}`);
+            await expectLinkWithEnabledBackwardsNavigation(sections?.[1].title, `/test/attempt/${quizId}/page/2`, `/test/attempt/${quizId}`);
         });
 
-        it('shows "Continue" button that loads the attempts page and allows navigating back', async () => {
+        it('shows "Continue" button that loads first page and allows navigating back', async () => {
             await studentAttemptsQuiz();
-            await expectButtonWithEnabledBackwardsNavigation("Continue", `/test/attempt/${quizId}/page/1`, `/test/attempt/${quizId}`);
+            await expectLinkWithEnabledBackwardsNavigation("Continue", `/test/attempt/${quizId}/page/1`, `/test/attempt/${quizId}`);
         });
     });
 
+    describe("question page", () => {
+        const studentAttemptsQuestionPage = (p: number) => renderQuizAttempt({ role: 'STUDENT', quizId: `${quizId}/page/${p}` });
+
+        it('shows "Back" button that loads previous page and allows navigating back', async () => {
+            await studentAttemptsQuestionPage(1);
+            await expectLinkWithEnabledBackwardsNavigation("Back", `/test/attempt/${quizId}`, `/test/attempt/${quizId}/page/1`);
+        });
+
+        it('shows "Next" button that loads following page and allows navigating back', async () => {
+            await studentAttemptsQuestionPage(1);
+            await expectLinkWithEnabledBackwardsNavigation("Next", `/test/attempt/${quizId}/page/2`, `/test/attempt/${quizId}/page/1`);
+        });
+
+        describe('on the last page', () => {
+            it('shows "Finish" button that loads overview page and allows navigating back', async () => {
+                await studentAttemptsQuestionPage(2);
+                await expectLinkWithEnabledBackwardsNavigation("Finish", `/test/attempt/${quizId}`, `/test/attempt/${quizId}/page/2`);
+            });
+        });
+    });
 
     describe('for unregistered users', () => {
         const anonymousAttemptsMissingQuiz = () => renderQuizAttempt({ role: 'ANONYMOUS', quizId: 'some_non_existent_test'}); 

--- a/src/test/pages/QuizPreview.test.tsx
+++ b/src/test/pages/QuizPreview.test.tsx
@@ -1,7 +1,8 @@
 import { expectLinkWithEnabledBackwardsNavigation, expectH1, expectH4, expectTitledSection, expectUrl } from "../testUtils";
-import {mockPreviews} from "../../mocks/data";
-import { siteSpecific } from "../../app/services";
+import { mockPreviews } from "../../mocks/data";
+import { isPhy, siteSpecific } from "../../app/services";
 import { expectActionMessage, expectAdaBreadCrumbs, expectErrorMessage, expectPhyBreadCrumbs, renderQuizPage, testSectionsHeader } from "../helpers/quiz";
+import { screen } from "@testing-library/react";
 
 describe("QuizPreview", () => {
     const quizId = Object.keys(mockPreviews)[0];
@@ -12,6 +13,12 @@ describe("QuizPreview", () => {
     const teacherPreviewsQuiz = () => rederQuizPreview({ role: 'TEACHER', quizId });
 
     describe("overview", () => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+        isPhy && it('applies subject-specific theme', async () => {
+            await teacherPreviewsQuiz();
+            expect(screen.getByTestId('quiz-preview')).toHaveAttribute('data-bs-theme', 'physics');
+        });
+
         it('shows quiz title on the breadcrumbs', async () => {
             await teacherPreviewsQuiz();
             siteSpecific(

--- a/src/test/pages/QuizPreview.test.tsx
+++ b/src/test/pages/QuizPreview.test.tsx
@@ -1,20 +1,14 @@
-import {act, screen, within} from "@testing-library/react";
-import { expectLinkWithEnabledBackwardsNavigation, expectH1, expectH4, expectTextInElementWithId, expectTitledSection, expectUrl, renderTestEnvironment, setUrl, waitForLoaded } from "../testUtils";
+import { expectLinkWithEnabledBackwardsNavigation, expectH1, expectH4, expectTitledSection, expectUrl } from "../testUtils";
 import {mockPreviews} from "../../mocks/data";
-import type {UserRole} from "../../IsaacApiTypes";
 import { siteSpecific } from "../../app/services";
+import { expectActionMessage, expectAdaBreadCrumbs, expectErrorMessage, expectPhyBreadCrumbs, renderQuizPage, testSectionsHeader } from "../helpers/quiz";
 
 describe("QuizAttempt", () => {
     const quizId = Object.keys(mockPreviews)[0];
     const preview = mockPreviews[quizId];
     const sections = preview.children;
 
-    const rederQuizPreview =  async ({role, quizId}: {role: UserRole | "ANONYMOUS", quizId: string}) => {
-        await act(async () => renderTestEnvironment({ role }));
-        await act(async () => setUrl({ pathname: `/test/preview/${quizId}` }));
-        await waitForLoaded();
-    };
-
+    const rederQuizPreview = renderQuizPage('/test/preview');
     const teacherPreviewsQuiz = () => rederQuizPreview({ role: 'TEACHER', quizId });
 
     describe("overview", () => {
@@ -112,21 +106,3 @@ describe("QuizAttempt", () => {
         });
     });
 });
-
-const expectErrorMessage = expectTextInElementWithId('error-message');
-const expectActionMessage = expectTextInElementWithId('quiz-action');
-const testSectionsHeader = () => screen.queryByRole('heading', {name: "Test sections"});
-const expectPhyBreadCrumbs = ({href, text}: {href: string, text: string}) => {
-    const breadcrumbs = within(screen.getByRole('navigation', { name: 'breadcrumb' })).getByRole('list');
-    expect(Array.from(breadcrumbs.children).map(e => e.innerHTML)).toEqual([
-        `<a href="${href}"><span>${text}</span></a>`,
-    ]);
-};
-const expectAdaBreadCrumbs = ([first, second, third]: [{href: string, text: string}, {href: string, text: string}, string | undefined]) => {
-    const breadcrumbs = within(screen.getByRole('navigation', { name: 'breadcrumb' })).getByRole('list');
-    expect(Array.from(breadcrumbs.children).map(e => e.innerHTML)).toEqual([
-        `<a href="${first.href}"><span>${first.text}</span></a>`,
-        `<a href="${second.href}"><span>${second.text}</span></a>`,
-        `<span>${third}</span>`
-    ]);
-};

--- a/src/test/pages/QuizPreview.test.tsx
+++ b/src/test/pages/QuizPreview.test.tsx
@@ -1,7 +1,7 @@
 import { expectLinkWithEnabledBackwardsNavigation, expectH1, expectH4, expectTitledSection, expectUrl } from "../testUtils";
 import { mockPreviews } from "../../mocks/data";
 import { isPhy, siteSpecific } from "../../app/services";
-import { expectActionMessage, expectAdaBreadCrumbs, expectErrorMessage, expectPhyBreadCrumbs, renderQuizPage, testSectionsHeader } from "../helpers/quiz";
+import { expectActionMessage, expectAdaBreadCrumbs, expectErrorMessage, expectPhyBreadCrumbs, expectSidebarToggle, renderQuizPage, sideBarTestCases, testSectionsHeader } from "../helpers/quiz";
 import { screen } from "@testing-library/react";
 
 describe("QuizPreview", () => {
@@ -52,6 +52,15 @@ describe("QuizPreview", () => {
         it('shows "View questions" button that loads first page and allows navigating back', async () => {
             await teacherPreviewsQuiz();
             await expectLinkWithEnabledBackwardsNavigation("View questions", `/test/preview/${quizId}/page/1`, `/test/preview/${quizId}`);
+        });
+
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+        isPhy && describe('sidebar on redesigned Physics site', sideBarTestCases(teacherPreviewsQuiz));
+        
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+        isPhy && it('sidebar toggle is called "Sections"', async () => {
+            await teacherPreviewsQuiz();
+            await expectSidebarToggle("Sections");
         });
     });
 

--- a/src/test/pages/QuizPreview.test.tsx
+++ b/src/test/pages/QuizPreview.test.tsx
@@ -1,0 +1,132 @@
+import {act, screen, within} from "@testing-library/react";
+import { expectLinkWithEnabledBackwardsNavigation, expectH1, expectH4, expectTextInElementWithId, expectTitledSection, expectUrl, renderTestEnvironment, setUrl, waitForLoaded } from "../testUtils";
+import {mockPreviews} from "../../mocks/data";
+import type {UserRole} from "../../IsaacApiTypes";
+import { siteSpecific } from "../../app/services";
+
+describe("QuizAttempt", () => {
+    const quizId = Object.keys(mockPreviews)[0];
+    const preview = mockPreviews[quizId];
+    const sections = preview.children;
+
+    const rederQuizPreview =  async ({role, quizId}: {role: UserRole | "ANONYMOUS", quizId: string}) => {
+        await act(async () => renderTestEnvironment({ role }));
+        await act(async () => setUrl({ pathname: `/test/preview/${quizId}` }));
+        await waitForLoaded();
+    };
+
+    const teacherPreviewsQuiz = () => rederQuizPreview({ role: 'TEACHER', quizId });
+
+    describe("overview", () => {
+        it('shows quiz title on the breadcrumbs', async () => {
+            await teacherPreviewsQuiz();
+            siteSpecific(
+                () => expectPhyBreadCrumbs({href: "/set_tests", text: "Set / Manage Tests"}),
+                () => expectAdaBreadCrumbs([{href: '/', text: "Home"}, {href: "/set_tests", text: "Set tests"}, `${preview.title} Preview`])
+            )();
+        });
+
+        it('shows quiz title', async () => {
+            await teacherPreviewsQuiz();
+            expectH1(`${preview.title} Preview`);
+        });
+
+        it('shows message about this page', async () => {
+            await teacherPreviewsQuiz();
+            expectActionMessage('You are previewing this test.');
+        });
+
+        it('shows quiz rubric', async () => {
+            await teacherPreviewsQuiz();
+            expectTitledSection("Instructions", preview.rubric?.children?.[0].value);
+        });
+
+        it("shows Test sections that load section and allow navigating back", async () => {
+            await teacherPreviewsQuiz();
+            expect(testSectionsHeader()).toBeInTheDocument();
+            await expectLinkWithEnabledBackwardsNavigation(sections?.[0].title, `/test/preview/${quizId}/page/1`, `/test/preview/${quizId}`);
+            await expectLinkWithEnabledBackwardsNavigation(sections?.[1].title, `/test/preview/${quizId}/page/2`, `/test/preview/${quizId}`);
+        });
+
+        it('shows "View questions" button that loads first page and allows navigating back', async () => {
+            await teacherPreviewsQuiz();
+            await expectLinkWithEnabledBackwardsNavigation("View questions", `/test/preview/${quizId}/page/1`, `/test/preview/${quizId}`);
+        });
+    });
+
+    describe("question page", () => {
+        const teacherPreviewsQuestionPage = (p: number) => rederQuizPreview({ role: 'TEACHER', quizId: `${quizId}/page/${p}` });
+
+        it('shows "Back" button that loads previous page and allows navigating back', async () => {
+            await teacherPreviewsQuestionPage(1);
+            await expectLinkWithEnabledBackwardsNavigation("Back", `/test/preview/${quizId}`, `/test/preview/${quizId}/page/1`);
+        });
+
+        it('shows "Next" button that loads following page and allows navigating back', async () => {
+            await teacherPreviewsQuestionPage(1);
+            await expectLinkWithEnabledBackwardsNavigation("Next", `/test/preview/${quizId}/page/2`, `/test/preview/${quizId}/page/1`);
+        });
+
+        describe('on the last page', () => {
+            it('shows "Back to Contents" button that loads overview page and allows navigating back', async () => {
+                await teacherPreviewsQuestionPage(2);
+                await expectLinkWithEnabledBackwardsNavigation("Back to Contents", `/test/preview/${quizId}`, `/test/preview/${quizId}/page/2`);
+            });
+        });
+    });
+
+    describe('for students', () => {
+        const studentPreviewsQuiz = () => rederQuizPreview({ role: 'STUDENT', quizId: 'some_non_existent_test'}); 
+        
+        it('redirects to account upgrade', async () => {
+            await studentPreviewsQuiz();
+            await expectUrl(siteSpecific('/pages/contact_us_teacher', '/teacher_account_request'));
+        });
+    });
+
+    describe('for unregistered users', () => {
+        const anonymousAttemptsMissingQuiz = () => rederQuizPreview({ role: 'ANONYMOUS', quizId: 'some_non_existent_test'}); 
+        
+        it('redirects to log in', async () => {
+            await anonymousAttemptsMissingQuiz();
+            await expectUrl('/login');
+        });
+    });
+
+    describe('when quiz does not exist', () => {
+        const teacherPreviewsMissingQuiz = () => rederQuizPreview({ role: 'TEACHER', quizId: 'some_non_existent_test'});
+
+        it ('shows Test Preview on breadcrumbs', async () => {
+            await teacherPreviewsMissingQuiz();
+            siteSpecific(
+                () => expectPhyBreadCrumbs({href: '/tests', text: "My Tests"}),
+                () => expectAdaBreadCrumbs([{href: '/', text: "Home"}, {href: "/tests", text: "My tests"}, "Test Preview"])
+            )();
+        });
+        
+        it('shows error', async () => {
+            await teacherPreviewsMissingQuiz();
+            expectH1('Test Preview');
+            expectH4('Error loading test preview');
+            expectErrorMessage('This test has become unavailable.');
+        });
+    });
+});
+
+const expectErrorMessage = expectTextInElementWithId('error-message');
+const expectActionMessage = expectTextInElementWithId('quiz-action');
+const testSectionsHeader = () => screen.queryByRole('heading', {name: "Test sections"});
+const expectPhyBreadCrumbs = ({href, text}: {href: string, text: string}) => {
+    const breadcrumbs = within(screen.getByRole('navigation', { name: 'breadcrumb' })).getByRole('list');
+    expect(Array.from(breadcrumbs.children).map(e => e.innerHTML)).toEqual([
+        `<a href="${href}"><span>${text}</span></a>`,
+    ]);
+};
+const expectAdaBreadCrumbs = ([first, second, third]: [{href: string, text: string}, {href: string, text: string}, string | undefined]) => {
+    const breadcrumbs = within(screen.getByRole('navigation', { name: 'breadcrumb' })).getByRole('list');
+    expect(Array.from(breadcrumbs.children).map(e => e.innerHTML)).toEqual([
+        `<a href="${first.href}"><span>${first.text}</span></a>`,
+        `<a href="${second.href}"><span>${second.text}</span></a>`,
+        `<span>${third}</span>`
+    ]);
+};

--- a/src/test/pages/QuizPreview.test.tsx
+++ b/src/test/pages/QuizPreview.test.tsx
@@ -3,7 +3,7 @@ import {mockPreviews} from "../../mocks/data";
 import { siteSpecific } from "../../app/services";
 import { expectActionMessage, expectAdaBreadCrumbs, expectErrorMessage, expectPhyBreadCrumbs, renderQuizPage, testSectionsHeader } from "../helpers/quiz";
 
-describe("QuizAttempt", () => {
+describe("QuizPreview", () => {
     const quizId = Object.keys(mockPreviews)[0];
     const preview = mockPreviews[quizId];
     const sections = preview.children;

--- a/src/test/pages/QuizView.test.tsx
+++ b/src/test/pages/QuizView.test.tsx
@@ -1,4 +1,4 @@
-import {act, screen, waitFor, within} from "@testing-library/react";
+import {act, screen, within} from "@testing-library/react";
 import { expectButtonWithEnabledBackwardsNavigation, expectH1, expectH4, expectTextInElementWithId, expectTitledSection, expectUrl, renderTestEnvironment, setUrl, waitForLoaded } from "../testUtils";
 import {mockRubrics} from "../../mocks/data";
 import {isPhy, siteSpecific} from "../../app/services";

--- a/src/test/pages/QuizView.test.tsx
+++ b/src/test/pages/QuizView.test.tsx
@@ -1,5 +1,5 @@
 import {act, screen, waitFor, within} from "@testing-library/react";
-import {clickButton, expectH1, expectH4, expectTextInElementWithId, expectTitledSection, expectUrl, goBack, renderTestEnvironment, setUrl, waitForLoaded} from "../testUtils";
+import { expectButtonWithEnabledBackwardsNavigation, expectH1, expectH4, expectTextInElementWithId, expectTitledSection, expectUrl, renderTestEnvironment, setUrl, waitForLoaded } from "../testUtils";
 import {mockRubrics} from "../../mocks/data";
 import {isPhy, siteSpecific} from "../../app/services";
 import type {UserRole} from "../../IsaacApiTypes";
@@ -55,11 +55,12 @@ describe("QuizView", () => {
 
     it('shows "Take Test" button that loads the attempts page and allows navigating back', async () => {
         await studentViewsQuiz();
-        await clickButton("Take Test");
-        expectActionMessage("You are freely attempting this test");
-        expectH1(mockRubric.title);
-        goBack();
-        await waitFor(() => expectActionMessage("You are viewing the rubric for this test."));
+        await expectButtonWithEnabledBackwardsNavigation("Take Test", `/test/attempt/${rubricId}`, `/test/view/${rubricId}`);
+    });
+
+    it('does not show "Preview" button', async() => {
+        await studentViewsQuiz();
+        expect(previewButton()).toBe(null);
     });
 
     describe('for teachers', () => {
@@ -68,6 +69,11 @@ describe("QuizView", () => {
         it('shows Set Test button', async () => {
             await teacherViewsQuiz();
             expect(setTestButton()).toBeInTheDocument();
+        });
+
+        it('shows "Preview" button that loads the preview page and allows navigating back', async () => {
+            await teacherViewsQuiz();
+            await expectButtonWithEnabledBackwardsNavigation("Preview", `/test/preview/${rubricId}`, `/test/view/${rubricId}`);
         });
     });
 
@@ -85,6 +91,11 @@ describe("QuizView", () => {
         it('does not show edit button', async () => {
             await editorViewsQuiz();
             expect(editButton()).toBe(null);
+        });
+
+        it('shows "Preview" button that loads the preview page and allows navigating back', async () => {
+            await editorViewsQuiz();
+            await expectButtonWithEnabledBackwardsNavigation("Preview", `/test/preview/${rubricId}`, `/test/view/${rubricId}`);
         });
     });
 
@@ -121,6 +132,7 @@ const expectErrorMessage = expectTextInElementWithId('error-message');
 const expectActionMessage = expectTextInElementWithId('quiz-action');
 const setTestButton = () => screen.queryByRole('button', {name: "Set Test"});
 const editButton = () => screen.queryByRole('heading', {name: "Published ✎"});
+const previewButton = () => screen.queryByRole('link', {name: "Preview"});
 const testSectionsHeader = () => screen.queryByRole('heading', {name: "Test sections"});
 const expectPhyBreadCrumbs = ({href, text}: {href: string, text: string}) => {
     const breadcrumbs = within(screen.getByRole('navigation', { name: 'breadcrumb' })).getByRole('list');

--- a/src/test/pages/QuizView.test.tsx
+++ b/src/test/pages/QuizView.test.tsx
@@ -1,14 +1,10 @@
 import {act, screen, within} from "@testing-library/react";
 import { expectButtonWithEnabledBackwardsNavigation, expectH1, expectH4, expectTextInElementWithId, expectTitledSection, expectUrl, renderTestEnvironment, setUrl, waitForLoaded } from "../testUtils";
 import {mockRubrics} from "../../mocks/data";
-import {isPhy, siteSpecific} from "../../app/services";
+import {siteSpecific} from "../../app/services";
 import type {UserRole} from "../../IsaacApiTypes";
 
 describe("QuizView", () => {
-    if (!isPhy) {
-        return it('does not exist yet', () => {});
-    };
-
     const rubricId = Object.keys(mockRubrics)[0];
     const mockRubric = mockRubrics[rubricId];
 

--- a/src/test/pages/QuizView.test.tsx
+++ b/src/test/pages/QuizView.test.tsx
@@ -1,0 +1,81 @@
+import {act, screen} from "@testing-library/react";
+import {expectH1, expectH4, expectTextInElementWithId, expectTitledSection, expectUrl, renderTestEnvironment, setUrl, waitForLoaded} from "../testUtils";
+import {mockRubrics} from "../../mocks/data";
+import {isPhy} from "../../app/services";
+import type {UserRole} from "../../IsaacApiTypes";
+
+describe("QuizView", () => {
+    if (!isPhy) {
+        return it('does not exist yet', () => {});
+    };
+
+    const rubricId = Object.keys(mockRubrics)[0];
+    const mockRubric = mockRubrics[rubricId];
+
+    const renderQuizView =  async ({role, pathname}: {role: UserRole | "ANONYMOUS", pathname: string}) => {
+        await act(async () => renderTestEnvironment({ role }));
+        await act(async () => setUrl({ pathname }));
+        await waitForLoaded();
+    };
+
+    it('shows the rubric for the quiz', async () => {
+        await renderQuizView({ role: 'STUDENT', pathname: `/test/view/${rubricId}/` });
+        expectH1(mockRubric.title);
+        expectTitledSection("Instructions", mockRubric.rubric?.children?.[0].value);
+    });
+
+    it('does not show the Set Test button', async () => {
+        await renderQuizView({ role: 'STUDENT', pathname: `/test/view/${rubricId}/` });
+        expect(setTestButton()).toBe(null);
+    });
+
+    it("does not show the edit button", async () => {
+        await renderQuizView({ role: 'STUDENT', pathname: `/test/view/${rubricId}/` });
+        expect(editButton()).toBe(null);
+    });
+
+    describe('for teachers', () => {
+        it('shows the Set Test button', async () => {
+            await renderQuizView({ role: 'TEACHER', pathname: `/test/view/${rubricId}/` });
+            expect(setTestButton()).toBeInTheDocument();
+        });
+
+        it("does not show the edit button", async () => {
+            await renderQuizView({ role: 'TEACHER', pathname: `/test/view/${rubricId}/` });
+            expect(editButton()).toBe(null);
+        });
+    });
+
+    describe('for content editors', () => {
+        it('shows the Set Test Button', async () => {
+            await renderQuizView({ role: 'CONTENT_EDITOR', pathname: `/test/view/${rubricId}/` });
+            expect(setTestButton()).toBeInTheDocument();
+        });
+
+        // we'd need canonicalSourceFile for this, which the endpoint doesn't return
+        it('does not show the edit button', async () => {
+            await renderQuizView({ role: 'CONTENT_EDITOR', pathname: `/test/view/${rubricId}/` });
+            expect(editButton()).toBe(null);
+        });
+    });
+
+    describe('for unregistered users', () => {
+        it('redirects to log in', async () => {
+            await renderQuizView({ role: 'ANONYMOUS', pathname: '/test/view/some_non_existent_test'});
+            await expectUrl('/login');
+        });
+    });
+
+    describe('when a quiz does not exist', () => {
+        it('shows an error', async () => {
+            await renderQuizView({ role: 'STUDENT', pathname: '/test/view/some_non_existent_test'});
+            expectH1('Viewing Test');
+            expectH4('There was an error loading that test.');
+            expectErrorMessage('This test has become unavailable.');
+        });
+    });
+});
+
+const expectErrorMessage = expectTextInElementWithId('error-message');
+const setTestButton = () => screen.queryByRole('button', {name: "Set Test"});
+const editButton = () => screen.queryByRole('header', {name: "Published ✎"});

--- a/src/test/pages/QuizView.test.tsx
+++ b/src/test/pages/QuizView.test.tsx
@@ -18,7 +18,7 @@ describe("QuizView", () => {
         await waitForLoaded();
     };
 
-    const studentViewsQuiz = () => renderQuizView({ role: 'STUDENT', pathname: `/test/view/${rubricId}/` }); 
+    const studentViewsQuiz = () => renderQuizView({ role: 'STUDENT', pathname: `/test/view/${rubricId}` }); 
 
     it('shows quiz title on the breadcrumbs', async () => {
         await studentViewsQuiz();
@@ -38,14 +38,14 @@ describe("QuizView", () => {
         expectActionMessage('You are viewing the rubric for this test.');
     });
 
-    it('shows quiz rubric', async () => {
-        await studentViewsQuiz();
-        expectTitledSection("Instructions", mockRubric.rubric?.children?.[0].value);
-    });
-
     it('does not show Set Test button', async () => {
         await studentViewsQuiz();
         expect(setTestButton()).toBe(null);
+    });
+
+    it('shows quiz rubric', async () => {
+        await studentViewsQuiz();
+        expectTitledSection("Instructions", mockRubric.rubric?.children?.[0].value);
     });
 
     it("does not show Test sections", async () => {
@@ -53,8 +53,13 @@ describe("QuizView", () => {
         expect(testSectionsHeader()).toBe(null);
     });
 
+    it('shows "Take Test" button', async () => {
+        await studentViewsQuiz();
+        expect(takeTestButton()).toHaveAttribute('href', `/test/attempt/${rubricId}`);
+    });
+
     describe('for teachers', () => {
-        const teacherViewsQuiz = () => renderQuizView({ role: 'TEACHER', pathname: `/test/view/${rubricId}/` }); 
+        const teacherViewsQuiz = () => renderQuizView({ role: 'TEACHER', pathname: `/test/view/${rubricId}` }); 
         
         it('shows Set Test button', async () => {
             await teacherViewsQuiz();
@@ -63,7 +68,7 @@ describe("QuizView", () => {
     });
 
     describe('for content editors', () => {
-        const editorViewsQuiz = () => renderQuizView({ role: 'TEACHER', pathname: `/test/view/${rubricId}/` });
+        const editorViewsQuiz = () => renderQuizView({ role: 'TEACHER', pathname: `/test/view/${rubricId}` });
 
         it('shows Set Test Button', async () => {
             await editorViewsQuiz();
@@ -127,3 +132,4 @@ const expectAdaBreadCrumbs = ([first, second, third]: [{href: string, text: stri
         `<span>${third}</span>`
     ]);
 };
+const takeTestButton = () => screen.getByRole('link', { name: "Take Test" });

--- a/src/test/pages/QuizView.test.tsx
+++ b/src/test/pages/QuizView.test.tsx
@@ -1,5 +1,5 @@
-import {act, screen, within} from "@testing-library/react";
-import {expectH1, expectH4, expectTextInElementWithId, expectTitledSection, expectUrl, renderTestEnvironment, setUrl, waitForLoaded} from "../testUtils";
+import {act, screen, waitFor, within} from "@testing-library/react";
+import {clickButton, expectH1, expectH4, expectTextInElementWithId, expectTitledSection, expectUrl, goBack, renderTestEnvironment, setUrl, waitForLoaded} from "../testUtils";
 import {mockRubrics} from "../../mocks/data";
 import {isPhy, siteSpecific} from "../../app/services";
 import type {UserRole} from "../../IsaacApiTypes";
@@ -53,9 +53,13 @@ describe("QuizView", () => {
         expect(testSectionsHeader()).toBe(null);
     });
 
-    it('shows "Take Test" button', async () => {
+    it('shows a "Take Test" button that loads the attempts page and allows navigating back', async () => {
         await studentViewsQuiz();
-        expect(takeTestButton()).toHaveAttribute('href', `/test/attempt/${rubricId}`);
+        await clickButton("Take Test");
+        expectActionMessage("You are freely attempting this test");
+        expectH1(mockRubric.title);
+        goBack();
+        await waitFor(() => expectActionMessage("You are viewing the rubric for this test."));
     });
 
     describe('for teachers', () => {
@@ -132,4 +136,3 @@ const expectAdaBreadCrumbs = ([first, second, third]: [{href: string, text: stri
         `<span>${third}</span>`
     ]);
 };
-const takeTestButton = () => screen.getByRole('link', { name: "Take Test" });

--- a/src/test/pages/QuizView.test.tsx
+++ b/src/test/pages/QuizView.test.tsx
@@ -1,19 +1,13 @@
-import {act, screen, within} from "@testing-library/react";
-import { expectLinkWithEnabledBackwardsNavigation, expectH1, expectH4, expectTextInElementWithId, expectTitledSection, expectUrl, renderTestEnvironment, setUrl, waitForLoaded } from "../testUtils";
+import { expectLinkWithEnabledBackwardsNavigation, expectH1, expectH4, expectTitledSection, expectUrl } from "../testUtils";
 import {mockRubrics} from "../../mocks/data";
 import {siteSpecific} from "../../app/services";
-import type {UserRole} from "../../IsaacApiTypes";
+import { editButton, expectActionMessage, expectAdaBreadCrumbs, expectErrorMessage, expectPhyBreadCrumbs, previewButton, renderQuizPage, setTestButton, testSectionsHeader } from "../helpers/quiz";
 
 describe("QuizView", () => {
     const quizId = Object.keys(mockRubrics)[0];
     const rubric = mockRubrics[quizId];
 
-    const renderQuizView =  async ({role, quizId}: {role: UserRole | "ANONYMOUS", quizId: string}) => {
-        await act(async () => renderTestEnvironment({ role }));
-        await act(async () => setUrl({ pathname: `/test/view/${quizId}` }));
-        await waitForLoaded();
-    };
-
+    const renderQuizView = renderQuizPage('/test/view');
     const studentViewsQuiz = () => renderQuizView({ role: 'STUDENT', quizId }); 
 
     it('shows quiz title on the breadcrumbs', async () => {
@@ -123,24 +117,3 @@ describe("QuizView", () => {
         });
     });
 });
-
-const expectErrorMessage = expectTextInElementWithId('error-message');
-const expectActionMessage = expectTextInElementWithId('quiz-action');
-const setTestButton = () => screen.queryByRole('button', {name: "Set Test"});
-const editButton = () => screen.queryByRole('heading', {name: "Published ✎"});
-const previewButton = () => screen.queryByRole('link', {name: "Preview"});
-const testSectionsHeader = () => screen.queryByRole('heading', {name: "Test sections"});
-const expectPhyBreadCrumbs = ({href, text}: {href: string, text: string}) => {
-    const breadcrumbs = within(screen.getByRole('navigation', { name: 'breadcrumb' })).getByRole('list');
-    expect(Array.from(breadcrumbs.children).map(e => e.innerHTML)).toEqual([
-        `<a href="${href}"><span>${text}</span></a>`,
-    ]);
-};
-const expectAdaBreadCrumbs = ([first, second, third]: [{href: string, text: string}, {href: string, text: string}, string | undefined]) => {
-    const breadcrumbs = within(screen.getByRole('navigation', { name: 'breadcrumb' })).getByRole('list');
-    expect(Array.from(breadcrumbs.children).map(e => e.innerHTML)).toEqual([
-        `<a href="${first.href}"><span>${first.text}</span></a>`,
-        `<a href="${second.href}"><span>${second.text}</span></a>`,
-        `<span>${third}</span>`
-    ]);
-};

--- a/src/test/pages/QuizView.test.tsx
+++ b/src/test/pages/QuizView.test.tsx
@@ -34,6 +34,11 @@ describe("QuizView", () => {
         expect(editButton()).toBe(null);
     });
 
+    it("does not show Test sections", async () => {
+        await renderQuizView({ role: 'STUDENT', pathname: `/test/view/${rubricId}/` });
+        expect(testSectionsHeader()).toBe(null);
+    });
+
     describe('for teachers', () => {
         it('shows the Set Test button', async () => {
             await renderQuizView({ role: 'TEACHER', pathname: `/test/view/${rubricId}/` });
@@ -78,4 +83,5 @@ describe("QuizView", () => {
 
 const expectErrorMessage = expectTextInElementWithId('error-message');
 const setTestButton = () => screen.queryByRole('button', {name: "Set Test"});
-const editButton = () => screen.queryByRole('header', {name: "Published ✎"});
+const editButton = () => screen.queryByRole('heading', {name: "Published ✎"});
+const testSectionsHeader = () => screen.queryByRole('heading', {name: "Test sections"});

--- a/src/test/pages/QuizView.test.tsx
+++ b/src/test/pages/QuizView.test.tsx
@@ -1,6 +1,6 @@
 import { expectLinkWithEnabledBackwardsNavigation, expectH1, expectH4, expectTitledSection, expectUrl } from "../testUtils";
 import {mockRubrics} from "../../mocks/data";
-import { editButton, expectActionMessage, expectAdaBreadCrumbs, expectErrorMessage, expectPhyBreadCrumbs, previewButton, renderQuizPage, setTestButton, testSectionsHeader } from "../helpers/quiz";
+import { editButton, expectActionMessage, expectAdaBreadCrumbs, expectErrorMessage, expectPhyBreadCrumbs, expectSidebarToggle, previewButton, renderQuizPage, setTestButton, sideBarTestCases, testSectionsHeader } from "../helpers/quiz";
 import { isPhy, siteSpecific } from "../../app/services";
 import { screen } from "@testing-library/react";
 
@@ -58,6 +58,15 @@ describe("QuizView", () => {
     it('does not show "Preview" button', async() => {
         await studentViewsQuiz();
         expect(previewButton()).toBe(null);
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    isPhy && describe('sidebar on redesigned Physics site', sideBarTestCases(studentViewsQuiz));
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    isPhy && it('sidebar toggle is called "Details"', async () => {
+        await studentViewsQuiz();
+        await expectSidebarToggle("Details");
     });
 
     describe('for teachers', () => {

--- a/src/test/pages/QuizView.test.tsx
+++ b/src/test/pages/QuizView.test.tsx
@@ -1,5 +1,5 @@
 import {act, screen, within} from "@testing-library/react";
-import { expectButtonWithEnabledBackwardsNavigation, expectH1, expectH4, expectTextInElementWithId, expectTitledSection, expectUrl, renderTestEnvironment, setUrl, waitForLoaded } from "../testUtils";
+import { expectLinkWithEnabledBackwardsNavigation, expectH1, expectH4, expectTextInElementWithId, expectTitledSection, expectUrl, renderTestEnvironment, setUrl, waitForLoaded } from "../testUtils";
 import {mockRubrics} from "../../mocks/data";
 import {siteSpecific} from "../../app/services";
 import type {UserRole} from "../../IsaacApiTypes";
@@ -51,7 +51,7 @@ describe("QuizView", () => {
 
     it('shows "Take Test" button that loads the attempts page and allows navigating back', async () => {
         await studentViewsQuiz();
-        await expectButtonWithEnabledBackwardsNavigation("Take Test", `/test/attempt/${quizId}`, `/test/view/${quizId}`);
+        await expectLinkWithEnabledBackwardsNavigation("Take Test", `/test/attempt/${quizId}`, `/test/view/${quizId}`);
     });
 
     it('does not show "Preview" button', async() => {
@@ -69,7 +69,7 @@ describe("QuizView", () => {
 
         it('shows "Preview" button that loads the preview page and allows navigating back', async () => {
             await teacherViewsQuiz();
-            await expectButtonWithEnabledBackwardsNavigation("Preview", `/test/preview/${quizId}`, `/test/view/${quizId}`);
+            await expectLinkWithEnabledBackwardsNavigation("Preview", `/test/preview/${quizId}`, `/test/view/${quizId}`);
         });
     });
 
@@ -91,7 +91,7 @@ describe("QuizView", () => {
 
         it('shows "Preview" button that loads the preview page and allows navigating back', async () => {
             await editorViewsQuiz();
-            await expectButtonWithEnabledBackwardsNavigation("Preview", `/test/preview/${quizId}`, `/test/view/${quizId}`);
+            await expectLinkWithEnabledBackwardsNavigation("Preview", `/test/preview/${quizId}`, `/test/view/${quizId}`);
         });
     });
 

--- a/src/test/pages/QuizView.test.tsx
+++ b/src/test/pages/QuizView.test.tsx
@@ -5,28 +5,28 @@ import {siteSpecific} from "../../app/services";
 import type {UserRole} from "../../IsaacApiTypes";
 
 describe("QuizView", () => {
-    const rubricId = Object.keys(mockRubrics)[0];
-    const mockRubric = mockRubrics[rubricId];
+    const quizId = Object.keys(mockRubrics)[0];
+    const rubric = mockRubrics[quizId];
 
-    const renderQuizView =  async ({role, pathname}: {role: UserRole | "ANONYMOUS", pathname: string}) => {
+    const renderQuizView =  async ({role, quizId}: {role: UserRole | "ANONYMOUS", quizId: string}) => {
         await act(async () => renderTestEnvironment({ role }));
-        await act(async () => setUrl({ pathname }));
+        await act(async () => setUrl({ pathname: `/test/view/${quizId}` }));
         await waitForLoaded();
     };
 
-    const studentViewsQuiz = () => renderQuizView({ role: 'STUDENT', pathname: `/test/view/${rubricId}` }); 
+    const studentViewsQuiz = () => renderQuizView({ role: 'STUDENT', quizId }); 
 
     it('shows quiz title on the breadcrumbs', async () => {
         await studentViewsQuiz();
         siteSpecific(
             () => expectPhyBreadCrumbs({href: "/practice_tests", text: "Practice Tests"}),
-            () => expectAdaBreadCrumbs([{href: '/', text: "Home"}, {href: "/practice_tests", text: "Practice Tests"}, mockRubric.title])
+            () => expectAdaBreadCrumbs([{href: '/', text: "Home"}, {href: "/practice_tests", text: "Practice Tests"}, rubric.title])
         )();
     });
 
     it('shows quiz title', async () => {
         await studentViewsQuiz();
-        expectH1(mockRubric.title);
+        expectH1(rubric.title);
     });
 
     it('shows message about this page', async () => {
@@ -41,7 +41,7 @@ describe("QuizView", () => {
 
     it('shows quiz rubric', async () => {
         await studentViewsQuiz();
-        expectTitledSection("Instructions", mockRubric.rubric?.children?.[0].value);
+        expectTitledSection("Instructions", rubric.rubric?.children?.[0].value);
     });
 
     it("does not show Test sections", async () => {
@@ -51,7 +51,7 @@ describe("QuizView", () => {
 
     it('shows "Take Test" button that loads the attempts page and allows navigating back', async () => {
         await studentViewsQuiz();
-        await expectButtonWithEnabledBackwardsNavigation("Take Test", `/test/attempt/${rubricId}`, `/test/view/${rubricId}`);
+        await expectButtonWithEnabledBackwardsNavigation("Take Test", `/test/attempt/${quizId}`, `/test/view/${quizId}`);
     });
 
     it('does not show "Preview" button', async() => {
@@ -60,7 +60,7 @@ describe("QuizView", () => {
     });
 
     describe('for teachers', () => {
-        const teacherViewsQuiz = () => renderQuizView({ role: 'TEACHER', pathname: `/test/view/${rubricId}` }); 
+        const teacherViewsQuiz = () => renderQuizView({ role: 'TEACHER', quizId }); 
         
         it('shows Set Test button', async () => {
             await teacherViewsQuiz();
@@ -69,12 +69,12 @@ describe("QuizView", () => {
 
         it('shows "Preview" button that loads the preview page and allows navigating back', async () => {
             await teacherViewsQuiz();
-            await expectButtonWithEnabledBackwardsNavigation("Preview", `/test/preview/${rubricId}`, `/test/view/${rubricId}`);
+            await expectButtonWithEnabledBackwardsNavigation("Preview", `/test/preview/${quizId}`, `/test/view/${quizId}`);
         });
     });
 
     describe('for content editors', () => {
-        const editorViewsQuiz = () => renderQuizView({ role: 'TEACHER', pathname: `/test/view/${rubricId}` });
+        const editorViewsQuiz = () => renderQuizView({ role: 'TEACHER', quizId });
 
         it('shows Set Test Button', async () => {
             await editorViewsQuiz();
@@ -91,12 +91,12 @@ describe("QuizView", () => {
 
         it('shows "Preview" button that loads the preview page and allows navigating back', async () => {
             await editorViewsQuiz();
-            await expectButtonWithEnabledBackwardsNavigation("Preview", `/test/preview/${rubricId}`, `/test/view/${rubricId}`);
+            await expectButtonWithEnabledBackwardsNavigation("Preview", `/test/preview/${quizId}`, `/test/view/${quizId}`);
         });
     });
 
     describe('for unregistered users', () => {
-        const anonymousViewsMissingQuiz = () => renderQuizView({ role: 'ANONYMOUS', pathname: '/test/view/some_non_existent_test'}); 
+        const anonymousViewsMissingQuiz = () => renderQuizView({ role: 'ANONYMOUS', quizId: 'some_non_existent_test'}); 
         
         it('redirects to log in', async () => {
             await anonymousViewsMissingQuiz();
@@ -105,7 +105,7 @@ describe("QuizView", () => {
     });
 
     describe('when quiz does not exist', () => {
-        const studentViewsMissingQuiz = () => renderQuizView({ role: 'STUDENT', pathname: '/test/view/some_non_existent_test'});
+        const studentViewsMissingQuiz = () => renderQuizView({ role: 'STUDENT', quizId: 'some_non_existent_test'});
 
         it ('shows Unknown Test on breadcrumbs', async () => {
             await studentViewsMissingQuiz();

--- a/src/test/pages/QuizView.test.tsx
+++ b/src/test/pages/QuizView.test.tsx
@@ -53,7 +53,7 @@ describe("QuizView", () => {
         expect(testSectionsHeader()).toBe(null);
     });
 
-    it('shows a "Take Test" button that loads the attempts page and allows navigating back', async () => {
+    it('shows "Take Test" button that loads the attempts page and allows navigating back', async () => {
         await studentViewsQuiz();
         await clickButton("Take Test");
         expectActionMessage("You are freely attempting this test");

--- a/src/test/pages/QuizView.test.tsx
+++ b/src/test/pages/QuizView.test.tsx
@@ -1,7 +1,7 @@
 import { expectLinkWithEnabledBackwardsNavigation, expectH1, expectH4, expectTitledSection, expectUrl } from "../testUtils";
 import {mockRubrics} from "../../mocks/data";
-import {siteSpecific} from "../../app/services";
 import { editButton, expectActionMessage, expectAdaBreadCrumbs, expectErrorMessage, expectPhyBreadCrumbs, previewButton, renderQuizPage, setTestButton, testSectionsHeader } from "../helpers/quiz";
+import { siteSpecific } from "../../app/services";
 
 describe("QuizView", () => {
     const quizId = Object.keys(mockRubrics)[0];
@@ -14,7 +14,7 @@ describe("QuizView", () => {
         await studentViewsQuiz();
         siteSpecific(
             () => expectPhyBreadCrumbs({href: "/practice_tests", text: "Practice Tests"}),
-            () => expectAdaBreadCrumbs([{href: '/', text: "Home"}, {href: "/practice_tests", text: "Practice Tests"}, rubric.title])
+            () => expectAdaBreadCrumbs([{href: '/', text: "Home"}, {href: "/practice_tests", text: "Practice tests"}, rubric.title])
         )();
     });
 
@@ -105,7 +105,7 @@ describe("QuizView", () => {
             await studentViewsMissingQuiz();
             siteSpecific(
                 () => expectPhyBreadCrumbs({href: '/practice_tests', text: "Practice Tests"}),
-                () => expectAdaBreadCrumbs([{href: '/', text: "Home"}, {href: "/practice_tests", text: "Practice Tests"}, "Unknown Test"])
+                () => expectAdaBreadCrumbs([{href: '/', text: "Home"}, {href: "/practice_tests", text: "Practice tests"}, "Unknown Test"])
             )();
         });
         

--- a/src/test/pages/QuizView.test.tsx
+++ b/src/test/pages/QuizView.test.tsx
@@ -1,7 +1,8 @@
 import { expectLinkWithEnabledBackwardsNavigation, expectH1, expectH4, expectTitledSection, expectUrl } from "../testUtils";
 import {mockRubrics} from "../../mocks/data";
 import { editButton, expectActionMessage, expectAdaBreadCrumbs, expectErrorMessage, expectPhyBreadCrumbs, previewButton, renderQuizPage, setTestButton, testSectionsHeader } from "../helpers/quiz";
-import { siteSpecific } from "../../app/services";
+import { isPhy, siteSpecific } from "../../app/services";
+import { screen } from "@testing-library/react";
 
 describe("QuizView", () => {
     const quizId = Object.keys(mockRubrics)[0];
@@ -9,6 +10,12 @@ describe("QuizView", () => {
 
     const renderQuizView = renderQuizPage('/test/view');
     const studentViewsQuiz = () => renderQuizView({ role: 'STUDENT', quizId }); 
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    isPhy && it('applies subject-specific theme', async () => {
+        await studentViewsQuiz();
+        expect(screen.getByTestId('quiz-view')).toHaveAttribute('data-bs-theme', 'physics');
+    });
 
     it('shows quiz title on the breadcrumbs', async () => {
         await studentViewsQuiz();

--- a/src/test/pages/QuizView.test.tsx
+++ b/src/test/pages/QuizView.test.tsx
@@ -18,87 +18,89 @@ describe("QuizView", () => {
         await waitForLoaded();
     };
 
-    it('shows the breadcrumbs', async () => {
-        await renderQuizView({ role: 'STUDENT', pathname: `/test/view/${rubricId}/` });
+    const studentViewsQuiz = () => renderQuizView({ role: 'STUDENT', pathname: `/test/view/${rubricId}/` }); 
+
+    it('shows quiz title on the breadcrumbs', async () => {
+        await studentViewsQuiz();
         siteSpecific(
             () => expectPhyBreadCrumbs({href: "/practice_tests", text: "Practice Tests"}),
             () => expectAdaBreadCrumbs([{href: '/', text: "Home"}, {href: "/practice_tests", text: "Practice Tests"}, mockRubric.title])
         )();
     });
 
-    it('shows the quiz title', async () => {
-        await renderQuizView({ role: 'STUDENT', pathname: `/test/view/${rubricId}/` });
+    it('shows quiz title', async () => {
+        await studentViewsQuiz();
         expectH1(mockRubric.title);
     });
 
-    it('shows what page you are on', async () => {
-        await renderQuizView({ role: 'STUDENT', pathname: `/test/view/${rubricId}/` });
+    it('shows message about this page', async () => {
+        await studentViewsQuiz();
         expectActionMessage('You are viewing the rubric for this test.');
     });
 
-    it('shows the quiz rubric', async () => {
-        await renderQuizView({ role: 'STUDENT', pathname: `/test/view/${rubricId}/` });
+    it('shows quiz rubric', async () => {
+        await studentViewsQuiz();
         expectTitledSection("Instructions", mockRubric.rubric?.children?.[0].value);
     });
 
-    it('does not show the Set Test button', async () => {
-        await renderQuizView({ role: 'STUDENT', pathname: `/test/view/${rubricId}/` });
+    it('does not show Set Test button', async () => {
+        await studentViewsQuiz();
         expect(setTestButton()).toBe(null);
     });
 
-    it("does not show the edit button", async () => {
-        await renderQuizView({ role: 'STUDENT', pathname: `/test/view/${rubricId}/` });
-        expect(editButton()).toBe(null);
-    });
-
     it("does not show Test sections", async () => {
-        await renderQuizView({ role: 'STUDENT', pathname: `/test/view/${rubricId}/` });
+        await studentViewsQuiz();
         expect(testSectionsHeader()).toBe(null);
     });
 
     describe('for teachers', () => {
-        it('shows the Set Test button', async () => {
-            await renderQuizView({ role: 'TEACHER', pathname: `/test/view/${rubricId}/` });
+        const teacherViewsQuiz = () => renderQuizView({ role: 'TEACHER', pathname: `/test/view/${rubricId}/` }); 
+        
+        it('shows Set Test button', async () => {
+            await teacherViewsQuiz();
             expect(setTestButton()).toBeInTheDocument();
-        });
-
-        it("does not show the edit button", async () => {
-            await renderQuizView({ role: 'TEACHER', pathname: `/test/view/${rubricId}/` });
-            expect(editButton()).toBe(null);
         });
     });
 
     describe('for content editors', () => {
-        it('shows the Set Test Button', async () => {
-            await renderQuizView({ role: 'CONTENT_EDITOR', pathname: `/test/view/${rubricId}/` });
+        const editorViewsQuiz = () => renderQuizView({ role: 'TEACHER', pathname: `/test/view/${rubricId}/` });
+
+        it('shows Set Test Button', async () => {
+            await editorViewsQuiz();
             expect(setTestButton()).toBeInTheDocument();
         });
 
-        // we'd need canonicalSourceFile for this, which the endpoint doesn't return
-        it('does not show the edit button', async () => {
-            await renderQuizView({ role: 'CONTENT_EDITOR', pathname: `/test/view/${rubricId}/` });
+        // It'd be more consistent with, eg. the `/preview` page to show the edit button.
+        // However, we'd need `canonicalSourceFile` for this, which the `/rubric` endpoint doesn't return.
+        // For now, James suggested this was not worth the effort.
+        it('does not show edit button', async () => {
+            await editorViewsQuiz();
             expect(editButton()).toBe(null);
         });
     });
 
     describe('for unregistered users', () => {
+        const anonymousViewsMissingQuiz = () => renderQuizView({ role: 'ANONYMOUS', pathname: '/test/view/some_non_existent_test'}); 
+        
         it('redirects to log in', async () => {
-            await renderQuizView({ role: 'ANONYMOUS', pathname: '/test/view/some_non_existent_test'});
+            await anonymousViewsMissingQuiz();
             await expectUrl('/login');
         });
     });
 
-    describe('when a quiz does not exist', () => {
-        it ('shows the breadcrumbs', async () => {
-            await renderQuizView({ role: 'STUDENT', pathname: '/test/view/some_non_existent_test'});
+    describe('when quiz does not exist', () => {
+        const studentViewsMissingQuiz = () => renderQuizView({ role: 'STUDENT', pathname: '/test/view/some_non_existent_test'});
+
+        it ('shows Unknown Test on breadcrumbs', async () => {
+            await studentViewsMissingQuiz();
             siteSpecific(
                 () => expectPhyBreadCrumbs({href: '/practice_tests', text: "Practice Tests"}),
                 () => expectAdaBreadCrumbs([{href: '/', text: "Home"}, {href: "/practice_tests", text: "Practice Tests"}, "Unknown Test"])
             )();
         });
         
-        it('shows an error', async () => {
-            await renderQuizView({ role: 'STUDENT', pathname: '/test/view/some_non_existent_test'});
+        it('shows error', async () => {
+            await studentViewsMissingQuiz();
             expectH1('Unknown Test');
             expectH4('There was an error loading that test.');
             expectErrorMessage('This test has become unavailable.');

--- a/src/test/pages/SetAssignments.test.tsx
+++ b/src/test/pages/SetAssignments.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 import {SetAssignments} from "../../app/components/pages/SetAssignments";
 import {mockActiveGroups, mockGameboards, mockSetAssignments} from "../../mocks/data";
 import {dayMonthYearStringToDate, DDMMYYYY_REGEX, ONE_DAY_IN_MS, SOME_FIXED_FUTURE_DATE} from "../dateUtils";
-import {clickButton, renderTestEnvironment, withMockedDate} from "../testUtils";
+import {clickOn, renderTestEnvironment, withMockedDate} from "../testUtils";
 
 import {API_PATH, isAda, isPhy, PATHS, siteSpecific} from "../../app/services";
 import { http, HttpHandler, HttpResponse } from "msw";
@@ -183,7 +183,7 @@ describe("SetAssignments", () => {
         expect(allAssignments[0].textContent).toContain(mockActiveGroups[0].groupName);
 
         // Click button
-        await clickButton('Assign to group', Promise.resolve(modal));
+        await clickOn('Assign to group', Promise.resolve(modal));
 
         // Expect request to be sent off with expected parameters
         await waitFor(() => {
@@ -254,7 +254,7 @@ describe("SetAssignments", () => {
 
                 await toggleGroupSelect();
                 await selectGroup(mockActiveGroups[1].groupName);
-                await clickButton('Assign to group', modal());
+                await clickOn('Assign to group', modal());
 
                 await waitFor(() => expect(observer.observedParams![0].dueDate).toEqual(expectedDueDatePosted)); // Sunday
             });
@@ -280,7 +280,7 @@ describe("SetAssignments", () => {
 
                 await toggleGroupSelect();
                 await selectGroup(mockActiveGroups[1].groupName);
-                await clickButton('Assign to group', modal());
+                await clickOn('Assign to group', modal());
 
                 expect(await groupSelector()).toHaveTextContent('Group(s):None');
                 expect(await dateInput(/Schedule an assignment start date/)).toHaveValue('');

--- a/src/test/pages/SubjectLandingPage.test.tsx
+++ b/src/test/pages/SubjectLandingPage.test.tsx
@@ -1,5 +1,5 @@
 import {act, screen} from "@testing-library/react";
-import { clickButton, renderTestEnvironment, setUrl, waitForLoaded, withMockedRandom} from "../testUtils";
+import { clickOn, renderTestEnvironment, setUrl, waitForLoaded, withMockedRandom} from "../testUtils";
 import { mockQuestionFinderResults } from "../../mocks/data";
 import { isAda } from "../../app/services";
 import { buildFunctionHandler } from "../../mocks/handlers";
@@ -58,7 +58,7 @@ describe("SubjectLandingPage", () => {
                     await waitForLoaded();
                     await expectInDocument(questions[0].title);
     
-                    await clickButton("Get a different question");
+                    await clickOn("Get a different question");
                     await waitForLoaded();
                     await expectInDocument(questions[1].title);
                     expect(requestCounter.count).toEqual(2);

--- a/src/test/test-factory.tsx
+++ b/src/test/test-factory.tsx
@@ -7,12 +7,19 @@ import {
 } from "../IsaacApiTypes";
 import {UserPreferencesDTO} from "../IsaacAppTypes";
 
-export const errorResponses: {[key: string]: object} = {
+export type ErrorType = 'mustBeLoggedIn401' | 'testUnavailable404';
+export const errorResponses: Record<ErrorType, object> = {
     mustBeLoggedIn401: {
-        "responseCode":401,
-        "responseCodeType":"Unauthorized",
-        "errorMessage":"You must be logged in to access this resource.",
-        "bypassGenericSiteErrorPage":false
+        responseCode: 401,
+        responseCodeType: "Unauthorized",
+        errorMessage: "You must be logged in to access this resource.",
+        bypassGenericSiteErrorPage: false
+    },
+    testUnavailable404: {
+        responseCode: 404,
+        responseCodeType: "Not found",
+        errorMessage: "This test has become unavailable.",
+        bypassGenericSiteErrorPage: false
     }
 };
 

--- a/src/test/testUtils.tsx
+++ b/src/test/testUtils.tsx
@@ -210,7 +210,7 @@ export const expectTitledSection = (title: string, message: string | undefined) 
     if (titleE.parentElement === null) {
         throw new Error(`Could not find parent for heading: ${title}`);
     }
-    const paragraph = within(titleE.parentElement).getByRole('paragraph');
+    const [paragraph] = within(titleE.parentElement).getAllByRole('paragraph');
     return expect(paragraph).toHaveTextContent(`${message}`);
 }
 ;

--- a/src/test/testUtils.tsx
+++ b/src/test/testUtils.tsx
@@ -161,6 +161,10 @@ export const waitForLoaded = () => waitFor(() => {
     expect(screen.queryAllByText("Loading...")).toHaveLength(0);
 });
 
+export const expectUrl = (text: string) => waitFor(() => {
+    expect(history.location.pathname).toBe(text);
+});
+
 export const expectUrlParams = (text: string) => waitFor(() => {
     expect(history.location.search).toBe(text);
 });
@@ -189,4 +193,21 @@ export const withMockedDate = async (date: number, fn: () => Promise<void>) => {
     } finally {
         jest.spyOn(global.Date, 'now').mockRestore();
     }
+};
+
+const expectHeader = (n: number) => (txt?: string) => expect(screen.getByRole('heading', { level: n })).toHaveTextContent(`${txt}`);
+
+export const expectH1 = expectHeader(1);
+
+export const expectH4 = expectHeader(4);
+
+export const expectTextInElementWithId = (testId: string) => (msg: string) => expect(screen.getByTestId(testId)).toHaveTextContent(msg);
+
+export const expectTitledSection = (title: string, message: string | undefined) => {
+    const titleE = screen.getByRole('heading', { name: title });
+    if (titleE.parentElement === null) {
+        throw new Error(`Could not find parent for heading: ${title}`);
+    }
+    const paragraph = within(titleE.parentElement).getByRole('paragraph');
+    return expect(paragraph).toHaveTextContent(`${message}`);
 };

--- a/src/test/testUtils.tsx
+++ b/src/test/testUtils.tsx
@@ -10,7 +10,7 @@ import {Provider} from "react-redux";
 import {IsaacApp} from "../app/components/navigation/IsaacApp";
 import React from "react";
 import {MemoryRouter} from "react-router";
-import {screen, waitFor, within} from "@testing-library/react";
+import {fireEvent, screen, waitFor, within, act} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {SOME_FIXED_FUTURE_DATE_AS_STRING} from "./dateUtils";
 import * as miscUtils from '../app/services/miscUtils';
@@ -168,6 +168,27 @@ export const expectUrl = (text: string) => waitFor(() => {
 export const expectUrlParams = (text: string) => waitFor(() => {
     expect(history.location.search).toBe(text);
 });
+
+export const withSizedWindow = async (width: number, height: number, cb: () => void) => {
+    const originalWindow = {
+        width: window.innerWidth,
+        height: window.innerHeight,
+    };
+    try {
+        await act(async () => {
+            window.innerWidth = width;
+            window.innerHeight = height;    
+        });
+        fireEvent(window, new Event('resize'));
+        cb();
+    } finally {
+        await act(async () => {
+            window.innerWidth = originalWindow.width;
+            window.innerHeight = originalWindow.height;    
+        });
+        fireEvent(window, new Event('resize'));
+    }
+};
 
 export const setUrl = (location: LocationDescriptor) => history.push(location);
 

--- a/src/test/testUtils.tsx
+++ b/src/test/testUtils.tsx
@@ -171,6 +171,8 @@ export const expectUrlParams = (text: string) => waitFor(() => {
 
 export const setUrl = (location: LocationDescriptor) => history.push(location);
 
+export const goBack = () => history.goBack();
+
 export const withMockedRandom = async (fn: (randomSequence: (n: number[]) => void) => Promise<void>) => {
     const nextRandom = {
         values: [] as number[],

--- a/src/test/testUtils.tsx
+++ b/src/test/testUtils.tsx
@@ -195,11 +195,11 @@ export const withMockedDate = async (date: number, fn: () => Promise<void>) => {
     }
 };
 
-const expectHeader = (n: number) => (txt?: string) => expect(screen.getByRole('heading', { level: n })).toHaveTextContent(`${txt}`);
+const expectHeading = (n: number) => (txt?: string) => expect(screen.getByRole('heading', { level: n })).toHaveTextContent(`${txt}`);
 
-export const expectH1 = expectHeader(1);
+export const expectH1 = expectHeading(1);
 
-export const expectH4 = expectHeader(4);
+export const expectH4 = expectHeading(4);
 
 export const expectTextInElementWithId = (testId: string) => (msg: string) => expect(screen.getByTestId(testId)).toHaveTextContent(msg);
 

--- a/src/test/testUtils.tsx
+++ b/src/test/testUtils.tsx
@@ -141,12 +141,12 @@ export const switchAccountTab = async (tab: ACCOUNT_TAB) => {
     await userEvent.click(tabLink);
 };
 
-export const clickButton = async (text: string, container?: Promise<HTMLElement>) => {
-    const [button] = await (container ? within(await container).findAllByText(text).then(e => e) : screen.findAllByText(text));
-    if (button.hasAttribute('disabled')) {
-        throw new Error(`Can't click on disabled button ${button.textContent}`);
+export const clickOn = async (text: string, container?: Promise<HTMLElement>) => {
+    const [target] = await (container ? within(await container).findAllByText(text).then(e => e) : screen.findAllByText(text));
+    if (target.hasAttribute('disabled')) {
+        throw new Error(`Can't click on disabled button ${target.textContent}`);
     }
-    await userEvent.click(button);
+    await userEvent.click(target);
 };
 
 export const enterInput = async (placeholder: string, input: string) => {
@@ -214,8 +214,11 @@ export const expectTitledSection = (title: string, message: string | undefined) 
     return expect(paragraph).toHaveTextContent(`${message}`);
 }
 ;
-export const expectButtonWithEnabledBackwardsNavigation = async (text: string, targetHref: string, originalHref: string) => {
-    await clickButton(text);
+export const expectLinkWithEnabledBackwardsNavigation = async (text: string | undefined, targetHref: string, originalHref: string) => {
+    if (text === undefined) {
+        throw new Error("Target text is undefined");
+    }
+    await clickOn(text);
     await expectUrl(targetHref);
     goBack();
     await expectUrl(originalHref);

--- a/src/test/testUtils.tsx
+++ b/src/test/testUtils.tsx
@@ -212,4 +212,11 @@ export const expectTitledSection = (title: string, message: string | undefined) 
     }
     const paragraph = within(titleE.parentElement).getByRole('paragraph');
     return expect(paragraph).toHaveTextContent(`${message}`);
+}
+;
+export const expectButtonWithEnabledBackwardsNavigation = async (text: string, targetHref: string, originalHref: string) => {
+    await clickButton(text);
+    await expectUrl(targetHref);
+    goBack();
+    await expectUrl(originalHref);
 };


### PR DESCRIPTION
Besides applying https://github.com/isaacphysics/isaac-react-app/pull/1396, which introduces the `test/view` page, contains the following changes
- `QuizSidebar` now shows the `subject` and `topics`
- `QuizFooter` now consistently ends at `QuizSidebar` across the `attempt` and `preview` pages