### PR TITLE
Searchable book pages

### DIFF
--- a/public/assets/phy/icons/redesign/page-generic-bg.svg
+++ b/public/assets/phy/icons/redesign/page-generic-bg.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="28" height="29" version="1.1" viewBox="0 0 28 29" xmlns="http://www.w3.org/2000/svg">
+<g fill="none" stroke="#000" stroke-width="1.7">
+<path d="m17 4h-11v22h16v-17l-5-5h-1M17 4v5h5"/>
+</g>
+</svg>

--- a/public/assets/phy/icons/redesign/page-generic-fg.svg
+++ b/public/assets/phy/icons/redesign/page-generic-fg.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="28" height="29" version="1.1" viewBox="0 0 28 29" xmlns="http://www.w3.org/2000/svg">
+<g fill="none" stroke="#000" stroke-width="2">
+<path d="m9 12h10M9 15.5h10M9 19h10"/>
+</g>
+</svg>

--- a/src/app/components/elements/list-groups/ListView.tsx
+++ b/src/app/components/elements/list-groups/ListView.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { AbstractListViewItem, AbstractListViewItemProps, ListViewTagProps } from "./AbstractListViewItem";
 import { ShortcutResponse, ViewingContext } from "../../../../IsaacAppTypes";
 import { determineAudienceViews } from "../../../services/userViewingContext";
-import { DOCUMENT_TYPE, documentTypePathPrefix, getThemeFromContextAndTags, PATHS, SEARCH_RESULT_TYPE, siteSpecific, Subject, TAG_ID, TAG_LEVEL, tags } from "../../../services";
+import { DOCUMENT_TYPE, documentTypePathPrefix, getThemeFromContextAndTags, ISAAC_BOOKS, PATHS, SEARCH_RESULT_TYPE, siteSpecific, Subject, TAG_ID, TAG_LEVEL, tags } from "../../../services";
 import { ListGroup, ListGroupItem, ListGroupProps } from "reactstrap";
 import { TitleIconProps } from "../PageTitle";
 import { AffixButton } from "../AffixButton";
@@ -216,6 +216,42 @@ export const ShortcutListViewItem = ({item, ...rest}: ShortcutListViewItemProps)
     />;
 };
 
