### PR TITLE
Propogate user privilege to inequality modal

### DIFF
--- a/src/app/components/elements/modals/inequality/InequalityModal.tsx
+++ b/src/app/components/elements/modals/inequality/InequalityModal.tsx
@@ -1,8 +1,8 @@
 import React, {FormEvent, useCallback, useContext, useEffect, useLayoutEffect, useMemo, useRef, useState} from "react";
 import {Inequality, WidgetSpec} from "inequality";
 import {
-    isAdminOrEventManager,
     isDefined,
+    isStaff,
     parsePseudoSymbolicAvailableSymbols,
     sanitiseInequalityState, siteSpecific
 } from "../../../../services";
@@ -360,9 +360,7 @@ const InequalityModal = ({availableSymbols, logicSyntax, editorMode, close, onEd
 
     useEffect(() => {
         if (sketch.current) {
-            sketch.current.isUserPrivileged = () => {
-                return isAdminOrEventManager(user);
-            };
+            sketch.current.isUserPrivileged = () => isStaff(user);
         }
     }, [sketch, user]);
 

--- a/src/app/components/elements/modals/inequality/InequalityModal.tsx
+++ b/src/app/components/elements/modals/inequality/InequalityModal.tsx
@@ -1,6 +1,7 @@
 import React, {FormEvent, useCallback, useContext, useEffect, useLayoutEffect, useMemo, useRef, useState} from "react";
 import {Inequality, WidgetSpec} from "inequality";
 import {
+    isAdminOrEventManager,
     isDefined,
     parsePseudoSymbolicAvailableSymbols,
     sanitiseInequalityState, siteSpecific
@@ -18,7 +19,7 @@ import {
     MenuItemProps,
     MenuItems
 } from "./constants";
-import {closeActiveModal, openActiveModal, store, useAppDispatch} from "../../../../state";
+import {closeActiveModal, openActiveModal, selectors, store, useAppDispatch, useAppSelector} from "../../../../state";
 import {PageFragment} from "../../PageFragment";
 import uniq from "lodash/uniq";
 import {
@@ -327,6 +328,8 @@ const InequalityModal = ({availableSymbols, logicSyntax, editorMode, close, onEd
     const [menuOpen, setMenuOpen] = useState<boolean>(false);
     const disableLetters = availableSymbols?.includes("_no_alphabet") ?? false;
 
+    const user = useAppSelector(selectors.user.orNull);
+
     // Setting up the Inequality `sketch` object
     const sketch = useRef<Nullable<Inequality>>(null);
     const [editorState, setEditorState] = useState<any>({});
@@ -354,6 +357,14 @@ const InequalityModal = ({availableSymbols, logicSyntax, editorMode, close, onEd
             }
         };
     }, [onEditorStateChange]);
+
+    useEffect(() => {
+        if (sketch.current) {
+            sketch.current.isUserPrivileged = () => {
+                return isAdminOrEventManager(user);
+            };
+        }
+    }, [sketch, user]);
 
     // Help modal logic
     const dispatch = useAppDispatch();


### PR DESCRIPTION
The `isUserPrivileged` property is intended to be used to inform inequality whether the user is staff or otherwise should have access to certain features and behaviour. Currently, this is only used for overriding `isDetatchable` behaviour (for components like derivatives) that may otherwise be confusing for students to dismantle.

This is **always** enabled for text input (as it may otherwise break things), but had not been propagated for the dragging modal input. This PR enables it for staff.