### PR TITLE
Maintain Set Assignments filter state under bf navigation

### DIFF
--- a/src/app/components/pages/MyGameboards.tsx
+++ b/src/app/components/pages/MyGameboards.tsx
@@ -28,6 +28,7 @@ import { GameboardsCards, GameboardsCardsProps, GameboardsTable, GameboardsTable
 import classNames from "classnames";
 import { MainContent, MyGameboardsSidebar, SidebarLayout } from "../elements/layout/SidebarLayout";
 import { PageMetadata } from "../elements/PageMetadata";
+import { useHistoryState } from "../../state/actions/history";
 
 export interface GameboardsDisplaySettingsProps {
     boardView: BoardViews,
@@ -121,8 +122,8 @@ export const MyGameboards = () => {
     const user = useAppSelector(selectors.user.orNull) as RegisteredUserDTO;
 
     const [selectedBoards, setSelectedBoards] = useState<GameboardDTO[]>([]);
-    const [boardCreator, setBoardCreator] = useState<BoardCreators>(BoardCreators.all);
-    const [boardCompletion, setBoardCompletion] = useState<BoardCompletions>(BoardCompletions.any);
+    const [boardCreator, setBoardCreator] = useHistoryState<BoardCreators>("boardCreator", BoardCreators.all);
+    const [boardCompletion, setBoardCompletion] = useHistoryState<BoardCompletions>("boardCompletion", BoardCompletions.any);
     const [inProgress, setInProgress] = useState(0);
     const [notStarted, setNotStarted] = useState(0);
     const [showFilters, setShowFilters] = useState(false);

--- a/src/app/components/pages/SetAssignments.tsx
+++ b/src/app/components/pages/SetAssignments.tsx
@@ -123,35 +123,7 @@ const PhyTable = (props: SetAssignmentsTableProps) => {
 
     return <Card className="mt-2 mb-7">
         <CardBody id="boards-table">
-            <Row>
-                <Col lg={4}>
-                    <Label className="w-100">
-                        Filter decks <Input type="text"
-                            onChange={e => setBoardTitleFilter(e.target.value)}
-                            placeholder="Filter decks by name"/>
-                    </Label>
-                </Col>
-                <Col sm={6} lg={2}>
-                    <Label className="w-100">
-                        Subject <Input type="select" value={boardSubject}
-                            onChange={e => setBoardSubject(e.target.value as BoardSubjects)}>
-                            {Object.values(BoardSubjects).map(subject => <option key={subject}
-                                value={subject}>{subject}</option>)}
-                        </Input>
-                    </Label>
-                </Col>
-                <Col lg={2}>
-                    <Label className="w-100">
-                        Creator <Input type="select" value={boardCreator}
-                            onChange={e => setBoardCreator(e.target.value as BoardCreators)}>
-                            {Object.values(BoardCreators).map(creator => <option key={creator}
-                                value={creator}>{creator}</option>)}
-                        </Input>
-                    </Label>
-                </Col>
-            </Row>
-
-            <HorizontalScroller enabled={filteredBoards ? filteredBoards.length > 6 : false} className="mt-3">
+            <HorizontalScroller enabled={filteredBoards ? filteredBoards.length > 6 : false}>
                 <Table className="mb-0">
                     <thead>
                         {tableHeader}

--- a/src/app/components/pages/SetAssignments.tsx
+++ b/src/app/components/pages/SetAssignments.tsx
@@ -60,6 +60,7 @@ import {PromptBanner} from "../elements/cards/PromptBanner";
 import { PageMetadata } from "../elements/PageMetadata";
 import { SetAssignmentsModal } from "../elements/modals/SetAssignmentsModal";
 import { PageFragment } from "../elements/PageFragment";
+import { useHistoryState } from "../../state/actions/history";
 
 interface SetAssignmentsTableProps {
     user: RegisteredUserDTO;
@@ -313,8 +314,8 @@ export const SetAssignments = () => {
     const {data: assignmentsSetByMe} = useGetMySetAssignmentsQuery(undefined);
     const groupsByGameboard = useMemo(() => getAssigneesByBoard(assignmentsSetByMe), [assignmentsSetByMe]);
 
-    const [boardCreator, setBoardCreator] = useState<BoardCreators>(BoardCreators.all);
-    const [boardSubject, setBoardSubject] = useState<BoardSubjects>(BoardSubjects.all);
+    const [boardCreator, setBoardCreator] = useHistoryState<BoardCreators>("boardCreator", BoardCreators.all);
+    const [boardSubject, setBoardSubject] = useHistoryState<BoardSubjects>("boardSubject", BoardSubjects.all);
 
     const deviceSize = useDeviceSize();
     const {

--- a/src/app/services/gameboards.tsx
+++ b/src/app/services/gameboards.tsx
@@ -20,6 +20,7 @@ import {
     useAppSelector,
     useLazyGetGameboardsQuery
 } from "../state";
+import { useHistoryState } from "../state/actions/history";
 
 export enum BoardCompletions {
     "any" = "Any",
@@ -235,10 +236,10 @@ export const useGameboards = (initialView: BoardViews, initialLimit: BoardLimit)
     const [ loadGameboards ] = useLazyGetGameboardsQuery();
     const boards = useAppSelector(selectors.boards.boards);
 
-    const [boardOrder, setBoardOrder] = useState<AssignmentBoardOrder>(AssignmentBoardOrder.visited);
-    const [boardView, setBoardView] = useState<BoardViews>((boards && boards.boards.length > 6) ? BoardViews.table : initialView);
-    const [boardLimit, setBoardLimit] = useState<BoardLimit>(initialLimit);
-    const [boardTitleFilter, setBoardTitleFilter] = useState<string>("");
+    const [boardOrder, setBoardOrder] = useHistoryState<AssignmentBoardOrder>("boardOrder", AssignmentBoardOrder.visited);
+    const [boardView, setBoardView] = useHistoryState<BoardViews>("boardView", (boards && boards.boards.length > 6) ? BoardViews.table : initialView);
+    const [boardLimit, setBoardLimit] = useHistoryState<BoardLimit>("boardLimit", initialLimit);
+    const [boardTitleFilter, setBoardTitleFilter] = useHistoryState<string>("boardTitle", "");
 
     const [loading, setLoading] = useState(false);
 


### PR DESCRIPTION
I have an outstanding question as to "where else should this functionality be used?", but for now since the request was only for the Set Assignments page, only this (and the related Gameboards page, which uses the same `useGameboards` hook) has been modified.

There is also a small change here to remove the duplicated filters in Set Assignments' Table View; these are in the sidebar already for Sci.