### PR TITLE
Fix Ada sidebar breakpoint inconsistency

### DIFF
--- a/src/app/components/elements/layout/SidebarLayout.tsx
+++ b/src/app/components/elements/layout/SidebarLayout.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect } from "react";
 import { Col, ColProps, RowProps, Offcanvas, OffcanvasBody, OffcanvasHeader, Container, Accordion, AccordionItem, AccordionHeader, AccordionBody } from "reactstrap";
 import classNames from "classnames";
-import { above, isPhy, siteSpecific, useDeviceSize } from "../../../services";
+import { isPhy, siteSpecific, useFullSidebarLayout } from "../../../services";
 import { mainContentIdSlice, selectors, sidebarSlice, useAppDispatch, useAppSelector } from "../../../state";
 import { ContentSidebarContext, SidebarContext } from "../../../../IsaacAppTypes";
 import { AffixButton } from "../AffixButton";
@@ -53,7 +53,7 @@ export interface ContentSidebarProps extends SidebarProps {
 export const ContentSidebar = (props: ContentSidebarProps) => {
     // A content sidebar is used to interact with the main content, e.g. filters or search boxes, or for in-page nav (e.g. lessons and revision);
     // the content in such a sidebar will collapse into a button accessible from above the main content on smaller screens
-    const deviceSize = useDeviceSize();
+    const fullSidebarLayout = useFullSidebarLayout();
     const dispatch = useAppDispatch();
     const sidebarOpen = useAppSelector(selectors.sidebar.open);
     const toggleMenu = () => dispatch(sidebarSlice.actions.toggle());
@@ -64,10 +64,8 @@ export const ContentSidebar = (props: ContentSidebarProps) => {
     const sidebarContext = useContext(SidebarContext);
     if (!sidebarContext?.sidebarPresent) return <></>;
 
-    const breakpoint = siteSpecific("lg", "md");
-
     const { className, buttonTitle, hideButton, optionBar, ...rest } = props;
-    return above[breakpoint](deviceSize)
+    return fullSidebarLayout
         ? siteSpecific(
             <Col tag="aside" data-testid="sidebar" aria-label="Sidebar" lg={4} xl={3} {...rest} className={classNames("d-none d-lg-flex flex-column sidebar no-print ps-lg-3 py-lg-4 pe-lg-5 order-0", className)} />,
             <Col tag="aside" data-testid="sidebar" aria-label="Sidebar" {...rest} className={classNames("flex-column sidebar no-print order-0", className)} />

--- a/src/app/components/elements/layout/SidebarLayout.tsx
+++ b/src/app/components/elements/layout/SidebarLayout.tsx
@@ -13,9 +13,10 @@ interface SidebarLayoutProps extends RowProps {
 
 export const SidebarLayout = (props: SidebarLayoutProps) => {
     const { className, show=true, ...rest } = props;
+    const fullSidebarLayout = useFullSidebarLayout();
     return show
         ? <SidebarContext.Provider value={{sidebarPresent: true}}>
-            <div {...rest} className={classNames("d-flex flex-column sidebar-layout", siteSpecific("flex-lg-row", "flex-md-row"), className)}/>
+            <div {...rest} className={classNames("d-flex sidebar-layout", fullSidebarLayout ? "flex-row" : "flex-column", className)}/>
         </SidebarContext.Provider>
         : props.children;
 };

--- a/src/app/components/elements/sidebar/MyAdaSidebar.tsx
+++ b/src/app/components/elements/sidebar/MyAdaSidebar.tsx
@@ -3,7 +3,7 @@ import { ContentSidebar, ContentSidebarProps } from "../layout/SidebarLayout";
 import { StyledTabPicker } from "../inputs/StyledTabPicker";
 import classNames from "classnames";
 import { selectors, sidebarSlice, useAppDispatch, useAppSelector } from "../../../state";
-import { above, below, isStudent, isTeacherOrAbove, isTutorOrAbove, useDeviceSize, useUserNotifications } from "../../../services";
+import { isStudent, isTeacherOrAbove, isTutorOrAbove, useFullSidebarLayout, useUserNotifications } from "../../../services";
 import { Spacer } from "../Spacer";
 import { useLocation } from "react-router";
 
@@ -97,16 +97,16 @@ export const MyAdaSidebar = (props: ContentSidebarProps) => {
     const location = useLocation();
     const dispatch = useAppDispatch();
     const user = useAppSelector(selectors.user.loggedInOrNull);
-    const deviceSize = useDeviceSize();
 
     const { notifications: _, workCounts } = useUserNotifications();
+    const fullSidebarLayout = useFullSidebarLayout();
 
     const isOpen = useAppSelector(selectors.sidebar.open);
     const toggleSidebar = () => dispatch(sidebarSlice.actions.toggle());
 
     return <ContentSidebar {...props} className={classNames(props.className, {"collapsed": !isOpen})} buttonTitle="My Ada">
         <div className="sticky-top overflow-x-hidden">
-            {above['md'](deviceSize) && <AdaSidebarCollapser collapsed={!isOpen} toggleSidebar={toggleSidebar} />}
+            {fullSidebarLayout && <AdaSidebarCollapser collapsed={!isOpen} toggleSidebar={toggleSidebar} />}
 
             {Object.entries(MyAdaTabs)
                 .filter(([_, tab]) => {
@@ -131,7 +131,7 @@ export const MyAdaSidebar = (props: ContentSidebarProps) => {
                         </div>}
                         checked={isActive}
                         className={classNames("nav-link my-ada-tab ps-1")}
-                        onClick={() => below['sm'](deviceSize) && isOpen && toggleSidebar()}
+                        onClick={() => !fullSidebarLayout && isOpen && toggleSidebar()}
                         type="link"
                         to={tab.url}
                     />;

--- a/src/app/services/device.ts
+++ b/src/app/services/device.ts
@@ -34,7 +34,7 @@ const descDeviceSizes = [DeviceSize.XXXL, DeviceSize.XXL, DeviceSize.XL, DeviceS
 
 export const useDeviceSize = () => {
     const getSize = (): DeviceSize => {
-        const shouldIncludeSidebar = isAda && window.innerWidth >= 768;
+        const shouldIncludeSidebar = isAda && window.innerWidth >= 988;
         const width = window.innerWidth - (shouldIncludeSidebar ? 220 : 0);
         if (width >= 1800) return DeviceSize.XXXL;
         else if (width >= 1400) return DeviceSize.XXL;
@@ -77,6 +77,20 @@ export const useDeviceHeight = () => {
     }, []);
 
     return windowHeight;
+};
+
+export const useFullSidebarLayout = () => {
+    const shouldUseFullLayout = (): boolean => window.innerWidth >= siteSpecific(768, 988);
+
+    const [fullSidebarLayout, setFullSidebarLayout] = useState(shouldUseFullLayout);
+
+    useEffect(() => {
+        const handleResize = () => {setFullSidebarLayout(shouldUseFullLayout());};
+        window.addEventListener('resize', handleResize);
+        return () => window.removeEventListener('resize', handleResize);
+    }, []);
+
+    return fullSidebarLayout;
 };
 
 export const useNavbarExpanded = () => {

--- a/src/app/services/device.ts
+++ b/src/app/services/device.ts
@@ -80,7 +80,7 @@ export const useDeviceHeight = () => {
 };
 
 export const useFullSidebarLayout = () => {
-    const shouldUseFullLayout = (): boolean => window.innerWidth >= siteSpecific(768, 988);
+    const shouldUseFullLayout = (): boolean => window.innerWidth >= siteSpecific(992, 988);
 
     const [fullSidebarLayout, setFullSidebarLayout] = useState(shouldUseFullLayout);
 

--- a/src/scss/cs/isaac.scss
+++ b/src/scss/cs/isaac.scss
@@ -297,8 +297,9 @@ $sidebar-width: 220px;
 
 $grid-breakpoints: (
   xs: 0,
-  sm: 576px, // sidebar only appears at md and above; sm remains the same
-  md: calc(768px + $sidebar-width),
+  sm: 576px,
+  md: 768px, 
+  // sidebar appears at $md + $sidebar-width = 988px, which changes the effective screen size back to 768px. as such, we should remain at md until the effective screen size reaches 992px.
   lg: calc(992px + $sidebar-width),
   xl: calc(1200px + $sidebar-width),
   nav: 1256px, // nav expansion is independent of sidebar


### PR DESCRIPTION
Attempts to resolve the sidebar issues described in https://github.com/isaacphysics/isaac-react-app/pull/2168, caused by the sidebar using a modified page-width-obtaining function that compensates for the sidebar existing on the page – when it obviously should not since it *is* the sidebar!

This is very similar in approach to https://github.com/isaacphysics/isaac-react-app/pull/2168/changes/25ae05eb42c7e4b10b77784faa6965302b81a66b, but fixes a bug where `shouldIncludeSidebar` was expecting the sidebar to be `>=992px` when it should be `>=(768px + $sidebar-width)` = `>=988px`. This explains the buggy behaviour at precisely 988-991 pixels on the original.

This is, however, intentionally less fully-featured; for example, `useDeviceSize` does not change according to whether the sidebar is shown (i.e. `...&& Object.values(MyAdaTabs).some(tab => window.location.pathname.includes(tab.url)) && ...`). This does mean that all Ada pages are affected by the modified widths, not just those that have a sidebar.

The reason for not doing this is that right now, Bootstrap `d-md-x` etc classes can only represent exactly one, non-changing value owing to SCSS being compiled, and if we allowed `useDeviceSize` to mean two different things, there would be inconsistency between Bootstrap and e.g. `above`/`below`. I believe sitewide consistency between these is too fundamental *not* to cause a slew of bugs if we do not keep it as is. 

Of course, if there was a way for Bootstrap's meanings to differ in different situations, I would be all for it. I am not particularly keen to spend much time on it, however, as BS have announced containerised Bootstrap will be coming in v6 which would solve all of this, and we'd only be reinventing the wheel (very awkwardly, since we can't modify BS ourselves...).