### PR TITLE
Mobile sidebar closing unexpectedly

### DIFF
--- a/src/app/services/pageLoad.ts
+++ b/src/app/services/pageLoad.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { sidebarSlice, useAppDispatch } from "../state";
 import { scrollTopOnPageLoad } from "./scrollManager";
 import { history } from "./";
@@ -9,11 +9,16 @@ export const OnPageLoad = () => {
     const dispatch = useAppDispatch();
     const reducedMotion = useReducedMotion();
     const scrollTop = scrollTopOnPageLoad(reducedMotion);
+    const [loadedPathname, setLoadedPathname] = useState<string | undefined>(undefined);
 
     const onPageLoad = useCallback((location: Location, action: Action) => {
-        dispatch(sidebarSlice.actions.setOpen(false));
-        scrollTop(location, action);
-    }, [dispatch, scrollTop]);
+        if (loadedPathname !== location.pathname) {
+            // this should only run on initial page load or when the pathname changes, not query params or hash changes
+            dispatch(sidebarSlice.actions.setOpen(false));
+            scrollTop(loadedPathname, location.pathname, action);
+            setLoadedPathname(location.pathname);
+        }
+    }, [dispatch, scrollTop, loadedPathname]);
 
     useEffect(() => {
         const unregisterListener = history.listen(onPageLoad);


### PR DESCRIPTION
Restructures the `pageLoad` component to only run changes on initial page load and true path changes, not for query params in e.g. QF. 

This logic already existed in `scrollTop`, so I have mostly just moved this up one layer.