### PR TITLE
Use only defined `progress` child to calculate length

### DIFF
--- a/src/app/components/elements/quiz/QuizProgressCommon.tsx
+++ b/src/app/components/elements/quiz/QuizProgressCommon.tsx
@@ -453,7 +453,7 @@ export function ResultsTablePartBreakdown({
         [(reverseOrder ? "desc" : "asc"), "asc"]
     ), [progress, reverseOrder, sortBySelectedSortOrder]);
 
-    const classAverages = sortedProgress[0]?.questionPartResults?.[questionIndex]?.map((_, i) => {
+    const classAverages = sortedProgress.find(p => !!p.questionPartResults)?.questionPartResults?.[questionIndex]?.map((_, i) => {
         const totalCorrect = sortedProgress.reduce((acc, p) => acc + (p.questionPartResults?.[questionIndex][i] === "CORRECT" ? 1 : 0), 0);
         const total = sortedProgress.length;
         return [totalCorrect, total] as [number, number];
@@ -471,7 +471,7 @@ export function ResultsTablePartBreakdown({
                     >
                         Name
                     </SortItemHeader>
-                    {sortedProgress[0].questionPartResults?.[questionIndex]?.map((_, i) =>
+                    {sortedProgress.find(p => !!p.questionPartResults)?.questionPartResults?.[questionIndex]?.map((_, i) =>
                         // <th key={i} className="text-center">
                         <SortItemHeader<ProgressSortOrder>
                             defaultOrder={i}


### PR DESCRIPTION
We previously used the first child (user) in `progress` to calculate its internal structure, but if this user has revoked progress the properties we care about are all `null`. This changes the calculation to find and use the first non-null entry, using the "no users" path if none are found.