### PR TITLE
Exclude unnecessary URL params on question search

### DIFF
--- a/src/app/components/elements/modals/QuestionSearchModal.tsx
+++ b/src/app/components/elements/modals/QuestionSearchModal.tsx
@@ -100,14 +100,13 @@ export const QuestionSearchModal = (
             }
 
             const tags = (isBookSearch ? book : [...([topics].map((tags) => tags.join(" ")))].filter((query) => query != "")).join(" ");
-            const examBoardString = examBoards.join(",");
 
             dispatch(searchQuestions({
-                searchString: searchString,
-                tags,
+                searchString: searchString || undefined,
+                tags: tags || undefined,
                 stages: stages.join(",") || undefined,
                 difficulties: difficulties.join(",") || undefined,
-                examBoards: examBoardString,
+                examBoards: examBoards.join(",") || undefined,
                 fasttrack,
                 startIndex,
                 limit: 300

--- a/src/app/components/pages/QuestionFinder.tsx
+++ b/src/app/components/pages/QuestionFinder.tsx
@@ -151,8 +151,8 @@ export const QuestionFinder = withRouter(({location}: RouteComponentProps) => {
 
     const [selections, setSelections] = useState<Item<TAG_ID>[][]>(
         processTagHierarchy(
-            arrayFromPossibleCsv(params.subjects), 
-            arrayFromPossibleCsv(params.fields), 
+            arrayFromPossibleCsv(params.subjects),
+            arrayFromPossibleCsv(params.fields),
             arrayFromPossibleCsv(params.topics)
         )
     );
@@ -210,22 +210,21 @@ export const QuestionFinder = withRouter(({location}: RouteComponentProps) => {
             } else {
                 filterParams["topics"] = [...topics].filter((query) => query != "");
             }
-            const examBoardString = examBoards.join(",");
 
             dispatch(searchQuestions({
-                searchString: searchString,
-                tags: "", // Tags currently not used
+                searchString: searchString || undefined,
+                tags: undefined, // Tags currently not used
                 fields: filterParams.fields?.join(",") || undefined,
                 subjects: filterParams.subjects?.join(",") || undefined,
                 topics: filterParams.topics?.join(",") || undefined,
                 books: (!excludeBooks && book.join(",")) || undefined,
                 stages: stages.join(",") || undefined,
                 difficulties: difficulties.join(",") || undefined,
-                examBoards: examBoardString,
+                examBoards: examBoards.join(",") || undefined,
                 questionCategories: isPhy
                     ? (excludeBooks ? "problem_solving" : "problem_solving,book")
                     : undefined,
-                statuses: questionStatusToURIComponent(questionStatuses),
+                statuses: questionStatusToURIComponent(questionStatuses), // Must not be undefined, to get attempt augmentation!
                 fasttrack: false,
                 startIndex,
                 limit: SEARCH_RESULTS_PER_PAGE + 1, // request one more than we need to know if there are more results


### PR DESCRIPTION
All blank or empty parameters can be undefined for the search, which means they won't be included in the API call URL in silly ways like e.g. /questions?searchString=&tags=&examBoards=&subjects=physics&... in every single request.

The API treats these empty string values identically to the null case, except "statuses", where the empty string means "don't filter by status but _do_ augment results with attempt data". So for the question finder, this argument must never be undefined but may well meaningfully be "".