### PR TITLE
Enforce a white background behind news/event pod images

### DIFF
--- a/src/scss/phy/cards.scss
+++ b/src/scss/phy/cards.scss
@@ -16,6 +16,10 @@
   }
 }
 
+.pod-img > img {
+  background-color: $color-neutral-white; // enforce that pod images use a white background, independent of dark mode styling
+}
+
 div:has(> .pod) {
   container: pod-parent / inline-size;
 


### PR DESCRIPTION
i.e. ignore dark mode lightness changes