### PR TITLE
Don't unnecessarily show scrollbar on event cards

### DIFF
--- a/src/app/components/pages/SubjectLandingPage.tsx
+++ b/src/app/components/pages/SubjectLandingPage.tsx
@@ -148,7 +148,7 @@ const FooterRow = ({context, books, news, events}: FooterRowProps) => {
                 <h4 className="m-0">Events <span className="text-theme">({relevantEvents.length})</span></h4>
                 <div className="section-divider-bold flex-grow-1"/>
             </div>
-            <Row className="h-100 item-list-container">
+            <Row className={classNames("h-100 item-list-container", {"overflow-hidden": relevantEvents.length === 1})}>
                 {relevantEvents.map((event, i) =>
                     <Col xs={12} key={i} className={classNames({"mb-3": ['xs', 'md'].includes(deviceSize)})}>
                         {event && <EventCard event={event} layout={"landing-page"} className={classNames({"force-horizontal": !['xs', 'md'].includes(deviceSize)})} />}


### PR DESCRIPTION
If there's only one event card shown it doesn't need a scrollbar, but at certain screen sizes one was shown anyway.