### PR TITLE
Feature/anvil message forward

### DIFF
--- a/src/IsaacApiTypes.tsx
+++ b/src/IsaacApiTypes.tsx
@@ -407,6 +407,7 @@ export interface AnvilAppDTO extends ContentDTO {
     appAccessKey?: string;
 }
 
+export interface SkillsAppDTO extends ContentDTO {}
 export interface ChemicalFormulaDTO extends ChoiceDTO {
     mhchemExpression?: string;
 }

--- a/src/IsaacApiTypes.tsx
+++ b/src/IsaacApiTypes.tsx
@@ -880,6 +880,11 @@ export interface MisuseStatisticDTO {
     currentCounter: number;
 }
 
+export interface AnvilMarkingRequestDTO {
+    payload: string;
+    hmac: string;
+}
+
 export type GameboardCreationMethod = "FILTER" | "BUILDER";
 
 export type EventStatus = "OPEN" | "FULLY_BOOKED" | "CANCELLED" | "CLOSED" | "WAITING_LIST_ONLY" | "RESERVATION_ONLY";

--- a/src/IsaacApiTypes.tsx
+++ b/src/IsaacApiTypes.tsx
@@ -407,7 +407,9 @@ export interface AnvilAppDTO extends ContentDTO {
     appAccessKey?: string;
 }
 
-export interface SkillsAppDTO extends ContentDTO {}
+export interface SkillsAppDTO extends ContentDTO {
+    anvilApp?: AnvilAppDTO
+}
 export interface ChemicalFormulaDTO extends ChoiceDTO {
     mhchemExpression?: string;
 }

--- a/src/app/components/content/AnvilApp.tsx
+++ b/src/app/components/content/AnvilApp.tsx
@@ -1,6 +1,6 @@
 import React, {RefObject, useContext, useEffect} from 'react';
 import {AnvilAppDTO} from "../../../IsaacApiTypes";
-import {selectors, useAppSelector} from "../../state";
+import {selectors, useAppSelector, usePostAnswerMutation} from "../../state";
 import {AccordionSectionContext, QuestionContext} from "../../../IsaacAppTypes";
 import {selectQuestionPart} from "../../services";
 import { AnvilCookieHandler } from '../handlers/InterstitialCookieHandler';
@@ -67,26 +67,29 @@ export const AnvilApp = ({doc}: AnvilAppProps) => {
     }).join('&');
 
     const iframeSrc = `${baseURL}#?${queryParams}`;
