### PR TITLE
Ensure question attempt is always loaded into text input for symbolic questions

### DIFF
--- a/src/app/components/content/IsaacSymbolicChemistryQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicChemistryQuestion.tsx
@@ -10,6 +10,7 @@ import {
     parsePseudoSymbolicAvailableSymbols,
     initialiseInequality,
     useModalWithScroll,
+    isDefined,
 } from "../../services";
 import _flattenDeep from 'lodash/flattenDeep';
 import {IsaacQuestionProps} from "../../../IsaacAppTypes";
@@ -26,13 +27,14 @@ const InequalityModal = lazy(() => import("../elements/modals/inequality/Inequal
 const IsaacSymbolicChemistryQuestion = ({doc, questionId, readonly}: IsaacQuestionProps<IsaacSymbolicChemistryQuestionDTO>) => {
     const {currentAttempt, dispatchSetCurrentAttempt} = useCurrentQuestionAttempt<ChemicalFormulaDTO>(questionId);
     const currentAttemptValue: InequalityState | undefined = currentAttempt && currentAttempt.value ? jsonHelper.parseOrDefault(currentAttempt.value, {result: {tex: '\\textrm{PLACEHOLDER HERE}'}}) : undefined;
-    
+    const questionAttemptLoaded = useRef(!!currentAttemptValue);
+
     const [hideSeed, setHideSeed] = useState(!!currentAttempt);
     const initialSeed: SeedExpressions = useMemo(() => jsonHelper.parseOrDefault(doc.formulaSeed, undefined)?.[0]?.expression ?? '', [doc.formulaSeed]);  
     const previewText = (currentAttemptValue && currentAttemptValue.result)  
         ? currentAttemptValue.result.tex 
         : !hideSeed ? initialSeed.latex : undefined;  
-    const [textInput, setTextInput] = useState((currentAttemptValue ? currentAttemptValue.result?.mhchem : initialSeed.mhchem) ?? "");  
+    const [textInput, setTextInput] = useState((currentAttemptValue ? currentAttemptValue.result?.mhchem : initialSeed.mhchem) ?? "");
 
     const [hasStartedEditing, setHasStartedEditing] = useState(false);
     const [modalVisible, setModalVisible] = useState(false);
@@ -78,9 +80,10 @@ const IsaacSymbolicChemistryQuestion = ({doc, questionId, readonly}: IsaacQuesti
     };
 
     useEffect(() => {
-        // Only update the text-entry box if the graphical editor is visible
-        const mhchemExpression = (currentAttemptValue?.result && currentAttemptValue.result.mhchem) || "";
-        if (modalVisible) {
+        // Only update the text-entry box if the graphical editor is visible OR if the question attempt is loaded for the first time
+        const mhchemExpression = currentAttemptValue?.result && currentAttemptValue?.result.mhchem;
+        if (isDefined(mhchemExpression) && (modalVisible || !questionAttemptLoaded.current)) {
+            questionAttemptLoaded.current = true;
             setTextInput(mhchemExpression);
         }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/app/components/content/IsaacSymbolicChemistryQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicChemistryQuestion.tsx
@@ -82,9 +82,9 @@ const IsaacSymbolicChemistryQuestion = ({doc, questionId, readonly}: IsaacQuesti
     useEffect(() => {
         // Only update the text-entry box if the graphical editor is visible OR if the question attempt is loaded for the first time
         const mhchemExpression = currentAttemptValue?.result && currentAttemptValue?.result.mhchem;
-        if (isDefined(mhchemExpression) && (modalVisible || !questionAttemptLoaded.current)) {
+        if (modalVisible || (isDefined(mhchemExpression) && !questionAttemptLoaded.current)) {
             questionAttemptLoaded.current = true;
-            setTextInput(mhchemExpression);
+            setTextInput(mhchemExpression ?? "");
         }
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [currentAttempt]);

--- a/src/app/components/content/IsaacSymbolicLogicQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicLogicQuestion.tsx
@@ -53,7 +53,11 @@ const IsaacSymbolicLogicQuestion = ({doc, questionId, readonly}: IsaacQuestionPr
     const updateState = (state: InequalityState) => {
         const newState = sanitiseInequalityState(state);
         const pythonExpression = newState?.result?.python || "";
-        dispatchSetCurrentAttempt({type: 'logicFormula', value: JSON.stringify(newState), pythonExpression});
+        if (state.userInput !== "" || modalVisible) {
+            // Only call dispatch if the user has inputted text or is interacting with the modal
+            // Otherwise this causes the response to reset on reload removing the banner
+            dispatchSetCurrentAttempt({type: 'formula', value: JSON.stringify(newState), pythonExpression});
+        }
         initialEditorSymbols.current = state.symbols ?? [];
     };
 

--- a/src/app/components/content/IsaacSymbolicLogicQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicLogicQuestion.tsx
@@ -64,9 +64,9 @@ const IsaacSymbolicLogicQuestion = ({doc, questionId, readonly}: IsaacQuestionPr
     useEffect(() => {
         // Only update the text-entry box if the graphical editor is visible OR if the question attempt is loaded for the first time
         const pythonExpression = currentAttemptValue?.result && currentAttemptValue?.result.python;
-        if (isDefined(pythonExpression) && (modalVisible || !questionAttemptLoaded.current)) {
+        if (modalVisible || (isDefined(pythonExpression) && !questionAttemptLoaded.current)) {
             questionAttemptLoaded.current = true;
-            setTextInput(pythonExpression);
+            setTextInput(pythonExpression ?? "");
         }
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [currentAttempt]);

--- a/src/app/components/content/IsaacSymbolicLogicQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicLogicQuestion.tsx
@@ -5,6 +5,7 @@ import katex from "katex";
 import {
     ifKeyIsEnter,
     initialiseInequality,
+    isDefined,
     jsonHelper,
     sanitiseInequalityState,
     useCurrentQuestionAttempt,
@@ -24,6 +25,7 @@ const InequalityModal = lazy(() => import("../elements/modals/inequality/Inequal
 const IsaacSymbolicLogicQuestion = ({doc, questionId, readonly}: IsaacQuestionProps<IsaacSymbolicLogicQuestionDTO>) => {
     const {currentAttempt, dispatchSetCurrentAttempt} = useCurrentQuestionAttempt<LogicFormulaDTO>(questionId);
     const currentAttemptValue: InequalityState | undefined = currentAttempt?.value ? jsonHelper.parseOrDefault(currentAttempt.value, {result: {tex: '\\textrm{PLACEHOLDER HERE}'}}) : undefined;
+    const questionAttemptLoaded = useRef(!!currentAttemptValue);
 
     const [hideSeed, setHideSeed] = useState(!!currentAttempt);
     const initialSeed: SeedExpressions = useMemo(() => jsonHelper.parseOrDefault(doc.formulaSeed, undefined)?.[0]?.expression ?? '', [doc.formulaSeed]);  
@@ -56,9 +58,10 @@ const IsaacSymbolicLogicQuestion = ({doc, questionId, readonly}: IsaacQuestionPr
     };
 
     useEffect(() => {
-        // Only update the text-entry box if the graphical editor is visible
-        const pythonExpression = (currentAttemptValue?.result && currentAttemptValue?.result.python) || "";
-        if (modalVisible) {
+        // Only update the text-entry box if the graphical editor is visible OR if the question attempt is loaded for the first time
+        const pythonExpression = currentAttemptValue?.result && currentAttemptValue?.result.python;
+        if (isDefined(pythonExpression) && (modalVisible || !questionAttemptLoaded.current)) {
+            questionAttemptLoaded.current = true;
             setTextInput(pythonExpression);
         }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/app/components/content/IsaacSymbolicQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicQuestion.tsx
@@ -13,6 +13,7 @@ import katex from "katex";
 import {
     ifKeyIsEnter,
     initialiseInequality,
+    isDefined,
     jsonHelper,
     parsePseudoSymbolicAvailableSymbols,
     sanitiseInequalityState,
@@ -32,10 +33,11 @@ const InequalityModal = lazy(() => import("../elements/modals/inequality/Inequal
 const IsaacSymbolicQuestion = ({doc, questionId, readonly}: IsaacQuestionProps<IsaacSymbolicQuestionDTO>) => {
     const {currentAttempt, dispatchSetCurrentAttempt} = useCurrentQuestionAttempt<FormulaDTO>(questionId);
     const currentAttemptValue: InequalityState | undefined = currentAttempt?.value ? jsonHelper.parseOrDefault(currentAttempt.value, {result: {tex: '\\textrm{PLACEHOLDER HERE}'}}) : undefined;
-    
+    const questionAttemptLoaded = useRef(!!currentAttemptValue);
+
     const initialSeed: SeedExpressions = useMemo(() => jsonHelper.parseOrDefault(doc.formulaSeed, undefined)?.[0]?.expression ?? '', [doc.formulaSeed]);  
     const previewText = currentAttemptValue && currentAttemptValue.result && currentAttemptValue.result.tex;
-    const [textInput, setTextInput] = useState((currentAttemptValue ? currentAttemptValue.result?.python : initialSeed.python) ?? "");  
+    const [textInput, setTextInput] = useState((currentAttemptValue ? currentAttemptValue.result?.python : initialSeed.python) ?? "");
 
     const [hasStartedEditing, setHasStartedEditing] = useState<boolean>(false);
     const [modalVisible, setModalVisible] = useState<boolean>(false);
@@ -64,9 +66,10 @@ const IsaacSymbolicQuestion = ({doc, questionId, readonly}: IsaacQuestionProps<I
     };
 
     useEffect(() => {
-        // Only update the text-entry box if the graphical editor is visible
-        const pythonExpression = (currentAttemptValue?.result && currentAttemptValue?.result.python) || "";
-        if (modalVisible) {
+        // Only update the text-entry box if the graphical editor is visible OR if the question attempt is loaded for the first time
+        const pythonExpression = currentAttemptValue?.result && currentAttemptValue?.result.python;
+        if (isDefined(pythonExpression) && (modalVisible || !questionAttemptLoaded.current)) {
+            questionAttemptLoaded.current = true;
             setTextInput(pythonExpression);
         }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/app/components/content/IsaacSymbolicQuestion.tsx
+++ b/src/app/components/content/IsaacSymbolicQuestion.tsx
@@ -68,9 +68,9 @@ const IsaacSymbolicQuestion = ({doc, questionId, readonly}: IsaacQuestionProps<I
     useEffect(() => {
         // Only update the text-entry box if the graphical editor is visible OR if the question attempt is loaded for the first time
         const pythonExpression = currentAttemptValue?.result && currentAttemptValue?.result.python;
-        if (isDefined(pythonExpression) && (modalVisible || !questionAttemptLoaded.current)) {
+        if (modalVisible || (isDefined(pythonExpression) && !questionAttemptLoaded.current)) {
             questionAttemptLoaded.current = true;
-            setTextInput(pythonExpression);
+            setTextInput(pythonExpression ?? "");
         }
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [currentAttempt]);

--- a/src/app/components/elements/inputs/SymbolicTextInput.tsx
+++ b/src/app/components/elements/inputs/SymbolicTextInput.tsx
@@ -274,7 +274,7 @@ export const SymbolicTextInput = ({hiddenEditorRef, textInput, setTextInput, set
             </div>
             <QuestionInputValidation userInput={textInput} validator={(input) => symbolicTextInputValidator(input, editorMode, mayRequireStateSymbols, demoPage)}/>
         </InputGroup>
-        {!demoPage && <div className="eqn-editor-symbols">
+        {!demoPage && typedProps.symbolList && <div className="eqn-editor-symbols">
             The following symbols may be useful: <pre>{typedProps.symbolList}</pre>
         </div>}
     </div>;


### PR DESCRIPTION
In the pre-seed world, we had a rudimentary version of this which worked well enough because the text-entry box would always start empty: https://github.com/isaacphysics/isaac-react-app/blob/a095e72743e1f75c3e4bda3fdf06f924094b7b7c/src/app/components/content/IsaacSymbolicChemistryQuestion.tsx#L142-L146

This was removed and replaced with more thorough text initialisation within `useState` to account for seeds, which generally works except that it can cause a race condition in which the `currentAttempt` is not loaded in time to be set.

To fix this, the branch adds a `questionAttemptLoaded` ref. Behaviour does not change if `currentAttempt` has been loaded in time, but the text input is given a second chance to load in a `useEffect` if it has not.

---

Also fixes two other small issues:
- Only update state when the user has interacted on logic questions (so the feedback banner is visible on page reload). This was already the case for other questions - the code just hadn't been ported over
- Stop showing _"The following symbols may be useful:"_ when there is no `symbolList`