### PR TITLE
Redesign/general-improvements-9

### DIFF
--- a/src/app/components/content/IsaacQuestion.tsx
+++ b/src/app/components/content/IsaacQuestion.tsx
@@ -284,9 +284,7 @@ export const IsaacQuestion = withRouter(({doc, location}: {doc: ApiTypes.Questio
                 }
             </div>
             {/* Physics Hints */}
-            {isPhy && <div>
-                <IsaacTabbedHints questionPartId={doc.id as string} hints={doc.hints} />
-            </div>}
+            {isPhy && <IsaacTabbedHints questionPartId={doc.id as string} hints={doc.hints} />}
         </Form>
 
         {/* LLM free-text question validation response */}

--- a/src/app/components/elements/Book.tsx
+++ b/src/app/components/elements/Book.tsx
@@ -10,6 +10,7 @@ import { BookPage } from "./BookPage";
 import { skipToken } from "@reduxjs/toolkit/query";
 import { ShowLoadingQuery } from "../handlers/ShowLoadingQuery";
 import { TeacherNotes } from "./TeacherNotes";
+import { EditContentButton } from "./EditContentButton";
     
 interface BookProps {
     match: { params: { bookId: string } };
@@ -62,6 +63,7 @@ export const Book = ({match: {params: {bookId}}}: BookProps) => {
                                     thenRender={(bookDetailPage) => <BookPage page={bookDetailPage} />}
                                 />
                                 : <>
+                                    <EditContentButton doc={definedBookIndexPage}/>
                                     <TeacherNotes notes={definedBookIndexPage.teacherNotes} />
                                     <div>
                                         <div className="book-image-container mx-3 float-end">

--- a/src/app/components/elements/BookPage.tsx
+++ b/src/app/components/elements/BookPage.tsx
@@ -3,6 +3,7 @@ import { IsaacContentValueOrChildren } from "../content/IsaacContentValueOrChild
 import { ListView } from "./list-groups/ListView";
 import { IsaacBookDetailPageDTO } from "../../../IsaacApiTypes";
 import { TeacherNotes } from "./TeacherNotes";
+import { Markup } from "./markup";
 
 export const BookPage = ({ page }: { page: IsaacBookDetailPageDTO }) => {
     
@@ -10,7 +11,7 @@ export const BookPage = ({ page }: { page: IsaacBookDetailPageDTO }) => {
         <>
             <TeacherNotes notes={page.teacherNotes} />
 
-            <h3 className="mb-3">{page.title}</h3>
+            <h3 className="mb-3"><Markup encoding="latex">{page.title}</Markup></h3>
 
             {!!page.gameboards?.length && <>
                 <h4 className="mb-3" id="resources">Questions</h4>

--- a/src/app/components/elements/BookPage.tsx
+++ b/src/app/components/elements/BookPage.tsx
@@ -4,11 +4,14 @@ import { ListView } from "./list-groups/ListView";
 import { IsaacBookDetailPageDTO } from "../../../IsaacApiTypes";
 import { TeacherNotes } from "./TeacherNotes";
 import { Markup } from "./markup";
+import { EditContentButton } from "./EditContentButton";
 
 export const BookPage = ({ page }: { page: IsaacBookDetailPageDTO }) => {
     
     return <div className="book-page">
         <>
+            <EditContentButton doc={page}/>
+
             <TeacherNotes notes={page.teacherNotes} />
 
             <h3 className="mb-3"><Markup encoding="latex">{page.title}</Markup></h3>

--- a/src/app/components/elements/CollapsibleList.tsx
+++ b/src/app/components/elements/CollapsibleList.tsx
@@ -45,8 +45,8 @@ export const CollapsibleList = (props: CollapsibleListProps) => {
         ? <span>{props.title && props.asSubList ? props.title : <b>{props.title}</b>}</span>
         : props.title;
 
-    return <Col className={props.className} data-targetHeight={(headRef.current?.offsetHeight ?? 0) + (expanded ? expandedHeight : 0)}>
-        <div className="row collapsible-head" ref={headRef}>
+    return <Col className={classNames("collapsible-list-container", props.className)} data-targetHeight={(headRef.current?.offsetHeight ?? 0) + (expanded ? expandedHeight : 0)}>
+        <div className="row m-0 collapsible-head" ref={headRef}>
             <button className={classNames("w-100 d-flex align-items-center p-3 text-start", {"bg-white": isAda, "bg-transparent": isPhy, "ps-4": props.asSubList})} onClick={toggle}>
                 {title && <span>{title}</span>}
                 <Spacer/>
@@ -56,7 +56,7 @@ export const CollapsibleList = (props: CollapsibleListProps) => {
             </button>
         </div>
         <div
-            className={`collapsible-body overflow-hidden ${expanded ? "open" : "closed"}`} 
+            className={`collapsible-body ${expanded ? "open" : "closed"}`} 
             style={{height: expanded ? expandedHeight : 0, maxHeight: expanded ? expandedHeight : 0, marginBottom: expanded ? (props.additionalOffset ?? 0) : 0}}
         >
             <div ref={listRef} className={classNames({"ms-2": props.asSubList})} {...{"inert": expanded ? undefined : "true"}}> 

--- a/src/app/components/elements/inputs/StyledCheckbox.tsx
+++ b/src/app/components/elements/inputs/StyledCheckbox.tsx
@@ -2,7 +2,7 @@ import React, {useEffect, useMemo, useState} from "react";
 import {InputProps} from "reactstrap";
 import {v4} from "uuid";
 import {Spacer} from "../Spacer";
-import {ifKeyIsEnter, isAda} from "../../../services";
+import {ifKeyIsEnter, isAda, isPhy} from "../../../services";
 import classNames from "classnames";
 
 // A custom checkbox, dealing with mouse and keyboard input. Pass `onChange((e : ChangeEvent) => void)`, `checked: bool`, and `label: Element` as required as props to use.
@@ -15,7 +15,7 @@ export const StyledCheckbox = (props: InputProps & {partial?: boolean}) => {
     const [checked, setChecked] = useState(props.checked ?? false);
     const id = useMemo(() => {return (props.id ?? "") + "-" + v4();}, [props.id]);
     const onCheckChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        props.onChange && props.onChange(e);
+        if (props.onChange) props.onChange(e);
         setChecked(e.target.checked);
     };
 
@@ -37,4 +37,14 @@ export const StyledCheckbox = (props: InputProps & {partial?: boolean}) => {
         {label && <label htmlFor={id} className={classNames({"text-muted" : props.disabled, "hover-override" : ignoreLabelHover})} {...label.props}/>}
         <Spacer/>
     </div>;
+};
+
+interface CheckboxWrapperProps extends React.HTMLAttributes<HTMLDivElement> {
+    active?: boolean;
+}
+
+// in many places, we want a stylised wrapper around the checkbox indicating selection.
+export const CheckboxWrapper = (props: CheckboxWrapperProps) => {
+    const {active, className, ...rest} = props;
+    return <div {...rest} className={classNames("ps-3 checkbox-wrapper", {"ms-2": isPhy, "bg-white": isAda, "checkbox-active": active}, className)}/>;
 };

--- a/src/app/components/elements/layout/SidebarLayout.tsx
+++ b/src/app/components/elements/layout/SidebarLayout.tsx
@@ -469,7 +469,7 @@ export const GenericConceptsSidebar = (props: ConceptListSidebarProps) => {
                     const descendentTags = tags.getDirectDescendents(subjectTag.id);
                     const isSelected = conceptFilters.includes(subjectTag) || descendentTags.some(tag => conceptFilters.includes(tag));
                     const isPartial = descendentTags.some(tag => conceptFilters.includes(tag)) && descendentTags.some(tag => !conceptFilters.includes(tag));
-                    return <div key={i} className={classNames("ps-2", {"checkbox-region": isSelected})}>
+                    return <div key={i} className={classNames("ps-2", {"checkbox-active": isSelected})}>
                         <FilterCheckbox 
                             checkboxStyle="button" color="theme" data-bs-theme={subject} tag={subjectTag} conceptFilters={conceptFilters} 
                             setConceptFilters={setConceptFilters} tagCounts={tagCounts} dependentTags={descendentTags} incompatibleTags={descendentTags}
@@ -614,7 +614,7 @@ export const PracticeQuizzesSidebar = (props: PracticeQuizzesSidebarProps) => {
                     const descendentTags = tags.getDirectDescendents(subjectTag.id);
                     const isSelected = filterTags?.includes(subjectTag) || descendentTags.some(tag => filterTags?.includes(tag));
                     const isPartial = descendentTags.some(tag => filterTags?.includes(tag)) && descendentTags.some(tag => !filterTags?.includes(tag));
-                    return <li key={i} className={classNames("ps-2", {"checkbox-region": isSelected})}>
+                    return <li key={i} className={classNames("ps-2", {"checkbox-active": isSelected})}>
                         <FilterCheckbox 
                             checkboxStyle="button" color="theme" data-bs-theme={subject} tag={subjectTag} conceptFilters={filterTags as Tag[]} 
                             setConceptFilters={setFilterTags} tagCounts={tagCounts} dependentTags={descendentTags} incompatibleTags={descendentTags}

--- a/src/app/components/elements/layout/SidebarLayout.tsx
+++ b/src/app/components/elements/layout/SidebarLayout.tsx
@@ -30,6 +30,7 @@ import { CollapsibleList } from "../CollapsibleList";
 import { extendUrl } from "../../pages/subjectLandingPageComponents";
 import { getProgressIcon } from "../../pages/Gameboard";
 import { tags as tagsService } from "../../../services";
+import { Markup } from "../markup";
 
 export const SidebarLayout = (props: RowProps) => {
     const { className, ...rest } = props;
@@ -1519,7 +1520,7 @@ export const BookSidebar = ({ book, urlBookId, pageId }: BookSidebarProps) => {
                             <StyledTabPicker
                                 checkboxTitle={<div className="d-flex">
                                     <span className="text-theme me-2">{section.label}</span>
-                                    <span className="flex-grow-1">{section.title}</span>
+                                    <span className="flex-grow-1"><Markup encoding="latex">{section.title}</Markup></span>
                                 </div>}
                                 checked={pageId === section.bookPageId}
                                 onClick={() => history.push(`/books/${urlBookId}/${section.bookPageId?.slice((book.id?.length ?? 0) + 1)}`)}

--- a/src/app/components/elements/list-groups/AbstractListViewItem.tsx
+++ b/src/app/components/elements/list-groups/AbstractListViewItem.tsx
@@ -116,7 +116,7 @@ export const AbstractListViewItem = ({icon, title, subject, subtitle, breadcrumb
                     </div>}
                 </div>
                 {subtitle && <div className="small text-muted text-wrap">
-                    {subtitle}
+                    <Markup encoding="latex">{subtitle}</Markup>
                 </div>}
                 {breadcrumb && <span className="hierarchy-tags d-flex flex-wrap mw-auto">
                     <Breadcrumb breadcrumb={breadcrumb}/>

--- a/src/app/components/elements/panels/QuestionFinderFilterPanel.tsx
+++ b/src/app/components/elements/panels/QuestionFinderFilterPanel.tsx
@@ -268,17 +268,24 @@ export function QuestionFinderFilterPanel(props: QuestionFinderFilterPanelProps)
                             onChange={() => setExcludeBooks(p => !p)}
                             label={<span className="me-2">Exclude skills book questions</span>}
                         />
-                    </div>
+                    <div className="section-divider ms-3 my-2"/>
                     {bookOptions.map((book, index) => (
                         <div className={classNames("w-100 ps-3 py-1 ms-2", {"checkbox-region": searchBooks.includes(book.tag) && !excludeBooks})} key={index}>
                             <StyledCheckbox
                                 color="primary" disabled={excludeBooks}
                                 checked={searchBooks.includes(book.tag) && !excludeBooks}
-                                onChange={() => setSearchBooks(
-                                    s => s.includes(book.tag)
-                                        ? s.filter(v => v !== book.tag)
-                                        : [...s, book.tag]
-                                )}
+                                onChange={() => {
+                                    if (excludeBooks) {
+                                        setExcludeBooks(false);
+                                        setSearchBooks([book.tag]);
+                                    } else {
+                                        setSearchBooks(
+                                            s => s.includes(book.tag)
+                                                ? s.filter(v => v !== book.tag)
+                                                : [...s, book.tag]
+                                        );
+                                    }
+                                }}
                                 label={<span className="me-2">{book.shortTitle ?? book.title}</span>}
                             />
                         </div>

--- a/src/app/components/elements/panels/QuestionFinderFilterPanel.tsx
+++ b/src/app/components/elements/panels/QuestionFinderFilterPanel.tsx
@@ -22,7 +22,7 @@ import {
 import { Difficulty, ExamBoard } from "../../../../IsaacApiTypes";
 import { pageStageToSearchStage, QuestionStatus } from "../../pages/QuestionFinder";
 import classNames from "classnames";
-import { StyledCheckbox } from "../inputs/StyledCheckbox";
+import { CheckboxWrapper, StyledCheckbox } from "../inputs/StyledCheckbox";
 import { DifficultyIcons } from "../svg/DifficultyIcons";
 import { GroupBase } from "react-select";
 import { HierarchyFilterTreeList } from "../svg/HierarchyFilter";
@@ -159,14 +159,14 @@ export function QuestionFinderFilterPanel(props: QuestionFinderFilterPanelProps)
                 numberSelected={(isAda && searchStages.includes(STAGE.ALL)) ? searchStages.length - 1 : searchStages.length}
             >
                 {getFilteredStageOptions().filter(stage => pageStageToSearchStage(pageContext?.stage).includes(stage.value) || !pageContext?.stage?.length).map((stage, index) => (
-                    <div className={classNames("w-100 ps-3 py-1", {"bg-white": isAda, "ms-2": isPhy, "checkbox-region": isPhy && searchStages.includes(stage.value)})} key={index}>
+                    <CheckboxWrapper active={searchStages.includes(stage.value)} key={index}>
                         <StyledCheckbox
                             color="primary"
                             checked={searchStages.includes(stage.value)}
                             onChange={() => setSearchStages(s => s.includes(stage.value) ? s.filter(v => v !== stage.value) : [...s, stage.value])}
                             label={<span>{stage.label}</span>}
                         />
-                    </div>
+                    </CheckboxWrapper>
                 ))}
             </CollapsibleList>}
             {isAda && <CollapsibleList
@@ -175,14 +175,14 @@ export function QuestionFinderFilterPanel(props: QuestionFinderFilterPanelProps)
                 numberSelected={searchExamBoards.length}
             >
                 {getFilteredExamBoardOptions({byStages: searchStages}).map((board, index) => (
-                    <div className="w-100 ps-3 py-1 bg-white" key={index}>
+                    <CheckboxWrapper active={searchExamBoards.includes(board.value)} key={index}>
                         <StyledCheckbox
                             color="primary"
                             checked={searchExamBoards.includes(board.value)}
                             onChange={() => setSearchExamBoards(s => s.includes(board.value) ? s.filter(v => v !== board.value) : [...s, board.value])}
                             label={<span>{board.label}</span>}
                         />
-                    </div>
+                    </CheckboxWrapper>
                 ))}
             </CollapsibleList>}
             <CollapsibleList
@@ -191,14 +191,12 @@ export function QuestionFinderFilterPanel(props: QuestionFinderFilterPanelProps)
                 numberSelected={siteSpecific(getChoiceTreeLeaves(selections).filter(l => l.value !== pageContext?.subject).length, searchTopics.length)}
             >
                 {siteSpecific(
-                    <div>
-                        <HierarchyFilterTreeList root {...{
-                            tier: pageContext?.subject ? 1 : 0,
-                            index: pageContext?.subject as TAG_ID ?? TAG_LEVEL.subject,
-                            choices, selections, setSelections,
-                            questionFinderFilter: true
-                        }}/>
-                    </div>,
+                    <HierarchyFilterTreeList root {...{
+                        tier: pageContext?.subject ? 1 : 0,
+                        index: pageContext?.subject as TAG_ID ?? TAG_LEVEL.subject,
+                        choices, selections, setSelections,
+                        questionFinderFilter: true
+                    }}/>,
                     groupBaseTagOptions.map((tag, index) => (
                         <CollapsibleList
                             title={tag.label} key={index} asSubList
@@ -206,7 +204,7 @@ export function QuestionFinderFilterPanel(props: QuestionFinderFilterPanelProps)
                             toggle={() => listStateDispatch({type: "toggle", id: `topics ${sublistDelimiter} ${tag.label}`, focus: true})}
                         >
                             {tag.options.map((topic, index) => (
-                                <div className={classNames("w-100 ps-3 py-1", {"bg-white": isAda})} key={index}>
+                                <div className={classNames("ps-3", {"bg-white": isAda})} key={index}>
                                     <StyledCheckbox
                                         color="primary"
                                         checked={searchTopics.includes(topic.value)}
@@ -238,7 +236,7 @@ export function QuestionFinderFilterPanel(props: QuestionFinderFilterPanelProps)
                     <b className="small text-start">{siteSpecific("Learn more about difficulty levels", "What do the difficulty levels mean?")}</b>
                 </button>
                 {SIMPLE_DIFFICULTY_ITEM_OPTIONS.map((difficulty, index) => (
-                    <div className={classNames("w-100 ps-3 py-1", {"bg-white": isAda, "ms-2": isPhy, "checkbox-region": isPhy && searchDifficulties.includes(difficulty.value)})} key={index}>
+                    <CheckboxWrapper active={searchDifficulties.includes(difficulty.value)} key={index}>
                         <StyledCheckbox
                             color="primary"
                             checked={searchDifficulties.includes(difficulty.value)}
@@ -252,7 +250,7 @@ export function QuestionFinderFilterPanel(props: QuestionFinderFilterPanelProps)
                                 <DifficultyIcons difficulty={difficulty.value} blank className={classNames({"mt-n2": isAda, "mt-2": isPhy})}/>
                             </div>}
                         />
-                    </div>
+                    </CheckboxWrapper>
                 ))}
             </CollapsibleList>
             {isPhy && bookOptions.length > 0 && <CollapsibleList
@@ -261,18 +259,19 @@ export function QuestionFinderFilterPanel(props: QuestionFinderFilterPanelProps)
                 numberSelected={excludeBooks ? 1 : searchBooks.length}
             >
                 <>
-                    <div className={classNames("w-100 ps-3 py-1 ms-2", {"checkbox-region": excludeBooks})}>
+                    <CheckboxWrapper active={excludeBooks}>
                         <StyledCheckbox
                             color="primary"
                             checked={excludeBooks}
                             onChange={() => setExcludeBooks(p => !p)}
                             label={<span className="me-2">Exclude skills book questions</span>}
                         />
+                    </CheckboxWrapper>
                     <div className="section-divider ms-3 my-2"/>
                     {bookOptions.map((book, index) => (
-                        <div className={classNames("w-100 ps-3 py-1 ms-2", {"checkbox-region": searchBooks.includes(book.tag) && !excludeBooks})} key={index}>
+                        <CheckboxWrapper active={searchBooks.includes(book.tag) && !excludeBooks} key={index}>
                             <StyledCheckbox
-                                color="primary" disabled={excludeBooks}
+                                color="primary"
                                 checked={searchBooks.includes(book.tag) && !excludeBooks}
                                 onChange={() => {
                                     if (excludeBooks) {
@@ -288,7 +287,7 @@ export function QuestionFinderFilterPanel(props: QuestionFinderFilterPanelProps)
                                 }}
                                 label={<span className="me-2">{book.shortTitle ?? book.title}</span>}
                             />
-                        </div>
+                        </CheckboxWrapper>
                     ))}
                 </>
             </CollapsibleList>}
@@ -297,7 +296,7 @@ export function QuestionFinderFilterPanel(props: QuestionFinderFilterPanelProps)
                 toggle={() => listStateDispatch({type: "toggle", id: "questionStatus", focus: below["md"](deviceSize)})}
                 numberSelected={Object.values(searchStatuses).reduce((acc, item) => acc + item, 0)}
             >
-                <div className={classNames("w-100 ps-3 py-1 d-flex align-items-center", {"bg-white": isAda, "ms-2": isPhy, "checkbox-region": isPhy && searchStatuses.notAttempted})}>
+                <CheckboxWrapper active={searchStatuses.notAttempted}>
                     <StyledCheckbox
                         color="primary"
                         checked={searchStatuses.notAttempted}
@@ -313,8 +312,8 @@ export function QuestionFinderFilterPanel(props: QuestionFinderFilterPanelProps)
                             </div>
                         )}
                     />
-                </div>
-                <div className={classNames("w-100 ps-3 py-1 d-flex align-items-center", {"bg-white": isAda, "ms-2": isPhy, "checkbox-region": isPhy && searchStatuses.complete})}>
+                </CheckboxWrapper>
+                <CheckboxWrapper active={searchStatuses.complete}>
                     <StyledCheckbox
                         color="primary"
                         checked={searchStatuses.complete}
@@ -330,8 +329,8 @@ export function QuestionFinderFilterPanel(props: QuestionFinderFilterPanelProps)
                             </div>
                         )}
                     />
-                </div>
-                <div className={classNames("w-100 ps-3 py-1 d-flex align-items-center", {"bg-white": isAda, "ms-2": isPhy, "checkbox-region": isPhy && searchStatuses.tryAgain})}>
+                </CheckboxWrapper>
+                <CheckboxWrapper active={searchStatuses.tryAgain}>
                     <StyledCheckbox
                         color="primary"
                         checked={searchStatuses.tryAgain}
@@ -347,7 +346,7 @@ export function QuestionFinderFilterPanel(props: QuestionFinderFilterPanelProps)
                             </div>
                         )}
                     />
-                </div>
+                </CheckboxWrapper>
             </CollapsibleList>
             {/* TODO: implement once necessary tags are available
             <div className="pb-2">

--- a/src/app/components/elements/svg/HierarchyFilter.tsx
+++ b/src/app/components/elements/svg/HierarchyFilter.tsx
@@ -4,7 +4,7 @@ import {
     TAG_LEVEL
 } from "../../../services";
 import classNames from "classnames";
-import { StyledCheckbox } from "../inputs/StyledCheckbox";
+import { CheckboxWrapper, StyledCheckbox } from "../inputs/StyledCheckbox";
 import { ChoiceTree, getChoiceTreeLeaves } from "../panels/QuestionFinderFilterPanel";
 import { pruneTreeNode } from "../../../services/questionHierarchy";
 
@@ -23,7 +23,7 @@ interface HierarchyFilterProps {
 }
 
 export function HierarchyFilterTreeList({tier, index, choices, selections, questionFinderFilter, className, root, setSelections}: HierarchyFilterProps) {  
-    return <div className={classNames("ms-3", className)}>
+    return <div className={className}>
         {choices[tier] && choices[tier][index] && choices[tier][index].map((choice) => {
             const isSelected = selections[tier] && selections[tier][index]?.map(s => s.value).includes(choice.value);
             const isLeaf = getChoiceTreeLeaves(selections).map(l => l.value).includes(choice.value);
@@ -42,22 +42,20 @@ export function HierarchyFilterTreeList({tier, index, choices, selections, quest
                 setSelections(newSelections);
             };
 
-            return <div key={choice.value} className={classNames("ps-2", {"search-field": tier===2, "checkbox-region": isSelected && tier !== 2, "hierarchy-true-root": root && tier === 0})}>
-                <div className="d-flex align-items-center">
-                    <StyledCheckbox
-                        partial
-                        color="white"
-                        bsSize={root ? "lg" : "sm"}
-                        checked={isSelected}
-                        onChange={selectValue}
-                        label={<span>{choice.label}</span>}
-                        className={classNames({"icon-checkbox-off": !isSelected, "icon icon-checkbox-partial-alt": isSelected && !isLeaf, "icon-checkbox-selected": isLeaf})}
-                    />
-                </div>
+            return <CheckboxWrapper key={choice.value} active={isSelected && tier !== 2} className={classNames({"search-field": tier===2, "hierarchy-true-root": root && tier === 0})}>
+                <StyledCheckbox
+                    partial
+                    color="white"
+                    bsSize={root ? "lg" : "sm"}
+                    checked={isSelected}
+                    onChange={selectValue}
+                    label={<span>{choice.label}</span>}
+                    className={classNames({"icon-checkbox-off": !isSelected, "icon icon-checkbox-partial-alt": isSelected && !isLeaf, "icon-checkbox-selected": isLeaf})}
+                />
                 {tier < 2 && choices[tier+1] && choice.value in choices[tier+1] && 
                     <HierarchyFilterTreeList {...{tier: tier+1, index: choice.value, choices, selections, questionFinderFilter, setSelections}}/>
                 }
-            </div>;
+            </CheckboxWrapper>;
         }
         )}
     </div>;

--- a/src/app/components/navigation/TrackedRoute.tsx
+++ b/src/app/components/navigation/TrackedRoute.tsx
@@ -2,7 +2,7 @@ import React, {useEffect} from "react";
 import {Redirect, Route, RouteComponentProps, RouteProps, useLocation} from "react-router";
 import {FigureNumberingContext, PotentialUser} from "../../../IsaacAppTypes";
 import {ShowLoading} from "../handlers/ShowLoading";
-import {selectors, useAppSelector} from "../../state";
+import {docSlice, selectors, useAppDispatch, useAppSelector} from "../../state";
 import {
     isNotPartiallyLoggedIn,
     isTeacherOrAbove,
@@ -34,9 +34,11 @@ export const TrackedRoute = function({component, componentProps, ...rest}: Track
     // Store react-router's location, rather than window's location, during the react render to track changes in history so that we
     // can ensure it handles the location correctly even if there is a react-router <Redirect ...> before the useEffect is called.
     const location = useLocation();
+    const dispatch = useAppDispatch();
     useEffect(() => {
         // Use window's location for the origin to match trackPageview's normal URL format - react-router does not record origin.
         trackPageview({ url: window.location.origin + location.pathname + location.search + location.hash });
+        dispatch(docSlice.actions.resetPage()); // reset redux's doc after any page change
     }, [location.pathname]);
 
     const user = useAppSelector(selectors.user.orNull);

--- a/src/app/components/site/phy/HeaderPhy.tsx
+++ b/src/app/components/site/phy/HeaderPhy.tsx
@@ -9,11 +9,11 @@ import { MenuOpenContext } from "../../navigation/NavigationBar";
 import classNames from "classnames";
 import { NavigationMenuPhy } from "./NavigationMenuPhy";
 
-export const LoginLogoutButton = (props : React.HTMLAttributes<HTMLElement>) => {
+export const LoginLogoutButton = (props : React.HTMLAttributes<HTMLButtonElement>) => {
     const user = useAppSelector(selectors.user.orNull);
     
     return user && (user.loggedIn 
-        ? <Link to="/logout" {...props}>Log out</Link>
+        ? <Button tag={Link} to="/logout" color="link" {...props}>Log out</Button>
         : <Button color="solid" size="sm" tag={Link} to="/login" {...props}>Sign up / log in</Button>
     );
 };
@@ -60,7 +60,7 @@ export const HeaderPhy = () => {
                                 <Offcanvas id="header-offcanvas" direction="end" isOpen={menuOpen} toggle={toggleMenu} container="#root">
                                     <OffcanvasHeader toggle={toggleMenu} className="justify-content-between" close={
                                         <div className="d-flex justify-content-end align-items-center flex-wrap gap-3 py-3">
-                                            <LoginLogoutButton/>
+                                            <LoginLogoutButton onClick={toggleMenu}/>
                                             <AffixButton color="tint" size="lg" onClick={toggleMenu} affix={{
                                                 affix: "icon-close", 
                                                 position: "suffix", 

--- a/src/app/components/site/phy/HomepagePhy.tsx
+++ b/src/app/components/site/phy/HomepagePhy.tsx
@@ -119,7 +119,7 @@ export const HomepagePhy = () => {
 
     const user = useAppSelector(selectors.user.orNull);
     
-    const {data: news} = useGetNewsPodListQuery({subject: "physics"});
+    const newsQuery = useGetNewsPodListQuery({subject: "physics"});
 
     const [dashboardView, setDashboardView] = useState<"student" | "teacher" | undefined>(undefined);
 
@@ -190,12 +190,15 @@ export const HomepagePhy = () => {
                             </div>
                             <ShowLoadingQuery
                                 query={eventsQuery}
-                                defaultErrorTitle={"Error loading events list"}
+                                ifError={(() => <p>There was an error loading the events list. Please try again later!</p>)}
                                 thenRender={({events}) => {
                                     return <Row className="h-100">
-                                        {events.map(event => <Col key={event.id}>
-                                            <EventCard event={event} />
-                                        </Col>)}
+                                        {events.length
+                                            ? events.map(event => <Col key={event.id}>
+                                                <EventCard event={event} />
+                                            </Col>)
+                                            : <p>No events available. Check back soon!</p>}
+
                                     </Row>;
                                 }}/>
                         </div>
@@ -205,11 +208,20 @@ export const HomepagePhy = () => {
                                 <Link to="/news" className="news-events-link">More news</Link>                     
                                 <div className="section-divider-bold"/>
                             </div>
-                            {news && <Row className="h-100">
-                                {news.slice(0, 2).map(newsItem => <Col key={newsItem.id}>
-                                    <NewsCard newsItem={newsItem} />
-                                </Col>)}
-                            </Row>}
+                            <ShowLoadingQuery
+                                query={newsQuery}
+                                ifError={(() => <p>There was an error loading the news list. Please try again later!</p>)}
+                                thenRender={(news) => {
+                                    return <Row className="h-100">
+                                        {news.length
+                                            ? news.slice(0, 2).map(newsItem => <Col key={newsItem.id}>
+                                                <NewsCard newsItem={newsItem} />
+                                            </Col>)
+                                            : <p>No news available. Check back soon!</p>
+                                        }
+                                    </Row>;
+                                }}
+                            />
                         </div>
                     </Row>
                 </section>

--- a/src/scss/common/elements.scss
+++ b/src/scss/common/elements.scss
@@ -339,7 +339,6 @@ iframe.email-html {
   overflow: hidden;
   border-top: 1px solid rgba(0, 0, 0, 0.15);
   opacity: 1;
-  width: 100%;
 }
 
 .section-divider-y {

--- a/src/scss/common/elements.scss
+++ b/src/scss/common/elements.scss
@@ -281,13 +281,12 @@ iframe.email-html {
 //  }
 //}
 
-.collapsible-head {
-  margin-left: 0;
-  margin-right: 0;
-  border-top-style: solid;
-  border-bottom-style: solid;
-  border-width: 1px;
-  border-color: $gray-107;
+.collapsible-list-container {
+  border-top: 2px solid $gray-107;
+
+  &:last-of-type {
+    border-bottom: 2px solid $gray-107;
+  }
 
   img {
     transition: transform 0.1s ease;

--- a/src/scss/common/questions.scss
+++ b/src/scss/common/questions.scss
@@ -24,7 +24,7 @@ $cloze-scrollbar-height: 4px;
   min-width: auto;
 }
 
-.question-component {
+form:has(> .question-component) {
   margin-bottom: 2rem;
   clear: both;
 
@@ -68,6 +68,12 @@ $cloze-scrollbar-height: 4px;
       }
     }
   }
+}
+
+.question-component {
+  background-color: white;
+  box-shadow: 0 2px 30px 0 rgba(0, 0, 0, 0.08);
+  padding: 1rem;
 }
 
 $inline-feedback-size: 20px;
@@ -393,13 +399,6 @@ $inline-feedback-padding: 2px;
   p {
     margin-bottom: 0;
   }
-}
-
-// NOMENSA question.scss
-.question-component {
-  background-color: white;
-  box-shadow: 0 2px 30px 0 rgba(0, 0, 0, 0.08);
-  padding: 1rem;
 }
 
 .cloze-question {

--- a/src/scss/phy/checkbox.scss
+++ b/src/scss/phy/checkbox.scss
@@ -7,7 +7,20 @@
     }
   }
 
-.checkbox-region {
+.checkbox-wrapper {
+    // prefer border over outline to prevent cutoff from overflows
+    border: 1px solid transparent;
+
+    &:not(:has(> .checkbox-small)) {
+        padding: 2px 0;
+    }
+}
+
+.checkbox-wrapper + .checkbox-wrapper {
+    margin-top: -1px;
+}
+
+.checkbox-active {
     border-radius: 4px;
 
     .search-field {
@@ -17,9 +30,9 @@
     }
 }
 
-.checkbox-region:not(.hierarchy-true-root) {
+.checkbox-active:not(.hierarchy-true-root) {
     background-color: $color-neutral-100;
-    outline: 1px solid $color-neutral-200;
+    border: 1px solid $color-neutral-200;
 }
 
 .styled-checkbox-wrapper div input[type="checkbox"] { 

--- a/src/scss/phy/questions.scss
+++ b/src/scss/phy/questions.scss
@@ -125,26 +125,35 @@
 }
 
 // styling for question components outside an accordion
-.question-component {
+form:has(> .question-component) {
   border: 2px solid var(--nav-primary);
   padding: 0;
   border-radius: 8px;
   margin-bottom: 1rem;
 
-  > div:first-child {
+  > .question-component > div:first-child {
     padding: 2rem 2rem 0.5rem;
 
     &:last-child {
       padding-bottom: 3rem;
     }
   }
+
+  > .tabbed-hints {
+    padding: 0 2rem;
+  }
 }
 
 // any such styling that should not be present in an accordion
-.isaac-accordion .question-component {
+.isaac-accordion form:has(> .question-component) {
   border: unset;
   // padding is overridden above
   border-radius: unset;
+
+  > .tabbed-hints {
+    padding: 0;
+  }
+  
 }
 
 .content-metadata-container {


### PR DESCRIPTION
Yet more bugfixes!

Of the larger changes:
- Reset the status of our Redux store's `doc` on page switch so that calls to `doc.get` (used in various content components to determine the page type) are not stale;
- Move the styling of accordion-less questions one component out (to the surrounding `<Form/>`) so that hints are included and appear in the same "block";
- Refactor QF to make spacing around checkboxes consistent, and to fix an issue with the book filters