### PR TITLE
Display question metadata in a one-line view while printing

### DIFF
--- a/src/app/components/pages/Question.tsx
+++ b/src/app/components/pages/Question.tsx
@@ -105,7 +105,7 @@ const QuestionMetaData = (props: QuestionMetaDataProps) => {
         {/* One-line version of the question metadata, only used for printing */}
         <div className="only-print">
             <div className="d-flex my-2">
-                <span className="me-2 fw-bold">Topic:</span>
+                <span className="me-2 fw-bold">Subject & topics:</span>
                 <div>
                     {getTags(doc.tags).map((tag, index, arr) => <>
                         <span key={tag.title}> {tag.title} </span>


### PR DESCRIPTION
In order to make this consistently fit onto one line, some of the metadata is written in shorthand, i.e. "Subjects & topics" -> "Topic", "All Attempted (some errors)" -> "All attempted", and the difficulties to their existing short labels such as "Practice 3" -> "P3". Arguably we wouldn't need this if we didn't display Status (as it doesn't seem too necessary for this use-case), but the request for this change still mentions it so I'll keep it around for now.

After some searching, the longest metadata I can find for a question is [Finding Currents in Many Branches](http://localhost:8004/questions/itsp24_current_class_q8) with a status of _**All Attempted (some errors)**_ and that still fits onto the printed page with a few characters leeway, so I'm fairly confident this covers everything.