### PR TITLE
Fix Ada sidebar container overflows

### DIFF
--- a/src/app/components/elements/PageMetadata.tsx
+++ b/src/app/components/elements/PageMetadata.tsx
@@ -50,7 +50,7 @@ interface ActionButtonsProps extends React.HTMLAttributes<HTMLDivElement> {
 export const ActionButtons = ({location, isQuestion, helpModalId, doc, ...rest}: ActionButtonsProps) => {
     const deviceSize = useDeviceSize();
 
-    const anyActionButtonShown = isPhy && helpModalId || above['sm'](deviceSize) || doc?.id;
+    const anyActionButtonShown = isPhy && helpModalId || (above['sm'](deviceSize) && (doc || isPhy)) || doc?.id;
 
     return anyActionButtonShown && <div {...rest} className={classNames("d-flex no-print gap-2", rest.className)}>
         {isPhy && isQuestion && <FeatureFlagWrapper flag={FeatureFlag.ENABLE_SCI_BOOKMARKS}>
@@ -59,7 +59,7 @@ export const ActionButtons = ({location, isQuestion, helpModalId, doc, ...rest}:
         }
         {isPhy && helpModalId && <HelpButton modalId={helpModalId} />}
         {above['sm'](deviceSize) && <>
-            <ShareLink linkUrl={location.pathname + location.hash} clickAwayClose />
+            {(doc || isPhy) && <ShareLink linkUrl={location.pathname + location.hash} clickAwayClose />}
             {doc && <PrintButton questionPage={isQuestion} />} {/* don't show print for internal (non content-driven) pages */}
         </>}
         {doc?.id && <ReportButton pageId={doc.id} />}

--- a/src/app/components/elements/layout/PageContainer.tsx
+++ b/src/app/components/elements/layout/PageContainer.tsx
@@ -47,7 +47,7 @@ export const PageContainer = (props: PageContainerProps) => {
         <SidebarLayout className="g-md-0" id={id} show={!!sidebar}>
             {sidebar}
             <MainContent className="overflow-x-auto">
-                <Container fluid {...rest} className={classNames("my-ada-container mw-1600 px-md-4 px-lg-6 mb-2", rest.className)}>
+                <Container fluid {...rest} className={classNames("my-ada-container overflow-x-auto mw-1600 px-md-4 px-lg-6 mb-2", rest.className)}>
                     {pageTitle}
                     {children}
                 </Container>


### PR DESCRIPTION
Fixes overflow caused by changes to the Ada sidebar container.

Before (overflows to the right):
<img width="1438" height="460" alt="image" src="https://github.com/user-attachments/assets/f4b068c6-6083-4122-99e5-3b1a3bb18840" />
After:
<img width="1438" height="460" alt="image" src="https://github.com/user-attachments/assets/4f60e3b3-827f-4f11-b486-47d369ad6005" />

---

Also fixes the bad float position on the share link causing certain pages without toptext to appear too small, just by hiding it for non-content pages.

Before:
<img width="1438" height="460" alt="image" src="https://github.com/user-attachments/assets/f08878bd-2acc-4f7f-84a2-ec850af9ffcb" />
After:
<img width="1438" height="460" alt="image" src="https://github.com/user-attachments/assets/7b881b5a-533e-4619-b9a0-e0d7d89059ac" />

