### PR TITLE
Improve spacing above "scheduled work" dashboard card links

### DIFF
--- a/src/app/components/elements/TeacherDashboard.tsx
+++ b/src/app/components/elements/TeacherDashboard.tsx
@@ -74,7 +74,7 @@ const AssignmentsPanel = ({ assignments, quizzes, groups }: AssignmentsPanelProp
             }}
         />
         <Spacer/>
-        <div className="d-flex align-items-center">
+        <div className="d-flex align-items-center mt-3">
             <Link to="/assignment_schedule" className="d-inline text-center panel-link me-3">
                 See assignment schedule
             </Link>


### PR DESCRIPTION
Makes this card consistent with the "groups" card above on `xs` screens