### PR TITLE
Stop parsing solitary round brackets as function

### DIFF
--- a/src/app/components/elements/modals/inequality/utils.ts
+++ b/src/app/components/elements/modals/inequality/utils.ts
@@ -473,7 +473,7 @@ export function generateMenuItems({editorMode, logicSyntax, parsedAvailableSymbo
 
         parsedAvailableSymbols.forEach((l) => {
             const availableSymbol = l.trim();
-            if (availableSymbol.endsWith('()')) {
+            if (availableSymbol.endsWith('()') && availableSymbol !== '()') {
                 // Functions
                 const functionName = availableSymbol.replace('()', '');
                 if (TRIG_FUNCTION_NAMES.includes(functionName)) {


### PR DESCRIPTION
When checking for functions like `sin()` or `log()`, we were seeing if the symbol ended with `()`. This also catches `()` itself. It should instead pass through to `otherChemistryFunctions`.

Quite a silly mistake. I'm surprised this lasted > three years (without ever being used in a question) 🫣