### PR TITLE
Mild event details layout fixes

### DIFF
--- a/src/app/components/pages/EventDetails.tsx
+++ b/src/app/components/pages/EventDetails.tsx
@@ -95,7 +95,7 @@ const KeyEventInfo = ({user, event, eventId, isVirtual, canMakeABooking, booking
     const KeyInfo = siteSpecific("div", Card);
 
     return <>
-        <MetadataContainer className={classNames("overflow-scroll", {"mt-3": isAda})}>
+        <MetadataContainer className={classNames("overflow-auto", {"mt-3": isAda})}>
             <KeyInfo className={classNames("event-key-info", siteSpecific("px-4", "gap-3 p-4"))}>
                 <Row>
                     <Col className={classNames(firstColumnWidths, "align-items-start")}>

--- a/src/app/components/pages/EventDetails.tsx
+++ b/src/app/components/pages/EventDetails.tsx
@@ -397,8 +397,9 @@ const EventDetails = () => {
                         </span>}
                     </>}
                 >
-                    <KeyEventInfo {...eventBookingProps} />
+                    {isPhy && <KeyEventInfo {...eventBookingProps} />}
                 </PageMetadata>
+                {isAda && <KeyEventInfo {...eventBookingProps} />}
                 <div className={siteSpecific("", "mt-4 pt-2 card")}>
                     <div className={siteSpecific("", "card-body")}>
                         <Row> 

--- a/src/app/components/pages/EventDetails.tsx
+++ b/src/app/components/pages/EventDetails.tsx
@@ -402,15 +402,11 @@ const EventDetails = () => {
                 {isAda && <KeyEventInfo {...eventBookingProps} />}
                 <div className={siteSpecific("", "mt-4 pt-2 card")}>
                     <div className={siteSpecific("", "card-body")}>
-                        <Row> 
-                            <Col>
-                                <div className="d-flex flex-column-reverse d-md-block">
-                                    <ImageAndMap {...eventBookingProps} />
-                                    <IsaacContent doc={event}/>
-                                </div>
-                                <BookingForm {...eventBookingProps} />
-                            </Col>
-                        </Row>
+                        <div className="d-flex flex-column-reverse d-md-block">
+                            <ImageAndMap {...eventBookingProps} />
+                            <IsaacContent doc={event}/>
+                        </div>
+                        <BookingForm {...eventBookingProps} />
                     </div>
                 </div>
                 <Button tag={Link} to="/events" color="keyline" className="float-end my-4">


### PR DESCRIPTION
1) overflow-scroll -> overflow-auto (wrong way around in commit oops) so the scroll bar isn't always visible in the box when it isn't needed for applicable browsers
2) Change DOM structure so info box is always strictly below action buttons for Ada
3) Remove `<Row>` and `<Col>` from DOM which are no longer having an effect