### PR TITLE
Rename SQA to Qualifications Scotland

### DIFF
--- a/src/app/components/pages/ExamSpecifications.tsx
+++ b/src/app/components/pages/ExamSpecifications.tsx
@@ -2,7 +2,7 @@ import React, {useEffect, useState} from "react";
 import {Col, Container, Row} from "reactstrap";
 import {Tabs} from "../elements/Tabs";
 import {PageFragment} from "../elements/PageFragment";
-import {CS_EXAM_BOARDS_BY_STAGE, EXAM_BOARD, STAGE, STAGES_CS, stageLabelMap} from "../../services";
+import {CS_EXAM_BOARDS_BY_STAGE, EXAM_BOARD, STAGE, STAGES_CS, stageLabelMap, examBoardLabelMap} from "../../services";
 import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
 import {MetaDescription} from "../elements/MetaDescription";
 import {ExamBoard} from "../../../IsaacApiTypes";
@@ -93,7 +93,7 @@ export const ExamSpecifications = ({stageFilter, examBoardFilter, title}: ExamSp
             }}
         >
             {Object.assign({}, ...stageExamBoards.map(examBoard => ({
-                [examBoard.toUpperCase()]: <></>
+                [examBoardLabelMap[examBoard]]: <></>
             })))}
         </Tabs>}), {});
 

--- a/src/app/services/constants.ts
+++ b/src/app/services/constants.ts
@@ -310,7 +310,7 @@ export const examBoardLabelMap: {[examBoard in ExamBoard]: string} = {
     [EXAM_BOARD.EDUQAS]: "EDUQAS",
     [EXAM_BOARD.OCR]: "OCR",
     [EXAM_BOARD.WJEC]: "WJEC",
-    [EXAM_BOARD.SQA]: "SQA",
+    [EXAM_BOARD.SQA]: "Qualifications Scotland",
     [EXAM_BOARD.ADA]: "Ada CS",
     [EXAM_BOARD.ALL]: "All exam boards",
 };

--- a/src/app/services/userViewingContext.ts
+++ b/src/app/services/userViewingContext.ts
@@ -175,7 +175,7 @@ const _EXAM_BOARD_ITEM_OPTIONS = [ /* best not to export - use getFiltered */
     {label: "Eduqas", value: EXAM_BOARD.EDUQAS},
     {label: "OCR", value: EXAM_BOARD.OCR},
     {label: "WJEC", value: EXAM_BOARD.WJEC},
-    {label: "SQA", value: EXAM_BOARD.SQA},
+    {label: "Scotland", value: EXAM_BOARD.SQA},
 ];
 interface ExamBoardFilterOptions {
     byUser?: Immutable<PotentialUser> | null;


### PR DESCRIPTION
We'll still use the SQA tag under the hood, and use "Scotland" in places where the full "Qualifications Scotland" would be too verbose.