### PR TITLE
Fix Ada accordions reloading bug

### DIFF
--- a/src/app/services/navigation.ts
+++ b/src/app/services/navigation.ts
@@ -28,7 +28,6 @@ import {AssignmentDTO, AudienceContext, ContentDTO, GameboardDTO, IsaacTopicSumm
 import {NOT_FOUND_TYPE, PageContextState} from "../../IsaacAppTypes";
 import {skipToken} from "@reduxjs/toolkit/query";
 import {useLocation} from "react-router-dom";
-import {useGetTopicQuery} from "../state";
 
 export interface LinkInfo {title: string; to?: string; replace?: boolean}
 export type CollectionType = "Question deck" | "Quiz" | "Topic" | "Master Mathematics";
@@ -48,9 +47,7 @@ export const useNavigation = (doc: ContentDTO | NOT_FOUND_TYPE | null): PageNavi
     const {board: gameboardId, topic, questionHistory} = useQueryParams(true);
     const currentDocId = doc && doc !== NOT_FOUND ? doc.id as string : "";
     const {data: currentGameboard} = useGetGameboardByIdQuery(gameboardId || skipToken);
-
-    const isNotConceptPage = isDefined(doc) && doc !== NOT_FOUND && doc?.type !== DOCUMENT_TYPE.CONCEPT;
-    const {data: currentTopic} = useGetTopicQuery(isNotConceptPage && topic ? topic : skipToken);
+    const currentTopic = useAppSelector(selectors.topic.currentTopic) ?? undefined;
 
     const user = useAppSelector(selectors.user.orNull);
     const queryArg = user?.loggedIn && isNotPartiallyLoggedIn(user) ? undefined : skipToken;

--- a/src/app/services/navigation.ts
+++ b/src/app/services/navigation.ts
@@ -1,6 +1,6 @@
-import React, {useEffect} from "react";
+import React from "react";
 import queryString from "query-string";
-import {selectors, useAppDispatch, useAppSelector, useGetGameboardByIdQuery, useGetMyAssignmentsQuery} from "../state";
+import {selectors, useAppSelector, useGetGameboardByIdQuery, useGetMyAssignmentsQuery} from "../state";
 import {
     determineCurrentCreationContext,
     determineGameboardHistory,
@@ -14,7 +14,6 @@ import {
     GENERIC_QUESTION_CRUMB,
     HUMAN_STAGES,
     HUMAN_SUBJECTS,
-    isAda,
     isDefined,
     isFullyDefinedContext,
     isFound,
@@ -23,7 +22,6 @@ import {
     isSingleStageContext,
     makeAttemptAtTopicHistory,
     NOT_FOUND, PATHS, siteSpecific,
-    TAG_ID,
     useQueryParams,
 } from "./";
 import {AssignmentDTO, AudienceContext, ContentDTO, GameboardDTO, IsaacTopicSummaryPageDTO} from "../../IsaacApiTypes";
@@ -49,9 +47,10 @@ export const useNavigation = (doc: ContentDTO | NOT_FOUND_TYPE | null): PageNavi
     const {search} = useLocation();
     const {board: gameboardId, topic, questionHistory} = useQueryParams(true);
     const currentDocId = doc && doc !== NOT_FOUND ? doc.id as string : "";
-    const dispatch = useAppDispatch();
     const {data: currentGameboard} = useGetGameboardByIdQuery(gameboardId || skipToken);
-    const {data: currentTopic} = useGetTopicQuery(topic || skipToken);
+
+    const isNotConceptPage = isDefined(doc) && doc !== NOT_FOUND && doc?.type !== DOCUMENT_TYPE.CONCEPT;
+    const {data: currentTopic} = useGetTopicQuery(isNotConceptPage && topic ? topic : skipToken);
 
     const user = useAppSelector(selectors.user.orNull);
     const queryArg = user?.loggedIn && isNotPartiallyLoggedIn(user) ? undefined : skipToken;

--- a/src/app/state/slices/doc.ts
+++ b/src/app/state/slices/doc.ts
@@ -15,10 +15,15 @@ export const docSlice = createSlice({
     name: 'docSlice',
     initialState: null as DocState,
     reducers: {
-        updatePage: (state, action: actionType) => ({
-            ...state,
-            doc: action.payload?.doc ?? null,
-        }),
+        updatePage: (state, action: actionType) => {
+            if (state?.doc === null) {
+                return {
+                    ...state,
+                    doc: action.payload?.doc ?? null,
+                };
+            }
+            return state;
+        },
         resetPage: (state) => ({
             ...state,
             doc: null,

--- a/src/app/state/slices/doc.ts
+++ b/src/app/state/slices/doc.ts
@@ -15,15 +15,10 @@ export const docSlice = createSlice({
     name: 'docSlice',
     initialState: null as DocState,
     reducers: {
-        updatePage: (state, action: actionType) => {
-            if (state?.doc === null) {
-                return {
-                    ...state,
-                    doc: action.payload?.doc ?? null,
-                };
-            }
-            return state;
-        },
+        updatePage: (state, action: actionType) => ({
+            ...state,
+            doc: action.payload?.doc ?? null,
+        }),
         resetPage: (state) => ({
             ...state,
             doc: null,


### PR DESCRIPTION
Fixes a bug on Ada where reloading a concept page causes the accordions' stage labels to disappear.

This bug was introduced by the move to using slices to handle the topic Redux state. When the concept page is reloaded, the current topic is set to the id of the topic overview page. This PR is a workaround to just not attempt to set the current topic on concept pages at all; I don't _think_ this breaks anything else, but if it does then we might need some bigger changes to the way topic state is handled.