### PR TITLE
Use consistent header across markbook assignments/tests

### DIFF
--- a/src/app/components/pages/AssignmentProgressGroup.tsx
+++ b/src/app/components/pages/AssignmentProgressGroup.tsx
@@ -29,6 +29,7 @@ import {StyledDropdown} from '../elements/inputs/DropdownInput';
 import {Loading} from '../handlers/IsaacSpinner';
 import {skipToken} from '@reduxjs/toolkit/query';
 import classNames from 'classnames';
+import { useHistoryState } from '../../state/actions/history';
 
 const AssignmentLikeLink = ({assignment}: {assignment: EnhancedAssignment | AppQuizAssignment}) => {
     const dispatch = useAppDispatch();
@@ -49,7 +50,7 @@ const AssignmentLikeLink = ({assignment}: {assignment: EnhancedAssignment | AppQ
     return <Link to={quiz ? `/test/assignment/${assignment.id}/feedback` : `${PATHS.ASSIGNMENT_PROGRESS}/${assignment.id}`} className="w-100 d-block no-underline mt-2">
         <div className="d-flex align-items-center assignment-progress-group w-100 p-3">
             <div className="d-flex flex-column">
-                <span className="d-flex">
+                <span className="d-inline-flex flex-wrap">
                     <b data-testid="assignment-name">{(quiz ? assignment.quizSummary?.title : assignment.gameboard?.title) ?? "Unknown quiz"}</b>
                     {isScheduled && <em className="mx-1">(scheduled)</em>}
                     <a className="new-tab-link" href={quiz ? assignment.quizSummary?.url : `${PATHS.GAMEBOARD}#${assignment.gameboard?.id}`} target="_blank" onClick={(e) => e.stopPropagation()}>
@@ -73,7 +74,7 @@ const AssignmentLikeLink = ({assignment}: {assignment: EnhancedAssignment | AppQ
                 </div>
             </div>
             <Spacer/>
-            {!isScheduled && <strong className="align-content-center">
+            {!isScheduled && <strong className="align-content-center mw-max-content">
                 <a href={csvDownloadLink} className="assignment-csv-download-link" target="_blank" rel="noopener" onClick={(e) => openAssignmentDownloadLink(e)}>
                     Download CSV
                 </a>
@@ -93,7 +94,7 @@ export const AssignmentProgressGroup = ({user, group}: {user: RegisteredUserDTO,
     const dispatch = useAppDispatch();
 
     const [searchText, setSearchText] = useState("");
-    const [activeTab, setActiveTab] = useState<"assignments" | "tests">("assignments");
+    const [activeTab, setActiveTab] = useHistoryState<"assignments" | "tests">("markbookTab", "assignments");
 
     const deviceSize = useDeviceSize();
 

--- a/src/app/components/pages/AssignmentProgressIndividual.tsx
+++ b/src/app/components/pages/AssignmentProgressIndividual.tsx
@@ -145,7 +145,7 @@ const GroupAssignmentTab = ({assignment, progress}: GroupAssignmentTabProps) => 
                 </div>
             </div>
 
-            <ResultsTableHeader settingsVisible={settingsVisible} />
+            <ResultsTableHeader settingsVisible={settingsVisible} isAssignment={true} />
             {isPhy && <AssignmentProgressLegend id={`${assignment.id ?? ""}`} />}
 
             <ResultsTable<GameboardItem> assignmentId={assignment.id} progress={progress} questions={questions}
@@ -156,7 +156,7 @@ const GroupAssignmentTab = ({assignment, progress}: GroupAssignmentTabProps) => 
     </Card>;
 };
 
-export const ResultsTableHeader = ({settingsVisible} : {settingsVisible: boolean}) => {
+export const ResultsTableHeader = ({settingsVisible, isAssignment} : {settingsVisible: boolean, isAssignment: boolean}) => {
     const assignmentProgressContext = useContext(AssignmentProgressPageSettingsContext);
 
     return <>
@@ -174,13 +174,13 @@ export const ResultsTableHeader = ({settingsVisible} : {settingsVisible: boolean
                     label={<span className="text-muted">Show mark as percentages</span>}
                 />
                 <Spacer />
-                <AdaAssignmentProgressKey />
+                <AdaAssignmentProgressKey isAssignment={isAssignment} />
             </>}
         </div>
     </>;
 };
 
-export const AdaAssignmentProgressKey = () => {
+export const AdaAssignmentProgressKey = ({isAssignment}: {isAssignment: boolean}) => {
     const context = useContext(AssignmentProgressPageSettingsContext);
 
     const KeyItem = ({icon, label}: {icon: React.ReactNode, label: string}) => (
@@ -189,13 +189,13 @@ export const AdaAssignmentProgressKey = () => {
         </span>
     );
 
-    return <div className="d-flex flex-column flex-md-row align-items-md-center column-gap-4 row-gap-2">
+    return <div className={classNames("d-flex flex-column column-gap-4 row-gap-2", isAssignment ? "flex-md-row align-items-md-center" : "flex-sm-row align-items-sm-center")}>
         <span className="d-inline d-lg-none d-xl-inline font-size-1 fw-bold">Key</span>
         {context?.attemptedOrCorrect === "CORRECT"
             ? <>
                 <div className="d-flex flex-column flex-sm-row flex-md-col column-gap-4 row-gap-2">
                     <KeyItem icon={ICON.correct} label="Correct" />
-                    <KeyItem icon={ICON.partial} label="Partially correct" />
+                    {isAssignment && <KeyItem icon={ICON.partial} label="Partially correct" />}
                 </div>
                 <div className="d-flex flex-column flex-sm-row flex-md-col column-gap-4 row-gap-2">
                     <KeyItem icon={ICON.incorrect} label="Incorrect" />
@@ -205,7 +205,7 @@ export const AdaAssignmentProgressKey = () => {
             : <>
                 <div className="d-flex flex-column flex-md-row column-gap-4 row-gap-2">
                     <KeyItem icon={ICON.correct} label="Fully attempted" />
-                    <KeyItem icon={ICON.partial} label="Partially attempted" />
+                    {isAssignment && <KeyItem icon={ICON.partial} label="Partially attempted" />}
                     <KeyItem icon={ICON.notAttempted} label="Not attempted" />
                 </div>
             </>

--- a/src/app/components/pages/AssignmentProgressIndividual.tsx
+++ b/src/app/components/pages/AssignmentProgressIndividual.tsx
@@ -129,7 +129,7 @@ const GroupAssignmentTab = ({assignment, progress}: GroupAssignmentTabProps) => 
 
     return <Card>
         <CardBody>
-            <div className="d-flex w-100 flex-column flex-md-row align-items-start align-items-md-center">
+            <div className={classNames("d-flex w-100 flex-column flex-md-row align-items-start align-items-md-center", {"mb-3": isPhy})}>
                 <div className="d-flex w-100 align-items-start justify-content-between">
                     <div>
                         {siteSpecific(
@@ -145,24 +145,7 @@ const GroupAssignmentTab = ({assignment, progress}: GroupAssignmentTabProps) => 
                 </div>
             </div>
 
-            <div className={classNames("d-flex flex-column flex-lg-row row-gap-2 my-2", {"pt-1": isAda /* increase space for checkbox */})}>
-                {isPhy && <CollapsibleContainer expanded={settingsVisible} className="w-100">
-                    <div className="py-3">
-                        <AssignmentProgressSettings />
-                    </div>
-                </CollapsibleContainer>}
-
-                {isAda && <>
-                    <StyledCheckbox
-                        checked={assignmentProgressContext?.formatAsPercentage}
-                        onChange={(e) => assignmentProgressContext?.setFormatAsPercentage?.(e.currentTarget.checked)}
-                        label={<span className="text-muted">Show mark as percentages</span>}
-                    />
-                    <Spacer />
-                    <AdaKey />
-                </>}
-            </div>
-
+            <ResultsTableHeader settingsVisible={settingsVisible} />
             {isPhy && <AssignmentProgressLegend id={`${assignment.id ?? ""}`} />}
 
             <ResultsTable<GameboardItem> assignmentId={assignment.id} progress={progress} questions={questions}
@@ -173,7 +156,31 @@ const GroupAssignmentTab = ({assignment, progress}: GroupAssignmentTabProps) => 
     </Card>;
 };
 
-const AdaKey = () => {
+export const ResultsTableHeader = ({settingsVisible} : {settingsVisible: boolean}) => {
+    const assignmentProgressContext = useContext(AssignmentProgressPageSettingsContext);
+
+    return <>
+        <div className={classNames("d-flex flex-column flex-lg-row row-gap-2 my-2", {"pt-1": isAda /* increase space for checkbox */})}>
+            {isPhy && <CollapsibleContainer expanded={settingsVisible} className="w-100">
+                <div className="pb-3">
+                    <AssignmentProgressSettings />
+                </div>
+            </CollapsibleContainer>}
+
+            {isAda && <>
+                <StyledCheckbox
+                    checked={assignmentProgressContext?.formatAsPercentage}
+                    onChange={(e) => assignmentProgressContext?.setFormatAsPercentage?.(e.currentTarget.checked)}
+                    label={<span className="text-muted">Show mark as percentages</span>}
+                />
+                <Spacer />
+                <AdaAssignmentProgressKey />
+            </>}
+        </div>
+    </>;
+};
+
+export const AdaAssignmentProgressKey = () => {
     const context = useContext(AssignmentProgressPageSettingsContext);
 
     const KeyItem = ({icon, label}: {icon: React.ReactNode, label: string}) => (

--- a/src/app/components/pages/quizzes/QuizTeacherFeedback.tsx
+++ b/src/app/components/pages/quizzes/QuizTeacherFeedback.tsx
@@ -49,10 +49,9 @@ import {
 import {FetchBaseQueryError} from "@reduxjs/toolkit/query";
 import {SerializedError} from "@reduxjs/toolkit";
 import {ShowLoadingQuery} from "../../handlers/ShowLoadingQuery";
-import {AssignmentProgressSettings, markClassesInternal} from "../AssignmentProgressIndividual";
+import {markClassesInternal, ResultsTableHeader} from "../AssignmentProgressIndividual";
 import classNames from "classnames";
 import {Spacer} from "../../elements/Spacer";
-import {CollapsibleContainer} from "../../elements/CollapsibleContainer";
 
 const pageHelp = <span>
     See the feedback for your students for this test assignment.
@@ -146,9 +145,8 @@ export const QuizTeacherFeedback = ({user}: {user: RegisteredUserDTO}) => {
 
                 <div className={`assignment-progress-details bg-transparent ${pageSettings.colourBlind ? " colour-blind" : ""}`}>
                     <AssignmentProgressPageSettingsContext.Provider value={pageSettings}>
-                        {/* <AssignmentProgressLegend showQuestionKey /> */}
                         <Card className="p-4 my-3">
-                            <div className="d-flex mb-3">
+                            <div className={classNames("d-flex", {"mb-3": isPhy})}>
                                 {siteSpecific(
                                     <h4>Group results</h4>,
                                     <h3>Group results</h3>
@@ -159,11 +157,9 @@ export const QuizTeacherFeedback = ({user}: {user: RegisteredUserDTO}) => {
                                     <i className={classNames("icon icon-cog anim-rotate-45", { "active": settingsVisible })}/>
                                 </button>}
                             </div>
-                            {isPhy && <CollapsibleContainer expanded={settingsVisible} className="w-100">
-                                <div className="py-3">
-                                    <AssignmentProgressSettings />
-                                </div>
-                            </CollapsibleContainer>}
+
+                            <ResultsTableHeader settingsVisible={settingsVisible} />
+
                             <QuizProgressDetails assignment={quizAssignment} />
                         </Card>
                     </AssignmentProgressPageSettingsContext.Provider>

--- a/src/app/components/pages/quizzes/QuizTeacherFeedback.tsx
+++ b/src/app/components/pages/quizzes/QuizTeacherFeedback.tsx
@@ -158,7 +158,7 @@ export const QuizTeacherFeedback = ({user}: {user: RegisteredUserDTO}) => {
                                 </button>}
                             </div>
 
-                            <ResultsTableHeader settingsVisible={settingsVisible} />
+                            <ResultsTableHeader settingsVisible={settingsVisible} isAssignment={false} />
 
                             <QuizProgressDetails assignment={quizAssignment} />
                         </Card>


### PR DESCRIPTION
Moves the (assignment) markbook header into its own component and reuses this across both assignments and tests.

Main intention is for Ada's "Show as percentages" to appear on tests; also ensures future consistency.

Also applies minor improvements to the Groups page.