### PR TITLE
ALVI retype and restructure

### DIFF
--- a/src/IsaacAppTypes.tsx
+++ b/src/IsaacAppTypes.tsx
@@ -1,4 +1,4 @@
-import React, {ReactElement} from "react";
+import React, {ReactElement, ReactNode} from "react";
 import * as ApiTypes from "./IsaacApiTypes";
 import {
     AssignmentDTO,
@@ -314,14 +314,13 @@ export interface Toast {
 
 export interface ActiveModal {
     centered?: boolean;
-    noPadding?: boolean;
     closeAction?: () => void;
     closeLabelOverride?: string;
-    size?: string;
+    size?: "sm" | "md" | "lg" | "xl";
     title?: string;
-    body: any;
-    buttons?: any[];
-    overflowVisible?: boolean;
+    body: ReactNode | (() => ReactNode);
+    bodyContainerClassName?: string;
+    buttons?: ReactNode[];
 }
 
 export type ProgressSortOrder = number | "name" | "totalQuestionPartPercentage" | "totalQuestionPercentage";

--- a/src/app/components/elements/BookPage.tsx
+++ b/src/app/components/elements/BookPage.tsx
@@ -44,8 +44,8 @@ export const BookPage = ({ page }: { page: IsaacBookDetailPageDTO }) => {
                 <span>Expand your boundaries by having a go at these additional extension questions.</span>
                 <div className="mt-3 mb-5 list-results-container p-2">
                     <ListView
-                        type="item"
-                        items={page.extensionGameboards.map(g => ({...g, type: "gameboard"}))}
+                        type="gameboard"
+                        items={convertToALVIGameboards(page.extensionGameboards)}
                     />
                 </div>
             </>}

--- a/src/app/components/elements/BookPage.tsx
+++ b/src/app/components/elements/BookPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { IsaacContentValueOrChildren } from "../content/IsaacContentValueOrChildren";
-import { ListView } from "./list-groups/ListView";
+import { convertToALVIGameboards, ListView } from "./list-groups/ListView";
 import { IsaacBookDetailPageDTO } from "../../../IsaacApiTypes";
 import { TeacherNotes } from "./TeacherNotes";
 import { Markup } from "./markup";
@@ -19,9 +19,9 @@ export const BookPage = ({ page }: { page: IsaacBookDetailPageDTO }) => {
             {!!page.gameboards?.length && <>
                 <h4 className="mb-3" id="resources">Questions</h4>
                 <div className="mt-3 mb-5 list-results-container p-2">
-                    <ListView
-                        items={page.gameboards.map(g => ({...g, type: "gameboard"}))}
-                        fullWidth
+                    <ListView 
+                        type="gameboard"
+                        items={convertToALVIGameboards(page.gameboards)}
                     />
                 </div>
             </>}
@@ -30,8 +30,8 @@ export const BookPage = ({ page }: { page: IsaacBookDetailPageDTO }) => {
             {!!page.relatedContent?.length && <>
                 <div className="my-3 list-results-container p-2">
                     <ListView
+                        type="item"
                         items={page.relatedContent}
-                        fullWidth
                     />
                 </div>
             </>}
@@ -44,8 +44,8 @@ export const BookPage = ({ page }: { page: IsaacBookDetailPageDTO }) => {
                 <span>Expand your boundaries by having a go at these additional extension questions.</span>
                 <div className="mt-3 mb-5 list-results-container p-2">
                     <ListView
+                        type="item"
                         items={page.extensionGameboards.map(g => ({...g, type: "gameboard"}))}
-                        fullWidth
                     />
                 </div>
             </>}

--- a/src/app/components/elements/list-groups/AbstractListViewItem.tsx
+++ b/src/app/components/elements/list-groups/AbstractListViewItem.tsx
@@ -1,14 +1,16 @@
 import { Link } from "react-router-dom";
-import React, { HTMLAttributes, ReactNode } from "react";
+import React, { HTMLAttributes, ReactNode, useMemo } from "react";
 import { StageAndDifficultySummaryIcons } from "../StageAndDifficultySummaryIcons";
 import { ViewingContext} from "../../../../IsaacAppTypes";
 import classNames from "classnames";
 import { Button, Col, ListGroupItem, ListGroupItemProps } from "reactstrap";
-import { CompletionState } from "../../../../IsaacApiTypes";
-import { below, isPhy, siteSpecific, Subject, useDeviceSize } from "../../../services";
+import { CompletionState, GameboardDTO } from "../../../../IsaacApiTypes";
+import { below, isDefined, isPhy, isTeacherOrAbove, siteSpecific, Subject, useDeviceSize } from "../../../services";
 import { PhyHexIcon } from "../svg/PhyHexIcon";
 import { TitleIconProps } from "../PageTitle";
 import { Markup } from "../markup";
+import { closeActiveModal, openActiveModal, selectors, useAppDispatch, useAppSelector, useGetGroupsQuery, useGetMySetAssignmentsQuery, useUnassignGameboardMutation } from "../../../state";
+import { getAssigneesByBoard, SetAssignmentsModal } from "../../pages/SetAssignments";
 
 const Breadcrumb = ({breadcrumb}: {breadcrumb: string[]}) => {
     return <>
@@ -75,35 +77,61 @@ export enum AbstractListViewItemState {
     DISABLED = "disabled",
 }
 
-export interface AbstractListViewItemProps extends ListGroupItemProps {
+export type AbstractListViewItemProps = {
     title?: string;
     icon?: TitleIconProps;
     subject?: Subject;
     subtitle?: string;
     breadcrumb?: string[];
-    status?: CompletionState;
     tags?: string[];
-    supersededBy?: string;
-    linkTags?: ListViewTagProps[];
-    quizTag?: string;
-    url?: string;
-    audienceViews?: ViewingContext[];
-    previewQuizUrl?: string;
-    quizButton?: JSX.Element;
-    isCard?: boolean;
     fullWidth?: boolean;
+    url?: string;
     state?: AbstractListViewItemState;
-}
+    className?: string;
+} & (
+    // ALVI types
+    {
+        // most ALVIs, represents plain lists with optional difficulties; questions, concepts, books, etc.
+        alviType: "item";
+        supersededBy?: string;
+        audienceViews?: ViewingContext[];
+        status?: CompletionState;
+        quizTag?: string; // this is for quick quizzes only, which are currently just gameboards; may change in future
+    } | {
+        // quizzes – have exclusive "preview" and "view test" buttons
+        alviType: "quiz";
+        previewQuizUrl?: string;
+        quizButton?: JSX.Element;
+        audienceViews?: ViewingContext[];
+        status?: CompletionState;
+    } | {
+        // gameboards – have exclusive "assign" buttons
+        alviType: "gameboard";
+    }
+) & (
+    // ALVI layouts
+    {
+        alviLayout: "card"
+        linkTags?: ListViewTagProps[];
+    } | {
+        alviLayout: "list";
+    }
+);
 
-export const AbstractListViewItem = ({icon, title, subject, subtitle, breadcrumb, status, tags, supersededBy, linkTags, quizTag, url, audienceViews, previewQuizUrl, quizButton, isCard, fullWidth, state, ...rest}: AbstractListViewItemProps) => { 
+export const AbstractListViewItem = ({title, icon, subject, subtitle, breadcrumb, tags, fullWidth, url, state, className, ...typedProps}: AbstractListViewItemProps) => { 
     const deviceSize = useDeviceSize();
-    const isQuiz: boolean = !!(previewQuizUrl || quizButton);
+    const user = useAppSelector(selectors.user.orNull);
+
+    const isItem = typedProps.alviType === "item";
+    const isGameboard = typedProps.alviType === "gameboard";
+    const isQuiz = typedProps.alviType === "quiz";
+    const isCard = typedProps.alviLayout === "card";
     const isDisabled = state && [AbstractListViewItemState.COMING_SOON, AbstractListViewItemState.DISABLED].includes(state);
     
-    fullWidth = fullWidth || below["sm"](deviceSize) || ((status || audienceViews || previewQuizUrl || quizButton) ? false : true);
+    fullWidth = fullWidth || below["sm"](deviceSize) || (isItem && !(typedProps.status || typedProps.audienceViews));
     const cardBody =
     <div className="w-100 d-flex flex-row">
-        <Col className={classNames("d-flex flex-grow-1", {"mt-3": isCard && linkTags?.length, "mb-3": isCard && !linkTags?.length})}>
+        <Col className={classNames("d-flex flex-grow-1", {"mt-3": isCard && typedProps.linkTags?.length, "mb-3": isCard && !typedProps.linkTags?.length})}>
             <div className="position-relative">
                 {icon && (
                     icon.type === "img" ? <img src={icon.icon} alt="" className="me-3"/> 
@@ -111,24 +139,26 @@ export const AbstractListViewItem = ({icon, title, subject, subtitle, breadcrumb
                             : icon.type === "placeholder" ? <div style={{width: icon.width, height: icon.height}}/> 
                                 : undefined
                 )}
-                {status && status === CompletionState.ALL_CORRECT && <div className="list-view-status-indicator">
-                    <StatusDisplay status={status} showText={false} />
+                {isItem && typedProps.status && typedProps.status === CompletionState.ALL_CORRECT && <div className="list-view-status-indicator">
+                    <StatusDisplay status={typedProps.status} showText={false} />
                 </div>}
             </div>
             <div className="align-content-center text-overflow-ellipsis pe-2">
                 <div className="d-flex text-wrap">
                     <span className={classNames("link-title", {"question-link-title": isPhy || !isQuiz})}><Markup encoding="latex">{title}</Markup></span>
-                    {quizTag && <span className="quiz-level-1-tag ms-sm-2">{quizTag}</span>}
-                    {isPhy && <div className="d-flex flex-column justify-self-end">
-                        {supersededBy && <a 
-                            className="superseded-tag mx-1 ms-sm-3 align-self-end" 
-                            href={`/questions/${supersededBy}`}
-                            onClick={(e) => e.stopPropagation()}
-                        >SUPERSEDED</a>}
-                        {tags?.includes("nofilter") && <span
-                            className="superseded-tag mx-1 ms-sm-3 align-self-end" 
-                        >NO-FILTER</span>}
-                    </div>}
+                    {isItem && <>
+                        {typedProps.quizTag && <span className="quiz-level-1-tag ms-sm-2">{typedProps.quizTag}</span>}
+                        {isPhy && <div className="d-flex flex-column justify-self-end">
+                            {typedProps.supersededBy && <a 
+                                className="superseded-tag mx-1 ms-sm-3 align-self-end" 
+                                href={`/questions/${typedProps.supersededBy}`}
+                                onClick={(e) => e.stopPropagation()}
+                            >SUPERSEDED</a>}
+                            {tags?.includes("nofilter") && <span
+                                className="superseded-tag mx-1 ms-sm-3 align-self-end" 
+                            >NO-FILTER</span>}
+                        </div>}
+                    </>}
                 </div>
                 {subtitle && <div className="small text-muted text-wrap">
                     <Markup encoding="latex">{subtitle}</Markup>
@@ -136,36 +166,37 @@ export const AbstractListViewItem = ({icon, title, subject, subtitle, breadcrumb
                 {breadcrumb && <span className="hierarchy-tags d-flex flex-wrap mw-auto">
                     <Breadcrumb breadcrumb={breadcrumb}/>
                 </span>}
-                {audienceViews && fullWidth && <div className="d-flex mt-1"> 
-                    <StageAndDifficultySummaryIcons audienceViews={audienceViews} stack/> 
+                {isItem && fullWidth && typedProps.audienceViews && <div className="d-flex mt-1"> 
+                    <StageAndDifficultySummaryIcons audienceViews={typedProps.audienceViews} stack/> 
                 </div>}
-                {status && status !== CompletionState.ALL_CORRECT && fullWidth &&
-                    <StatusDisplay status={status} showText className="py-1" />
+                {isItem && fullWidth && typedProps.status && typedProps.status !== CompletionState.ALL_CORRECT &&
+                    <StatusDisplay status={typedProps.status} showText className="py-1" />
                 }
                 {linkTags && <div className="d-flex py-3 flex-wrap">
                     <LinkTags linkTags={linkTags}/>
+                {isCard && typedProps.linkTags && <div className="d-flex py-3 flex-wrap">
+                    <LinkTags linkTags={typedProps.linkTags}/>
                 </div>}
                 {isQuiz && fullWidth && <div className="d-flex d-md-none align-items-center">
-                    <QuizLinks previewQuizUrl={previewQuizUrl} quizButton={quizButton}/>
+                    <QuizLinks previewQuizUrl={typedProps.previewQuizUrl} quizButton={typedProps.quizButton}/>
                 </div>}
             </div>
         </Col>
         {!fullWidth &&
             <>
-                {status && status !== CompletionState.ALL_CORRECT && <StatusDisplay status={status} showText className="ms-2 me-3" />}
-                {audienceViews && <div className={classNames("d-none d-md-flex justify-content-end wf-13", {"list-view-border": audienceViews.length > 0})}>
-                    <StageAndDifficultySummaryIcons audienceViews={audienceViews} stack className="w-100"/> 
+                {isItem && typedProps.status && typedProps.status !== CompletionState.ALL_CORRECT && <StatusDisplay status={typedProps.status} showText className="ms-2 me-3" />}
+                {isItem && typedProps.audienceViews && <div className={classNames("d-none d-md-flex justify-content-end wf-13", {"list-view-border": typedProps.audienceViews.length > 0})}>
+                    <StageAndDifficultySummaryIcons audienceViews={typedProps.audienceViews} stack className="w-100"/> 
                 </div>}
                 {isQuiz && <Col md={6} className="d-none d-md-flex align-items-center justify-content-end">
-                    <QuizLinks previewQuizUrl={previewQuizUrl} quizButton={quizButton}/> 
+                    <QuizLinks previewQuizUrl={typedProps.previewQuizUrl} quizButton={typedProps.quizButton}/> 
                 </Col>}
             </>
         }
     </div>;
 
-    return <ListGroupItem 
-        {...rest} 
-        className={classNames("content-summary-item", {"correct": status === CompletionState.ALL_CORRECT}, rest.className, state)} 
+    return <ListGroupItem
+        className={classNames("content-summary-item", {"correct": isItem && typedProps.status === CompletionState.ALL_CORRECT}, className, state)} 
         data-bs-theme={subject && !isDisabled ? subject : "neutral"}
     >
         {url && !isDisabled

--- a/src/app/components/elements/list-groups/AbstractListViewItem.tsx
+++ b/src/app/components/elements/list-groups/AbstractListViewItem.tsx
@@ -103,6 +103,33 @@ export enum AbstractListViewItemState {
     DISABLED = "disabled",
 }
 
+type ALVIType = {
+    // most ALVIs, represents plain lists with optional difficulties; questions, concepts, books, etc.
+    alviType: "item";
+    supersededBy?: string;
+    audienceViews?: ViewingContext[];
+    status?: CompletionState;
+    quizTag?: string; // this is for quick quizzes only, which are currently just gameboards; may change in future
+} | {
+    // quizzes – have exclusive "preview" and "view test" buttons
+    alviType: "quiz";
+    previewQuizUrl?: string;
+    quizButton?: JSX.Element;
+    audienceViews?: ViewingContext[];
+    status?: CompletionState;
+} | {
+    // gameboards – have exclusive "assign" buttons
+    alviType: "gameboard";
+    board?: GameboardDTO;
+};
+
+type ALVILayout = {
+    alviLayout: "card"
+    linkTags?: ListViewTagProps[];
+} | {
+    alviLayout: "list";
+};
+
 export type AbstractListViewItemProps = {
     title?: string;
     icon?: TitleIconProps;
@@ -114,36 +141,7 @@ export type AbstractListViewItemProps = {
     url?: string;
     state?: AbstractListViewItemState;
     className?: string;
-} & (
-    // ALVI types
-    {
-        // most ALVIs, represents plain lists with optional difficulties; questions, concepts, books, etc.
-        alviType: "item";
-        supersededBy?: string;
-        audienceViews?: ViewingContext[];
-        status?: CompletionState;
-        quizTag?: string; // this is for quick quizzes only, which are currently just gameboards; may change in future
-    } | {
-        // quizzes – have exclusive "preview" and "view test" buttons
-        alviType: "quiz";
-        previewQuizUrl?: string;
-        quizButton?: JSX.Element;
-        audienceViews?: ViewingContext[];
-        status?: CompletionState;
-    } | {
-        // gameboards – have exclusive "assign" buttons
-        alviType: "gameboard";
-        board?: GameboardDTO;
-    }
-) & (
-    // ALVI layouts
-    {
-        alviLayout: "card"
-        linkTags?: ListViewTagProps[];
-    } | {
-        alviLayout: "list";
-    }
-);
+} & ALVIType & ALVILayout;
 
 export const AbstractListViewItem = ({title, icon, subject, subtitle, breadcrumb, tags, fullWidth, url, state, className, ...typedProps}: AbstractListViewItemProps) => { 
     const deviceSize = useDeviceSize();

--- a/src/app/components/elements/list-groups/ListView.tsx
+++ b/src/app/components/elements/list-groups/ListView.tsx
@@ -10,8 +10,7 @@ import { Link } from "react-router-dom";
 import { selectors, showQuizSettingModal, useAppDispatch, useAppSelector } from "../../../state";
 import classNames from "classnames";
 
-interface ListViewCardItemProps extends Extract<AbstractListViewItemProps, {alviType: "item", alviLayout: "card"}> {
-};
+type ListViewCardItemProps = Extract<AbstractListViewItemProps, {alviType: "item", alviLayout: "card"}>;
 
 export const ListViewCardItem = (props: ListViewCardItemProps) => {
     return <AbstractListViewItem 
@@ -117,7 +116,7 @@ export const convertToALVIGameboard = (gameboard: GameboardDTO): ALVIGameboard =
 };
 export const convertToALVIGameboards = (gameboards: GameboardDTO[]): ALVIGameboard[] => {
     return gameboards.map(convertToALVIGameboard);
-}
+};
 interface QuestionDeckListViewItemProps extends Extract<AbstractListViewItemProps, {alviType: "gameboard", alviLayout: "list"}> {
     item: ALVIGameboard;
 }
@@ -279,38 +278,18 @@ type ListViewItemProps =
     | BookIndexListViewItemProps
     | BookDetailListViewItemProps;
 
-// type ListViewProps<T extends "item" | "gameboard" | "quiz"> = {
-type ListViewProps = {
+type ListViewProps<T, G extends "item" | "gameboard" | "quiz"> = {
     className?: string;
     fullWidth?: boolean;
-// } & (
-//     {
-//         items: Extract<ListViewItemProps, {alviType: T}>['item'][];
-//         type: T;
-//     } 
-//     & Omit<Extract<ListViewItemProps, {alviType: T}>, "item" | keyof AbstractListViewItemProps>
-// )
 } & (
     {
-        items: Extract<ListViewItemProps, {alviType: "item"}>['item'][];
-        type: "item";
+        items: Required<T> extends Required<Extract<ListViewItemProps, {alviType: G}>['item']> ? T[] : never;
+        type: G;
     } 
-    & Omit<Extract<ListViewItemProps, {alviType: "item"}>, "item" | keyof AbstractListViewItemProps>
-| 
-    {
-        items: Extract<ListViewItemProps, {alviType: "gameboard"}>['item'][];
-        type: "gameboard";
-    }
-    & Omit<Extract<ListViewItemProps, {alviType: "gameboard"}>, "item" | keyof AbstractListViewItemProps>
-| 
-    {
-        items: Extract<ListViewItemProps, {alviType: "quiz"}>['item'][];
-        type: "quiz";
-    }
-    & Omit<Extract<ListViewItemProps, {alviType: "quiz"}>, "item" | keyof AbstractListViewItemProps>
+    & Omit<Extract<ListViewItemProps, {alviType: G}>, "item" | keyof AbstractListViewItemProps>
 );
 
-export const ListView = (props: ListViewProps) => {
+export const ListView = <T extends {type?: string}, G extends "item" | "gameboard" | "quiz">(props: ListViewProps<T, G>) => {
     const {items, className, type, ...rest} = props;
 
     const failedToRender = (item: typeof items[number]) => {

--- a/src/app/components/elements/list-groups/ListView.tsx
+++ b/src/app/components/elements/list-groups/ListView.tsx
@@ -141,6 +141,7 @@ export const QuestionDeckListViewItem = ({item, ...rest}: QuestionDeckListViewIt
         subject={questionSubjects.length === 1 ? questionSubjects[0].id as Subject : undefined}
         breadcrumb={breadcrumb}
         url={url}
+        board={item}
         {...rest}
     />;
 };

--- a/src/app/components/elements/list-groups/ListView.tsx
+++ b/src/app/components/elements/list-groups/ListView.tsx
@@ -1,40 +1,26 @@
 import React from "react";
-import { AbstractListViewItem, AbstractListViewItemProps, AbstractListViewItemState, ListViewTagProps } from "./AbstractListViewItem";
+import { AbstractListViewItem, AbstractListViewItemProps } from "./AbstractListViewItem";
 import { ShortcutResponse, ViewingContext } from "../../../../IsaacAppTypes";
 import { determineAudienceViews } from "../../../services/userViewingContext";
 import { DOCUMENT_TYPE, documentTypePathPrefix, getThemeFromContextAndTags, ISAAC_BOOKS, PATHS, SEARCH_RESULT_TYPE, siteSpecific, Subject, TAG_ID, TAG_LEVEL, tags } from "../../../services";
 import { ListGroup, ListGroupItem, ListGroupProps } from "reactstrap";
-import { TitleIconProps } from "../PageTitle";
 import { AffixButton } from "../AffixButton";
-import { GameboardDTO, QuizSummaryDTO } from "../../../../IsaacApiTypes";
+import { ContentSummaryDTO, GameboardDTO, QuizSummaryDTO } from "../../../../IsaacApiTypes";
 import { Link } from "react-router-dom";
 import { selectors, showQuizSettingModal, useAppDispatch, useAppSelector } from "../../../state";
 import classNames from "classnames";
 
-export interface ListViewCardProps extends Omit<AbstractListViewItemProps, "icon" | "title" | "subject" | "subtitle" | "linkTags" | "isCard"> {
-    item: ShortcutResponse;
-    icon?: TitleIconProps;
-    subject?: Subject;
-    linkTags?: ListViewTagProps[];
-    state?: AbstractListViewItemState;
-    url?: string;
-}
+interface ListViewCardItemProps extends Extract<AbstractListViewItemProps, {alviType: "item", alviLayout: "card"}> {
+};
 
-export const ListViewCard = ({item, icon, subject, linkTags, state, ...rest}: ListViewCardProps) => {
-    return <AbstractListViewItem
-        icon={icon}
-        title={item.title ?? ""}
-        subject={subject}
-        subtitle={item.subtitle}
-        linkTags={linkTags}
-        state={state}  
-        isCard
-        {...rest}
+export const ListViewCardItem = (props: ListViewCardItemProps) => {
+    return <AbstractListViewItem 
+        {...props}
     />;
 };
 
-interface QuestionListViewItemProps extends Omit<AbstractListViewItemProps, "icon" | "title" | "subject" | "tags" | "supersededBy" | "subtitle" | "breadcrumb" | "status" | "url" | "audienceViews"> {
-    item: ShortcutResponse;
+interface QuestionListViewItemProps extends Extract<AbstractListViewItemProps, {alviType: "item", alviLayout: "list"}> {
+    item: ContentSummaryDTO;
 }
 
 export const QuestionListViewItem = (props : QuestionListViewItemProps) => {
@@ -60,8 +46,8 @@ export const QuestionListViewItem = (props : QuestionListViewItemProps) => {
     />;
 };
 
-interface ConceptListViewItemProps extends Omit<AbstractListViewItemProps, "icon" | "title" | "subject" | "subtitle" | "url"> {
-    item: ShortcutResponse;
+interface ConceptListViewItemProps extends Extract<AbstractListViewItemProps, {alviType: "item", alviLayout: "list"}> {
+    item: ContentSummaryDTO;
 }
 
 export const ConceptListViewItem = ({item, ...rest}: ConceptListViewItemProps) => {
@@ -79,7 +65,7 @@ export const ConceptListViewItem = ({item, ...rest}: ConceptListViewItemProps) =
     />;
 };
 
-interface EventListViewItemProps extends Omit<AbstractListViewItemProps, "icon" | "title" | "subject" | "subtitle" | "url"> {
+interface EventListViewItemProps extends Extract<AbstractListViewItemProps, {alviType: "item", alviLayout: "list"}> {
     item: ShortcutResponse;
 }
 
@@ -97,7 +83,7 @@ export const EventListViewItem = ({item, ...rest}: EventListViewItemProps) => {
     />;
 };
 
-interface QuizListViewItemProps extends Omit<AbstractListViewItemProps, "icon" | "title" | "subject" | "previewQuizIrl" | "quizButton"> {
+interface QuizListViewItemProps extends Extract<AbstractListViewItemProps, {alviType: "quiz", alviLayout: "list"}> {
     item: QuizSummaryDTO;
     isQuizSetter?: boolean;
     useViewQuizLink?: boolean;
@@ -124,8 +110,16 @@ export const QuizListViewItem = ({item, isQuizSetter, useViewQuizLink, ...rest}:
     />;
 };
 
-interface QuestionDeckListViewItemProps extends Omit<AbstractListViewItemProps, "icon" | "title" | "subject" | "subtitle" | "breadcrumb" | "url"> {
-    item: GameboardDTO;
+type ALVIGameboard = GameboardDTO & {type?: string};
+
+export const convertToALVIGameboard = (gameboard: GameboardDTO): ALVIGameboard => {
+    return {...gameboard, type: SEARCH_RESULT_TYPE.GAMEBOARD};
+};
+export const convertToALVIGameboards = (gameboards: GameboardDTO[]): ALVIGameboard[] => {
+    return gameboards.map(convertToALVIGameboard);
+}
+interface QuestionDeckListViewItemProps extends Extract<AbstractListViewItemProps, {alviType: "gameboard", alviLayout: "list"}> {
+    item: ALVIGameboard;
 }
 
 export const QuestionDeckListViewItem = ({item, ...rest}: QuestionDeckListViewItemProps) => {
@@ -144,7 +138,7 @@ export const QuestionDeckListViewItem = ({item, ...rest}: QuestionDeckListViewIt
 
     return <AbstractListViewItem
         icon={{type: "hex", icon: "icon-question-deck", size: "lg"}}
-        title={item.title ?? ""}
+        title={item.title ?? "no title"}
         subject={questionSubjects.length === 1 ? questionSubjects[0].id as Subject : undefined}
         breadcrumb={breadcrumb}
         url={url}
@@ -152,7 +146,7 @@ export const QuestionDeckListViewItem = ({item, ...rest}: QuestionDeckListViewIt
     />;
 };
 
-interface QuickQuizListViewItemProps extends Omit<AbstractListViewItemProps, "icon" | "title" | "subject" | "subtitle" | "breadcrumb" | "status" | "quizTag" | "url" | "audienceViews"> {
+interface QuickQuizListViewItemProps extends Extract<AbstractListViewItemProps, {alviType: "item", alviLayout: "list"}> {
     item: ShortcutResponse;
 }
 
@@ -176,7 +170,7 @@ export const QuickQuizListViewItem = ({item, ...rest}: QuickQuizListViewItemProp
     />;
 };
 
-interface GenericListViewItemProps extends Omit<AbstractListViewItemProps, "icon" | "title" | "subject" | "subtitle" | "tags" | "supersededBy" | "breadcrumb" | "status" | "url" | "audienceViews"> {
+interface GenericListViewItemProps extends Extract<AbstractListViewItemProps, {alviType: "item", alviLayout: "list"}> {
     item: ShortcutResponse;
 }
 
@@ -201,7 +195,7 @@ export const GenericListViewItem = ({item, ...rest}: GenericListViewItemProps) =
     />;
 };
 
-interface ShortcutListViewItemProps extends Omit<AbstractListViewItemProps, "icon" | "title" | "subject" | "subtitle" | "tags" | "supersededBy" | "breadcrumb" | "status" | "url" | "audienceViews"> {
+interface ShortcutListViewItemProps extends Extract<AbstractListViewItemProps, {alviType: "item", alviLayout: "list"}> {
     item: ShortcutResponse;
 }
 
@@ -226,7 +220,7 @@ export const ShortcutListViewItem = ({item, ...rest}: ShortcutListViewItemProps)
     />;
 };
 
-interface BookIndexListViewItemProps extends Omit<AbstractListViewItemProps, "icon" | "url"> {
+interface BookIndexListViewItemProps extends Extract<AbstractListViewItemProps, {alviType: "item", alviLayout: "list"}> {
     item: ShortcutResponse;
 }
 
@@ -243,7 +237,7 @@ export const BookIndexListViewItem = ({item, ...rest}: BookIndexListViewItemProp
     />;
 };
 
-interface BookDetailListViewItemProps extends AbstractListViewItemProps {
+interface BookDetailListViewItemProps extends Extract<AbstractListViewItemProps, {alviType: "item", alviLayout: "list"}> {
     item: ShortcutResponse;
 }
 
@@ -264,57 +258,113 @@ export const BookDetailListViewItem = ({item, ...rest}: BookDetailListViewItemPr
     />;
 };
 
+export type ListViewCardProps = Omit<Extract<AbstractListViewItemProps, {alviType: "item", alviLayout: "card"}>, "alviType" | "alviLayout">;
+
 export const ListViewCards = (props: {cards: (ListViewCardProps | null)[]} & {showBlanks?: boolean} & ListGroupProps) => {
     const { cards, showBlanks, ...rest } = props;
     return <ListGroup {...rest} className={classNames("list-view-card-container link-list list-group-links p-0 m-0 flex-row row-cols-1 row-cols-lg-2 row", rest.className)}>
-        {cards.map((card, index) => card ? <ListViewCard key={index} {...card}/> : (showBlanks ? <ListGroupItem key={index}/> : null))}
+        {cards.map((card, index) => card ? <ListViewCardItem {...card} key={index} alviType="item" alviLayout="card"/> : (showBlanks ? <ListGroupItem key={index}/> : null))}
     </ListGroup>;
 };
 
 type ListViewItemProps = 
-    | Omit<ListViewCardProps, "item"> 
-    | Omit<QuestionListViewItemProps, "item"> 
-    | Omit<ConceptListViewItemProps, "item"> 
-    | Omit<EventListViewItemProps, "item"> 
-    | Omit<QuizListViewItemProps, "item"> 
-    | Omit<QuestionDeckListViewItemProps, "item"> 
-    | Omit<QuickQuizListViewItemProps, "item">
-    | Omit<GenericListViewItemProps, "item"> 
-    | Omit<ShortcutListViewItemProps, "item">;
+    | QuestionListViewItemProps
+    | ConceptListViewItemProps
+    | EventListViewItemProps
+    | QuizListViewItemProps
+    | QuestionDeckListViewItemProps
+    | QuickQuizListViewItemProps
+    | GenericListViewItemProps
+    | ShortcutListViewItemProps
+    | BookIndexListViewItemProps
+    | BookDetailListViewItemProps;
 
-interface ListViewProps {
-    items: ShortcutResponse[];
+// type ListViewProps<T extends "item" | "gameboard" | "quiz"> = {
+type ListViewProps = {
     className?: string;
-}
+    fullWidth?: boolean;
+// } & (
+//     {
+//         items: Extract<ListViewItemProps, {alviType: T}>['item'][];
+//         type: T;
+//     } 
+//     & Omit<Extract<ListViewItemProps, {alviType: T}>, "item" | keyof AbstractListViewItemProps>
+// )
+} & (
+    {
+        items: Extract<ListViewItemProps, {alviType: "item"}>['item'][];
+        type: "item";
+    } 
+    & Omit<Extract<ListViewItemProps, {alviType: "item"}>, "item" | keyof AbstractListViewItemProps>
+| 
+    {
+        items: Extract<ListViewItemProps, {alviType: "gameboard"}>['item'][];
+        type: "gameboard";
+    }
+    & Omit<Extract<ListViewItemProps, {alviType: "gameboard"}>, "item" | keyof AbstractListViewItemProps>
+| 
+    {
+        items: Extract<ListViewItemProps, {alviType: "quiz"}>['item'][];
+        type: "quiz";
+    }
+    & Omit<Extract<ListViewItemProps, {alviType: "quiz"}>, "item" | keyof AbstractListViewItemProps>
+);
 
-export const ListView = ({items, className, ...rest}: ListViewProps & ListViewItemProps) => {
+export const ListView = (props: ListViewProps) => {
+    const {items, className, type, ...rest} = props;
+
+    const failedToRender = (item: typeof items[number]) => {
+        // Do not render an item if there is no matching DOCUMENT_TYPE
+        console.error("Not able to display item as a ListViewItem: ", item);
+        return null;
+    };
+
     return <ListGroup className={`link-list list-group-links ${className}`}>
-        {items.map((item, index) => {
-            switch (item.type) {
-                case (DOCUMENT_TYPE.GENERIC):
-                    return <GenericListViewItem key={index} {...rest} item={item}/>;
-                case (SEARCH_RESULT_TYPE.SHORTCUT):
-                    return <ShortcutListViewItem key={index} {...rest} item={item}/>;
-                case (DOCUMENT_TYPE.QUESTION):
-                case (DOCUMENT_TYPE.FAST_TRACK_QUESTION):
-                    return <QuestionListViewItem key={index} {...rest} item={item}/>;
-                case (DOCUMENT_TYPE.CONCEPT):
-                    return <ConceptListViewItem key={index} {...rest} item={item}/>;
-                case (DOCUMENT_TYPE.EVENT):
-                    return <EventListViewItem key={index} {...rest} item={item}/>;
-                case (DOCUMENT_TYPE.QUIZ):
-                    return <QuizListViewItem key={index} {...rest} item={item}/>;
-                case SEARCH_RESULT_TYPE.GAMEBOARD:
-                    return <QuestionDeckListViewItem key={index} {...rest} item={item}/>;
-                case DOCUMENT_TYPE.BOOK_INDEX_PAGE:
-                    return <BookIndexListViewItem key={index} {...rest} item={item}/>;
-                case SEARCH_RESULT_TYPE.BOOK_DETAIL_PAGE:
-                    return <BookDetailListViewItem key={index} {...rest} item={item}/>;
+        {(() => {
+            switch (type) {
+                case "item":
+                    return items.map((item, index) => {
+                        switch (item.type) {
+                            case (DOCUMENT_TYPE.GENERIC):
+                                return <GenericListViewItem key={index} {...rest} item={item} alviType={type} alviLayout="list"/>;
+                            case (SEARCH_RESULT_TYPE.SHORTCUT):
+                                return <ShortcutListViewItem key={index} {...rest} item={item} alviType={type} alviLayout="list"/>;
+                            case (DOCUMENT_TYPE.QUESTION):
+                            case (DOCUMENT_TYPE.FAST_TRACK_QUESTION):
+                                return <QuestionListViewItem key={index} {...rest} item={item} alviType={type} alviLayout="list"/>;
+                            case (DOCUMENT_TYPE.CONCEPT):
+                                return <ConceptListViewItem key={index} {...rest} item={item} alviType={type} alviLayout="list"/>;
+                            case (DOCUMENT_TYPE.EVENT):
+                                return <EventListViewItem key={index} {...rest} item={item} alviType={type} alviLayout="list"/>;
+                            case DOCUMENT_TYPE.BOOK_INDEX_PAGE:
+                                return <BookIndexListViewItem key={index} {...rest} item={item} alviType={type} alviLayout="list"/>;
+                            case SEARCH_RESULT_TYPE.BOOK_DETAIL_PAGE:
+                                return <BookDetailListViewItem key={index} {...rest} item={item} alviType={type} alviLayout="list"/>;
+                            default:
+                                return failedToRender(item);
+                        }
+                    });
+                case "gameboard":
+                    return items.map((item, index) => {
+                        switch (item.type) {
+                            case SEARCH_RESULT_TYPE.GAMEBOARD:
+                                return <QuestionDeckListViewItem key={index} {...rest} item={item} alviType={type} alviLayout="list"/>;
+                            default:
+                                return failedToRender(item);
+                        }
+                    });
+                case "quiz":
+                    return items.map((item, index) => {
+                        switch (item.type) {
+                            case (DOCUMENT_TYPE.QUIZ):
+                                return <QuizListViewItem key={index} {...rest} item={item} alviType={type} alviLayout="list"/>;
+                            default:
+                                return failedToRender(item);
+                        }
+                    });
                 default:
-                    // Do not render this item if there is no matching DOCUMENT_TYPE
-                    console.error("Not able to display item as a ListViewItem: ", item);
                     return null;
             }
-        })}
+        })()}
     </ListGroup>;
 };

--- a/src/app/components/elements/modals/ActiveModal.tsx
+++ b/src/app/components/elements/modals/ActiveModal.tsx
@@ -10,7 +10,6 @@ interface ActiveModalProps {
 }
 
 export const ActiveModal = ({activeModal}: ActiveModalProps) => {
-    const ActiveModalBody = activeModal && activeModal.body;
     const dispatch = useAppDispatch();
 
     const toggle = () => {
@@ -24,7 +23,7 @@ export const ActiveModal = ({activeModal}: ActiveModalProps) => {
         };
     });
 
-    return <Modal data-testid={"active-modal"} toggle={toggle} isOpen={true} size={(activeModal && activeModal.size) || "lg"} centered={activeModal?.centered} data-bs-theme="neutral">
+    return <Modal data-testid={"active-modal"} toggle={toggle} isOpen={true} size={activeModal?.size ?? "lg"} centered={activeModal?.centered} data-bs-theme="neutral">
         {activeModal && <React.Fragment>
             {<ModalHeader
                 data-testid={"modal-header"}
@@ -46,11 +45,11 @@ export const ActiveModal = ({activeModal}: ActiveModalProps) => {
             >
                 {activeModal.title}
             </ModalHeader>}
-            <ModalBody className={classNames({"pt-0": !activeModal.title, "pb-2 mx-4": !activeModal?.noPadding, "pb-0": activeModal?.noPadding, "overflow-visible": activeModal?.overflowVisible})}>
-                {typeof ActiveModalBody === "function" ? <ActiveModalBody /> : ActiveModalBody}
+            <ModalBody className={classNames(activeModal.bodyContainerClassName, "pb-2", {"mx-4": ["lg", "xl", undefined].includes(activeModal.size), "pt-0": !activeModal.title})}>
+                {typeof activeModal?.body === "function" ? <activeModal.body /> : activeModal?.body}
             </ModalBody>
             {activeModal.buttons &&
-                <ModalFooter className="mb-4 mx-2 align-self-center">
+                <ModalFooter className="mb-4 mx-2">
                     {activeModal.buttons}
                 </ModalFooter>
             }

--- a/src/app/components/elements/modals/ReservationsModal.tsx
+++ b/src/app/components/elements/modals/ReservationsModal.tsx
@@ -420,6 +420,6 @@ export const reservationsModal = ({event}: {event: AugmentedEvent}): ActiveModal
         size: 'xl',
         title: "Group reservations",
         body: <ReservationsModal event={event} />,
-        overflowVisible: true
+        bodyContainerClassName: "overflow-visible",
     };
 };

--- a/src/app/components/pages/Concepts.tsx
+++ b/src/app/components/pages/Concepts.tsx
@@ -156,7 +156,7 @@ export const Concepts = withRouter((props: RouteComponentProps) => {
                                     </div>}
             
                                     {shortcutAndFilteredSearchResults.length
-                                        ? <ListView items={shortcutAndFilteredSearchResults}/>
+                                        ? <ListView type="item" items={shortcutAndFilteredSearchResults}/>
                                         : <em>No results found</em>
                                     }
                                 </>;

--- a/src/app/components/pages/MyProgress.tsx
+++ b/src/app/components/pages/MyProgress.tsx
@@ -205,7 +205,7 @@ const MyProgress = withRouter((props: MyProgressProps) => {
                         {progress?.mostRecentQuestions && progress?.mostRecentQuestions.length > 0 && <Col md={12} lg={6} className="mt-4">
                             <h4>Most recently answered questions</h4>
                             {isPhy ?
-                                <ListView items={progress.mostRecentQuestions} fullWidth={below["lg"](screenSize)}/> :
+                                <ListView type="item" items={progress.mostRecentQuestions} fullWidth={below["lg"](screenSize)}/> :
                                 <LinkToContentSummaryList
                                     items={progress.mostRecentQuestions}
                                     contentTypeVisibility={ContentTypeVisibility.FULLY_HIDDEN}
@@ -215,7 +215,7 @@ const MyProgress = withRouter((props: MyProgressProps) => {
                         {progress?.oldestIncompleteQuestions && progress?.oldestIncompleteQuestions.length > 0 && <Col md={12} lg={6} className="mt-4">
                             <h4>Oldest unsolved questions</h4>
                             {isPhy ?
-                                <ListView items={progress.oldestIncompleteQuestions} fullWidth={below["lg"](screenSize)}/> :
+                                <ListView type="item" items={progress.oldestIncompleteQuestions} fullWidth={below["lg"](screenSize)}/> :
                                 <LinkToContentSummaryList
                                     items={progress.oldestIncompleteQuestions}
                                     contentTypeVisibility={ContentTypeVisibility.FULLY_HIDDEN}

--- a/src/app/components/pages/QuestionFinder.tsx
+++ b/src/app/components/pages/QuestionFinder.tsx
@@ -20,7 +20,6 @@ import {
     LearningStage,
     ListParams,
     nextSeed,
-    SEARCH_CHAR_LENGTH_LIMIT,
     SEARCH_RESULTS_PER_PAGE,
     simpleDifficultyLabelMap,
     siteSpecific,
@@ -548,7 +547,7 @@ export const QuestionFinder = withRouter(({location}: RouteComponentProps) => {
                                 <ShowLoading until={displayQuestions} placeholder={loadingPlaceholder}>
                                     {displayQuestions?.length
                                         ? isPhy 
-                                            ? <ListView items={displayQuestions}/> 
+                                            ? <ListView type="item" items={displayQuestions} /> 
                                             : <LinkToContentSummaryList 
                                                 items={displayQuestions} className="m-0" 
                                                 contentTypeVisibility={ContentTypeVisibility.ICON_ONLY} 

--- a/src/app/components/pages/Search.tsx
+++ b/src/app/components/pages/Search.tsx
@@ -167,7 +167,7 @@ export const Search = withRouter((props: RouteComponentProps) => {
                             <ShowLoading until={shortcutAndFilteredSearchResults}>
                                 {gotResults ?
                                     isPhy ? 
-                                        <ListView items={shortcutAndFilteredSearchResults}/> :
+                                        <ListView type="item" items={shortcutAndFilteredSearchResults}/> :
                                         <LinkToContentSummaryList 
                                             items={shortcutAndFilteredSearchResults} showBreadcrumb={true}
                                             contentTypeVisibility={ContentTypeVisibility.SHOWN}   

--- a/src/app/components/pages/SubjectLandingPage.tsx
+++ b/src/app/components/pages/SubjectLandingPage.tsx
@@ -67,7 +67,7 @@ const RandomQuestionBanner = ({context}: {context?: PageContextState}) => {
         </div>
         <Card className="w-100 px-0 hf-6">
             {question
-                ? <ListView items={[{
+                ? <ListView type="item" items={[{
                     type: DOCUMENT_TYPE.QUESTION,
                     title: question.title,
                     tags: question.tags,

--- a/src/app/components/pages/SubjectLandingPage.tsx
+++ b/src/app/components/pages/SubjectLandingPage.tsx
@@ -17,6 +17,7 @@ import classNames from "classnames";
 import { NewsCard } from "../elements/cards/NewsCard";
 import { BookCard } from "./BooksOverview";
 import { placeholderIcon } from "../elements/PageTitle";
+import { ContentSummaryDTO } from "../../../IsaacApiTypes";
 
 
 const RandomQuestionBanner = ({context}: {context?: PageContextState}) => {
@@ -73,7 +74,7 @@ const RandomQuestionBanner = ({context}: {context?: PageContextState}) => {
                     tags: question.tags,
                     id: question.id,
                     audience: question.audience,
-                }]}/>
+                } as ContentSummaryDTO]}/>
                 : <div className="w-100 d-flex justify-content-center">
                     <IsaacSpinner size="sm" />
                 </div>

--- a/src/app/components/pages/quizzes/PracticeQuizzes.tsx
+++ b/src/app/components/pages/quizzes/PracticeQuizzes.tsx
@@ -120,7 +120,8 @@ const PracticeQuizzesComponent = () => {
                                     setCopied(true);
                                 }} onMouseLeave={() => setCopied(false)} />
                             </Col>
-                            <ListView 
+                            <ListView
+                                type="quiz"
                                 items={quizzes.filter((quiz) => isRelevant(quiz))} 
                                 className={classNames({"quiz-list border-radius-2 mb-3": isAda})}
                                 useViewQuizLink

--- a/src/app/components/pages/quizzes/SetQuizzes.tsx
+++ b/src/app/components/pages/quizzes/SetQuizzes.tsx
@@ -404,7 +404,7 @@ const SetQuizzesPageComponent = ({user}: SetQuizzesPageProps) => {
                                 {undeprecatedQuizzes.length === 0 && <p><em>There are no tests you can set which match your search term.</em></p>}
                                 
                                 {siteSpecific(
-                                    <ListView items={undeprecatedQuizzes} isQuizSetter/>, 
+                                    <ListView type="quiz" items={undeprecatedQuizzes} isQuizSetter/>, 
                                     <ListGroup className="mb-2 quiz-list">
                                         {undeprecatedQuizzes.map(quiz => <ListGroupItem className="p-0 bg-transparent" key={quiz.id}>
                                             <Row className="w-100">

--- a/src/app/components/pages/subjectLandingPageComponents.ts
+++ b/src/app/components/pages/subjectLandingPageComponents.ts
@@ -8,42 +8,34 @@ export const extendUrl = (context: NonNullable<Required<PageContextState>>, page
 };
 
 const QuestionFinderCard = (context: NonNullable<Required<PageContextState>>): ListViewCardProps => ({
-    item: {
-        title: "Question finder",
-        subtitle: `Find ${getHumanContext(context)} questions to try by topic and difficulty level.`
-    },
+    title: "Question finder",
+    subtitle: `Find ${getHumanContext(context)} questions to try by topic and difficulty level.`,
     icon: {type: "hex", icon: "icon-finder"},
     subject: context.subject,
     linkTags: [{tag: "Find questions", url: extendUrl(context, 'questions')}]
 });
 
 const ConceptPageCard = (context: NonNullable<Required<PageContextState>>): ListViewCardProps => ({
-    item: {
-        title: "Concepts",
-        subtitle: `Review the key concepts for ${getHumanContext(context)}.`
-    },
+    title: "Concepts",
+    subtitle: `Review the key concepts for ${getHumanContext(context)}.`,
     icon: {type: "hex", icon: "icon-concept"},
     subject: context.subject,
     linkTags: [{tag: "Explore concepts", url: extendUrl(context, 'concepts')}]
 });
 
 const PracticeTestsCard = (context: NonNullable<Required<PageContextState>>): ListViewCardProps => ({
-    item: {
-        title: context.stage.includes("university") ? "Practice admissions tests" : "Tests",
-        subtitle: `Use tests to ${context.stage.includes("university") ? "prepare for university admissions tests" : "practise a range of topics"}. These tests are available for you to freely attempt.`
-    },
+    title: context.stage.includes("university") ? "Practice admissions tests" : "Tests",
+    subtitle: `Use tests to ${context.stage.includes("university") ? "prepare for university admissions tests" : "practise a range of topics"}. These tests are available for you to freely attempt.`,
     icon: {type: "hex", icon: "icon-tests"},
     subject: context.subject,
     linkTags: [{tag: "Find a test", url: extendUrl(context, 'practice_tests')}]
 });
 
 const BoardsByTopicCard = (context: NonNullable<Required<PageContextState>>): ListViewCardProps => ({
-    item: {
-        title: "Question decks by topic",
-        subtitle: context.subject === "chemistry" && context.stage.includes("university")
-            ? "Consolidate your chemistry understanding with these questions by topic."
-            : "Practise specific topics by using our ready-made question decks."
-    },
+    title: "Question decks by topic",
+    subtitle: context.subject === "chemistry" && context.stage.includes("university")
+        ? "Consolidate your chemistry understanding with these questions by topic."
+        : "Practise specific topics by using our ready-made question decks.",
     icon: {type: "hex", icon: "icon-question-deck"},
     subject: context.subject,
     linkTags: [{tag: "View topic question decks", url: extendUrl(context, 'question_decks')}]
@@ -51,10 +43,8 @@ const BoardsByTopicCard = (context: NonNullable<Required<PageContextState>>): Li
 
 // TODO: replace the link tags with links to lessons by *field* (see designs)
 const LessonsAndRevisionCard = (context: NonNullable<Required<PageContextState>>): ListViewCardProps => ({
-    item: {
-        title: "Revision",
-        subtitle: "Revise with our summary videos, topic tests and question decks."
-    },
+    title: "Revision",
+    subtitle: "Revise with our summary videos, topic tests and question decks.",
     icon: {type: "hex", icon: "icon-revision"},
     subject: context.subject,
     linkTags: [{tag: "List of revision areas", url: extendUrl(context, 'revision')}],
@@ -62,30 +52,24 @@ const LessonsAndRevisionCard = (context: NonNullable<Required<PageContextState>>
 });
 
 const CoreSkillsCard = (context: NonNullable<Required<PageContextState>>): ListViewCardProps => ({
-    item: {
-        title: "Core skills practice",
-        subtitle: `Practise core skills required in ${getHumanContext(context)}.`
-    },
+    title: "Core skills practice",
+    subtitle: `Practise core skills required in ${getHumanContext(context)}.`,
     icon: {type: "hex", icon: "icon-quiz"},
     subject: context.subject,
     linkTags: [{tag: "Practise a core skill", url: extendUrl(context, 'quick_quizzes')}]
 });
 
 const GlossaryCard = (context: NonNullable<Required<PageContextState>>): ListViewCardProps => ({
-    item: {
-        title: "Glossary",
-        subtitle: `Use the glossary to understand the vocabulary you need for ${getHumanContext(context)}.`
-    },
+    title: "Glossary",
+    subtitle: `Use the glossary to understand the vocabulary you need for ${getHumanContext(context)}.`,
     icon: {type: "hex", icon: "icon-tests"},
     subject: context.subject,
     linkTags: [{tag: "Browse the glossary", url: extendUrl(context, 'glossary')}]
 });
 
 const BookCard = (book: BookInfo, description: string) => (context: NonNullable<Required<PageContextState>>): ListViewCardProps => ({
-    item: {
-        title: book.title,
-        subtitle: description
-    },
+    title: book.title,
+    subtitle: description,
     icon: {type: "hex", icon: "icon-book"},
     subject: context.subject,
     linkTags: [{tag: book.title, url: book.path}]
@@ -95,10 +79,8 @@ const StepIntoPhyCard = BookCard(ISAAC_BOOKS_BY_TAG["phys_book_step_into"], "Dis
 const StepUpPhyCard = BookCard(ISAAC_BOOKS_BY_TAG["phys_book_step_up"], "Build a strong foundation in physics. Aimed at students in year 9.");
 
 const ArbitraryPageLinkCard = (title: string, subtitle: string, linkTags: ListViewTagProps[], state?: AbstractListViewItemState) => (context: NonNullable<Required<PageContextState>>): ListViewCardProps => ({
-    item: {
-        title,
-        subtitle
-    },
+    title,
+    subtitle,
     icon: {type: "hex", icon: "icon-revision"},
     subject: context.subject,
     linkTags,

--- a/src/app/components/site/phy/HomepagePhy.tsx
+++ b/src/app/components/site/phy/HomepagePhy.tsx
@@ -7,7 +7,6 @@ import { NewsCard } from "../../elements/cards/NewsCard";
 import { ShowLoadingQuery } from "../../handlers/ShowLoadingQuery";
 import { EventCard } from "../../elements/cards/EventCard";
 import { StudentDashboard } from "../../elements/StudentDashboard";
-import { ShortcutResponse } from "../../../../IsaacAppTypes";
 import { ListViewCardProps, ListViewCards } from "../../elements/list-groups/ListView";
 import { Spacer } from "../../elements/Spacer";
 import { TeacherDashboard } from "../../elements/TeacherDashboard";
@@ -96,13 +95,10 @@ const subjectDescriptions: Record<Subject, string> = {
 };
 
 const getListViewSubjectCard = (sc: subjectCategory) => {
-    const item: ShortcutResponse = {
-        title: sc.humanSubject,
-        subtitle: subjectDescriptions[sc.subject as Subject],
-    };
 
     const listViewSubjectCard: ListViewCardProps = {
-        item: item,
+        title: sc.humanSubject,
+        subtitle: subjectDescriptions[sc.subject as Subject],
         icon: {
             type: "img", 
             icon: `/assets/phy/icons/redesign/subject-${sc.subject}.svg`,

--- a/src/scss/common/list-groups.scss
+++ b/src/scss/common/list-groups.scss
@@ -17,7 +17,6 @@
     a {
       display: flex;
       text-decoration: none;
-      position: relative;
     }
   }
 }

--- a/src/scss/common/modals.scss
+++ b/src/scss/common/modals.scss
@@ -7,8 +7,9 @@
 // NOMENSA modal.scss
 
 .modal-content {
-  border-radius: 0;
   max-width: 459px;
+  border-radius: 0.5rem;
+  box-shadow: 0px 0px 20px 3px rgba(0,0,0,0.2);
 
   .modal-footer,
   .modal-header {

--- a/src/scss/phy/list-groups.scss
+++ b/src/scss/phy/list-groups.scss
@@ -4,6 +4,12 @@
 .content-summary-item {
   min-height: 88px;
   padding: 1rem;
+
+  &:has(a.alvi-title) {
+    button {
+      z-index: 2;
+    }
+  }
 }
 
 .list-view-border {
@@ -59,6 +65,25 @@
 .list-group-links {
   .link-title {
     color: var(--subject-color-900);
+  }
+
+  .alvi-title {
+    @extend .link-title;
+
+    &::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      z-index: 1;
+      cursor: pointer;
+    }
+
+    &:focus-visible {
+      box-shadow: none !important;
+      &::before {
+        @include focus-outline;
+      }
+    }
   }
 
   .question-link-title {


### PR DESCRIPTION
Retypes ALVIs and ListViews so that properties on ListViews can only exist if they apply to the same element. This does require restricting ListViews to be one of three types (generic item / quiz / gameboard) when constructing, meaning it will no longer compile if e.g. a gameboard and quiz exist in the same view. This does, however, enforce consistency across all items in the ListView, ensuring all elements will align correctly, etc. It also allows for automatic completion of applicable properties to a ListView while coding, as determined by the type prop.

Another beneficial side effect of this type property is that it becomes possible to correctly determine what type of ListView an ALVI is in without relying on optional parameters; this makes the computation of `isQuiz` or `isGameboard` possible and, importantly, necessarily indepedent; before there was no such guarantee that a quiz parameter and a gameboard parameter couldn't exist on the same object.

This PR also modifies gameboard ALVIs to include an "Assign" button, using the modal from Set Assignments to do so.

The typings (particularly in ListView) are somewhat more complex than before and I am happy to walk through in more detail with someone :)