### PR TITLE
log federated sign-in attempts

### DIFF
--- a/src/app/state/actions/index.tsx
+++ b/src/app/state/actions/index.tsx
@@ -67,7 +67,7 @@ export function extractMessage(e: Error) {
     return API_REQUEST_FAILURE_MESSAGE;
 }
 
-export function fetchErrorFromParameters(parameters: string): { error?: string, errorDescription?: string } {
+export function fetchErrorFromParameters(parameters: string): { error?: string, errorDescription?: string, parseError?: string } {
     try {
         const parsed = new URLSearchParams(parameters);
         const [error, errorDescription] = [parsed.get('error'), parsed.get('error_description')];
@@ -75,8 +75,12 @@ export function fetchErrorFromParameters(parameters: string): { error?: string, 
             ...(null !== error && { error }),
             ...(null !== errorDescription && { errorDescription })
         };
-    } catch {
-        return {};
+    } catch (e) {
+        let parseError = `Failed to parse "${parameters}".`;
+        if (e !== null && typeof e === 'object' && 'message' in e) {
+            parseError += ` ${e.message}`;
+        }
+        return { parseError };
     }
 }
 


### PR DESCRIPTION
I'd like to see the drop off rate for sign-in with Microsoft (as well as sign-in with Google, for comparison). I'm worried too many users might be giving up / are unable to use sign-in with Microsoft because of the lack of verification.

I've decided to pool sign-ins from the log-in page as well as attempts at linking an account as `sign-in attempted`, primarily because I couldn't find a way to differentiate between the two sources for the `sign-in failed` event.

For details on viewing results, see the trello card.