### PR TITLE
fix bug where inequality editor did not work on iOS

### DIFF
--- a/src/app/components/elements/PageMetadata.tsx
+++ b/src/app/components/elements/PageMetadata.tsx
@@ -9,6 +9,7 @@ import { TeacherNotes } from './TeacherNotes';
 import { useLocation } from 'react-router';
 import { SidebarButton } from './SidebarButton';
 import { below, isAda, isPhy, useDeviceSize } from '../../services';
+import type { Location } from 'history';
 
 type PageMetadataProps = {
     doc?: SeguePageDTO;
@@ -27,21 +28,21 @@ type PageMetadataProps = {
     }
 );
 
+const ActionButtons = ({location, isQuestion, doc}: {location: Location, isQuestion: boolean, doc?: SeguePageDTO}) => {
+    return (
+        <div className="d-flex no-print gap-2 ms-auto">
+            {<ShareLink linkUrl={location.pathname + location.hash} clickAwayClose />}
+            <PrintButton questionPage={isQuestion} />
+            {doc?.id && <ReportButton pageId={doc.id} />}
+        </div>
+    );
+};
+
 export const PageMetadata = (props: PageMetadataProps) => {
     const { doc, title, subtitle, badges, children, noTitle, showSidebarButton, sidebarButtonText } = props;
     const isQuestion = doc?.type === "isaacQuestionPage";
     const location = useLocation();
     const deviceSize = useDeviceSize();
-
-    const ActionButtons = () => {
-        return (
-            <div className="d-flex no-print gap-2 ms-auto">
-                {<ShareLink linkUrl={location.pathname + location.hash} clickAwayClose />}
-                <PrintButton questionPage={isQuestion} />
-                {doc?.id && <ReportButton pageId={doc.id} />}
-            </div>
-        );
-    };
 
     return <>
         {noTitle 
@@ -50,7 +51,7 @@ export const PageMetadata = (props: PageMetadataProps) => {
                     <div>
                         {children}
                     </div>
-                    <ActionButtons />
+                    <ActionButtons location={location} isQuestion={isQuestion} doc={doc}/>
                     {isAda && <EditContentButton doc={doc} />}
                 </div>
             </>
@@ -71,7 +72,7 @@ export const PageMetadata = (props: PageMetadataProps) => {
                         {doc?.subtitle && <h5><Markup encoding="latex">{subtitle ?? doc.subtitle}</Markup></h5>}
                     </div>}
                     {isAda && <EditContentButton doc={doc} />}
-                    <ActionButtons />
+                    <ActionButtons location={location} isQuestion={isQuestion} doc={doc}/>
                 </div>
                 {children}
             </>


### PR DESCRIPTION
The editor opened, but the buttons for selecting numbers, symbols, etc. did not do anything. The bug was introduced 4 weeks ago, in commit `096b17867fd49db9fff01aacaf3a3f6ed8272b69`. It only affected iOS devices regardless of viewport size (confirmed on both iPhone and iPad). We've noticed that the `onClick` handlers never fired on `InequalityMenuTabs`. I can't explain very well why this change fixes the bug (maybe something about the nested component didn't properly unregister after re-renders and was somehow interfering with the modal). React's linter rules do state that nested component definitions should be avoided, and even that their use might lead to "unexpected behaviour".
https://eslint-react.xyz/docs/rules/no-nested-component-definitions