### PR TITLE
Restore ?board= param to question decks

### DIFF
--- a/src/app/components/elements/list-groups/AbstractListViewItem.tsx
+++ b/src/app/components/elements/list-groups/AbstractListViewItem.tsx
@@ -120,7 +120,6 @@ type ALVIType = {
     audienceViews?: ViewingContext[];
     status?: CompletionState;
     quizTag?: string; // this is for quick quizzes only, which are currently just gameboards; may change in future
-    linkedBoardId?: string; // if the item is part of a gameboard
 } | {
     // quizzes – have exclusive "preview" and "view test" buttons
     alviType: "quiz";
@@ -163,11 +162,6 @@ export const AbstractListViewItem = ({title, icon, subject, subtitle, breadcrumb
     const isQuiz = typedProps.alviType === "quiz";
     const isCard = typedProps.alviLayout === "card";
     const isDisabled = state && [AbstractListViewItemState.COMING_SOON, AbstractListViewItemState.DISABLED].includes(state);
-
-    const fullUrl = url ? new URL(url, window.location.origin) : undefined;
-    if (fullUrl && typedProps.alviType === "item" && typedProps.linkedBoardId) {
-        fullUrl.searchParams.set("board", typedProps.linkedBoardId);
-    }
     
     fullWidth = fullWidth || below["sm"](deviceSize) || (isItem && !(typedProps.status || typedProps.audienceViews));
     const cardBody =
@@ -187,8 +181,8 @@ export const AbstractListViewItem = ({title, icon, subject, subtitle, breadcrumb
             </div>
             <div className="align-content-center text-overflow-ellipsis pe-2">
                 <div className="d-flex text-wrap">
-                    {fullUrl && !isDisabled
-                        ? <a href={fullUrl.toString()} className={classNames("alvi-title", {"question-link-title": isPhy || !isQuiz})}>
+                    {url && !isDisabled
+                        ? <a href={url} className={classNames("alvi-title", {"question-link-title": isPhy || !isQuiz})}>
                             <Markup encoding="latex">{title}</Markup>
                         </a>
                         : <span className={classNames("alvi-title", {"question-link-title": isPhy || !isQuiz})}>

--- a/src/app/components/elements/list-groups/ListView.tsx
+++ b/src/app/components/elements/list-groups/ListView.tsx
@@ -8,6 +8,7 @@ import { AffixButton } from "../AffixButton";
 import { ContentSummaryDTO, GameboardDTO, QuizSummaryDTO } from "../../../../IsaacApiTypes";
 import { Link } from "react-router-dom";
 import { selectors, showQuizSettingModal, useAppDispatch, useAppSelector } from "../../../state";
+import { UnionToIntersection } from "@reduxjs/toolkit/dist/tsHelpers";
 import classNames from "classnames";
 
 type ListViewCardItemProps = Extract<AbstractListViewItemProps, {alviType: "item", alviLayout: "card"}>;
@@ -20,15 +21,16 @@ export const ListViewCardItem = (props: ListViewCardItemProps) => {
 
 interface QuestionListViewItemProps extends Extract<AbstractListViewItemProps, {alviType: "item", alviLayout: "list"}> {
     item: ContentSummaryDTO;
+    linkedBoardId?: string;
 }
 
 export const QuestionListViewItem = (props : QuestionListViewItemProps) => {
-    const { item, ...rest } = props;
+    const { item, linkedBoardId, ...rest } = props;
     const breadcrumb = tags.getByIdsAsHierarchy((item.tags || []) as TAG_ID[]).map(tag => tag.title);
     const audienceViews: ViewingContext[] = determineAudienceViews(item.audience);
     const pageSubject = useAppSelector(selectors.pageContext.subject);
     const itemSubject = getThemeFromContextAndTags(pageSubject, tags.getSubjectTags((item.tags || []) as TAG_ID[]).map(t => t.id));
-    const url = `/${documentTypePathPrefix[DOCUMENT_TYPE.QUESTION]}/${item.id}`;
+    const url = `/${documentTypePathPrefix[DOCUMENT_TYPE.QUESTION]}/${item.id}` + (linkedBoardId ? `?board=${linkedBoardId}` : "");
 
     return <AbstractListViewItem
         {...rest}
@@ -287,8 +289,33 @@ type ListViewProps<T, G extends "item" | "gameboard" | "quiz"> = {
         items: Required<T> extends Required<Extract<ListViewItemProps, {alviType: G}>['item']> ? T[] : never;
         type: G;
     } 
-    & Omit<Extract<ListViewItemProps, {alviType: G}>, "item" | keyof AbstractListViewItemProps>
-);
+    & Omit<UnionToIntersection<Extract<ListViewItemProps, {alviType: G}>>, "item" | keyof AbstractListViewItemProps>
+)
+
+// ListView type system in excessive detail:
+//   ListView is a wrapper component for rendering a group of various types of ListViewItems. The idea is that ListView is always the component you want when
+//   building anything; there is no need to know the details of which ListViewItem is being rendered. You merely provide the "type" of ListView, the "layout"
+//   (i.e. list / cards), and then pass in the items you want to render.
+
+//   The different types exist to allow the underlying AbstractListViewItem to render different types of item. The most common type is "item", used for questions,
+//   concepts, search results... – these have titles, subtitles, tags, and a url (e.g. ContentSummaryDTOs, ShortcutResponses). The other types are "gameboard",
+//   which have exclusive "Assign" buttons for teachers, and "quiz", which have exclusive "Preview" and "Take quiz" buttons.
+
+//   On to the typing. ListView has two generic types, T and G, which should not be specified directly in a component – if TS can infer them, you're using it 
+//   right. T is the type of the items being passed in; G is the type of ListView being rendered ("item" | "gameboard" | "quiz"). 
+
+//   In order to ensure that the items being passed in are valid under the context of type G, T is not immediately inferred from the items prop. Instead, it is
+//   checked against the union of all possible ListViewItem prop types, provided that ListViewItem is of the type G. The items prop is valid if its type extends
+//   the type of any single ListViewItem type of type G. We use `Required` as most of these types (e.g. ContentSummaryDTO) are fully optional by nature.
+
+//   The second part of the type system is the {...rest} props. These are props that can be passed to an individual ListViewItem type; for example, a 
+//   QuestionListViewItem can have a `linkedBoardId` prop, which is not present on a ConceptListViewItem. In a ListView where this is prop is set 
+//   (<ListView type="item" linkedBoardId="123" items={...} />), all question items will have the `linkedBoardId` prop passed to them. The prop is ignored on
+//   other item types.
+
+//   These type of {...rest} props is calculated similarly to the items prop. However, with items, we wanted validity to be checked entirely against a single
+//   ListViewItem type. Here, we want to allow props that are valid on any ListViewItem of type G, even if they are not valid on another. As such, we need convert
+//   the union of all ListViewItem types of type G into an intersection, as to obtain all props for that type.
 
 export const ListView = <T extends {type?: string}, G extends "item" | "gameboard" | "quiz">(props: ListViewProps<T, G>) => {
     const {items, className, type, ...rest} = props;


### PR DESCRIPTION
There were two options on how to implement this:

1. Put the board in the `item` object
    - This allows setting the board on a per-question basis
    - But, `item` is a `ContentSummaryDTO` at the moment, which does not support a board field. We could make `item` extend this and add one, but this is quite ugly. 
    - Also, while per-question boards might be useful, I can't see a case where we would want this *and this information isn't being propagated by the API* (in which case changing `ContentSummaryDTO` itself would be the way to go).

2. Have a board prop on `item` `ListView`s
    - This means all items in the list view are necessarily linked to the same board. 
    - It would, however, be possible to make only questions link to the board, and other things not. My issue with this is that ALVI is supposed to be abstract and not know what type it is; having a type check like this goes against the implementation.
    - Also, having the param on concept/generic pages doesn't do anything *bad*.

~~I've gone with option 2 here, with careful consideration of the `url` param as we do not want to overwrite any existing query parameters or hash anchors.~~

3. The same as 2, but put the prop on `QuestionListViewItem` rather than in the ALVI. This has the advantage of not requiring the ALVI to know about the board param, but does mean we would be duplicating logic if we ever want board params elsewhere.

Implementing 3 exposed a bug in the ALVI type system, which has also been fixed in this PR.