### PR TITLE
Ada action buttons focus-visible interaction

### DIFF
--- a/src/app/components/elements/ShareLink.tsx
+++ b/src/app/components/elements/ShareLink.tsx
@@ -68,7 +68,7 @@ export const ShareLink = ({linkUrl, reducedWidthLink, gameboardId, clickAwayClos
             className={classNames(innerClassName, "w-max-content h-max-content action-button", {"icon-button-sm": size == "sm"})}
             aria-label={buttonAriaLabel}
             title="Share page"
-            color="tint"
+            color={siteSpecific("tint", "primary")}
             data-bs-theme="neutral"
             onClick={(e) => { e.preventDefault(); toggleShareLink(); }}
             {...buttonProps}

--- a/src/scss/common/focus.scss
+++ b/src/scss/common/focus.scss
@@ -17,7 +17,8 @@
   color: $gray-160 !important;
 }
 
-:focus-visible:not([tabindex="-1"]):not(.select__input) {
+// Doubled to raise specificity above certain elements such as Ada action buttons
+:focus-visible:focus-visible:not([tabindex="-1"]):not(.select__input) {
   @include focus-outline;
 }
 

--- a/src/scss/cs/button.scss
+++ b/src/scss/cs/button.scss
@@ -139,6 +139,9 @@
 .action-button {
   &:not(.outline) {
     @include ada-icon-button-base(48px, 48px, false);
+    &:focus-visible {
+      @include focus-outline;
+    }
   }
   &.outline {
     @include ada-icon-button-base(48px, 48px, true);

--- a/src/scss/cs/button.scss
+++ b/src/scss/cs/button.scss
@@ -139,9 +139,6 @@
 .action-button {
   &:not(.outline) {
     @include ada-icon-button-base(48px, 48px, false);
-    &:focus-visible {
-      @include focus-outline;
-    }
   }
   &.outline {
     @include ada-icon-button-base(48px, 48px, true);


### PR DESCRIPTION
- The share button did get an outline, but its background disappeared when highlighted. This is because it was `btn-tint` rather than `btn-primary` like the other two action buttons (this is site-specific). This has been fixed.

- The print and report buttons did not get an outline. This is because the `$outlined` property was false in its `ada-icon-button-base` mixin, and of the same specificity as the general `focus-outline` mixin application. A more specific `focus-outline` is added in the same place to override this.