### PR TITLE
Add part totals to markbook

### DIFF
--- a/src/IsaacAppTypes.tsx
+++ b/src/IsaacAppTypes.tsx
@@ -333,7 +333,7 @@ export interface ActiveModalWithoutState {
     bodyContainerClassName?: string;
 }
 
-export type ProgressSortOrder = number | "name" | "totalQuestionPartPercentage" | "totalQuestionPercentage" | "totalAttemptedQuestionPercentage";
+export type ProgressSortOrder = number | "name" | "totalPartPercentage" | "totalAttemptedPartPercentage" | "totalQuestionPercentage" | "totalAttemptedQuestionPercentage";
 
 export enum QuizzesBoardOrder {
     "title" = "title",

--- a/src/app/components/elements/CollapsibleContainer.tsx
+++ b/src/app/components/elements/CollapsibleContainer.tsx
@@ -12,10 +12,18 @@ export const CollapsibleContainer = (props: CollapsibleContainerProps) => {
     const divRef = useRef<HTMLDivElement>(null);
 
     useLayoutEffect(() => {
+        // see CollapsibleList for explanation of this logic
         if (expanded) {
-            setExpandedHeight(divRef?.current ? [...divRef.current.children].map(c => 
-                c.getAttribute("data-targetheight") ? parseInt(c.getAttribute("data-targetheight") as string) : c.clientHeight
-            ).reduce((a, b) => a + b, 0) : 0);
+            const containerHeight = divRef?.current 
+                ? Math.max([...divRef.current.children].map(c => c.getAttribute("data-targetheight") 
+                    ? parseInt(c.getAttribute("data-targetheight") as string) 
+                    : c.clientHeight
+                ).reduce((a, b) => a + b, 0), divRef.current.clientHeight)
+                : undefined;
+            
+            if (containerHeight !== 0) {
+                setExpandedHeight(containerHeight ?? 0);
+            }
         }
     }, [expanded, props.children]);
 

--- a/src/app/components/elements/CollapsibleList.tsx
+++ b/src/app/components/elements/CollapsibleList.tsx
@@ -31,15 +31,21 @@ export const CollapsibleList = (props: CollapsibleListProps) => {
 
     useLayoutEffect(() => {
         if (expanded) {
-            setExpandedHeight(listRef?.current 
+            const containerHeight = listRef?.current 
                 // clientHeight cannot determine margin (nor can any reasonable alternative, since margins can overlap)! this will be smaller than the true height
                 // if margin exists. if this is the case, use additionalOffset to add additional space to the bottom of the list
                 ? Math.max([...listRef.current.children].map(c => c.getAttribute("data-targetheight") 
                     ? parseInt(c.getAttribute("data-targetheight") as string) 
                     : c.clientHeight
-                ).reduce((a, b) => a + b, 0), listRef.current.clientHeight) 
-                : 0
-            );
+                ).reduce((a, b) => a + b, 0), listRef.current.clientHeight)
+                : undefined;
+            
+            if (containerHeight !== 0) {
+                // if children are present in the DOM but have zero clientHeight (e.g. display: none from being on an inactive tab), 
+                // without this condition we would set the target expansion height to 0 if the children update through some external means. 
+                // this would hide the children when their correct height / visibility is restored.
+                setExpandedHeight(containerHeight ?? 0);
+            }
         }
     }, [expanded, props.children]);
 

--- a/src/app/components/pages/AssignmentProgressIndividual.tsx
+++ b/src/app/components/pages/AssignmentProgressIndividual.tsx
@@ -2,7 +2,7 @@ import React, {useContext, useMemo, useState} from "react";
 import { Link } from "react-router-dom";
 import { AssignmentProgressDTO, GameboardItem, CompletionState } from "../../../IsaacApiTypes";
 import { EnhancedAssignmentWithProgress, AssignmentProgressPageSettingsContext, AuthorisedAssignmentProgress } from "../../../IsaacAppTypes";
-import { getAssignmentProgressCSVDownloadLink, getThemeFromTags, isAda, isAuthorisedFullAccess, isPhy, PATHS, siteSpecific } from "../../services";
+import { getAssignmentProgressCSVDownloadLink, isAda, isAuthorisedFullAccess, isPhy, PATHS, siteSpecific } from "../../services";
 import { ICON, passMark, ResultsTable, ResultsTablePartBreakdown } from "../elements/quiz/QuizProgressCommon";
 import { Badge, Button, Card, CardBody } from "reactstrap";
 import { formatDate } from "../elements/DateString";
@@ -291,6 +291,10 @@ const DetailedMarksTab = ({assignment, progress}: DetailedMarksTabProps) => {
                 <h3>Performance on questions</h3>
             )}
             <span>See the questions your students answered{isPhy && " and which parts they struggled with"}.</span>
+
+            {isPhy && <div className="py-3 mt-2">
+                <AssignmentProgressSettings />
+            </div>}
 
             {questions.map((_, questionIndex) => (
                 <DetailedMarksCard

--- a/src/scss/common/assignment-progress.scss
+++ b/src/scss/common/assignment-progress.scss
@@ -485,12 +485,13 @@ $failed-bg-size: 25%;
 
   .progress-table-header-footer .correct-attempted-header {
     @include respond-below(md) {
+      font-size: 0.9rem;
       width: 6rem;
-      min-width: 4rem;
+      min-width: 6rem;
     }
-    @include respond-above(lg) {
-      width: 10rem;
-      min-width: 8rem;
+    @include respond-above(md) {
+      width: 8rem;
+      min-width: 7rem;
     }
   }
 


### PR DESCRIPTION
Adds a second totals column to relevant markbook pages, "Parts (total)", which counts the total parts that were attempted/correct for a given student. Renames the adjacent column to "Questions (total)" for consistency. Does not show the Parts column in Detailed Marks view, nor on tests (although the "Questions (total)" column is _renamed_ on tests to be "Parts (total)", as this is less confusing for teachers).

Maintains the markbook as is on Ada.