-
-    const onMessage = function(e: any) {
-        if (iframeRef.current && e.source !== (iframeRef.current as HTMLIFrameElement).contentWindow) {
-            return;
-        }
-
-        const data = e.data;
-
-        if (iframeRef.current && (data.fn == "newAppHeight")) {
-            (iframeRef.current as HTMLIFrameElement).height = data.newHeight + 15;
-        }
-    };
+    const [postAnswer] = usePostAnswerMutation();
 
     useEffect(() => {
+        const onMessage = function(e: any) {
+            if (iframeRef.current && e.source !== (iframeRef.current as HTMLIFrameElement).contentWindow) {
+                return;
+            }
+
+            const data = e.data;
+
+            if (iframeRef.current && (data.fn == "newAppHeight")) {
+                (iframeRef.current as HTMLIFrameElement).height = data.newHeight + 15;
+            } else if (doc.appId && e.origin === `https://${doc.appId.toLocaleLowerCase()}.anvil.app` && data.type === 'SUBMISSION_MARKED') {
+                void postAnswer({ hmac: e.data.hmac, payload: e.data.payload });
+            }
+        };
+
         window.addEventListener("message", onMessage);
 
         return () => {
             window.removeEventListener("message", onMessage);
         };
-    }, [onMessage]);
+    }, [postAnswer, doc.appId]);
 
     return <AnvilCookieHandler afterAcceptedElement={
         <iframe ref={iframeRef} src={iframeSrc} title={title} className="anvil-app"/>

--- a/src/app/components/content/AnvilApp.tsx
+++ b/src/app/components/content/AnvilApp.tsx
@@ -72,16 +72,17 @@ export const AnvilApp = ({doc, skillId}: AnvilAppProps) => {
 
     useEffect(() => {
         const onMessage = function(e: MessageEvent<ResizeEvent | SubmissionMarkedEvent>) {
-            if (iframeRef.current && e.source !== (iframeRef.current as HTMLIFrameElement).contentWindow) {
+            if (!iframeRef.current || e.source !== (iframeRef.current as HTMLIFrameElement).contentWindow
+                    || e.origin !== `https://${doc.appId?.toLowerCase()}.anvil.app`) {
                 return;
             }
 
             const data = e.data;
 
-            if (iframeRef.current && (data.fn == "newAppHeight")) {
+            if (data.fn == "newAppHeight") {
                 (iframeRef.current as HTMLIFrameElement).height = `${data.newHeight + 15}`;
-            } else if (iframeRef.current && user?.loggedIn && e.origin === `https://${doc.appId?.toLowerCase()}.anvil.app` && data.type === 'SUBMISSION_MARKED' && skillId) {
-                void postSkillsAnswer({ appId: skillId, body: { hmac: data.hmac, payload: data.payload } });
+            } else if (user?.loggedIn  && data.type === 'SUBMISSION_MARKED') {
+                void postSkillsAnswer({ appId: skillId!, body: { hmac: data.hmac, payload: data.payload } });
             }
         };
 

--- a/src/app/components/content/AnvilApp.tsx
+++ b/src/app/components/content/AnvilApp.tsx
@@ -7,11 +7,12 @@ import { AnvilCookieHandler } from '../handlers/InterstitialCookieHandler';
 
 interface AnvilAppProps {
     doc: AnvilAppDTO;
+    skillId?: string
 }
 
 const sessionIdentifier = Math.random();
 
-export const AnvilApp = ({doc}: AnvilAppProps) => {
+export const AnvilApp = ({doc, skillId}: AnvilAppProps) => {
     const baseURL = `https://${doc.appId}.anvil.app/${doc.appAccessKey}?s=new${sessionIdentifier}`;
     const title = doc.value || "Anvil app";
     const page = useAppSelector(selectors.doc.get);
@@ -79,8 +80,8 @@ export const AnvilApp = ({doc}: AnvilAppProps) => {
 
             if (iframeRef.current && (data.fn == "newAppHeight")) {
                 (iframeRef.current as HTMLIFrameElement).height = data.newHeight + 15;
-            } else if (iframeRef.current && user?.loggedIn && e.origin === `https://${doc.appId?.toLowerCase()}.anvil.app` && data.type === 'SUBMISSION_MARKED') {
-                void postSkillsAnswer({ appId: `${typeof page === 'object' && page?.id}`, body: { hmac: data.hmac, payload: data.payload } });
+            } else if (iframeRef.current && user?.loggedIn && e.origin === `https://${doc.appId?.toLowerCase()}.anvil.app` && data.type === 'SUBMISSION_MARKED' && skillId) {
+                void postSkillsAnswer({ appId: skillId, body: { hmac: data.hmac, payload: data.payload } });
             }
         };
 
@@ -89,7 +90,7 @@ export const AnvilApp = ({doc}: AnvilAppProps) => {
         return () => {
             window.removeEventListener("message", onMessage);
         };
-    }, [postSkillsAnswer, doc.appId, page, user?.loggedIn]);
+    }, [postSkillsAnswer, skillId, doc.appId, user?.loggedIn]);
 
     return <AnvilCookieHandler afterAcceptedElement={
         <iframe ref={iframeRef} src={iframeSrc} title={title} className="anvil-app"/>

--- a/src/app/components/content/AnvilApp.tsx
+++ b/src/app/components/content/AnvilApp.tsx
@@ -79,8 +79,8 @@ export const AnvilApp = ({doc}: AnvilAppProps) => {
 
             if (iframeRef.current && (data.fn == "newAppHeight")) {
                 (iframeRef.current as HTMLIFrameElement).height = data.newHeight + 15;
-            } else if (user?.loggedIn && e.origin === `https://${doc.appId?.toLowerCase()}.anvil.app` && data.type === 'SUBMISSION_MARKED') {
-                void postSkillsAnswer({ appId: `${typeof page === 'object' && page?.id}`, body: { hmac: e.data.hmac, payload: e.data.payload } });
+            } else if (iframeRef.current && user?.loggedIn && e.origin === `https://${doc.appId?.toLowerCase()}.anvil.app` && data.type === 'SUBMISSION_MARKED') {
+                void postSkillsAnswer({ appId: `${typeof page === 'object' && page?.id}`, body: { hmac: data.hmac, payload: data.payload } });
             }
         };
 
@@ -89,7 +89,7 @@ export const AnvilApp = ({doc}: AnvilAppProps) => {
         return () => {
             window.removeEventListener("message", onMessage);
         };
-    }, [postSkillsAnswer, doc.appId, page, user]);
+    }, [postSkillsAnswer, doc.appId, page, user?.loggedIn]);
 
     return <AnvilCookieHandler afterAcceptedElement={
         <iframe ref={iframeRef} src={iframeSrc} title={title} className="anvil-app"/>

--- a/src/app/components/content/AnvilApp.tsx
+++ b/src/app/components/content/AnvilApp.tsx
@@ -1,6 +1,6 @@
 import React, {RefObject, useContext, useEffect} from 'react';
 import {AnvilAppDTO} from "../../../IsaacApiTypes";
-import {selectors, useAppSelector, usePostAnswerMutation} from "../../state";
+import {selectors, useAppSelector, usePostSkillsAnswerMutation} from "../../state";
 import {AccordionSectionContext, QuestionContext} from "../../../IsaacAppTypes";
 import {selectQuestionPart} from "../../services";
 import { AnvilCookieHandler } from '../handlers/InterstitialCookieHandler';
@@ -67,7 +67,7 @@ export const AnvilApp = ({doc}: AnvilAppProps) => {
     }).join('&');
 
     const iframeSrc = `${baseURL}#?${queryParams}`;
-    const [postAnswer] = usePostAnswerMutation();
+    const [postSkillsAnswer] = usePostSkillsAnswerMutation();
 
     useEffect(() => {
         const onMessage = function(e: any) {
@@ -79,8 +79,8 @@ export const AnvilApp = ({doc}: AnvilAppProps) => {
 
             if (iframeRef.current && (data.fn == "newAppHeight")) {
                 (iframeRef.current as HTMLIFrameElement).height = data.newHeight + 15;
-            } else if (doc.appId && e.origin === `https://${doc.appId.toLocaleLowerCase()}.anvil.app` && data.type === 'SUBMISSION_MARKED') {
-                void postAnswer({ hmac: e.data.hmac, payload: e.data.payload });
+            } else if (e.origin === `https://${doc.appId?.toLowerCase()}.anvil.app` && data.type === 'SUBMISSION_MARKED') {
+                void postSkillsAnswer({ appId: `${typeof page === 'object' && page?.id}`, body: { hmac: e.data.hmac, payload: e.data.payload } });
             }
         };
 
@@ -89,7 +89,7 @@ export const AnvilApp = ({doc}: AnvilAppProps) => {
         return () => {
             window.removeEventListener("message", onMessage);
         };
-    }, [postAnswer, doc.appId]);
+    }, [postSkillsAnswer, doc.appId, page]);
 
     return <AnvilCookieHandler afterAcceptedElement={
         <iframe ref={iframeRef} src={iframeSrc} title={title} className="anvil-app"/>

--- a/src/app/components/content/AnvilApp.tsx
+++ b/src/app/components/content/AnvilApp.tsx
@@ -79,7 +79,7 @@ export const AnvilApp = ({doc}: AnvilAppProps) => {
 
             if (iframeRef.current && (data.fn == "newAppHeight")) {
                 (iframeRef.current as HTMLIFrameElement).height = data.newHeight + 15;
-            } else if (e.origin === `https://${doc.appId?.toLowerCase()}.anvil.app` && data.type === 'SUBMISSION_MARKED') {
+            } else if (user?.loggedIn && e.origin === `https://${doc.appId?.toLowerCase()}.anvil.app` && data.type === 'SUBMISSION_MARKED') {
                 void postSkillsAnswer({ appId: `${typeof page === 'object' && page?.id}`, body: { hmac: e.data.hmac, payload: e.data.payload } });
             }
         };
@@ -89,7 +89,7 @@ export const AnvilApp = ({doc}: AnvilAppProps) => {
         return () => {
             window.removeEventListener("message", onMessage);
         };
-    }, [postSkillsAnswer, doc.appId, page]);
+    }, [postSkillsAnswer, doc.appId, page, user]);
 
     return <AnvilCookieHandler afterAcceptedElement={
         <iframe ref={iframeRef} src={iframeSrc} title={title} className="anvil-app"/>

--- a/src/app/components/content/AnvilApp.tsx
+++ b/src/app/components/content/AnvilApp.tsx
@@ -71,7 +71,7 @@ export const AnvilApp = ({doc, skillId}: AnvilAppProps) => {
     const [postSkillsAnswer] = usePostSkillsAnswerMutation();
 
     useEffect(() => {
-        const onMessage = function(e: any) {
+        const onMessage = function(e: MessageEvent<ResizeEvent | SubmissionMarkedEvent>) {
             if (iframeRef.current && e.source !== (iframeRef.current as HTMLIFrameElement).contentWindow) {
                 return;
             }
@@ -79,7 +79,7 @@ export const AnvilApp = ({doc, skillId}: AnvilAppProps) => {
             const data = e.data;
 
             if (iframeRef.current && (data.fn == "newAppHeight")) {
-                (iframeRef.current as HTMLIFrameElement).height = data.newHeight + 15;
+                (iframeRef.current as HTMLIFrameElement).height = `${data.newHeight + 15}`;
             } else if (iframeRef.current && user?.loggedIn && e.origin === `https://${doc.appId?.toLowerCase()}.anvil.app` && data.type === 'SUBMISSION_MARKED' && skillId) {
                 void postSkillsAnswer({ appId: skillId, body: { hmac: data.hmac, payload: data.payload } });
             }
@@ -96,3 +96,6 @@ export const AnvilApp = ({doc, skillId}: AnvilAppProps) => {
         <iframe ref={iframeRef} src={iframeSrc} title={title} className="anvil-app"/>
     } />;
 };
+
+type ResizeEvent = { fn: "newAppHeight", type: undefined, newHeight: number }
+type SubmissionMarkedEvent =  { fn: undefined, type: 'SUBMISSION_MARKED', hmac: string, payload: string};

--- a/src/app/components/content/IsaacContent.tsx
+++ b/src/app/components/content/IsaacContent.tsx
@@ -24,6 +24,7 @@ import InlineContextProvider from "../elements/InlineContextProvider";
 import { useLocation } from "react-router";
 import { DesmosEmbedding } from "./DesmosEmbedding";
 import { GeogebraEmbedding } from "./GeogebraEmbedding";
+import { SkillsApp } from "./SkillsApp";
 
 const IsaacCodeSnippet = lazy(() => import("./IsaacCodeSnippet"));
 
@@ -84,6 +85,7 @@ export const IsaacContent = (props: IsaacContentProps) => {
             case "isaacFeaturedProfile": selectedComponent = <IsaacFeaturedProfile {...props} key={props.doc.id} />; break;
             case "isaacQuestion": selectedComponent = <IsaacQuickQuestion {...props} key={props.doc.id} />; break;
             case "anvilApp": selectedComponent = <AnvilApp {...props} key={props.doc.id} />; break;
+            case "skillsApp": selectedComponent = <SkillsApp {...props} key = {props.doc.id}/>; break;
             case "desmosEmbedding": selectedComponent = <DesmosEmbedding {...props} key={props.doc.id} />; break;
             case "geogebraEmbedding": selectedComponent = <GeogebraEmbedding {...props} key={props.doc.id} />; break;
             case "isaacCard": selectedComponent = <IsaacCard {...props} key={props.doc.id} />; break;

--- a/src/app/components/content/SkillsApp.tsx
+++ b/src/app/components/content/SkillsApp.tsx
@@ -3,5 +3,5 @@ import { AnvilApp } from './AnvilApp';
 import { SkillsAppDTO } from '../../../IsaacApiTypes';
 
 export const SkillsApp = ({ doc }: { doc: SkillsAppDTO }) => 
-    doc.children?.length && doc.children?.length > 0 && doc.children[0].type == 'anvilApp' ?
-        <AnvilApp doc={doc.children[0]} skillId={doc.id}></AnvilApp> : <></>;
+    doc.anvilApp && doc.anvilApp.type === 'anvilApp' ?
+        <AnvilApp doc={doc.anvilApp} skillId={doc.id}></AnvilApp> : <></>;

--- a/src/app/components/content/SkillsApp.tsx
+++ b/src/app/components/content/SkillsApp.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { AnvilApp } from './AnvilApp';
+import { SkillsAppDTO } from '../../../IsaacApiTypes';
+
+export const SkillsApp = ({ doc }: { doc: SkillsAppDTO }) => 
+    doc.children?.length && doc.children?.length > 0 && doc.children[0].type == 'anvilApp' ?
+        <AnvilApp doc={doc.children[0]} skillId={doc.id}></AnvilApp> : <></>;

--- a/src/app/state/index.ts
+++ b/src/app/state/index.ts
@@ -37,6 +37,7 @@ export * from "./slices/api/accountApi";
 export * from "./slices/api/gameboardApi";
 export * from "./slices/api/assignmentsApi";
 export * from "./slices/api/bookmarksApi";
+export * from "./slices/api/skillsApi";
 export * from "./slices/api/contentApi";
 export * from "./slices/api/groupsApi";
 export * from "./slices/api/emailApi";

--- a/src/app/state/slices/api/skillsApi.ts
+++ b/src/app/state/slices/api/skillsApi.ts
@@ -1,0 +1,16 @@
+import { AnvilMarkingRequestDTO } from "../../../../IsaacApiTypes";
+import {isaacApi} from "./baseApi";
+
+export const skillsApi = isaacApi.injectEndpoints({
+    endpoints: (build) => ({
+        postAnswer: build.mutation<void, AnvilMarkingRequestDTO>({
+            query: (body: AnvilMarkingRequestDTO) => ({
+                url: "skills/app_page_mental_maths_overall/answer",
+                method: "POST",
+                body
+            })
+        }),
+    })
+});
+
+export const { usePostAnswerMutation } = skillsApi;

--- a/src/app/state/slices/api/skillsApi.ts
+++ b/src/app/state/slices/api/skillsApi.ts
@@ -4,17 +4,17 @@ import { onQueryLifecycleEvents } from "./utils";
 
 export const skillsApi = isaacApi.injectEndpoints({
     endpoints: (build) => ({
-        postAnswer: build.mutation<void, AnvilMarkingRequestDTO>({
-            query: (body: AnvilMarkingRequestDTO) => ({
-                url: "skills/app_page_mental_maths_overall/answer",
+        postSkillsAnswer: build.mutation<void, { appId: string, body: AnvilMarkingRequestDTO}>({
+            query: ({ appId, body }) => ({
+                url: `skills/${appId}/answer`,
                 method: "POST",
-                body
+                body,
             }),
             onQueryStarted: onQueryLifecycleEvents({
-                errorTitle: "Couldn't save answer."
+                errorTitle: "Couldn't save answer.",
             }),
         }),
     })
 });
 
-export const { usePostAnswerMutation } = skillsApi;
+export const { usePostSkillsAnswerMutation } = skillsApi;

--- a/src/app/state/slices/api/skillsApi.ts
+++ b/src/app/state/slices/api/skillsApi.ts
@@ -1,5 +1,6 @@
 import { AnvilMarkingRequestDTO } from "../../../../IsaacApiTypes";
 import {isaacApi} from "./baseApi";
+import { onQueryLifecycleEvents } from "./utils";
 
 export const skillsApi = isaacApi.injectEndpoints({
     endpoints: (build) => ({
@@ -8,7 +9,10 @@ export const skillsApi = isaacApi.injectEndpoints({
                 url: "skills/app_page_mental_maths_overall/answer",
                 method: "POST",
                 body
-            })
+            }),
+            onQueryStarted: onQueryLifecycleEvents({
+                errorTitle: "Couldn't save answer."
+            }),
         }),
     })
 });


### PR DESCRIPTION
This forwards marking messages from the Anvil app towards the Isaac backend. This completes the work on recording answers! The PR is ready for review now, but please hold off releasing until the backend (https://github.com/isaacphysics/isaac-api/pull/798) as well as config changes (https://github.com/isaacphysics/isaac-sops-config/pull/23) are merged and released. Without the backend changes, we would flood the user's screen with error messages each time they submitted an answer, although just in this one app: https://isaacscience.org/pages/app_page_mental_maths_overall.

To test this locally, apply the config and api changes locally, and visit the http://localhost:8004/pages/app_page_mental_maths_overall page. Watch out, as there is also a migration to apply. Once you've clicked submit, the answers should be recorded to your local database. 