### PR TITLE
Add regex check to ignore "decimals" in compounds

### DIFF
--- a/src/app/components/elements/inputs/SymbolicTextInput.tsx
+++ b/src/app/components/elements/inputs/SymbolicTextInput.tsx
@@ -132,7 +132,8 @@ export const symbolicTextInputValidator = (input: string, editorMode: EditorMode
         }
     }
 
-    if (["chemistry", "nuclear", "maths"].includes(editorMode) && /\.[0-9]/.test(input)) {
+    const decimalsOutsideCompound = input.match(/(?<![A-Za-z])\d+\.\d+\s*([A-Z]|$)|[A-Za-z]\d+\.\d+\s*$/);
+    if ((["nuclear", "maths"].includes(editorMode) && /\.[0-9]/.test(input)) || (editorMode === "chemistry" && decimalsOutsideCompound)) {
         errors.push('Please convert decimal numbers to fractions.');
     }
     if (editorMode === "chemistry" && /\(s\)|\(aq\)|\(l\)|\(g\)/.test(input) && !mayRequireStateSymbols) {

--- a/src/test/components/content/IsaacSymbolicQuestion.test.tsx
+++ b/src/test/components/content/IsaacSymbolicQuestion.test.tsx
@@ -56,7 +56,8 @@ describe("IsaacSymbolicQuestion", () => {
         // misc errors
         expect(symbolicChemistryInputValidator("2H2O -> 2H2 + O2")).toEqual([]);
         expect(symbolicChemistryInputValidator("2(H2O")).toEqual(['You are missing some brackets.']);
-        expect(symbolicChemistryInputValidator(".5")).toEqual(['Please convert decimal numbers to fractions.']);
+        expect(symbolicChemistryInputValidator("2.5")).toEqual(['Please convert decimal numbers to fractions.']);
+        expect(symbolicChemistryInputValidator("C2.5H2O")).toEqual([]);
         expect(symbolicChemistryInputValidator("2H2O(l) -> 2H2(g) + O2(g)")).toEqual(['This question does not require state symbols.']);
         expect(symbolicTextInputValidator("2H2O(l) -> 2H2(g) + O2(g)", "chemistry", true)).toEqual([]);
     });


### PR DESCRIPTION
Decimals are still unwanted in chemistry, but we don't want to mistake numbers separated by a dot in the middle of a compound as a decimal. These can be used to represent a water of crystallisation.

Also considering that spaces are allowed between coefficients and elements, but not between elements and subscripts.

This means:
- `2.5` should give a warning
- `2.5C...` should give a warning
- `...C2.5` should give a warning
- `2.5 C...` should give a warning
- `...C 2.5H...` should give a warning
- `...C2.5H...` should *not* give a warning
- `...C2.5 H...` should *not* give a warning

(and equivalent for other numbers and other elements, even if those elements can't be used for a water of crystallisation)
((a half-written equation may still give warnings, but that's fine - a similar thing happens for as-yet unclosed brackets))