### PR TITLE
Add migration warning banner to Isaac Physics

### DIFF
--- a/src/app/components/navigation/IsaacApp.tsx
+++ b/src/app/components/navigation/IsaacApp.tsx
@@ -82,6 +82,7 @@ import {QuestionFinder} from "../pages/QuestionFinder";
 import {SessionCookieExpired} from "../pages/SessionCookieExpired";
 import { AccountDeletion } from '../pages/AccountDeletion';
 import { AccountDeletionSuccess } from '../pages/AccountDeletionSuccess';
+import { IsaacScienceMigrationBanner } from './IsaacScienceMigrationBanner';
 
 const ContentEmails = lazy(() => import('../pages/ContentEmails'));
 const MyProgress = lazy(() => import('../pages/MyProgress'));
@@ -147,6 +148,7 @@ export const IsaacApp = () => {
         <SiteSpecific.Header />
         <Toasts />
         <ActiveModals />
+        <IsaacScienceMigrationBanner />
         <ResearchNotificationBanner />
         <UnsupportedBrowserBanner />
         <DowntimeWarningBanner />

--- a/src/app/components/navigation/IsaacScienceMigrationBanner.tsx
+++ b/src/app/components/navigation/IsaacScienceMigrationBanner.tsx
@@ -5,10 +5,9 @@ import { isPhy } from "../../services";
 export const IsaacScienceMigrationBanner = () => {
     return isPhy ? <Alert color="danger" className="mb-0 border-radius-0 mx-0 no-print" fade={false}>
         <Container className="text-center">
-            On August 11th 2025, all pages on Isaac Physics will redirect to the new <a href="https://isaacscience.org" target="_blank">Isaac Science</a> platform.
-            You can log in with the same account, and all progress, boards and groups have been maintained.
-            You can <a href="https://isaacphysics.org/pages/isaacscience" target="_blank">
-                learn more about these changes here <span className="visually-hidden">(opens in a new tab)</span>
+            On August 11th 2025, all pages on <a href="https://isaacphysics.org" target="_blank">isaacphysics.org</a> will redirect to <a href="https://isaacscience.org" target="_blank">isaacscience.org</a>.
+            Your account and activity will not be changing. You can <a href="https://isaacphysics.org/pages/isaacscience" target="_blank">
+                read more about the move <span className="visually-hidden">to Isaac Science</span> here
             </a>.
         </Container>
     </Alert> : null;

--- a/src/app/components/navigation/IsaacScienceMigrationBanner.tsx
+++ b/src/app/components/navigation/IsaacScienceMigrationBanner.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { Alert, Container } from "reactstrap";
+import { isPhy } from "../../services";
+
+export const IsaacScienceMigrationBanner = () => {
+    return isPhy ? <Alert color="danger" className="mb-0 border-radius-0 mx-0 no-print" fade={false}>
+        <Container className="text-center">
+            On August 11th 2025, all pages on Isaac Physics will redirect to the new <a href="https://isaacscience.org" target="_blank">Isaac Science</a> platform.
+            You can log in with the same account, and all progress, boards and groups have been maintained.
+            You can <a href="https://isaacphysics.org/pages/isaacscience" target="_blank">
+                learn more about these changes here <span className="visually-hidden">(opens in a new tab)</span>
+            </a>.
+        </Container>
+    </Alert> : null;
+};


### PR DESCRIPTION
Adds a non-dismissible warning banner to Isaac Physics regarding the move to Isaac Science