### PR TITLE
Nullable coordinate questions fix

### DIFF
--- a/src/app/components/content/IsaacCoordinateQuestion.tsx
+++ b/src/app/components/content/IsaacCoordinateQuestion.tsx
@@ -122,12 +122,19 @@ const IsaacCoordinateQuestion = ({doc, questionId, readonly}: IsaacQuestionProps
     const getEmptyCoordItem = useCallback((): CoordinateItemDTO => {
         return {type: "coordinateItem", coordinates: Array<string>(numberOfDimensions).fill("")};
     }, [numberOfDimensions]);
+    const getEmptyCoord = useCallback(() => {
+        return {type: "coordinateChoice", items: Array.from({length: doc.numberOfCoordinates ?? currentAttempt?.items?.length ?? 2}).map(getEmptyCoordItem)} satisfies CoordinateChoiceDTO;
+    }, [currentAttempt?.items?.length, doc.numberOfCoordinates, getEmptyCoordItem]);
 
     const updateItem = useCallback((index: number, value: Immutable<CoordinateItemDTO>) => {
         const items = [...(currentAttempt?.items ?? [])].map(item => isDefined(item) ? cleanItem(item) : getEmptyCoordItem());
+        if (doc.numberOfCoordinates && !items.length) {
+            // if the number of coordinates is fixed and we don't have a prior attempt, we need to fill all other items with blanks before updating the indexed item
+            items.push(...getEmptyCoord().items);
+        }
         items[index] = cleanItem(value);
         dispatchSetCurrentAttempt({type: "coordinateChoice", items});
-    }, [currentAttempt, dispatchSetCurrentAttempt, getEmptyCoordItem]);
+    }, [currentAttempt?.items, dispatchSetCurrentAttempt, doc.numberOfCoordinates, getEmptyCoord, getEmptyCoordItem]);
 
     const removeItem = useCallback((index: number) => {
         const items = [...(currentAttempt?.items ?? [])].map(item => isDefined(item) ? cleanItem(item) : getEmptyCoordItem());

--- a/src/app/components/content/IsaacCoordinateQuestion.tsx
+++ b/src/app/components/content/IsaacCoordinateQuestion.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback} from "react";
+import React, {useCallback, useEffect, useMemo} from "react";
 import {IsaacContentValueOrChildren} from "./IsaacContentValueOrChildren";
 import {CoordinateChoiceDTO, CoordinateItemDTO, IsaacCoordinateQuestionDTO} from "../../../IsaacApiTypes";
 import {Button, Input} from "reactstrap";
@@ -114,14 +114,18 @@ const CoordinateInput = (props: CoordinateInputProps) => {
 
 const IsaacCoordinateQuestion = ({doc, questionId, readonly}: IsaacQuestionProps<IsaacCoordinateQuestionDTO>) => {
 
-    const { currentAttempt, dispatchSetCurrentAttempt } = useCurrentQuestionAttempt<CoordinateChoiceDTO>(questionId);
-
     const numberOfDimensions = doc.numberOfDimensions ?? 2;
     const buttonText = doc.buttonText ?? "Add coordinate";
 
     const getEmptyCoordItem = useCallback((): CoordinateItemDTO => {
         return {type: "coordinateItem", coordinates: Array<string>(numberOfDimensions).fill("")};
     }, [numberOfDimensions]);
+
+    const { currentAttempt: nullableCurrentAttempt, dispatchSetCurrentAttempt } = useCurrentQuestionAttempt<CoordinateChoiceDTO>(questionId);
+    const currentAttempt = useMemo(() => {
+        return {...nullableCurrentAttempt, items: nullableCurrentAttempt?.items?.map(item => isDefined(item) ? item : getEmptyCoordItem())};
+    }, [getEmptyCoordItem, nullableCurrentAttempt]);
+
     const getEmptyCoord = useCallback(() => {
         return {type: "coordinateChoice", items: Array.from({length: doc.numberOfCoordinates ?? currentAttempt?.items?.length ?? 2}).map(getEmptyCoordItem)} satisfies CoordinateChoiceDTO;
     }, [currentAttempt?.items?.length, doc.numberOfCoordinates, getEmptyCoordItem]);
@@ -144,7 +148,7 @@ const IsaacCoordinateQuestion = ({doc, questionId, readonly}: IsaacQuestionProps
 
     const addCoord = useCallback(() => {
         if (!isDefined(currentAttempt)) {
-            dispatchSetCurrentAttempt({type: "coordinateChoice", items: [getEmptyCoordItem(), getEmptyCoordItem()]});
+            dispatchSetCurrentAttempt(getEmptyCoord());
         }
         else {
             updateItem(currentAttempt?.items?.length ?? 1, getEmptyCoordItem());

--- a/src/app/components/content/IsaacCoordinateQuestion.tsx
+++ b/src/app/components/content/IsaacCoordinateQuestion.tsx
@@ -137,6 +137,7 @@ const IsaacCoordinateQuestion = ({doc, questionId, readonly}: IsaacQuestionProps
 
     const { currentAttempt: nullableCurrentAttempt, dispatchSetCurrentAttempt } = useCurrentQuestionAttempt<CoordinateChoiceDTO>(questionId);
     const currentAttempt = useMemo(() => {
+        // see https://github.com/isaacphysics/isaac-react-app/pull/2093; it was previously possible to generate null items, which we must now deal with
         return {
             ...nullableCurrentAttempt, 
             items: nullableCurrentAttempt?.items?.map(item => isDefined(item) ? item : emptyCoordItem())

--- a/src/app/components/content/IsaacCoordinateQuestion.tsx
+++ b/src/app/components/content/IsaacCoordinateQuestion.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useMemo} from "react";
+import React, {useCallback, useMemo, useRef} from "react";
 import {IsaacContentValueOrChildren} from "./IsaacContentValueOrChildren";
 import {CoordinateChoiceDTO, CoordinateItemDTO, IsaacCoordinateQuestionDTO} from "../../../IsaacApiTypes";
 import {Button, Input} from "reactstrap";
@@ -112,48 +112,61 @@ const CoordinateInput = (props: CoordinateInputProps) => {
     </span>;
 };
 
+const generateEmptyCoordItem = (numberOfDimensions: number): CoordinateItemDTO => {
+    return {
+        type: "coordinateItem",
+        coordinates: Array<string>(numberOfDimensions).fill("")
+    };
+};
+
+const generateEmptyCoord = (numberOfCoordinates: number, numberOfDimensions: number) => {
+    return {
+        type: "coordinateChoice", 
+        items: Array.from({length: numberOfCoordinates}).map(() => generateEmptyCoordItem(numberOfDimensions))
+    } satisfies CoordinateChoiceDTO;
+};
+
 const IsaacCoordinateQuestion = ({doc, questionId, readonly}: IsaacQuestionProps<IsaacCoordinateQuestionDTO>) => {
 
-    const numberOfDimensions = doc.numberOfDimensions ?? 2;
+    const numberOfDimensions = useRef(doc.numberOfDimensions ?? 2);
+    const numberOfCoordinates = useRef(doc.numberOfCoordinates);
     const buttonText = doc.buttonText ?? "Add coordinate";
 
-    const getEmptyCoordItem = useCallback((): CoordinateItemDTO => {
-        return {type: "coordinateItem", coordinates: Array<string>(numberOfDimensions).fill("")};
-    }, [numberOfDimensions]);
+    const emptyCoordItem = () => generateEmptyCoordItem(numberOfDimensions.current);
+    const emptyCoord = () => generateEmptyCoord(numberOfCoordinates.current ?? 2, numberOfDimensions.current);
 
     const { currentAttempt: nullableCurrentAttempt, dispatchSetCurrentAttempt } = useCurrentQuestionAttempt<CoordinateChoiceDTO>(questionId);
     const currentAttempt = useMemo(() => {
-        return {...nullableCurrentAttempt, items: nullableCurrentAttempt?.items?.map(item => isDefined(item) ? item : getEmptyCoordItem())};
-    }, [getEmptyCoordItem, nullableCurrentAttempt]);
-
-    const getEmptyCoord = useCallback(() => {
-        return {type: "coordinateChoice", items: Array.from({length: doc.numberOfCoordinates ?? currentAttempt?.items?.length ?? 2}).map(getEmptyCoordItem)} satisfies CoordinateChoiceDTO;
-    }, [currentAttempt?.items?.length, doc.numberOfCoordinates, getEmptyCoordItem]);
+        return {
+            ...nullableCurrentAttempt, 
+            items: nullableCurrentAttempt?.items?.map(item => isDefined(item) ? item : emptyCoordItem())
+        };
+    }, [nullableCurrentAttempt]);
 
     const updateItem = useCallback((index: number, value: Immutable<CoordinateItemDTO>) => {
-        const items = [...(currentAttempt?.items ?? [])].map(item => isDefined(item) ? cleanItem(item) : getEmptyCoordItem());
-        if (doc.numberOfCoordinates && !items.length) {
+        const items = [...(currentAttempt?.items ?? [])].map(item => isDefined(item) ? cleanItem(item) : emptyCoordItem());
+        if (numberOfCoordinates.current && !items.length) {
             // if the number of coordinates is fixed and we don't have a prior attempt, we need to fill all other items with blanks before updating the indexed item
-            items.push(...getEmptyCoord().items);
+            items.push(...emptyCoord().items);
         }
         items[index] = cleanItem(value);
         dispatchSetCurrentAttempt({type: "coordinateChoice", items});
-    }, [currentAttempt?.items, dispatchSetCurrentAttempt, doc.numberOfCoordinates, getEmptyCoord, getEmptyCoordItem]);
+    }, [currentAttempt?.items, dispatchSetCurrentAttempt]);
 
     const removeItem = useCallback((index: number) => {
-        const items = [...(currentAttempt?.items ?? [])].map(item => isDefined(item) ? cleanItem(item) : getEmptyCoordItem());
+        const items = [...(currentAttempt?.items ?? [])].map(item => isDefined(item) ? cleanItem(item) : emptyCoordItem());
         items.splice(index, 1);
         dispatchSetCurrentAttempt({type: "coordinateChoice", items});
-    }, [currentAttempt, dispatchSetCurrentAttempt, getEmptyCoordItem]);
+    }, [currentAttempt?.items, dispatchSetCurrentAttempt]);
 
     const addCoord = useCallback(() => {
         if (!isDefined(currentAttempt)) {
-            dispatchSetCurrentAttempt(getEmptyCoord());
+            dispatchSetCurrentAttempt(emptyCoord());
         }
         else {
-            updateItem(currentAttempt?.items?.length ?? 1, getEmptyCoordItem());
+            updateItem(currentAttempt?.items?.length ?? 1, emptyCoordItem());
         }
-    }, [currentAttempt, dispatchSetCurrentAttempt, getEmptyCoordItem, updateItem]);
+    }, [currentAttempt, dispatchSetCurrentAttempt, updateItem]);
 
     return <div className="coordinate-question">
         <div className="question-content">
@@ -170,8 +183,8 @@ const IsaacCoordinateQuestion = ({doc, questionId, readonly}: IsaacQuestionProps
                     separator={doc.separator ?? ","}
                     prefixes={doc.prefixes}
                     suffixes={doc.suffixes}
-                    numberOfDimensions={numberOfDimensions}
-                    value={currentAttempt?.items?.[index] ?? getEmptyCoordItem()}
+                    numberOfDimensions={numberOfDimensions.current}
+                    value={currentAttempt?.items?.[index] ?? emptyCoordItem()}
                     readonly={readonly}
                     onChange={value => updateItem(index, value)}
                 />
@@ -185,7 +198,7 @@ const IsaacCoordinateQuestion = ({doc, questionId, readonly}: IsaacQuestionProps
                             separator={doc.separator ?? ","}
                             prefixes={doc.prefixes}
                             suffixes={doc.suffixes}
-                            numberOfDimensions={numberOfDimensions}
+                            numberOfDimensions={numberOfDimensions.current}
                             value={item}
                             readonly={readonly}
                             onChange={value => updateItem(index, value)}
@@ -200,8 +213,8 @@ const IsaacCoordinateQuestion = ({doc, questionId, readonly}: IsaacQuestionProps
                     separator={doc.separator ?? ","}
                     prefixes={doc.prefixes}
                     suffixes={doc.suffixes}
-                    numberOfDimensions={numberOfDimensions}
-                    value={getEmptyCoordItem()}
+                    numberOfDimensions={numberOfDimensions.current}
+                    value={emptyCoordItem()}
                     readonly={readonly}
                     onChange={value => updateItem(0, value)}
                 />


### PR DESCRIPTION
Fixes an issue with coordinate questions having the potential to generate null values in the `items` array. Also prevents errors with prior attempts that already have `null` values set. 

In `updateItem`, we run `items[index] = cleanItem(value);` to update the item at a given index. However, if no attempt exists, `items` (which comes from `(currentAttempt?.items ?? [])`) is of course an empty array. `[][2] = 'a'` will not throw an error, but instead modify the empty array to be `[null, null, 'a']`; this is then dispatched. 

We ought to be running an existence check on `items` before we update it, setting **all** values to empty if it does not exist before we update the array; the modified `updateItem` achieves this.