### PR TITLE
Markbook: fix test sorting behaviour

### DIFF
--- a/src/app/components/elements/quiz/QuizProgressCommon.tsx
+++ b/src/app/components/elements/quiz/QuizProgressCommon.tsx
@@ -198,9 +198,10 @@ export function ResultsTable<Q extends QuestionType>({
             case "totalQuestionPartPercentage":
                 return -item.correctQuestionPartsCount;
             case "totalQuestionPercentage":
-                return -item.tickCount;
+                return -(item.correctPartResults?.reduce((acc, curr) => acc + curr, 0) || 0);
             case "totalAttemptedQuestionPercentage":
-                return -(item.questionResults || []).filter(r => r !== CompletionState.NOT_ATTEMPTED).length;
+                // note that this one is reversed – there is no negative as we want the ones with the fewest not attempted (i.e. most attempted) to be at the top
+                return item.notAttemptedPartResults?.reduce((acc, curr) => acc + curr, 0) || 0;
             default:
                 if (pageSettings?.attemptedOrCorrect === "CORRECT") {
                     return -(item.correctPartResults || [])[sortOrder];
@@ -215,14 +216,14 @@ export function ResultsTable<Q extends QuestionType>({
             ? [sortBySelectedSortOrder, sortByNotAttemptedParts.bind(null, sortOrder), sortByName]
             : [sortBySelectedSortOrder, sortByName],
         typeof sortOrder === "number" 
-            ? [(reverseOrder ? "desc" : "asc"), "asc", "asc"]
+            ? [(reverseOrder ? "desc" : "asc"), (reverseOrder ? "desc" : "asc"), "asc"]
             : [(reverseOrder ? "desc" : "asc"), "asc"]
     ), [progress, reverseOrder, sortBySelectedSortOrder, sortOrder]);
 
 
     const tableHeaderFooter = <tr className="progress-table-header-footer fw-bold">
         <SortItemHeader<ProgressSortOrder> 
-            className="student-name ps-3 py-3" 
+            className="student-name pointer-cursor ps-3 py-3" 
             defaultOrder={"name"} 
             reverseOrder={"name"} 
             currentOrder={sortOrder} setOrder={toggleSort} reversed={reverseOrder}
@@ -233,7 +234,7 @@ export function ResultsTable<Q extends QuestionType>({
         </SortItemHeader>
         {pageSettings?.attemptedOrCorrect === "CORRECT"
             ? <SortItemHeader<ProgressSortOrder>
-                className="ps-3 wf-10"
+                className="pointer-cursor ps-3 wf-10"
                 defaultOrder={"totalQuestionPercentage"}
                 reverseOrder={"totalQuestionPercentage"}
                 currentOrder={sortOrder} setOrder={toggleSort} reversed={reverseOrder}
@@ -243,7 +244,7 @@ export function ResultsTable<Q extends QuestionType>({
                 Correct
             </SortItemHeader>
             : <SortItemHeader<ProgressSortOrder>
-                className="ps-3 wf-10"
+                className="pointer-cursor ps-3 wf-10"
                 defaultOrder={"totalAttemptedQuestionPercentage"}
                 reverseOrder={"totalAttemptedQuestionPercentage"}
                 currentOrder={sortOrder} setOrder={toggleSort} reversed={reverseOrder}

--- a/src/app/components/pages/quizzes/QuizTeacherFeedback.tsx
+++ b/src/app/components/pages/quizzes/QuizTeacherFeedback.tsx
@@ -227,12 +227,15 @@ export const QuizProgressDetails = ({assignment}: {assignment: QuizAssignmentDTO
             user: user.user as UserSummaryDTO,
             completed: user.feedback?.complete ?? false,
             // a list of the correct parts of an answer, one list for each question
-            correctPartResults: questions.map(q => user.feedback?.questionMarks?.[q?.id ?? 0]?.correct ?? 0),
-            incorrectPartResults: questions.map(q => user.feedback?.questionMarks?.[q?.id ?? 0]?.incorrect ?? 0),
-            notAttemptedPartResults: questions.map(q => user.feedback?.questionMarks?.[q?.id ?? 0]?.notAttempted ?? 0),
+            correctPartResults:      questions.map(q => user.feedback?.questionMarks?.[q?.id ?? 0]?.correct ?? 0),
+            incorrectPartResults:    questions.map(q => user.feedback?.questionMarks?.[q?.id ?? 0]?.incorrect ?? 0),
+            notAttemptedPartResults: user.feedback?.complete || user.feedback?.questionMarks !== undefined
+                ? questions.map(q => user.feedback?.questionMarks?.[q?.id ?? 0]?.notAttempted ?? 0)
+                // if the quiz has not been completed (i.e. submitted), then all parts are not attempted
+                : questions.map(q => q.questionPartsTotal ?? 0),
             questionResults: [],
             tickCount: user.feedback?.questionMarks?.[0]?.correct ?? 0,
-            correctQuestionPartsCount: questions.reduce((acc, q) => acc + (user.feedback?.questionMarks?.[q?.id ?? 0]?.correct ?? 0), 0),
+            correctQuestionPartsCount:   questions.reduce((acc, q) => acc + (user.feedback?.questionMarks?.[q?.id ?? 0]?.correct ?? 0), 0),
             incorrectQuestionPartsCount: questions.reduce((acc, q) => acc + (user.feedback?.questionMarks?.[q?.id ?? 0]?.incorrect ?? 0), 0),
         };
     });


### PR DESCRIPTION
Aligns the sorting of both assignments and tests to use `correctPartResults` and `notAttemptedPartResults`, which are calculated in the frontend for both types. This always ensures consistency between the two and opens the door for further simplification r.e. removing redundant variables (e.g. `tickCount`).