### PR TITLE
Don't show wildcard in sidebar for non-Isaac boards

### DIFF
--- a/src/app/components/pages/Concept.tsx
+++ b/src/app/components/pages/Concept.tsx
@@ -4,7 +4,7 @@ import {selectors, useAppSelector, useGetGameboardByIdQuery} from "../../state";
 import {Col, Row} from "reactstrap";
 import {IsaacContent} from "../content/IsaacContent";
 import {IsaacConceptPageDTO} from "../../../IsaacApiTypes";
-import {Subject, usePreviousPageContext, isAda, useNavigation, siteSpecific, useUserViewingContext, isFullyDefinedContext, isSingleStageContext, LEARNING_STAGE_TO_STAGES, isDefined} from "../../services";
+import {Subject, usePreviousPageContext, isAda, useNavigation, siteSpecific, useUserViewingContext, isFullyDefinedContext, isSingleStageContext, LEARNING_STAGE_TO_STAGES, isDefined, showWildcard} from "../../services";
 import {DocumentSubject, GameboardContext} from "../../../IsaacAppTypes";
 import {RelatedContent} from "../elements/RelatedContent";
 import {WithFigureNumbering} from "../elements/WithFigureNumbering";
@@ -49,6 +49,7 @@ export const Concept = ({conceptIdOverride, preview}: ConceptPageProps) => {
     const query = queryString.parse(location.search);
     const gameboardId = query.board instanceof Array ? query.board[0] : query.board;
     const {data: gameboard} = useGetGameboardByIdQuery(gameboardId || skipToken);
+    const wildcard = (gameboard && showWildcard(gameboard)) ? gameboard.wildCard : undefined;
 
     useEffect(() => {
         if (pageContext) {
@@ -89,7 +90,7 @@ export const Concept = ({conceptIdOverride, preview}: ConceptPageProps) => {
                     </>}
                     sidebar={siteSpecific(
                         isDefined(gameboardId) 
-                            ? <GameboardContentSidebar id={gameboardId} title={gameboard?.title || ""} questions={gameboard?.contents || []} wildCard={gameboard?.wildCard} currentContentId={doc.id}/>
+                            ? <GameboardContentSidebar id={gameboardId} title={gameboard?.title || ""} questions={gameboard?.contents || []} wildCard={wildcard} currentContentId={doc.id}/>
                             : <ConceptSidebar relatedContent={doc.relatedContent}/>,
                         undefined
                     )}

--- a/src/app/components/pages/Generic.tsx
+++ b/src/app/components/pages/Generic.tsx
@@ -2,7 +2,7 @@ import React, {useEffect} from "react";
 import {Col, Row} from "reactstrap";
 import {ContentSummaryDTO, GameboardDTO, SeguePageDTO} from "../../../IsaacApiTypes";
 import {IsaacContent} from "../content/IsaacContent";
-import {isAda, isPhy, siteSpecific, useUrlHashValue} from "../../services";
+import {isAda, isPhy, showWildcard, siteSpecific, useUrlHashValue} from "../../services";
 import {useParams} from "react-router-dom";
 import {RelatedContent} from "../elements/RelatedContent";
 import {DocumentSubject} from "../../../IsaacAppTypes";
@@ -46,7 +46,7 @@ const SciSidebar = ({pageId, tags, gameboard, relatedContent, ...sidebarProps}: 
     if (tags?.includes("news")) {
         return <NewsSidebar {...sidebarProps} />;
     }
-    if (gameboard?.id && gameboard.wildCard?.url === window.location.pathname) {
+    if (gameboard?.id && showWildcard(gameboard) && gameboard.wildCard?.url === window.location.pathname) {
         return <GameboardContentSidebar id={gameboard.id} title={gameboard.title || ""} questions={gameboard.contents || []} wildCard={gameboard.wildCard} currentContentId={pageId} {...sidebarProps} />;
     }
     if (relatedContent) {

--- a/src/app/components/pages/Question.tsx
+++ b/src/app/components/pages/Question.tsx
@@ -15,7 +15,8 @@ import {
     siteSpecific,
     Subject,
     useNavigation,
-    isDefined} from "../../services";
+    isDefined,
+    showWildcard} from "../../services";
 import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
 import {WithFigureNumbering} from "../elements/WithFigureNumbering";
 import {IsaacContent} from "../content/IsaacContent";
@@ -66,6 +67,7 @@ export const Question = ({questionIdOverride, preview}: QuestionPageProps) => {
 
     const pageContext = usePreviousPageContext(user && user.loggedIn && user.registeredContexts || undefined, doc && !isLoading ? doc : undefined);
     const {data: gameboard} = useGetGameboardByIdQuery(gameboardId || skipToken);
+    const wildcard = (gameboard && showWildcard(gameboard)) ? gameboard.wildCard : undefined;
 
     return <ShowLoadingQuery
         query={questionQuery}
@@ -91,7 +93,7 @@ export const Question = ({questionIdOverride, preview}: QuestionPageProps) => {
                     }
                     sidebar={siteSpecific(
                         isDefined(gameboardId) 
-                            ? <GameboardContentSidebar id={gameboardId} title={gameboard?.title || ""} questions={gameboard?.contents || []} wildCard={gameboard?.wildCard} currentContentId={questionId}/>
+                            ? <GameboardContentSidebar id={gameboardId} title={gameboard?.title || ""} questions={gameboard?.contents || []} wildCard={wildcard} currentContentId={questionId}/>
                             : <QuestionSidebar relatedContent={doc.relatedContent} />,
                         undefined
                     )}


### PR DESCRIPTION
On a board overview page, we only show wildcards on "Created by Isaac" or certain book boards. The same check should apply to wildcards displayed in the gameboard sidebar.