### PR TITLE
Fix reorder/parsons question selected item focus-outlines 

### DIFF
--- a/src/scss/common/questions.scss
+++ b/src/scss/common/questions.scss
@@ -428,6 +428,17 @@ figure .inline-container {
         }
       }
     }
+    
+    // The fixed position of a selected parsons-item causes the box-shadow to be drawn in the wrong place,
+    // so we need to apply it to the correctly positioned child instead
+    .parsons-item, .reorder-item {
+      &:focus-visible:focus-visible {
+        box-shadow: none;
+        > * {
+          @include focus-outline;
+        }
+      }
+    }
 
     &#parsons-choice-area {
       @for $i from 0 through $parsons-max-indent {


### PR DESCRIPTION
Currently a selected item will have its focus outline around the original item position, rather than the offset position used to indicate its selection.

This is because of an interaction with `position: fixed` causing the position of the item itself to not change while its children do. We can therefore just move the outline to the moved child to fix the visual issue.