+interface BookIndexListViewItemProps extends Omit<AbstractListViewItemProps, "icon" | "url"> {
+    item: ShortcutResponse;
+}
+
+export const BookIndexListViewItem = ({item, ...rest}: BookIndexListViewItemProps) => {
+    const itemSubject = tags.getSpecifiedTag(TAG_LEVEL.subject, item.tags as TAG_ID[])?.id as Subject;
+
+    return <AbstractListViewItem
+        {...item}
+        icon={{type: "hex", icon: "icon-book", size: "lg"}}
+        url={`/${documentTypePathPrefix[DOCUMENT_TYPE.BOOK_INDEX_PAGE]}/${item.id?.slice("book_".length)}`}
+        subject={itemSubject}
+        {...rest}
+    />;
+};
+
+interface BookDetailListViewItemProps extends AbstractListViewItemProps {
+    item: ShortcutResponse;
+}
+
+export const BookDetailListViewItem = ({item, ...rest}: BookDetailListViewItemProps) => {
+    const itemSubject = tags.getSpecifiedTag(TAG_LEVEL.subject, item.tags as TAG_ID[])?.id as Subject;
+    const itemBook = ISAAC_BOOKS.find((book) => item.tags?.includes(book.tag));
+    const itemLabel = itemBook ? item.id?.slice(`book_${itemBook.tag}_`.length) : undefined;
+
+    return <AbstractListViewItem
+        {...item}
+        icon={{type: "hex", icon: "icon-generic", size: "lg"}}
+        title={`${itemLabel ? (itemLabel?.toUpperCase() + " ") : ""}${item.title}`}
+        subtitle={itemBook?.title}
+        url={itemBook ? `/${documentTypePathPrefix[DOCUMENT_TYPE.BOOK_INDEX_PAGE]}/${itemBook.tag}/${itemLabel}` : undefined}
+        subject={itemSubject}
+        {...rest}
+    />;
+};
+
 export const ListViewCards = (props: {cards: (ListViewCardProps | null)[]} & {showBlanks?: boolean} & ListGroupProps) => {
     const { cards, showBlanks, ...rest } = props;
     return <ListGroup {...rest} className={classNames("list-view-card-container link-list list-group-links p-0 m-0 flex-row row-cols-1 row-cols-lg-2 row", rest.className)}>
@@ -258,6 +294,10 @@ export const ListView = ({items, className, ...rest}: ListViewProps & ListViewIt
                     return <QuizListViewItem key={index} {...rest} item={item}/>;
                 case SEARCH_RESULT_TYPE.GAMEBOARD:
                     return <QuestionDeckListViewItem key={index} {...rest} item={item}/>;
+                case DOCUMENT_TYPE.BOOK_INDEX_PAGE:
+                    return <BookIndexListViewItem key={index} {...rest} item={item}/>;
+                case SEARCH_RESULT_TYPE.BOOK_DETAIL_PAGE:
+                    return <BookDetailListViewItem key={index} {...rest} item={item}/>;
                 default:
                     // Do not render this item if there is no matching DOCUMENT_TYPE
                     console.error("Not able to display item as a ListViewItem: ", item);

--- a/src/app/components/pages/Generic.tsx
+++ b/src/app/components/pages/Generic.tsx
@@ -81,7 +81,11 @@ export const Generic = withRouter(({pageIdOverride, match: {params}}: GenericPag
             const sidebar = React.cloneElement(PHY_SIDEBAR.has(pageId) ? PHY_SIDEBAR.get(pageId)!() : <GenericPageSidebar/>, { optionBar });
             
             return <Container data-bs-theme={doc.subjectId}>
-                <TitleAndBreadcrumb currentPageTitle={doc.title as string} subTitle={doc.subtitle} /> {/* TODO add page icon, replace main title with "General"?? */}
+                <TitleAndBreadcrumb 
+                    currentPageTitle={doc.title as string} 
+                    subTitle={doc.subtitle} 
+                    icon={{type: "hex", icon: "icon-generic"}}
+                /> 
                 <MetaDescription description={doc.summary} />
                 <SidebarLayout>
                     {sidebar}

--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -913,6 +913,7 @@ export enum DOCUMENT_TYPE {
     CONCEPT = "isaacConceptPage",
     QUESTION = "isaacQuestionPage",
     FAST_TRACK_QUESTION = "isaacFastTrackQuestionPage",
+    BOOK_INDEX_PAGE = "isaacBookIndexPage",
     EVENT = "isaacEventPage",
     TOPIC_SUMMARY = "isaacTopicSummaryPage",
     GENERIC = "page",
@@ -925,12 +926,14 @@ export function isAQuestionLikeDoc(doc: ContentDTO): doc is IsaacQuestionPageDTO
 export enum SEARCH_RESULT_TYPE {
     SHORTCUT = "shortcut",
     GAMEBOARD = "gameboard",
+    BOOK_DETAIL_PAGE = "isaacBookDetailPage",
 }
 
 export const documentDescription: {[documentType in DOCUMENT_TYPE]: string} = {
     [DOCUMENT_TYPE.CONCEPT]: "Concepts",
     [DOCUMENT_TYPE.QUESTION]: "Questions",
     [DOCUMENT_TYPE.FAST_TRACK_QUESTION]: "Questions",
+    [DOCUMENT_TYPE.BOOK_INDEX_PAGE]: "Books",
     [DOCUMENT_TYPE.EVENT]: "Events",
     [DOCUMENT_TYPE.TOPIC_SUMMARY]: "Topics",
     [DOCUMENT_TYPE.GENERIC]: "Other pages",
@@ -942,6 +945,7 @@ export const documentTypePathPrefix: {[documentType in DOCUMENT_TYPE]: string} =
     [DOCUMENT_TYPE.CONCEPT]: "concepts",
     [DOCUMENT_TYPE.QUESTION]: "questions",
     [DOCUMENT_TYPE.FAST_TRACK_QUESTION]: "questions",
+    [DOCUMENT_TYPE.BOOK_INDEX_PAGE]: "books",
     [DOCUMENT_TYPE.EVENT]: "events",
     [DOCUMENT_TYPE.TOPIC_SUMMARY]: "topics",
     [DOCUMENT_TYPE.QUIZ]: "quiz",

--- a/src/scss/phy/icons.scss
+++ b/src/scss/phy/icons.scss
@@ -175,6 +175,14 @@
   );
 }
 
+.icon-generic {
+  @include svg-icon-layered(
+    '/assets/phy/icons/redesign/page-generic-fg.svg', 
+    '/assets/phy/icons/redesign/page-generic-bg.svg',
+    var(--icon-size), var(--icon-size), var(--mask-size, 60%), 52% center
+  );
+}
+
 .icon-question-deck {
   @include svg-icon-layered(
     '/assets/phy/icons/redesign/page-question-deck-fg.svg',


### PR DESCRIPTION
Works alongside [this](https://github.com/isaacphysics/isaac-api/tree/redesign%2Fsearchable-book-pages) API change to display book pages in site search.