### PR TITLE
Ada UX: Set assignments modal

### DIFF
--- a/src/app/components/elements/modals/ActiveModal.tsx
+++ b/src/app/components/elements/modals/ActiveModal.tsx
@@ -37,7 +37,7 @@ export const ActiveModal = <T,>({activeModal}: ActiveModalProps<T>) => {
                 (activeModal.title || activeModal.closeAction) &&
                     <ModalHeader
                         data-testid={"modal-header"}
-                        tag={siteSpecific(undefined, "h2")}
+                        tag={siteSpecific(undefined, "h3")}
                         className={classNames({
                             "d-flex justify-content-between": activeModal.closeAction,
                             "h-title": !!activeModal.title && isAda,

--- a/src/app/components/pages/SetAssignments.tsx
+++ b/src/app/components/pages/SetAssignments.tsx
@@ -199,7 +199,7 @@ export const SetAssignmentsModal = (props: SetAssignmentsModalProps): ActiveModa
     return {
         closeAction: toggle,
         size: "md",
-        title: board?.title,
+        title: `Assign "${board?.title}"`,
         body: <>
             <p className="px-1">{description}</p>
             <hr className="text-center"/>

--- a/src/scss/common/modals.scss
+++ b/src/scss/common/modals.scss
@@ -12,7 +12,7 @@
   box-shadow: 0px 0px 20px 3px rgba(0,0,0,0.2);
 
   .modal-header {
-    padding-left: 1.875rem;
+    padding-right: 1.75rem;
 
     button {
       &.close {

--- a/src/scss/cs/isaac.scss
+++ b/src/scss/cs/isaac.scss
@@ -365,7 +365,6 @@ $accordion-border-radius: 1rem;
 // Atoms
 @import "fonts";
 @import "typography";
-@import "../common/modals";
 @import "modals";
 @import "page-title";
 @import "questions";

--- a/src/scss/cs/modals.scss
+++ b/src/scss/cs/modals.scss
@@ -1,3 +1,5 @@
+@import "../common/modals";
+
 .modal-content {
   // todo: input styling on Ada CS is a bit of a mess at the moment - we should fix this everywhere, at which point this can go.
   & .form-control{
@@ -5,6 +7,10 @@
     border-radius: 10px !important;
     border: solid 2px #666;
     padding: 12px;
+  }
+
+  .modal-header {
+    padding-right: 1.75rem;
   }
 }
 

--- a/src/scss/phy/isaac.scss
+++ b/src/scss/phy/isaac.scss
@@ -369,7 +369,7 @@ $theme-colors-border-subtle: map-merge($theme-colors-border-subtle, $custom-colo
 @import "sidebar";
 @import "table";
 @import "../common/headings";
-@import "../common/modals";
+@import "modals";
 @import "forms";
 @import "elements";
 @import "breadcrumbs";

--- a/src/scss/phy/modals.scss
+++ b/src/scss/phy/modals.scss
@@ -1,0 +1,7 @@
+@import "../common/modals";
+
+.modal-content {
+  .modal-header {
+    padding-left: 1.75rem;
+  }
+}

--- a/src/test/pages/SetAssignments.test.tsx
+++ b/src/test/pages/SetAssignments.test.tsx
@@ -176,7 +176,7 @@ describe("SetAssignments", () => {
 
         // Wait for modal to appear, for the gameboard we expect
         const modal = await screen.findByTestId("active-modal");
-        expect(modal).toHaveModalTitle(mockGameboard.title);
+        expect(modal).toHaveModalTitle(`Assign "${mockGameboard.title}"`);
         // Ensure all active groups are selectable in the drop-down
         const groupSelector = await toggleGroupSelect();
         mockActiveGroups.forEach(g => {


### PR DESCRIPTION
Adjusts title of Set Assignments modal to create a clearer user flow when creating then setting an assignment. Also slightly modifies the spacing around ActiveModals (Phy+Ada) to better meet designs and center content.