### PR TITLE
Allow empty audience views to be displayed on the question builder modal

### DIFF
--- a/src/app/components/elements/GameboardBuilderRow.tsx
+++ b/src/app/components/elements/GameboardBuilderRow.tsx
@@ -58,7 +58,7 @@ const GameboardBuilderRow = (
     };
 
     const audienceViews = determineAudienceViews(question.audience, creationContext);
-    const filteredAudienceViews = filterAudienceViewsByProperties(audienceViews, AUDIENCE_DISPLAY_FIELDS);
+    const filteredAudienceViews = audienceViews.length === 0 ? [{stage: undefined, difficulty: undefined}] : filterAudienceViewsByProperties(audienceViews, AUDIENCE_DISPLAY_FIELDS);
 
     const cellClasses = "text-start align-middle";
     const isSelected = question.id !== undefined && currentQuestions.selectedQuestions.has(question.id);

--- a/src/app/components/elements/GameboardBuilderRow.tsx
+++ b/src/app/components/elements/GameboardBuilderRow.tsx
@@ -1,4 +1,3 @@
-import classnames from "classnames";
 import {
     tags,
     AUDIENCE_DISPLAY_FIELDS,
@@ -42,10 +41,6 @@ const GameboardBuilderRow = (
 ) => {
     const dispatch = useAppDispatch();
 
-    const topicTag = () => {
-        const tag = question.tags && tags.getSpecifiedTag(TAG_LEVEL.topic, question.tags as TAG_ID[]);
-        return tag && tag.title;
-    };
     const tagIcon = (tag: string) => {
         return <span key={tag} className={classNames("badge rounded-pill mx-1", siteSpecific("text-bg-warning", "text-bg-primary"))}>{tag}</span>;
     };
@@ -83,9 +78,7 @@ const GameboardBuilderRow = (
         }
     };
 
-    return filteredAudienceViews.map((view, i, arr) => <tr
-        key={`${question.id} ${i}`}
-    >
+    return filteredAudienceViews.map((view, i, arr) => <tr key={`${question.id} ${i}`}>
         {i === 0 && <>
             <td rowSpan={arr.length} className="w-5 text-center align-middle">
                 <div className="d-flex justify-content-center">
@@ -143,17 +136,15 @@ const GameboardBuilderRow = (
                 </div>
             </td>
             <td rowSpan={arr.length} className={classNames(cellClasses, siteSpecific("w-25", "w-20"))}>
-                {topicTag()}
+                {tags.getSpecifiedTag(TAG_LEVEL.topic, question.tags as TAG_ID[])?.title}
             </td>
         </>}
         <td className={classNames(cellClasses, "w-15")}>
             {view.stage && <span>{stageLabelMap[view.stage]}</span>}
         </td>
-        {(isPhy || i === 0) && <td rowSpan={siteSpecific(1, arr.length)} className={classNames(cellClasses, "w-15")}>
+        {(isPhy || (isAda && i === 0)) && <td rowSpan={siteSpecific(1, arr.length)} className={classNames(cellClasses, "w-15")}> 
             {/* Show each difficulty icon for Physics or just the first one for Ada */}
-            <div>
-                {view.difficulty && <DifficultyIcons difficulty={view.difficulty} />}
-            </div>
+            {view.difficulty && <DifficultyIcons difficulty={view.difficulty} />}
         </td>}
         {isAda && <td className={classNames(cellClasses, "w-15")}>
             {audienceViews.filter(audienceView => view.stage === audienceView.stage)

--- a/src/app/components/elements/modals/QuestionSearchModal.tsx
+++ b/src/app/components/elements/modals/QuestionSearchModal.tsx
@@ -171,7 +171,7 @@ export const QuestionSearchModal = (
 
     const addSelectionsRow = <div className="d-sm-flex flex-xl-column align-items-center">
         <div className="flex-grow-1 mb-1">
-            <strong className={selectedQuestions.size > 10 ? "text-danger" : ""}>
+            <strong className={classNames({"text-danger": selectedQuestions.size > 10})}>
                 {`${selectedQuestions.size} question${selectedQuestions.size !== 1 ? "s" : ""} selected`}
             </strong>
         </div>
@@ -245,7 +245,7 @@ export const QuestionSearchModal = (
                             inputId: "question-search-topic", tier: 0, index: TAG_LEVEL.subject,
                             choices: topicChoices, selections: topicSelections, setSelections: setTopicSelections}}/>
                     </div>}
-                    <div className={`mb-2 ${isBookSearch ? "d-none" : ""}`}>
+                    <div className={classNames("mb-2", {"d-none": isBookSearch})}>
                         <Label htmlFor="question-search-difficulty">Difficulty</Label>
                         <StyledSelect
                             inputId="question-search-difficulty" isClearable isMulti placeholder="Any" {...selectStyle}

--- a/src/app/components/elements/modals/QuestionSearchModal.tsx
+++ b/src/app/components/elements/modals/QuestionSearchModal.tsx
@@ -169,7 +169,7 @@ export const QuestionSearchModal = (
         );
     }, [questions, user, searchTopics, isBookSearch, questionsSort, creationContext]);
 
-    const addSelectionsRow = <div className="d-sm-flex flex-xl-column align-items-center">
+    const addSelectionsRow = <div className="d-sm-flex flex-xl-column align-items-center mt-2">
         <div className="flex-grow-1 mb-1">
             <strong className={classNames({"text-danger": selectedQuestions.size > 10})}>
                 {`${selectedQuestions.size} question${selectedQuestions.size !== 1 ? "s" : ""} selected`}
@@ -252,7 +252,7 @@ export const QuestionSearchModal = (
                             options={DIFFICULTY_ICON_ITEM_OPTIONS} onChange={selectOnChange(setSearchDifficulties, true)}
                         />
                         {isAda && <>
-                            <Label htmlFor="question-search-exam-board">Exam Board</Label>
+                            <Label className="mt-2" htmlFor="question-search-exam-board">Exam Board</Label>
                             <StyledSelect
                                 inputId="question-search-exam-board" isClearable isMulti placeholder="Any" {...selectStyle}
                                 value={getFilteredExamBoardOptions({byStages: searchStages}).filter(o => searchExamBoards.includes(o.value))}
@@ -262,7 +262,7 @@ export const QuestionSearchModal = (
                         </>}
                     </div>
                     <Label htmlFor="question-search-title">Search</Label>
-                    <Input id="question-search-title" className="mb-2"
+                    <Input id="question-search-title" className="mb-3"
                         type="text"
                         placeholder={siteSpecific("e.g. Man vs. Horse", "e.g. Creating an AST")}
                         onChange={(e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
The main change here is just the first commit, converting the `[]` to a `[{stage: undefined, difficulty: undefined}] AudienceContext[]`.

The rest of this is some mild cleanup, including using `classNames` where appropriate and adding some vertical spacing to the gameboard builder filters - particularly for Ada. These aren't important, so if there are any problems with them I'm happy to abandon them.