### PR TITLE
focus input fields when 2fa code is requested

### DIFF
--- a/src/app/components/pages/LogIn.tsx
+++ b/src/app/components/pages/LogIn.tsx
@@ -96,6 +96,8 @@ export const TFAInput = React.forwardRef(function TFAForm({rememberMe}: {remembe
                 }
                 invalid={isNaN(Number(mfaVerificationCode))}
                 required
+                // eslint-disable-next-line jsx-a11y/no-autofocus
+                autoFocus
             />
             <FormFeedback id="verification-code-validation-message">
                 {isNaN(Number(mfaVerificationCode)) && "Please enter a valid verification code"}


### PR DESCRIPTION
Anton has [asked for this](https://trello.com/c/1R5FyQGS/5730-2fa-code-entry). There is an eslint rule against using the autofocus attribute. After a web search, the concerns appear to be:
- on mobile, autofocus automatically opens the keyboard
- on large pages, autofocus can cause the page to scroll unexpectedly
- on a screen reader, it interrupts the narration by forcing the reader on the field

I've checked on my phone (Android, Chrome), and the keyboard does not open automatically. The page is small, so no scrolling occurs. I haven't tested with a screen reader, but that field is the only field on the page, so even for a screen reader user, jumping there seems like the right thing to do. This UI is only shown for Isaac staff (content editors and above).

Different implementations are possible, such as waiting for onload and checking the browser's user agent so this doesn't happen on mobile, but I don't think either of these is worth the complexity.