### PR TITLE
Make markbook totals columns sticky

### DIFF
--- a/src/app/components/elements/quiz/QuizProgressCommon.tsx
+++ b/src/app/components/elements/quiz/QuizProgressCommon.tsx
@@ -237,7 +237,7 @@ export function ResultsTable<Q extends QuestionType>({
         </SortItemHeader>
         {pageSettings?.attemptedOrCorrect === "CORRECT"
             ? <SortItemHeader<ProgressSortOrder>
-                className="pointer-cursor correct-attempted-header"
+                className={classNames("pointer-cursor correct-attempted-header", {"sticky-ca-col": isPhy})}
                 defaultOrder={"totalQuestionPercentage"}
                 reverseOrder={"totalQuestionPercentage"}
                 currentOrder={sortOrder} setOrder={toggleSort} reversed={reverseOrder}
@@ -253,7 +253,7 @@ export function ResultsTable<Q extends QuestionType>({
                 )}
             </SortItemHeader>
             : <SortItemHeader<ProgressSortOrder>
-                className="pointer-cursor correct-attempted-header"
+                className={classNames("pointer-cursor correct-attempted-header", {"sticky-ca-col": isPhy})}
                 defaultOrder={"totalAttemptedQuestionPercentage"}
                 reverseOrder={"totalAttemptedQuestionPercentage"}
                 currentOrder={sortOrder} setOrder={toggleSort} reversed={reverseOrder}
@@ -272,7 +272,7 @@ export function ResultsTable<Q extends QuestionType>({
         {isPhy && isAssignment && (
             pageSettings?.attemptedOrCorrect === "CORRECT"
                 ? <SortItemHeader<ProgressSortOrder>
-                    className="pointer-cursor correct-attempted-header"
+                    className={classNames("pointer-cursor correct-attempted-header", {"sticky-ca-col": isPhy})}
                     defaultOrder={"totalPartPercentage"}
                     reverseOrder={"totalPartPercentage"}
                     currentOrder={sortOrder} setOrder={toggleSort} reversed={reverseOrder}
@@ -288,7 +288,7 @@ export function ResultsTable<Q extends QuestionType>({
                     )}
                 </SortItemHeader>
                 : <SortItemHeader<ProgressSortOrder>
-                    className="pointer-cursor correct-attempted-header"
+                    className={classNames("pointer-cursor correct-attempted-header", {"sticky-ca-col": isPhy})}
                     defaultOrder={"totalAttemptedPartPercentage"}
                     reverseOrder={"totalAttemptedPartPercentage"}
                     currentOrder={sortOrder} setOrder={toggleSort} reversed={reverseOrder}
@@ -415,7 +415,7 @@ export function ResultsTable<Q extends QuestionType>({
                                     }
                                 </th>
                                 {/* total questions */}
-                                <th title={fullAccess ? undefined : "Not Sharing"}>
+                                <th title={fullAccess ? undefined : "Not Sharing"} className={classNames({"sticky-ca-col": isPhy})}>
                                     {fullAccess
                                         ? formatMark(
                                             isAssignment
@@ -432,7 +432,7 @@ export function ResultsTable<Q extends QuestionType>({
                                     }
                                 </th>
                                 {/* total parts */}
-                                {isPhy && isAssignment && <th title={fullAccess ? undefined : "Not Sharing"}>
+                                {isPhy && isAssignment && <th title={fullAccess ? undefined : "Not Sharing"} className={classNames({"sticky-ca-col": isPhy})}>
                                     {fullAccess
                                         ? formatMark(
                                             pageSettings?.attemptedOrCorrect === "CORRECT"
@@ -477,8 +477,8 @@ export function ResultsTable<Q extends QuestionType>({
                                     `Total fully ${pageSettings?.attemptedOrCorrect === "CORRECT" ? "correct" : "attempted"}`
                                 )}
                             </th>
-                            <th/>{/* questions column */}
-                            {isPhy && isAssignment && <th/>}{/* parts column */}
+                            <th className={classNames({"sticky-ca-col": isPhy})} />{/* questions column */}
+                            {isPhy && isAssignment && <th className={classNames({"sticky-ca-col": isPhy})} />}{/* parts column */}
                             {classAverages.map(([numerator, denominator], index) => (
                                 <td key={index} className={classNames({"selected": index === selectedQuestionIndex})}>
                                     {formatMark(numerator, denominator, !!pageSettings?.formatAsPercentage)}
@@ -564,7 +564,7 @@ export function ResultsTablePartBreakdown({
                     </SortItemHeader>
                     {isPhy && (pageSettings?.attemptedOrCorrect === "CORRECT"
                         ? <SortItemHeader<ProgressSortOrder>
-                            className="pointer-cursor correct-attempted-header"
+                            className={classNames("pointer-cursor correct-attempted-header", {"sticky-ca-col": isPhy})}
                             defaultOrder={"totalQuestionPercentage"}
                             reverseOrder={"totalQuestionPercentage"}
                             currentOrder={sortOrder} setOrder={toggleSort} reversed={reverseOrder}
@@ -579,7 +579,7 @@ export function ResultsTablePartBreakdown({
                             )}
                         </SortItemHeader>
                         : <SortItemHeader<ProgressSortOrder>
-                            className="pointer-cursor correct-attempted-header"
+                            className={classNames("pointer-cursor correct-attempted-header", {"sticky-ca-col": isPhy})}
                             defaultOrder={"totalAttemptedQuestionPercentage"}
                             reverseOrder={"totalAttemptedQuestionPercentage"}
                             currentOrder={sortOrder} setOrder={toggleSort} reversed={reverseOrder}
@@ -625,7 +625,7 @@ export function ResultsTablePartBreakdown({
 
                             {/* total correct/attempted */}
                             {isPhy && studentProgress.questionPartResults && 
-                                <td>
+                                <td className={classNames({"sticky-ca-col": isPhy})}>
                                     {formatMark(
                                         studentProgress.questionPartResults[questionIndex].reduce((acc, questionPartResult) => {
                                             if (pageSettings?.attemptedOrCorrect === "CORRECT") {
@@ -657,7 +657,7 @@ export function ResultsTablePartBreakdown({
                                 `Total fully ${pageSettings?.attemptedOrCorrect === "CORRECT" ? "correct" : "attempted"}`
                             )}
                         </th>
-                        {isPhy && <th/>}{/* correct column */}
+                        {isPhy && <th className={classNames({"sticky-ca-col": isPhy})}/> /* correct column */}
                         {classAverages.map(([numerator, denominator], index) => (
                             <td key={index}>{formatMark(numerator, denominator, !!pageSettings?.formatAsPercentage)}</td>
                         ))}

--- a/src/scss/common/assignment-progress.scss
+++ b/src/scss/common/assignment-progress.scss
@@ -483,20 +483,6 @@ $failed-bg-size: 25%;
     opacity: 1;
   }
 
-  .progress-table-header-footer .correct-attempted-header {
-    @include respond-between(sm, sm) {
-      font-size: 0.9rem;
-    }
-    @include respond-below(md) {
-      width: 6rem;
-      min-width: 6rem;
-    }
-    @include respond-above(md) {
-      width: 8rem;
-      min-width: 7rem;
-    }
-  }
-
   td, th {
     vertical-align: middle;
     text-align: center;
@@ -511,35 +497,43 @@ $failed-bg-size: 25%;
     font-weight: normal;
   }
 
-  .student-name {
-    min-width: 195px;
-    word-break: break-word;
-    width: 195px;
-  }
+  --student-name-width: 16rem;
+  --correct-attempted-width: 7rem;
 
   @include respond-below(md) {
-    .student-name {
-      min-width: 12rem;
-      width: 12rem;
-    }
+    --student-name-width: 12rem;
+    --correct-attempted-width: 6rem;
   }
 
   @include respond-below(sm) {
-    .student-name {
-      min-width: 8rem;
-      width: 8rem;
-    }
+    --student-name-width: 8rem;
   }
 
-  .total-column {
-    @include table-sticky;
-    right: 0;
-    top: 0;
-    &:after {
-      @include after-border;
-      border-right: 1px solid $gray-118;
-      border-left: 1px solid $gray-118;
-      pointer-events: none; // don't intercept clicks as we want links in the th element
+  .student-name {
+    min-width: var(--student-name-width);
+    width: var(--student-name-width);
+    word-break: break-word;
+  }
+
+  .progress-table-header-footer .correct-attempted-header {
+    @include respond-between(sm, sm) {
+      font-size: 0.9rem;
+    }
+    width: var(--correct-attempted-width);
+    min-width: var(--correct-attempted-width);
+  }
+
+  .sticky-ca-col {
+    @include respond-above(lg) {
+      position: sticky;
+      z-index: 2;
+      &:nth-child(2) {
+        left: var(--student-name-width);
+      }
+      
+      &:nth-child(3) {
+        left: calc(var(--student-name-width) + var(--correct-attempted-width));
+      }
     }
   }
 }


### PR DESCRIPTION
A small extension to my previous changes to add the parts column to the markbook, this change makes both that and the old questions total columns sticky on large screen sizes.