### PR TITLE
Anvil apps listing page

### DIFF
--- a/src/app/components/elements/layout/SidebarLayout.tsx
+++ b/src/app/components/elements/layout/SidebarLayout.tsx
@@ -6,7 +6,7 @@ import { AssignmentDTO, ContentSummaryDTO, GameboardDTO, GameboardItem, IsaacCon
 import { above, ACCOUNT_TAB, ACCOUNT_TABS, AUDIENCE_DISPLAY_FIELDS, below, BOARD_ORDER_NAMES, BoardCompletions, BoardCreators, BoardLimit, BoardSubjects, BoardViews, confirmThen, determineAudienceViews, EventStageMap,
     EventStatusFilter, EventTypeFilter, filterAssignmentsByStatus, filterAudienceViewsByProperties, getDistinctAssignmentGroups, getDistinctAssignmentSetters, getHumanContext, getThemeFromContextAndTags, HUMAN_STAGES,
     ifKeyIsEnter, isAda, isDefined, PHY_NAV_SUBJECTS, isTeacherOrAbove, QuizStatus, siteSpecific, TAG_ID, tags, STAGE, useDeviceSize, LearningStage, HUMAN_SUBJECTS, ArrayElement, isFullyDefinedContext, isSingleStageContext,
-    stageLabelMap, extractTeacherName, determineGameboardSubjects, PATHS, getQuestionPlaceholder, getFilteredStageOptions, isPhy, ISAAC_BOOKS, BookHiddenState, TAG_LEVEL} from "../../../services";
+    stageLabelMap, extractTeacherName, determineGameboardSubjects, PATHS, getQuestionPlaceholder, getFilteredStageOptions, isPhy, ISAAC_BOOKS, BookHiddenState, TAG_LEVEL, VALID_APPS_CONTEXTS} from "../../../services";
 import { StageAndDifficultySummaryIcons } from "../StageAndDifficultySummaryIcons";
 import { mainContentIdSlice, selectors, sidebarSlice, useAppDispatch, useAppSelector, useGetQuizAssignmentsAssignedToMeQuery } from "../../../state";
 import { Link, useHistory, useLocation } from "react-router-dom";
@@ -1599,6 +1599,23 @@ export const BooksOverviewSidebar = (props: ContentSidebarProps) => {
         <ul>
             {ISAAC_BOOKS.filter(book => book.hidden !== BookHiddenState.HIDDEN).map((book, index) => <li key={index}>
                 <StyledTabPicker checkboxTitle={book.title} checked={false} onClick={() => history.push(book.path)}/>
+            </li>)}
+        </ul>
+    </ContentSidebar>;
+};
+
+export const AnvilAppsListingSidebar = (props: ContentSidebarProps) => {
+    const history = useHistory();
+    const context = useAppSelector(selectors.pageContext.context);
+    return <ContentSidebar buttonTitle="See all apps" {...props}>
+        <div className="section-divider"/>
+        <h5>Select stage</h5>
+        <ul>
+            {isFullyDefinedContext(context) && Object.keys(VALID_APPS_CONTEXTS[context.subject] ?? {}).map((stage, index) => <li key={index}>
+                <StyledTabPicker 
+                    checkboxTitle={HUMAN_STAGES[stage as LearningStage]} checked={context?.stage?.includes(stage as LearningStage)}
+                    onClick={() => history.push(`/${context?.subject}/${stage}/apps`)} 
+                />
             </li>)}
         </ul>
     </ContentSidebar>;

--- a/src/app/components/pages/AnvilAppsListing.tsx
+++ b/src/app/components/pages/AnvilAppsListing.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { Container } from "reactstrap";
+import { generateSubjectLandingPageCrumbFromContext, TitleAndBreadcrumb } from "../elements/TitleAndBreadcrumb";
+import { getHumanContext, isFullyDefinedContext, isSingleStageContext, useUrlPageTheme, VALID_APPS_CONTEXTS } from "../../services";
+import { AnvilAppsListingSidebar, MainContent, SidebarLayout } from "../elements/layout/SidebarLayout";
+import { PageMetadata } from "../elements/PageMetadata";
+import { PageFragment } from "../elements/PageFragment";
+
+export const AnvilAppsListing = () => {
+    const pageContext = useUrlPageTheme();
+    const crumb = isFullyDefinedContext(pageContext) && generateSubjectLandingPageCrumbFromContext(pageContext);
+
+    if (!isFullyDefinedContext(pageContext) || !isSingleStageContext(pageContext)) {
+        return null;
+    }
+
+    if (!(pageContext.stage[0] in (VALID_APPS_CONTEXTS[pageContext.subject] || {}))) {
+        return <Container data-bs-theme={pageContext?.subject}>
+            <TitleAndBreadcrumb 
+                currentPageTitle="Apps"
+                intermediateCrumbs={crumb ? [crumb] : []}
+                icon={{ icon: "icon-revision", type: "hex" }}
+            />
+            <p className="mt-4">Apps are not available for {getHumanContext(pageContext)}.</p>
+        </Container>;
+    }
+
+    return <Container data-bs-theme={pageContext?.subject}>
+        <TitleAndBreadcrumb 
+            currentPageTitle={`${getHumanContext(pageContext)} Apps`}
+            intermediateCrumbs={crumb ? [crumb] : []}
+            icon={{icon: "icon-revision", type: "hex"}}
+        />
+        <SidebarLayout>
+            <AnvilAppsListingSidebar />
+            <MainContent>
+                <PageMetadata />
+                <PageFragment fragmentId={VALID_APPS_CONTEXTS[pageContext.subject]?.[pageContext.stage[0]] ?? ""} />
+            </MainContent>
+        </SidebarLayout>
+    </Container>;
+};

--- a/src/app/components/pages/subjectLandingPageComponents.ts
+++ b/src/app/components/pages/subjectLandingPageComponents.ts
@@ -91,7 +91,13 @@ const ArbitraryPageLinkCard = (title: string, subtitle: string, linkTags: ListVi
     state,
 });
 
