### PR TITLE
Limit contact form message length

### DIFF
--- a/src/app/components/pages/Contact.tsx
+++ b/src/app/components/pages/Contact.tsx
@@ -99,6 +99,7 @@ export const Contact = () => {
     }, [messageSent, successRef]);
 
     const isValidEmail = validateEmail(email);
+    const reachedMaxLength = message.length >= 5000; 
 
     const metaDescription = siteSpecific(
         "Contact the Isaac team with questions, comments or feedback about our resources.",
@@ -191,9 +192,10 @@ export const Contact = () => {
                                             <FormGroup className="form-group">
                                                 <Label htmlFor="message-input" className="form-required">Message</Label>
                                                 <Input id="message-input" type="textarea" name="message" rows={7} value={message}
-                                                    placeholder={presetPlaceholder}
+                                                    placeholder={presetPlaceholder} maxLength={5000}
                                                     onChange={e => setMessage(e.target.value)} required/>
                                             </FormGroup>
+                                            {reachedMaxLength && <Alert color="warning">Your message has reached the maximum length.</Alert>}
                                         </Col>
                                     </Row>
                                 </CardBody>

--- a/src/app/components/pages/Contact.tsx
+++ b/src/app/components/pages/Contact.tsx
@@ -17,6 +17,7 @@ import {
 } from "reactstrap";
 import {PotentialUser} from "../../../IsaacAppTypes";
 import {
+    CONTACT_FORM_CHAR_LENGTH_LIMIT,
     isPhy,
     isTeacherOrAbove,
     SITE_TITLE,
@@ -99,7 +100,7 @@ export const Contact = () => {
     }, [messageSent, successRef]);
 
     const isValidEmail = validateEmail(email);
-    const reachedMaxLength = message.length >= 5000; 
+    const reachedMaxLength = message.length >= CONTACT_FORM_CHAR_LENGTH_LIMIT; 
 
     const metaDescription = siteSpecific(
         "Contact the Isaac team with questions, comments or feedback about our resources.",
@@ -192,7 +193,7 @@ export const Contact = () => {
                                             <FormGroup className="form-group">
                                                 <Label htmlFor="message-input" className="form-required">Message</Label>
                                                 <Input id="message-input" type="textarea" name="message" rows={7} value={message}
-                                                    placeholder={presetPlaceholder} maxLength={5000}
+                                                    placeholder={presetPlaceholder} maxLength={CONTACT_FORM_CHAR_LENGTH_LIMIT}
                                                     onChange={e => setMessage(e.target.value)} required/>
                                             </FormGroup>
                                             {reachedMaxLength && <Alert color="warning">Your message has reached the maximum length.</Alert>}

--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -1240,6 +1240,8 @@ export const GRAY_120 = '#c9cad1';
 
 export const SEARCH_CHAR_LENGTH_LIMIT = 255;
 
+export const CONTACT_FORM_CHAR_LENGTH_LIMIT = 5000;
+
 export const SEARCH_RESULTS_PER_PAGE = 30;
 
 export const GAMEBOARD_UNDO_STACK_SIZE_LIMIT = 10;


### PR DESCRIPTION
Limits contact form messages to 5000 UTF-16 code units (which for most purposes is 5000 characters).