### PR TITLE
Improve inline cloze item alignment on Safari

### DIFF
--- a/src/app/components/elements/markup/portals/InlineDropZones.tsx
+++ b/src/app/components/elements/markup/portals/InlineDropZones.tsx
@@ -62,7 +62,7 @@ function InlineDropRegion({divId, zoneId, emptyWidth, emptyHeight, rootElement, 
 
     const draggableDropZone = <span
         style={{minHeight: height, minWidth: width}}
-        className={classNames("d-inline-block cloze-drop-zone", !item && `rounded bg-inline-question border ${isOver ? "border-dark" : "border-light"}`)}
+        className={classNames("d-inline-block cloze-drop-zone align-bottom", !item && `rounded bg-inline-question border ${isOver ? "border-dark" : "border-light"}`)}
         ref={setNodeRef}
     >
         {item


### PR DESCRIPTION
This feels fairly safe as this should only modify where on the line the cloze region generates. I haven't noticed any major differences on non-Safari browsers regardless.