-const AnvilAppsCard = (context: NonNullable<Required<PageContextState>>): ListViewCardProps => {
+// intended for GCSE / A Level, where the apps are relevant precisely to that stage
+const AnvilAppsCoreCard = (context: NonNullable<Required<PageContextState>>): ListViewCardProps => {
+    return ArbitraryPageLinkCard("Core skills practice", `Consolidate your ${context.subject} skills with these apps.`, [{tag: `Refine your ${context.subject} skills`, url: extendUrl(context, "apps")}])(context);
+};
+
+// intended for University, where the apps are more revision of previous stages
+const AnvilAppsRevisionCard = (context: NonNullable<Required<PageContextState>>): ListViewCardProps => {
     return ArbitraryPageLinkCard("Skills practice", `Consolidate your ${context.subject} skills with these apps.`, [{tag: `Refine your ${context.subject} skills`, url: extendUrl(context, "apps")}], AbstractListViewItemState.COMING_SOON)(context);
 };
 
@@ -131,9 +137,9 @@ const subjectSpecificCardsMap: {[subject in keyof typeof PHY_NAV_SUBJECTS]: {[st
         "university": [BoardsByTopicCard, MathsUniCard, null],
     },
     "chemistry": {
-        "gcse": [CoreSkillsCard, GlossaryCard],
-        "a_level": [BoardsByTopicCard, GlossaryCard, CoreSkillsCard],
-        "university": [BoardsByTopicCard, AnvilAppsCard, MathsUniCard],
+        "gcse": [AnvilAppsCoreCard, GlossaryCard],
+        "a_level": [BoardsByTopicCard, GlossaryCard, AnvilAppsCoreCard],
+        "university": [BoardsByTopicCard, AnvilAppsRevisionCard, MathsUniCard],
     },
     "maths": {
         "gcse": [BoardsByTopicCard, MathsSkillsCard],

--- a/src/app/components/site/phy/RoutesPhy.tsx
+++ b/src/app/components/site/phy/RoutesPhy.tsx
@@ -43,6 +43,7 @@ import { PreUniMaths } from "../../pages/books_old/pre_uni_maths";
 import { QuizView } from "../../pages/quizzes/QuizView";
 import { BooksOverview } from "../../pages/BooksOverview";
 import { RevisionPage } from "../../pages/RevisionDetailPage";
+import { AnvilAppsListing } from "../../pages/AnvilAppsListing";
 
 const Equality = lazy(() => import('../../pages/Equality'));
 const EventDetails = lazy(() => import('../../pages/EventDetails'));
@@ -57,6 +58,7 @@ const subjectStagePairPages : Record<string, React.ComponentType<RouteComponentP
     "/quick_quizzes": QuickQuizzes,
     "/question_decks": QuestionDecks,
     "/glossary": Glossary,
+    "/apps": AnvilAppsListing,
 };
 
 // TODO: remove these (and related imports) when we have replaced old book index pages with API-based ones

--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -606,6 +606,13 @@ export const ISAAC_BOOKS_BY_TAG: {[tag in BookTag]: BookInfo} = ISAAC_BOOKS.redu
 
 export const BOOK_DETAIL_ID_SEPARATOR = "__";
 
+export const VALID_APPS_CONTEXTS : Partial<Record<Subject, Partial<Record<LEARNING_STAGE, string>>>> = { 
+    "chemistry": {
+        [LEARNING_STAGE.GCSE]: "app_page_overview_gcse_chem_fragment",
+        [LEARNING_STAGE.A_LEVEL]: "app_page_overview_alevel_chem_fragment",
+    },
+};
+
 export const fastTrackProgressEnabledBoards = [
     'ft_core_2017', 'ft_core_2018', 'ft_core_stage2',
     'ft_mech_year1_2018', 'ft_mech_year2_2018', 'ft_further_stage1_2018',


### PR DESCRIPTION
Implements a breadcrumbed landing page for anvil apps at `{subject}/{stage}/apps`. Only accessible to GCSE and A Level Chemistry at present, will display a short error if you manually set the URL to any other combination.