### PR TITLE
Show clearer error message when site loaded offline

### DIFF
--- a/src/app/components/elements/Book.tsx
+++ b/src/app/components/elements/Book.tsx
@@ -50,7 +50,7 @@ export const Book = ({match: {params: {bookId}}}: BookProps) => {
         <SidebarLayout>
             <ShowLoadingQuery
                 query={bookIndexPageQuery}
-                defaultErrorTitle="Unable to load book contents."
+                defaultErrorTitle="Unable to load book contents"
                 thenRender={(definedBookIndexPage) => {
                     return <>
                         <BookSidebar book={definedBookIndexPage} urlBookId={bookId} pageId={pageId} />
@@ -58,7 +58,7 @@ export const Book = ({match: {params: {bookId}}}: BookProps) => {
                             {pageId 
                                 ? <ShowLoadingQuery
                                     query={bookDetailPageQuery}
-                                    defaultErrorTitle="Unable to load book page."
+                                    defaultErrorTitle="Unable to load book page"
                                     thenRender={(bookDetailPage) => <BookPage page={bookDetailPage} />}
                                 />
                                 : <>

--- a/src/app/components/elements/PageFragment.tsx
+++ b/src/app/components/elements/PageFragment.tsx
@@ -20,12 +20,12 @@ export const PageFragment = ({fragmentId, ifNotFound}: PageFragmentComponentProp
             <small>
                 {"We're sorry, page fragment not found: "}
                 <code>{fragmentId}</code>
-                <p>
+                {!window.navigator.onLine && <p>
                     <br />
                     It looks like you&apos;re offline. You may want to check your internet connection, and then refresh this page to try again.
                     <br />
                     If you are still having issues, please <a href={`mailto:${WEBMASTER_EMAIL}`}>let us know</a>. 
-                </p>
+                </p>}
             </small>
         </h3>
     </div>;

--- a/src/app/components/elements/PageFragment.tsx
+++ b/src/app/components/elements/PageFragment.tsx
@@ -5,6 +5,7 @@ import {EditContentButton} from "./EditContentButton";
 import {useGetPageFragmentQuery} from "../../state";
 import {ShowLoadingQuery} from "../handlers/ShowLoadingQuery";
 import { TeacherNotes } from "./TeacherNotes";
+import { WEBMASTER_EMAIL } from "../../services";
 
 interface PageFragmentComponentProps {
     fragmentId: string;
@@ -19,6 +20,12 @@ export const PageFragment = ({fragmentId, ifNotFound}: PageFragmentComponentProp
             <small>
                 {"We're sorry, page fragment not found: "}
                 <code>{fragmentId}</code>
+                <p>
+                    <br />
+                    It looks like you&apos;re offline. You may want to check your internet connection, and then refresh this page to try again.
+                    <br />
+                    If you are still having issues, please <a href={`mailto:${WEBMASTER_EMAIL}`}>let us know</a>. 
+                </p>
             </small>
         </h3>
     </div>;

--- a/src/app/components/elements/PageFragment.tsx
+++ b/src/app/components/elements/PageFragment.tsx
@@ -18,14 +18,17 @@ export const PageFragment = ({fragmentId, ifNotFound}: PageFragmentComponentProp
         <h2>Content not found</h2>
         <h3 className="my-4">
             <small>
-                {"We're sorry, page fragment not found: "}
-                <code>{fragmentId}</code>
-                {!window.navigator.onLine && <p>
-                    <br />
-                    It looks like you&apos;re offline. You may want to check your internet connection, and then refresh this page to try again.
-                    <br />
-                    If you are still having issues, please <a href={`mailto:${WEBMASTER_EMAIL}`}>let us know</a>. 
-                </p>}
+                {window.navigator.onLine ? 
+                    <>
+                        We&apos;re sorry, page fragment not found: 
+                        <code>{fragmentId}</code>
+                    </> :
+                    <p>
+                        <br />
+                        It looks like you&apos;re offline. You may want to check your internet connection, and then refresh this page to try again.
+                        <br />
+                        If you are still having issues, please <a href={`mailto:${WEBMASTER_EMAIL}`}>let us know</a>. 
+                    </p>}
             </small>
         </h3>
     </div>;

--- a/src/app/components/handlers/ShowLoadingQuery.tsx
+++ b/src/app/components/handlers/ShowLoadingQuery.tsx
@@ -15,10 +15,10 @@ const loadingPlaceholder = <div className="w-100 text-center pb-2">
 export const DefaultQueryError = ({error, title}: {error?: FetchBaseQueryError | SerializedError, title: string}) => {
     const errorDetails = getRTKQueryErrorMessage(error);
     return <Alert color={"warning"} className={"my-2"}>
-        {title ?? "Error fetching data from server"}: {errorDetails.message}
+        {title ?? "Error fetching data from server"}: {window.navigator.onLine ? errorDetails.message : "You appear to be offline."}
         {errorDetails.status ? <><br/>Status code: {errorDetails.status}</> : ""}
         <br/>
-        You may want to refresh the page, or <a href={`mailto:${WEBMASTER_EMAIL}`}>email</a> us if
+        You may want to{!window.navigator.onLine && " check your internet connection,"} refresh the page, or <a href={`mailto:${WEBMASTER_EMAIL}`}>email</a> us if
         this continues to happen.
         Please include in your email the name and email associated with this{" "}
         {SITE_TITLE} account, alongside the details of the error given above.

--- a/src/app/components/pages/NotFound.tsx
+++ b/src/app/components/pages/NotFound.tsx
@@ -12,10 +12,10 @@ const buildContactUrl = (state: {overridePathname?: string}, pathname: string) =
 export const NotFound = () => {
     const {pathname, state} = useLocation<{overridePathname?: string}>();
     return <Container>
-        <div>
+        <div className="pb-1">
             <TitleAndBreadcrumb
                 breadcrumbTitleOverride={siteSpecific("Unknown page", "404")}
-                currentPageTitle="Page not found"
+                currentPageTitle={window.navigator.onLine ? "Page not found" : "No internet"}
                 icon={{type: "hex", icon: "icon-error"}}
             />
             <p className="my-4">
@@ -24,12 +24,18 @@ export const NotFound = () => {
                     {(state && state.overridePathname) || pathname}
                 </code>
             </p>
-            <p>
-                Expecting to find something here?
-                <a className="ps-1" href={buildContactUrl(state, pathname)} >
-                    Let us know<span className="visually-hidden"> about this missing page</span>
-                </a>.
-            </p>
+            
+            {window.navigator.onLine ? 
+                <p>
+                    Expecting to find something here?
+                    <a className="ps-1" href={buildContactUrl(state, pathname)} >
+                        Let us know<span className="visually-hidden"> about this missing page</span>
+                    </a>.
+                </p> : 
+                <p>
+                    It looks like you&apos;re offline. Please check your internet connection.
+                </p>
+            }
         </div>
     </Container>;
 };

--- a/src/app/components/pages/NotFound.tsx
+++ b/src/app/components/pages/NotFound.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import {useLocation} from "react-router-dom";
 import {Container} from "reactstrap";
 import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
-import {siteSpecific} from "../../services";
+import {siteSpecific, WEBMASTER_EMAIL} from "../../services";
 
 const buildContactUrl = (state: {overridePathname?: string}, pathname: string) => {
     const page = encodeURIComponent((state && state.overridePathname) || pathname);
@@ -33,8 +33,10 @@ export const NotFound = () => {
                     </a>.
                 </p> : 
                 <p>
-                    It looks like you&apos;re offline. Please check your internet connection.
-                </p>
+                    It looks like you are offline. You may want to check your internet connection, and then refresh this page to try again.
+                    <br />
+                    If you are still having issues, please <a href={`mailto:${WEBMASTER_EMAIL}`}>let us know</a>. 
+                </p> // Email link rather than contact form, as the contact form may not work offline
             }
         </div>
     </Container>;

--- a/src/app/components/pages/NotFound.tsx
+++ b/src/app/components/pages/NotFound.tsx
@@ -33,7 +33,7 @@ export const NotFound = () => {
                     </a>.
                 </p> : 
                 <p>
-                    It looks like you are offline. You may want to check your internet connection, and then refresh this page to try again.
+                    It looks like you&apos;re offline. You may want to check your internet connection, and then refresh this page to try again.
                     <br />
                     If you are still having issues, please <a href={`mailto:${WEBMASTER_EMAIL}`}>let us know</a>. 
                 </p> // Email link rather than contact form, as the contact form may not work offline


### PR DESCRIPTION
This doesn't cover every case, but [window.navigator.onLine](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/onLine) cannot cause false negatives so this is a safe improvement over the current system. I've briefly tried it with Firefox, Chrome and Edge, and I trust the documentation that says its widely available. 

If we were sufficiently concerned about edge cases (e.g. being connected to a network but not receiving internet from it), we could try also reading JS errors or pinging the client, but I don't think its worth the effort.