### PR TITLE
Improve bullet points in content lists

### DIFF
--- a/src/scss/phy/color-theme.scss
+++ b/src/scss/phy/color-theme.scss
@@ -1,5 +1,6 @@
 @use "sass:map";
 @use "sass:color";
+@use "sass:string";
 
 // since the brand colours are not used as themes, we need to make them available (dark mode-inclusively) globally
 @include color-mode(light, $root: true) {
@@ -150,6 +151,14 @@
               color: var(--subject-color-900);
             }
           }
+        }
+
+        // create a subject-color-coded bullet for content lists
+        .content-value ul:not(.list-unstyled) {
+          $col: if($palette == "neutral", "#{$color-brand-500}", "#{map.get($subject-colors, 500)}");
+          $col-plain: string.slice($col, 2);
+          // this svg is made to be 8px x 8px – but using a larger width gives more space between the bullet and the text, and a slightly larger height centres it better with the text
+          list-style-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='24' height='9' viewBox='0 0 16 18'><polygon points='11.7,10.1 5.8,13.5 0,10.1 0,3.4 5.8,0 11.7,3.4' fill='%23#{$col-plain}'/></svg>");
         }
       }
     }

--- a/src/scss/phy/typography.scss
+++ b/src/scss/phy/typography.scss
@@ -66,31 +66,8 @@ code {
 
 ul {
   list-style-position: outside;
+  // overridden for content lists to allow subject colour-coding –– see color-theme.scss
   list-style-image: url('/assets/phy/icons/hexagon-bullet.svg');
-}
-
-.content-value {
-  ul:not(.list-unstyled) {
-    list-style-type: none;
-    list-style-image: none;
-    > li {
-      position: relative;
-      &::before {
-        content: "";
-        display: block;
-        position: absolute;
-        top: 0.6rem;
-        left: -1.2rem;
-
-        width: 8px;
-        height: 8px;
-
-        mask: url("/assets/phy/icons/redesign/hexagon.svg") center center no-repeat;
-        mask-size: 90%;
-        background-color: var(--subject-color-500);
-      }
-    }
-  }
 }
 
 .validation-response-panel.correct .content-value ul li::before {


### PR DESCRIPTION
Customising bullet points has proven a pain recently. We would like to have them be subject coloured, be hexagonal in shape, and obviously be in the correct position.

Currently, our bullets hit the first two points, but not the last. We use a `::before`-based approach, where we remove the `::marker` element entirely via `list-style-type: none; list-style-image: none`, then in its place add a `::before` to each `<li/>` that we can customise. The reason for this is that `::marker` is intentionally very limited in what can be done to it and how it can be positioned; the only things of note that can be modified are CSS font props and the text content if using `list-style-type`, or the image displayed if using `list-style-image`.

Unfortunately, `::before` has a major flaw in that content with inconsistent line heights cause the generated pseudo element to exist in the wrong place. On the site, for example, vectors cause issues:

<img width="608" height="382" alt="image" src="https://github.com/user-attachments/assets/7ae1d0f4-9e74-49f6-a27b-db00fa35e8d3" />

We can of course fix the tall, single-line case with e.g. `height: stretch` or `height: 100%` on the `::before`, but this then causes the bullet point for paragraphs to be in the centre:

<img width="608" height="500" alt="image" src="https://github.com/user-attachments/assets/0e41db07-c083-44b8-b614-ab7753ca5c71" />

---

`::marker` has no such issues and will generate inline with the first line of the adjacent paragraph, so is essential to have any chance of meeting all 3 requirements. This does, however, leave us with to deal with very limited customisation options.

This PR leverages the loop used to create colour themes to create a custom, inline SVG with the correct colour for each colour theme, that can be passed into `list-style-image`. These SVGs are uniquely sized to line up precisely with the centre of the text, avoiding the need for any customisation with regards to position.

> Note that inline SVGs do not inherit properties from the DOM, so unfortunately we cannot use the same SVG for all themes with `fill='var(--subject-color-500)'`. 

The final result looks like this:
<img width="608" height="382" alt="image" src="https://github.com/user-attachments/assets/380ad249-5ac0-48bf-a2d8-781a332470d2" />
