### PR TITLE
remove confusing text from View Test page

### DIFF
--- a/src/app/components/elements/quiz/QuizContentsComponent.tsx
+++ b/src/app/components/elements/quiz/QuizContentsComponent.tsx
@@ -121,14 +121,16 @@ function QuizDetails({attempt, sections, questions, pageLink}: QuizAttemptProps)
 
 function QuizHeader({attempt, preview, view, user}: QuizAttemptProps | QuizViewProps) {
     const dispatch = useAppDispatch();
-    if (preview || view) {
-        const quiz = view ? view.quiz : attempt.quiz;
+    if (view) {
+        return isTeacherOrAbove(user) && <Button className="float-end ms-2 mb-2" onClick={() => dispatch(showQuizSettingModal(view.quiz!))}>Set Test</Button>;
+    }
+    else if (preview) {
         return <>
             {preview && <EditContentButton doc={attempt.quiz} />}
             <div data-testid="quiz-action" className="d-flex">
                 <p>{ preview ? "You are previewing this test." : "You are viewing the rubric for this test."}</p>
                 <Spacer />
-                {isTeacherOrAbove(user) && <Button onClick={() => dispatch(showQuizSettingModal(quiz!))}>Set Test</Button>}
+                {isTeacherOrAbove(user) && <Button onClick={() => dispatch(showQuizSettingModal(attempt.quiz!))}>Set Test</Button>}
             </div>
         </>;
     } else if (isDefined(attempt.quizAssignment)) {
@@ -163,8 +165,8 @@ function QuizRubric({attempt, view}: Pick<QuizAttemptProps | QuizViewProps, "att
     const rubric = attempt ? attempt.quiz?.rubric : view?.quiz?.rubric;
     const renderRubric = (rubric?.children || []).length > 0;
     return <div>
-        {rubric && renderRubric && <div>
-            <h4>Instructions</h4>
+        {rubric && renderRubric && <div data-testid="quiz-rubric">
+            {!view && <h4>Instructions</h4>}
             <IsaacContentValueOrChildren value={rubric.value}>
                 {rubric.children}
             </IsaacContentValueOrChildren>

--- a/src/test/helpers/quiz.ts
+++ b/src/test/helpers/quiz.ts
@@ -12,6 +12,8 @@ export const expectErrorMessage = expectTextInElementWithId('error-message');
 
 export const expectActionMessage = expectTextInElementWithId('quiz-action');
 
+export const expectRubric = expectTextInElementWithId('quiz-rubric');
+
 export const setTestButton = () => screen.queryByRole('button', {name: "Set Test"});
 
 export const editButton = () => screen.queryByRole('heading', {name: "Published ✎"});

--- a/src/test/pages/QuizView.test.tsx
+++ b/src/test/pages/QuizView.test.tsx
@@ -1,7 +1,8 @@
-import { expectLinkWithEnabledBackwardsNavigation, expectH1, expectH4, expectTitledSection, expectUrl } from "../testUtils";
+import { expectLinkWithEnabledBackwardsNavigation, expectH1, expectH4, expectUrl } from "../testUtils";
 import {mockRubrics} from "../../mocks/data";
-import { editButton, expectActionMessage, expectBreadcrumbs, expectErrorMessage, previewButton, renderQuizPage, setTestButton, testSectionsHeader } from "../helpers/quiz";
+import { editButton, expectBreadcrumbs, expectErrorMessage, expectRubric, previewButton, renderQuizPage, setTestButton, testSectionsHeader } from "../helpers/quiz";
 import { siteSpecific } from "../../app/services";
+import {screen } from "@testing-library/react";
 
 describe("QuizView", () => {
     const quizId = Object.keys(mockRubrics)[0];
@@ -20,9 +21,9 @@ describe("QuizView", () => {
         expectH1(rubric.title);
     });
 
-    it('shows message about this page', async () => {
+    it('does not show message about this page', async () => {
         await studentViewsQuiz();
-        expectActionMessage('You are viewing the rubric for this test.');
+        expect(screen.queryByTestId("quiz-action")).not.toBeInTheDocument();
     });
 
     it('does not show Set Test button', async () => {
@@ -32,7 +33,7 @@ describe("QuizView", () => {
 
     it('shows quiz rubric', async () => {
         await studentViewsQuiz();
-        expectTitledSection("Instructions", rubric.rubric?.children?.[0].value);
+        expectRubric(rubric.rubric?.children?.[0].value);
     });
 
     it("does not show Test sections", async () => {


### PR DESCRIPTION
- no longer show "You are viewing the rubric for this test"
- no longer show the "Description" heading