### PR TITLE
Add Suspense to lazy loaded codeSnippet

### DIFF
--- a/src/app/components/content/IsaacContent.tsx
+++ b/src/app/components/content/IsaacContent.tsx
@@ -1,4 +1,4 @@
-import React, {lazy} from "react";
+import React, {lazy, Suspense} from "react";
 import {AnvilApp} from "./AnvilApp";
 import {IsaacContentValueOrChildren} from "./IsaacContentValueOrChildren";
 import {IsaacQuestion} from "./IsaacQuestion";
@@ -74,7 +74,8 @@ export const IsaacContent = withRouter((props: IsaacContentProps) => {
             case "figure": selectedComponent = <IsaacFigure {...keyedProps} />; break;
             case "image": selectedComponent = <IsaacImage {...keyedProps} />; break;
             case "video": selectedComponent = <IsaacVideo {...keyedProps} />; break;
-            case "codeSnippet": selectedComponent = <IsaacCodeSnippet {...keyedProps} />; break;
+            // IsaacCodeSnippet is lazy loaded, so wrap it in Suspense to prevent reload errors
+            case "codeSnippet": selectedComponent = <Suspense fallback={<div>Loading...</div>}> <IsaacCodeSnippet {...keyedProps} /> </Suspense>; break;
             case "interactiveCodeSnippet": selectedComponent = <IsaacInteractiveCodeSnippet {...keyedProps} />; break;
             case "glossaryTerm": selectedComponent = <IsaacGlossaryTerm {...keyedProps} />; break;
             case "isaacFeaturedProfile": selectedComponent = <IsaacFeaturedProfile {...keyedProps} />; break;


### PR DESCRIPTION
IsaacCodeSnippet is lazy loaded [in order to](https://github.com/isaacphysics/isaac-react-app/commit/87350c86b809e3705b7125c6eb61b3518ad5e505) prevent highlightjs being added to the webpack when unneeded, particularly for Sci. This has meant that to display a code snippet beyond the page's initial load (e.g. in hints), the page had to reload so the component can be loaded. This was also causing the preview renderer to crash.

Wrapping this in a Suspense means only the component itself needs to reload, which is safer behaviour for consistent page state.