### PR TITLE
submit inline questions in a sequence

### DIFF
--- a/src/app/components/content/IsaacInlineRegion.tsx
+++ b/src/app/components/content/IsaacInlineRegion.tsx
@@ -87,6 +87,9 @@ export const useInlineRegionPart = (pageQuestions: AppQuestionDTO[] | undefined)
 export const submitInlineRegion = async (inlineContext: ContextType<typeof InlineContext>, currentGameboard: GameboardDTO | undefined, currentUser: any, pageQuestions: AppQuestionDTO[] | undefined, dispatch: any, hidingAttempts : boolean) => {
     if (inlineContext && inlineContext.docId && pageQuestions) {
         inlineContext.setSubmitting(true);
+        inlineContext.canShowWarningToast = true;
+        if (Object.keys(inlineContext.elementToQuestionMap).length > 1) inlineContext.setFeedbackIndex(0);
+        
         const inlineQuestions = pageQuestions.filter(q => inlineContext.docId && q.id?.startsWith(inlineContext.docId) && q.id.includes("|inline-question:"));
         // we submit all modified answers, and those with undefined values. we must submit this latter group to get a validation response at the same time as the other answers
         const modifiedInlineQuestions = inlineQuestions.filter(q => (q.id && inlineContext.modifiedQuestionIds.includes(q.id)) || (q.currentAttempt?.value === undefined && (q.bestAttempt === undefined || hidingAttempts)));
@@ -96,8 +99,6 @@ export const submitInlineRegion = async (inlineContext: ContextType<typeof Inlin
                 inlineQuestion.id as string, inlineQuestion.type as string, currentGameboard, currentUser, dispatch, inlineContext
             );
         }
-        inlineContext.canShowWarningToast = true;
-        if (Object.keys(inlineContext.elementToQuestionMap).length > 1) inlineContext.setFeedbackIndex(0);
     }
 };
 

--- a/src/app/components/content/IsaacInlineRegion.tsx
+++ b/src/app/components/content/IsaacInlineRegion.tsx
@@ -84,14 +84,14 @@ export const useInlineRegionPart = (pageQuestions: AppQuestionDTO[] | undefined)
     };
 };
 
-export const submitInlineRegion = (inlineContext: ContextType<typeof InlineContext>, currentGameboard: GameboardDTO | undefined, currentUser: any, pageQuestions: AppQuestionDTO[] | undefined, dispatch: any, hidingAttempts : boolean) => {
+export const submitInlineRegion = async (inlineContext: ContextType<typeof InlineContext>, currentGameboard: GameboardDTO | undefined, currentUser: any, pageQuestions: AppQuestionDTO[] | undefined, dispatch: any, hidingAttempts : boolean) => {
     if (inlineContext && inlineContext.docId && pageQuestions) {
         inlineContext.setSubmitting(true);
         const inlineQuestions = pageQuestions.filter(q => inlineContext.docId && q.id?.startsWith(inlineContext.docId) && q.id.includes("|inline-question:"));
         // we submit all modified answers, and those with undefined values. we must submit this latter group to get a validation response at the same time as the other answers
         const modifiedInlineQuestions = inlineQuestions.filter(q => (q.id && inlineContext.modifiedQuestionIds.includes(q.id)) || (q.currentAttempt?.value === undefined && (q.bestAttempt === undefined || hidingAttempts)));
         for (const inlineQuestion of modifiedInlineQuestions) {
-            submitCurrentAttempt(
+            await submitCurrentAttempt(
                 {currentAttempt: inlineQuestion.currentAttempt},
                 inlineQuestion.id as string, inlineQuestion.type as string, currentGameboard, currentUser, dispatch, inlineContext
             );

--- a/src/app/services/questions.ts
+++ b/src/app/services/questions.ts
@@ -182,7 +182,7 @@ export function useCurrentQuestionAttempt<T extends ChoiceDTO>(questionId: strin
     };
 }
 
-export const submitCurrentAttempt = (questionPart: AppQuestionDTO | undefined, docId: string, questionType: string, currentGameboard: GameboardDTO | undefined, currentUser: any, dispatch: any, inlineContext?: ContextType<typeof InlineContext>) => {
+export const submitCurrentAttempt = (questionPart: AppQuestionDTO | undefined, docId: string, questionType: string, currentGameboard: GameboardDTO | undefined, currentUser: any, dispatch: any, inlineContext?: ContextType<typeof InlineContext>): Promise<void> => {
     if (questionPart?.currentAttempt) {
         // Notify Plausible that at least one question attempt has taken place today
         if (persistence.load(KEY.INITIAL_DAILY_QUESTION_ATTEMPT_TIME) == null || !wasTodayUTC(persistence.load(KEY.INITIAL_DAILY_QUESTION_ATTEMPT_TIME))) {
@@ -190,7 +190,7 @@ export const submitCurrentAttempt = (questionPart: AppQuestionDTO | undefined, d
             trackEvent("question_attempted");
         }
 
-        dispatch(attemptQuestion(docId, questionPart?.currentAttempt, questionType, currentGameboard?.id, inlineContext));
+        const attempt = dispatch(attemptQuestion(docId, questionPart?.currentAttempt, questionType, currentGameboard?.id, inlineContext));
 
         if (isLoggedIn(currentUser) && isNotPartiallyLoggedIn(currentUser) && currentGameboard?.id && !currentGameboard.savedToCurrentUser) {
             dispatch(saveGameboard({
@@ -199,7 +199,10 @@ export const submitCurrentAttempt = (questionPart: AppQuestionDTO | undefined, d
                 redirectOnSuccess: false
             }));
         }
+        
+        return attempt;
     }
+    return Promise.resolve();
 };
 
 export const getMostRecentCorrectAttemptDate = (questions: AppQuestionDTO[] | undefined) => {


### PR DESCRIPTION
This avoids a race condition where the API could not save multiple answers that were submitted at the same time for anonymous users. This is because, for anonymous users, when saving an answer, the API creates a lock using the user's ID, see:

https://github.com/isaacphysics/isaac-api/blob/51296605cef5b532f6f6b90d9a9575001172d4a6/src/main/java/uk/ac/cam/cl/dtg/isaac/quiz/PgQuestionAttempts.java#L92.
