### PR TITLE
Switch icon colours to css vars for more expressivity

### DIFF
--- a/src/scss/common/_mixins.scss
+++ b/src/scss/common/_mixins.scss
@@ -276,8 +276,8 @@ $viewport-sizes: (
 @mixin icon-color-override($color) {
   // only do this if masks are supported
   @supports (mask-position: center) {
-    --icon-foreground: #{$color};
-    --icon-background: #{$color};
+    --icon-foreground: #{$color} !important;
+    --icon-background: #{$color} !important;
   }
 }
 

--- a/src/scss/common/_mixins.scss
+++ b/src/scss/common/_mixins.scss
@@ -276,14 +276,8 @@ $viewport-sizes: (
 @mixin icon-color-override($color) {
   // only do this if masks are supported
   @supports (mask-position: center) {
-    background-color: var(--layered-icon-parent-bg-override, $color) !important;
-
-    &::before {
-      background-color: $color !important;
-    }
-    &::after {
-      background-color: $color !important;
-    }
+    --icon-foreground: #{$color};
+    --icon-background: #{$color};
   }
 }
 

--- a/src/scss/common/icons.scss
+++ b/src/scss/common/icons.scss
@@ -57,6 +57,17 @@ img[aria-disabled="true"] {
   opacity: 0.5;
 }
 
+%icon-fillable {
+  &:not(.fill):not(.fill)::before {
+    // this must override icon-color-xxx (specificity (0, 2, 2)), otherwise the icon always appears filled
+    --icon-background: transparent;
+  }
+
+  &.fill::before {
+    --icon-background: var(--icon-foreground);
+  }
+}
+
 .icon-download {
   @include svg-icon('/assets/common/icons/download.svg', var(--icon-size), var(--icon-size), var(--mask-size, 60%));
 }
@@ -211,48 +222,40 @@ img[aria-disabled="true"] {
 }
 
 i.icon:not(.icon-raw) {
-  &, &[color="primary"] {
-    background-color: var(--layered-icon-parent-bg-override, var(--icon-primary));
-    
-    @include not-reduced-motion {
-      transition: all 0.15s ease-in-out; // mirrors BS's $btn-transition
-    }
-  
-    // for layered icons, the ::after element takes the colour while the ::before remains uncoloured
-    &::after {
-      background-color: var(--icon-primary);
-      
-      @include not-reduced-motion {
-        transition: all 0.15s ease-in-out;
-      }
-    }
+  background-color: var(--layered-icon-parent-bg-override, var(--icon-foreground));
+  @include not-reduced-motion {
+    transition: all 0.15s ease-in-out; // mirrors BS's $btn-transition
+  }
 
-    // however, the ::before is also able to change colour, e.g. during hover inversions on keyline or tint buttons
-    &::before {
-      @include not-reduced-motion {
-        transition: all 0.15s ease-in-out;
-      }
+  &::after {
+    background-color: var(--icon-foreground);
+    @include not-reduced-motion {
+      transition: all 0.15s ease-in-out;
     }
+  }
+
+  &::before {
+    background-color: var(--icon-background);
+    @include not-reduced-motion {
+      transition: all 0.15s ease-in-out;
+    }
+  }
+
+  &, &[color="primary"] {
+    // default icon colours
+    --icon-foreground: var(--icon-primary);
+    --icon-background: var(--color-neutral-900, black);
   }
 
   &[color="secondary"] {
-    background-color: var(--layered-icon-parent-bg-override, var(--icon-secondary));
-    &::after {
-      background-color: var(--icon-secondary);
-    }
+    --icon-foreground: var(--icon-secondary);
   }
 
   &[color="tertiary"] {
-    background-color: var(--layered-icon-parent-bg-override, var(--icon-tertiary));
-    &::after {
-      background-color: var(--icon-tertiary);
-    }
+    --icon-foreground: var(--icon-tertiary);
   }
 
   &[color="white"] {
-    background-color: $white;
-    &::after {
-      background-color: $white;
-    }
+    --icon-foreground: white;
   }
 }

--- a/src/scss/phy/button.scss
+++ b/src/scss/phy/button.scss
@@ -54,11 +54,7 @@
   }
 
   i.icon {
-    background-color: var(--layered-icon-parent-bg-override, var(--buttons-dark-icon));
-  }
-
-  i.icon::after {
-    background-color: var(--buttons-dark-icon);
+    --icon-foreground: var(--buttons-dark-icon);
   }
 }
 
@@ -82,11 +78,7 @@
   }
 
   i.icon {
-    background-color: var(--layered-icon-parent-bg-override, var(--buttons-light-icon));
-  }
-
-  i.icon::after {
-    background-color: var(--buttons-light-icon);
+    --icon-foreground: var(--buttons-light-icon);
   }
 }
 
@@ -106,11 +98,7 @@
   }
 
   i.icon {
-    background-color: var(--layered-icon-parent-bg-override, var(--buttons-light-icon));
-  }
-
-  i.icon::after {
-    background-color: var(--buttons-light-icon);
+    --icon-foreground: var(--buttons-light-icon);
   }
 }
 
@@ -151,11 +139,7 @@
   }
 
   i.icon {
-    background-color: var(--layered-icon-parent-bg-override, var(--buttons-light-icon));
-  }
-
-  i.icon::after {
-    background-color: var(--buttons-light-icon);
+    --icon-foreground: var(--buttons-light-icon);
   }
 }
 

--- a/src/scss/phy/icons.scss
+++ b/src/scss/phy/icons.scss
@@ -318,15 +318,8 @@ svg {
 
 .btn.btn-keyline:hover > i.icon:not(.icon-raw), .btn.btn-secondary:hover > i.icon:not(.icon-raw),
 .btn.btn-tint:hover > i.icon:not(.icon-raw), .btn.btn-tertiary:hover > i.icon:not(.icon-raw) {
-  background-color: var(--layered-icon-parent-bg-override, var(--icon-hover));
-
-  &::before {
-    background-color: var(--icon-hover);
-  }
-
-  &::after {
-    background-color: var(--icon-hover);
-  }
+  --icon-foreground: var(--icon-hover);
+  --icon-background: var(--icon-hover);
 }
 
 .phy-hex-icon {
@@ -364,4 +357,8 @@ i.icon.icon-color-alert {
 
 i.icon.icon-color-black-hoverable {
   --buttons-light-icon: #{$color-neutral-900};
+}
+
+i.icon.icon-color-theme-hoverable {
+  --buttons-light-icon: var(--subject-color-500);
 }


### PR DESCRIPTION
Replaces repeated `background-color: ...` props for each icon type (especially on buttons) with changes to `--icon-foreground` and `--icon-background`. The `::after` element (or parent, if flat) takes the `--icon-foreground` var always, likewise for `::before` and `--icon-background`.

The reason for this change is twofold. 
- First, it significantly reduces the complexity of the CSS related to colour changes. Changing an icon's foreground is as simple as `--icon-foreground: ...`; the old approach required setting the background of both the parent (for flat icons) and the `::after`.
- Second, it enables animated filling of icons, via the new `%icon-fillable` template; this requires two icon svgs, one outlined and one filled. While initially transparent, when `.fill` is applied, the background transitions to `--icon-background: var(--icon-foreground);`, creating a smooth fill animation. This is not used anywhere in this PR, but will be used in upcoming ones.