### PR TITLE
Allow content to inherit `preview` prop

### DIFF
--- a/src/app/components/content/IsaacAccordion.tsx
+++ b/src/app/components/content/IsaacAccordion.tsx
@@ -50,7 +50,7 @@ const StageInsert = ({stage}: {stage: string}) => {
     </>;
 };
 
-export const IsaacAccordion = ({doc}: {doc: ContentDTO}) => {
+export const IsaacAccordion = ({doc, preview}: {doc: ContentDTO, preview?: boolean}) => {
     const page = useAppSelector(selectors.doc.get);
     const user = useAppSelector(selectors.user.orNull);
     const userContext = useUserViewingContext();
@@ -186,6 +186,7 @@ export const IsaacAccordion = ({doc}: {doc: ContentDTO}) => {
                     deEmphasised={section.deEmphasised}
                     trustedTitle={section?.title || ""}
                     audienceString={audienceString}
+                    preview={preview}
                 >
                     <IsaacContent doc={section} />
                 </Accordion>

--- a/src/app/components/content/IsaacContent.tsx
+++ b/src/app/components/content/IsaacContent.tsx
@@ -39,7 +39,8 @@ const classBasedLayouts = {
 
 export interface IsaacContentProps {
     doc: ContentDTO,
-    contentIndex?: number
+    contentIndex?: number,
+    preview?: boolean;
 }
 
 export const IsaacContent = (props: IsaacContentProps) => {
@@ -97,7 +98,7 @@ export const IsaacContent = (props: IsaacContentProps) => {
                     case "horizontal": selectedComponent = <IsaacHorizontal {...props} key={props.doc.id} />; break;
                     case "clearfix": selectedComponent = <>&nbsp;</>; break;
                     default: selectedComponent =
-                        <IsaacContentValueOrChildren encoding={encoding} value={value} key={props.doc.id} >
+                        <IsaacContentValueOrChildren encoding={encoding} value={value} key={props.doc.id} preview={props.preview}>
                             {children}
                         </IsaacContentValueOrChildren>;
                 }

--- a/src/app/components/content/IsaacContentValueOrChildren.tsx
+++ b/src/app/components/content/IsaacContentValueOrChildren.tsx
@@ -9,8 +9,9 @@ interface ContentValueOrChildrenProps {
     value?: string;
     encoding?: string;
     children?: ContentDTO[];
+    preview?: boolean;
 }
-export const IsaacContentValueOrChildren = ({value, encoding, children}: ContentValueOrChildrenProps) => {
+export const IsaacContentValueOrChildren = ({value, encoding, children, preview}: ContentValueOrChildrenProps) => {
     // Content chunking inherited from Isaac Physics
     const contentChunks: ContentOrAccordionChunk[] = []; // One of these for each chunk of content, where accordions may only appear on their own in a chunk.
     let breakOnTypeChange = false;
@@ -60,13 +61,13 @@ export const IsaacContentValueOrChildren = ({value, encoding, children}: Content
             if (contentChunk.isAccordion) {
                 return <React.Fragment key={chunkIndex}>
                     {contentChunk.map((content, contentIndex) =>
-                        <IsaacContent doc={content} key={contentIndex} contentIndex={contentIndex}/>)
+                        <IsaacContent doc={content} key={contentIndex} contentIndex={contentIndex} preview={preview}/>)
                     }
                 </React.Fragment>;
             } else {
                 return <div className="clearfix content-chunk" key={chunkIndex}>
                     {contentChunk.map((content, contentIndex) =>
-                        <IsaacContent doc={content} key={contentIndex} contentIndex={contentIndex}/>)}
+                        <IsaacContent doc={content} key={contentIndex} contentIndex={contentIndex} preview={preview}/>)}
                 </div>;
             }
         })}

--- a/src/app/components/elements/Accordion.tsx
+++ b/src/app/components/elements/Accordion.tsx
@@ -41,11 +41,12 @@ interface AccordionsProps {
     deEmphasised?: boolean;
     disabled?: string | boolean;
     audienceString?: string;
+    preview?: boolean;
 }
 
 let nextClientId = 0;
 
-export const Accordion = ({id, trustedTitle, index, children, startOpen, deEmphasised, disabled, audienceString}: AccordionsProps) => {
+export const Accordion = ({id, trustedTitle, index, children, startOpen, deEmphasised, disabled, audienceString, preview}: AccordionsProps) => {
     const dispatch = useAppDispatch();
     const location = useLocation();
     const componentId = useRef(uuid_v4().slice(0, 4)).current;
@@ -61,7 +62,8 @@ export const Accordion = ({id, trustedTitle, index, children, startOpen, deEmpha
         `accordion-${id ?? "unknown"}-${index ?? "unknown"}`,
         disabled 
             ? false 
-            : startOpen ?? (openFirst && isFirst)
+            : startOpen ?? (openFirst && isFirst),
+        preview, // do not update location when previewing; avoids firing useBlockers on relevant pages
     );
     
     // If start open changes we need to update whether or not the accordion section should be open

--- a/src/app/components/pages/Question.tsx
+++ b/src/app/components/pages/Question.tsx
@@ -133,7 +133,7 @@ export const Question = ({questionIdOverride, preview}: QuestionPageProps) => {
                             <RevisionWarningBanner />
 
                             <WithFigureNumbering doc={doc}>
-                                <IsaacContent doc={doc}/>
+                                <IsaacContent doc={doc} preview={preview}/>
                             </WithFigureNumbering>
 
                             {doc.supersededBy && isStudent(user) && <div className="alert alert-warning">

--- a/src/app/state/actions/history.tsx
+++ b/src/app/state/actions/history.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
-export function useHistoryState<T>(key: string, initialValue: T): [T, React.Dispatch<React.SetStateAction<T>>, boolean] {
+export function useHistoryState<T>(key: string, initialValue: T, withoutLocationUpdate?: boolean): [T, React.Dispatch<React.SetStateAction<T>>, boolean] {
     const navigate = useNavigate();
     const location = useLocation();
     const existingState = location.state?.[key as keyof typeof location.state];
@@ -16,21 +16,23 @@ export function useHistoryState<T>(key: string, initialValue: T): [T, React.Disp
 
     const setStateAndLocation = useCallback((value: React.SetStateAction<T>) => {
         // don't do anything if the value is already set (would create a new state object and not be reference-equal inside useEffect deps)
-        if (value === locationRef.current.state?.[key as keyof typeof locationRef.current.state]) return; 
+        if (!withoutLocationUpdate) {
+            if (value === locationRef.current.state?.[key as keyof typeof locationRef.current.state]) return; 
 
-        void navigate({
-            ...locationRef.current,
-        }, {
-            state: {
-                ...locationRef.current.state as Array<string>,
-                [key]: value
-            },
-            replace: true 
-        });
+            void navigate({
+                ...locationRef.current,
+            }, {
+                state: {
+                    ...locationRef.current.state as Array<string>,
+                    [key]: value
+                },
+                replace: true 
+            });
+        }
         setState(value);
 
         setLoadedFromHistory(false);
-    }, [navigate, key]);
+    }, [key, withoutLocationUpdate, navigate]);
 
     return [state, setStateAndLocation, loadedFromHistory];
 }

--- a/src/app/state/actions/history.tsx
+++ b/src/app/state/actions/history.tsx
@@ -15,8 +15,8 @@ export function useHistoryState<T>(key: string, initialValue: T, withoutLocation
     }, [location]);
 
     const setStateAndLocation = useCallback((value: React.SetStateAction<T>) => {
-        // don't do anything if the value is already set (would create a new state object and not be reference-equal inside useEffect deps)
         if (!withoutLocationUpdate) {
+            // don't do anything if the value is already set (would create a new state object and not be reference-equal inside useEffect deps)
             if (value === locationRef.current.state?.[key as keyof typeof locationRef.current.state]) return; 
 
             void navigate({


### PR DESCRIPTION
The original purpose here was to prevent a warning in builder previews when opening an accordion. Doing so was causing `useHistoryState` to `navigate` to the same page with a new `location.state`, attempting to store that the accordion was open when last visited. This was unfortunately triggering any `useBlocker`s on the base page, since a "navigation" was taking place.

In order to fix this, content and children will now inherit the `preview` prop if set. This allows accordions not to run the `navigate` part of `useHistoryState` if inside a preview. This will also certainly enable improved future preview behaviour, should we need it.