### PR TITLE
Convert Question Deck layout to ALVI list

### DIFF
--- a/src/IsaacApiTypes.tsx
+++ b/src/IsaacApiTypes.tsx
@@ -447,6 +447,7 @@ export interface ContentSummaryDTO {
     deprecated?: boolean;
     difficulty?: string;
     audience?: AudienceContext[];
+    className?: string;
 }
 
 export interface QuizSummaryDTO extends ContentSummaryDTO {

--- a/src/app/components/elements/layout/SidebarLayout.tsx
+++ b/src/app/components/elements/layout/SidebarLayout.tsx
@@ -270,12 +270,17 @@ export const GameboardSidebar = (props: GameboardSidebarProps) => {
 
     const GameboardDetails = () => {
         const subjects = determineGameboardSubjects(gameboard);
-        const topics = tags.getTopicTags(Array.from((gameboard?.contents || []).reduce((a, c) => {
+        
+        const gameboardTags = Array.from((gameboard?.contents || []).reduce((a, c) => {
             if (isDefined(c.tags) && c.tags.length > 0) {
                 return new Set([...Array.from(a), ...c.tags.map(id => id as TAG_ID)]);
             }
             return a;
-        }, new Set<TAG_ID>())).filter(tag => isDefined(tag))).map(tag => tag.title).sort();
+        }, new Set<TAG_ID>())).filter(tag => isDefined(tag));
+        const topics = (tags.getTopicTags(gameboardTags).length > 0 
+            ? tags.getTopicTags(gameboardTags) 
+            : tags.getFieldTags(gameboardTags)
+        ).map(tag => tag.title).sort();
 
         return <>
             <div className="mb-2">

--- a/src/app/components/elements/layout/SidebarLayout.tsx
+++ b/src/app/components/elements/layout/SidebarLayout.tsx
@@ -287,10 +287,10 @@ export const GameboardSidebar = (props: GameboardSidebarProps) => {
                 Subject{subjects.length > 1 && "s"}:
                 <ul className="d-inline ms-1">{subjects.map(s => <li className="d-inline" key={s}><Pill title={HUMAN_SUBJECTS[s]} theme={s}/></li>)}</ul>
             </div>
-            <div className="mb-2">
+            {(topics.length > 0) && <div className="mb-2">
                 Topic{subjects.length > 1 && "s"}:
                 <ul className="d-inline ms-1">{topics.map(t => <li key={t} className="d-inline"><Pill title={t}/></li>)}</ul>
-            </div>
+            </div>}
         </>;
     };
 

--- a/src/app/components/elements/list-groups/AbstractListViewItem.tsx
+++ b/src/app/components/elements/list-groups/AbstractListViewItem.tsx
@@ -182,9 +182,9 @@ export const AbstractListViewItem = ({title, icon, subject, subtitle, breadcrumb
             <div className="align-content-center text-overflow-ellipsis pe-2">
                 <div className="d-flex text-wrap">
                     {url && !isDisabled
-                        ? <Link to={url} className={classNames("alvi-title", {"question-link-title": isPhy || !isQuiz})}>
+                        ? <a href={url} className={classNames("alvi-title", {"question-link-title": isPhy || !isQuiz})}>
                             <Markup encoding="latex">{title}</Markup>
-                        </Link>
+                        </a>
                         : <span className={classNames("alvi-title", {"question-link-title": isPhy || !isQuiz})}>
                             <Markup encoding="latex">{title}</Markup>
                         </span>

--- a/src/app/components/elements/list-groups/ListView.tsx
+++ b/src/app/components/elements/list-groups/ListView.tsx
@@ -215,6 +215,7 @@ export const ShortcutListViewItem = ({item, ...rest}: ShortcutListViewItemProps)
         status={item.state}
         url={url}
         audienceViews={audienceViews}
+        className={item.className}
         {...rest}
     />;
 };

--- a/src/app/components/elements/list-groups/ListView.tsx
+++ b/src/app/components/elements/list-groups/ListView.tsx
@@ -203,9 +203,10 @@ export const ShortcutListViewItem = ({item, ...rest}: ShortcutListViewItemProps)
     const audienceViews: ViewingContext[] = determineAudienceViews(item.audience);
     const itemSubject = tags.getSpecifiedTag(TAG_LEVEL.subject, item.tags as TAG_ID[])?.id as Subject;
     const url = `${item.url}${item.hash ? `#${item.hash}` : ""}`;
+    const icon = (url.includes("concepts/") || !item.className?.includes("wildcard-list-view")) ? "icon-concept" : "icon-wildcard";
 
     return <AbstractListViewItem
-        icon={{type: "hex", icon: "icon-concept", size: "lg"}}
+        icon={{type: "hex", icon: icon, size: "lg"}}
         title={item.title ?? ""}
         subject={itemSubject}
         subtitle={item.subtitle}

--- a/src/app/components/pages/Gameboard.tsx
+++ b/src/app/components/pages/Gameboard.tsx
@@ -17,7 +17,6 @@ import {
     below,
     convertGameboardItemToContentSummary,
     determineAudienceViews,
-    DOCUMENT_TYPE,
     filterAudienceViewsByProperties,
     generateQuestionTitle,
     isAda,
@@ -174,7 +173,7 @@ export const Gameboard = withRouter(({ location }) => {
     const thisGameboardAssignments = isDefined(gameboardId) && isDefined(assignments) && isFound(assignments) && (assignments.filter(a => a.gameboardId?.includes(gameboardId)));
     const contentSummary: ContentSummaryDTO[] = gameboard?.contents?.map(q => { return {...convertGameboardItemToContentSummary(q), state: gameboardItemStateToCompletionState(q.state)}; }) || [];
     const wildCard: ContentSummaryDTO | undefined = {...gameboard?.wildCard, type: SEARCH_RESULT_TYPE.SHORTCUT, tags: []} as ContentSummaryDTO;
-    const displayQuestions = (wildCard && gameboard && !showWildcard(gameboard)) ? [wildCard, ...contentSummary] : contentSummary;
+    const displayQuestions = (wildCard && gameboard && showWildcard(gameboard)) ? [wildCard, ...contentSummary] : contentSummary;
 
     // Only log a gameboard view when we have a gameboard loaded:
     useEffect(() => {

--- a/src/app/components/pages/Gameboard.tsx
+++ b/src/app/components/pages/Gameboard.tsx
@@ -172,8 +172,8 @@ export const Gameboard = withRouter(({ location }) => {
     const {data: assignments} = useGetMyAssignmentsQuery(queryArg, {refetchOnMountOrArgChange: true, refetchOnReconnect: true});
     const thisGameboardAssignments = isDefined(gameboardId) && isDefined(assignments) && isFound(assignments) && (assignments.filter(a => a.gameboardId?.includes(gameboardId)));
     const contentSummary: ContentSummaryDTO[] = gameboard?.contents?.map(q => { return {...convertGameboardItemToContentSummary(q), state: gameboardItemStateToCompletionState(q.state)}; }) || [];
-    const wildCard: ContentSummaryDTO | undefined = {...gameboard?.wildCard, type: SEARCH_RESULT_TYPE.SHORTCUT, tags: []} as ContentSummaryDTO;
-    const displayQuestions = (wildCard && gameboard && showWildcard(gameboard)) ? [wildCard, ...contentSummary] : contentSummary;
+    const wildCard: ContentSummaryDTO = {...gameboard?.wildCard, type: SEARCH_RESULT_TYPE.SHORTCUT, tags: [], className: "wildcard-list-view"} as ContentSummaryDTO;
+    const displayQuestions = (wildCard && gameboard && !showWildcard(gameboard)) ? [wildCard, ...contentSummary] : contentSummary;
 
     // Only log a gameboard view when we have a gameboard loaded:
     useEffect(() => {

--- a/src/app/components/pages/Gameboard.tsx
+++ b/src/app/components/pages/Gameboard.tsx
@@ -70,22 +70,20 @@ export const getProgressIcon = (question: GameboardItem) => {
     return {itemClasses: classNames(itemClasses, `bg-${backgroundColor}`), icon, message};
 };
 
+// TODO Replace with new gameboard state (Correct / Some Errors / In Progress / Not Started) once implemented
 export const gameboardItemStateToCompletionState = (state?: GameboardItemState) => {
-    let a: CompletionState;
     switch (state) {
         case "PERFECT":
-            a = CompletionState.ALL_CORRECT;
-            break;
+            return CompletionState.ALL_CORRECT;
         case "PASSED":
         case "IN_PROGRESS":
-            a = CompletionState.IN_PROGRESS;
-            break;
+        case "FAILED": 
+            return CompletionState.IN_PROGRESS;
         case "NOT_ATTEMPTED":
         default: 
-            a = CompletionState.NOT_ATTEMPTED; 
+            return CompletionState.NOT_ATTEMPTED; 
     }
-    return a;
-}
+};
 
 const GameboardItemComponent = ({gameboard, question}: {gameboard: GameboardDTO, question: GameboardItem}) => {
     const {itemClasses, icon, message} = getProgressIcon(question);

--- a/src/app/components/pages/Gameboard.tsx
+++ b/src/app/components/pages/Gameboard.tsx
@@ -174,16 +174,9 @@ export const Gameboard = withRouter(({ location }) => {
     const queryArg = user?.loggedIn && isNotPartiallyLoggedIn(user) ? undefined : skipToken;
     const {data: assignments} = useGetMyAssignmentsQuery(queryArg, {refetchOnMountOrArgChange: true, refetchOnReconnect: true});
     const thisGameboardAssignments = isDefined(gameboardId) && isDefined(assignments) && isFound(assignments) && (assignments.filter(a => a.gameboardId?.includes(gameboardId)));
-    //const displayQuestions = ([gameboard?.wildCard, ...(gameboard?.contents ?? [])]).map(convertGameboardItemToContentSummary);
-    const contentSummary: ContentSummaryDTO[] = gameboard?.contents?.map(q => { 
-        return {
-            ...convertGameboardItemToContentSummary(q), 
-            state: gameboardItemStateToCompletionState(q.state)
-        }; 
-    }) || []; // http://localhost:8004/question_decks#6b56cf5a-78fb-4e5d-b05e-4dbea85a0e91
-    console.log("gc", gameboard?.contents);
-    const wildCard: ContentSummaryDTO | undefined = {...gameboard?.wildCard, type: SEARCH_RESULT_TYPE.SHORTCUT} as ContentSummaryDTO; // should not be "sig_figs_wildcard"
-    const displayQuestions = (wildCard && gameboard && showWildcard(gameboard)) ? [wildCard, ...contentSummary] : contentSummary;
+    const contentSummary: ContentSummaryDTO[] = gameboard?.contents?.map(q => { return {...convertGameboardItemToContentSummary(q), state: gameboardItemStateToCompletionState(q.state)}; }) || [];
+    const wildCard: ContentSummaryDTO | undefined = {...gameboard?.wildCard, type: SEARCH_RESULT_TYPE.SHORTCUT} as ContentSummaryDTO;
+    const displayQuestions = (wildCard && gameboard && !showWildcard(gameboard)) ? [wildCard, ...contentSummary] : contentSummary;
 
     // Only log a gameboard view when we have a gameboard loaded:
     useEffect(() => {
@@ -221,7 +214,6 @@ export const Gameboard = withRouter(({ location }) => {
                             <GameboardSidebar gameboard={gameboard} assignments={thisGameboardAssignments} hideButton />
                             <MainContent>
                                 <PageMetadata title={gameboard.title} showSidebarButton sidebarButtonText="Details"/>
-                                {/* // {isPhy && <h3 className="mt-3">{gameboard.title}</h3>} */}
                                 {isPhy 
                                     ? <ListView type="item" items={displayQuestions} className="mt-3"/>
                                     : <GameboardViewer gameboard={gameboard} className="mt-4 mt-lg-7" /> 

--- a/src/app/components/pages/Gameboard.tsx
+++ b/src/app/components/pages/Gameboard.tsx
@@ -173,7 +173,7 @@ export const Gameboard = withRouter(({ location }) => {
     const {data: assignments} = useGetMyAssignmentsQuery(queryArg, {refetchOnMountOrArgChange: true, refetchOnReconnect: true});
     const thisGameboardAssignments = isDefined(gameboardId) && isDefined(assignments) && isFound(assignments) && (assignments.filter(a => a.gameboardId?.includes(gameboardId)));
     const contentSummary: ContentSummaryDTO[] = gameboard?.contents?.map(q => { return {...convertGameboardItemToContentSummary(q), state: gameboardItemStateToCompletionState(q.state)}; }) || [];
-    const wildCard: ContentSummaryDTO | undefined = {...gameboard?.wildCard, type: SEARCH_RESULT_TYPE.SHORTCUT} as ContentSummaryDTO;
+    const wildCard: ContentSummaryDTO | undefined = {...gameboard?.wildCard, type: SEARCH_RESULT_TYPE.SHORTCUT, tags: []} as ContentSummaryDTO;
     const displayQuestions = (wildCard && gameboard && !showWildcard(gameboard)) ? [wildCard, ...contentSummary] : contentSummary;
 
     // Only log a gameboard view when we have a gameboard loaded:

--- a/src/app/components/pages/Gameboard.tsx
+++ b/src/app/components/pages/Gameboard.tsx
@@ -173,7 +173,7 @@ export const Gameboard = withRouter(({ location }) => {
     const thisGameboardAssignments = isDefined(gameboardId) && isDefined(assignments) && isFound(assignments) && (assignments.filter(a => a.gameboardId?.includes(gameboardId)));
     const contentSummary: ContentSummaryDTO[] = gameboard?.contents?.map(q => { return {...convertGameboardItemToContentSummary(q), state: gameboardItemStateToCompletionState(q.state)}; }) || [];
     const wildCard: ContentSummaryDTO = {...gameboard?.wildCard, type: SEARCH_RESULT_TYPE.SHORTCUT, tags: [], className: "wildcard-list-view"} as ContentSummaryDTO;
-    const displayQuestions = (wildCard && gameboard && !showWildcard(gameboard)) ? [wildCard, ...contentSummary] : contentSummary;
+    const displayQuestions = (wildCard && gameboard && showWildcard(gameboard)) ? [wildCard, ...contentSummary] : contentSummary;
 
     // Only log a gameboard view when we have a gameboard loaded:
     useEffect(() => {

--- a/src/app/services/gameboardBuilder.ts
+++ b/src/app/services/gameboardBuilder.ts
@@ -40,6 +40,7 @@ export const convertContentSummaryToGameboardItem = (question: ContentSummary): 
         level: undefined,
         url: undefined,
         deprecated: undefined,
+        className: undefined,
     };
     const newQuestion = {
         ...question,

--- a/src/scss/phy/icons.scss
+++ b/src/scss/phy/icons.scss
@@ -307,6 +307,19 @@
   )
 }
 
+.icon-wildcard {
+  @include svg-icon-layered(
+    '/assets/phy/icons/redesign/page-revision-fg.svg',
+    '/assets/phy/icons/redesign/page-generic-bg.svg',
+    var(--icon-size), var(--icon-size), var(--mask-size, 58%)
+  );
+
+  // Reusing layers from other icons so this needs slight adjustments to fit
+  &::after {
+    scale: 0.9;
+  }
+}
+
 svg {
   &.almost-fill {
     fill: $phy_extra_force_yellow;

--- a/src/scss/phy/isaac.scss
+++ b/src/scss/phy/isaac.scss
@@ -158,6 +158,8 @@ $color-misc-red: #b40c0c;
 $color-misc-pale-yellow: #f9fdd5;
 $color-misc-correct: #ecf7e9;
 
+$color-wildcard-orange: #ff7800;
+
 $isaac-color-palettes: (
   // brand is excluded as there are no pages with the "brand" colour scheme;
   // it is used exclusively for styling individual components

--- a/src/scss/phy/list-groups.scss
+++ b/src/scss/phy/list-groups.scss
@@ -10,6 +10,10 @@
       z-index: 2;
     }
   }
+
+  &.wildcard-list-view i.icon::after {
+    background-color: $color-wildcard-orange;
+  }
 }
 
 .list-view-border {


### PR DESCRIPTION
We've been requested that the question decks should by styled to appear like the question finder. This is mostly a straightforward conversion to ALVIs, but with the following points:
- Content don't want wildcards to be confused with questions, so they have their tags cleared and are portrayed in a neutral context
  - (Also some wildcards are absolute links, so I've had to switch from a `<Link>` to `<a>` in the ALVI itself to accommodate 
- In the sidebar: if topic tags are empty, display field tags. If field tags are ALSO empty, don't display the "Topic" heading at all
- While waiting for markbook changes to bring through the new question states, this includes a temporary function to convert between `GameboardItemState` and `CompletionState` to make sure _some_ state is still displayed