### PR TITLE
Prevent closing other accordions when jumping via hash

### DIFF
--- a/src/app/components/elements/Accordion.tsx
+++ b/src/app/components/elements/Accordion.tsx
@@ -89,10 +89,8 @@ export const Accordion = ({id, trustedTitle, index, children, startOpen, deEmpha
             const element = document.getElementById(hashAnchor);
             if (element) { // exists on page
                 if (hashAnchor === anchorId) {
-                    scrollVerticallyIntoView(element);
+                    scrollVerticallyIntoView(element, -50);
                     setOpen(true);
-                } else {
-                    setOpen(false);
                 }
             }
         }


### PR DESCRIPTION
For pages with multiple accordion sections, closing accordions prior to the one referenced in the hash means the calculated scroll position can be very wrong. We could either add a large delay to scrolling, or match the behaviour to normally opening / closing accordions via mouse click by not closing other accordions. This PR takes the latter approach.