### PR TITLE
2nd edition maths book

### DIFF
--- a/src/app/components/elements/modals/IsaacBooksModal.tsx
+++ b/src/app/components/elements/modals/IsaacBooksModal.tsx
@@ -1,14 +1,14 @@
-import {closeActiveModal, store, useAppDispatch} from "../../../state";
+import { closeActiveModal, store, useAppDispatch } from "../../../state";
 import React from "react";
-import {Col, Row} from "reactstrap";
-import {Link} from "react-router-dom";
-import { ISAAC_BOOKS, BookInfo } from "../../../services";
+import { Col, Row } from "reactstrap";
+import { Link } from "react-router-dom";
+import { BookHiddenState, BookInfo, ISAAC_BOOKS } from "../../../services";
 
 export const BookModalBody = () => {
     const dispatch = useAppDispatch();
 
     return <Row className={"pb-2 justify-content-center"}>
-        {ISAAC_BOOKS.map((book: BookInfo) => <Col key={book.title} className="mb-3" lg={3} sm={6}>
+        {ISAAC_BOOKS.filter((book: BookInfo) => book.hidden !== BookHiddenState.HIDDEN).map((book: BookInfo) => <Col key={book.title} className="mb-3" lg={3} sm={6}>
             <Link className={"text-center w-100"} onClick={() => dispatch(closeActiveModal())} to={book.path}>
                 <img className="ms-auto me-auto book-cover-small" src={book.image} alt="" />
                 <span>{book.title}</span>

--- a/src/app/components/pages/MyProgress.tsx
+++ b/src/app/components/pages/MyProgress.tsx
@@ -48,7 +48,7 @@ const siteSpecificStats: {questionCountByBookTag: {[bookTag in keyof typeof ISAA
             "physics_linking_concepts": 258,
             "maths_book_gcse": 639,
             "maths_book": 432,
-            "maths_book_2e": 485,
+            "maths_book_2e": 490,
             "chemistry_16": 338
         },
     },

--- a/src/app/components/pages/MyProgress.tsx
+++ b/src/app/components/pages/MyProgress.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef, useState} from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
     getMyAnsweredQuestionsByDate,
     getMyProgress,
@@ -8,38 +8,39 @@ import {
     useAppDispatch,
     useAppSelector
 } from "../../state";
-import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
-import {Card, CardBody, Col, Container, Row} from "reactstrap";
+import { TitleAndBreadcrumb } from "../elements/TitleAndBreadcrumb";
+import { Card, CardBody, Col, Container, Row } from "reactstrap";
 import {
     below,
-    HUMAN_QUESTION_TAGS,
+    BookHiddenState,
     HUMAN_QUESTION_TYPES,
+    ISAAC_BOOKS_BY_TAG,
     isPhy,
     isTeacherOrAbove,
     safePercentage,
     siteSpecific,
     useDeviceSize
 } from "../../services";
-import {RouteComponentProps, withRouter} from "react-router-dom";
-import {PotentialUser} from "../../../IsaacAppTypes";
-import {Unauthorised} from "./Unauthorised";
-import {AggregateQuestionStats} from "../elements/panels/AggregateQuestionStats";
-import {StreakPanel} from "../elements/panels/StreakPanel";
-import {Tabs} from "../elements/Tabs";
-import {FlushableRef, QuestionProgressCharts} from "../elements/views/QuestionProgressCharts";
-import {ActivityGraph} from "../elements/views/ActivityGraph";
-import {ProgressBar} from "../elements/views/ProgressBar";
-import {ContentTypeVisibility, LinkToContentSummaryList} from "../elements/list-groups/ContentSummaryListGroupItem";
+import { RouteComponentProps, withRouter } from "react-router-dom";
+import { PotentialUser } from "../../../IsaacAppTypes";
+import { Unauthorised } from "./Unauthorised";
+import { AggregateQuestionStats } from "../elements/panels/AggregateQuestionStats";
+import { StreakPanel } from "../elements/panels/StreakPanel";
+import { Tabs } from "../elements/Tabs";
+import { FlushableRef, QuestionProgressCharts } from "../elements/views/QuestionProgressCharts";
+import { ActivityGraph } from "../elements/views/ActivityGraph";
+import { ProgressBar } from "../elements/views/ProgressBar";
+import { ContentTypeVisibility, LinkToContentSummaryList } from "../elements/list-groups/ContentSummaryListGroupItem";
 import { ListView } from '../elements/list-groups/ListView';
 
-const siteSpecificStats = siteSpecific(
+const siteSpecificStats: {questionCountByBookTag: {[bookTag in keyof typeof ISAAC_BOOKS_BY_TAG]?: number}, questionTypeStatsList: string[]} = siteSpecific(
     // Physics
     {
         questionTypeStatsList: [
             "isaacMultiChoiceQuestion", "isaacNumericQuestion", "isaacSymbolicQuestion", "isaacSymbolicChemistryQuestion",
             "isaacClozeQuestion", "isaacReorderQuestion"
         ],
-        questionCountByTag: {
+        questionCountByBookTag: {
             "phys_book_step_up": 432,
             "phys_book_gcse": 534,
             "physics_skills_14": 75,
@@ -47,6 +48,7 @@ const siteSpecificStats = siteSpecific(
             "physics_linking_concepts": 258,
             "maths_book_gcse": 639,
             "maths_book": 432,
+            "maths_book_2e": 485,
             "chemistry_16": 338
         },
     },
@@ -56,7 +58,7 @@ const siteSpecificStats = siteSpecific(
             "isaacMultiChoiceQuestion", "isaacItemQuestion", "isaacParsonsQuestion", "isaacNumericQuestion",
             "isaacStringMatchQuestion", "isaacFreeTextQuestion", "isaacLLMFreeTextQuestion", "isaacSymbolicLogicQuestion", "isaacClozeQuestion"
         ],
-        questionCountByTag: {},
+        questionCountByBookTag: {},
     }
 );
 
@@ -155,17 +157,19 @@ const MyProgress = withRouter((props: MyProgressProps) => {
                         <h4>Isaac Books</h4>
                         Questions completed correctly, against questions attempted for each of our <a href={"/books"}>books</a>.
                         <Row>
-                            {Object.entries(siteSpecificStats.questionCountByTag).map(([qType, total]) => {
-                                const correct = Math.min(progress?.correctByTag?.[qType] || 0, total);
-                                const attempted = Math.min(progress?.attemptsByTag?.[qType] || 0, total);
+                            {Object.entries(siteSpecificStats.questionCountByBookTag).map(([bookTag, total]) => {
+                                const book = ISAAC_BOOKS_BY_TAG[bookTag as keyof typeof ISAAC_BOOKS_BY_TAG];
+                                const correct = Math.min(progress?.correctByTag?.[bookTag] || 0, total);
+                                const attempted = Math.min(progress?.attemptsByTag?.[bookTag] || 0, total);
                                 const correctPercentage = safePercentage(correct, total) || 0;
                                 const attemptedPercentage = safePercentage(attempted, total) || 0;
-                                return total > 0 && <Col key={qType} lg={12} className="mt-2 type-progress-bar">
+                                const showBook = !!book && total > 0 && (attempted > 0 || book.hidden !== BookHiddenState.HIDDEN);
+                                return showBook &&  <Col key={bookTag} lg={12} className="mt-2 type-progress-bar">
                                     <div className={"px-2"}>
-                                        {HUMAN_QUESTION_TAGS.get(qType)} questions
+                                        {book.title} questions
                                     </div>
                                     <div className={"px-2"}>
-                                        <ProgressBar percentage={correctPercentage} primaryTitle={`${correct} correct out of ${total}`} secondaryPercentage={attemptedPercentage} secondaryTitle={`${attempted} attempted out of ${total}`} type={qType}>
+                                        <ProgressBar percentage={correctPercentage} primaryTitle={`${correct} correct out of ${total}`} secondaryPercentage={attemptedPercentage} secondaryTitle={`${attempted} attempted out of ${total}`} type={bookTag}>
                                             <span aria-hidden>{`${correct} of ${total}`}</span>
                                         </ProgressBar>
                                     </div>

--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -506,7 +506,7 @@ export const PHY_NAV_STAGES = Object.values(LEARNING_STAGE).reduce((acc, stage) 
     return acc;
 }, {} as {[stage in LEARNING_STAGE]: Exclude<SUBJECTS, SUBJECTS.CS>[]});
 
-type BookTag = "phys_book_step_into" | "phys_book_step_up" | "phys_book_gcse" | "physics_skills_19" | "solving_physics_problems" | "physics_linking_concepts" | "qmp" | "maths_book_gcse" | "maths_book_2e" | "maths_book" | "chemistry_16";
+type BookTag = "phys_book_step_into" | "phys_book_step_up" | "phys_book_gcse" | "physics_skills_14" | "physics_skills_19" | "solving_physics_problems" | "physics_linking_concepts" | "qmp" | "maths_book_gcse" | "maths_book_2e" | "maths_book" | "chemistry_16";
 export enum BookHiddenState {
     BOOKS_LISTING_ONLY = "books_listing_only",
     HIDDEN = "hidden"
@@ -556,6 +556,13 @@ export const ISAAC_BOOKS: BookInfo[] = siteSpecific(
             description: "Covers core topics in A level, IB, and equivalent. Helps students practise applying the concepts of A-level Physics and apply them to solve numerical problems.",
         },
         {
+            title: "Essential Pre-University Physics (2nd Edition)", tag: "physics_skills_14",
+            shortTitle: "A Level Physics (2nd edition)", image: "/assets/phy/books/physics_skills_14.jpg",
+            path: "/books/physics_skills_14", subject: "physics", stages: ["a_level"],
+            description: "Covers core topics in A level, IB, and equivalent. Helps students practise applying the concepts of A-level Physics and apply them to solve numerical problems.",
+            hidden: BookHiddenState.HIDDEN,
+        },
+        {
             title: "Pre-University Mathematics for Sciences (2nd edition)", tag: "maths_book_2e",
             shortTitle: "Pre-Uni Maths (2nd edition)", image: "/assets/phy/books/2025_pre_uni_maths_2e.png",
             path: "/books/pre_uni_maths_2e", subject: "maths", stages: ["a_level", "university"],
@@ -565,6 +572,7 @@ export const ISAAC_BOOKS: BookInfo[] = siteSpecific(
             title: "Pre-University Mathematics for Sciences (1st edition)", tag: "maths_book",
             shortTitle: "Pre-Uni Maths (1st edition)", image: "/assets/phy/books/pre_uni_maths.jpg",
             path: "/books/pre_uni_maths", subject: "maths", stages: ["a_level", "university"],
+            description: "Provides questions on mathematical topics that underpin all the sciences, as well as giving practice and fluency for Maths and Further Maths A-levels themselves.",
             hidden: BookHiddenState.HIDDEN,
         },
         {

--- a/src/app/services/questions.ts
+++ b/src/app/services/questions.ts
@@ -65,18 +65,6 @@ export function isQuestion(doc: ContentDTO) {
     return doc.type ? doc.type in QUESTION_TYPES : false;
 }
 
-export const HUMAN_QUESTION_TAGS = new Map([
-    ["phys_book_step_up", "Step Up to GCSE Physics"],
-    ["phys_book_gcse", "Mastering Essential GCSE Physics"],
-    ["physics_skills_14", "Mastering Essential Pre-University Physics (2nd Edition)"],
-    ["physics_skills_19", "Mastering Essential Pre-University Physics (3rd Edition)"],
-    ["physics_linking_concepts", "Linking Concepts in Pre-University Physics"],
-    ["maths_book_gcse", "Using Essential GCSE Mathematics"],
-    ["maths_book", "Pre-University Mathematics for Sciences (1st edition)"],
-    ["maths_book_2e", "Pre-University Mathematics for Sciences (2nd edition)"],
-    ["chemistry_16", "Mastering Essential Pre-University Physical Chemistry"]
-]);
-
 export function selectQuestionPart(questions?: AppQuestionDTO[], questionPartId?: string) {
     return questions?.filter(question => question.id == questionPartId)[0];
 }
@@ -199,7 +187,7 @@ export const submitCurrentAttempt = (questionPart: AppQuestionDTO | undefined, d
                 redirectOnSuccess: false
             }));
         }
-        
+
         return attempt;
     }
     return Promise.resolve();


### PR DESCRIPTION
Add the 2nd Edition of the A-Level maths book to My Progress. Also make book titles consistent on this page.

Remove the 1st Edition from the books modal when adding new boards from books. This is so that the Physics Skills 14 book can also be added to the main books list (so that all book data is in one place and consistent titles are used) but be hidden from view everywhere.