### PR TITLE
Specify supported font weight and stretch for Safari

### DIFF
--- a/src/scss/phy/fonts.scss
+++ b/src/scss/phy/fonts.scss
@@ -26,10 +26,14 @@
   font-family: 'hanken-grotesk';
   src: url('/assets/phy/fonts/hanken-grotesk-variable-wght.ttf') format('truetype');
   font-style: normal;
+  font-weight: 100 900;
+  font-stretch: normal;
 }
 
 @font-face {
   font-family: 'hanken-grotesk';
   src: url('/assets/phy/fonts/hanken-grotesk-italic-variable-wght.ttf') format('truetype');
   font-style: italic;
+  font-weight: 100 900;
+  font-stretch: normal;
 }


### PR DESCRIPTION
Safari does not correctly infer the supported font weights of a provided font file, so is assuming that the font does not support dynamic weights and is thus [synthesising](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/font-synthesis) its own version (in this case, font weights above 600 are synthesised). Since the font actually does support dynamic weights, something about the synthesis process is going awry and causing text to become far too bold.

(synthesised extra-bold)
<img width="1384" height="536" alt="image" src="https://github.com/user-attachments/assets/b0a7bdc1-0189-4025-a582-33cddd4cd562" />
(expected)
<img width="1384" height="536" alt="image" src="https://github.com/user-attachments/assets/25c8cd64-65fa-4ea2-b1ca-7821bfa2a992" />

This appears to be much worse in certain situations, presumably (though unconfirmed) when the base font-weight is above 400, e.g. occuring inside a `<h1>-<h5>` element.

To fix this, we can set the `font-weight` ranges (and `font-stretch` for consistency) when we define the `@font-face` so that Safari correctly retrieves the font's supported weight ranges and so does not apply its awful synthesis.

(We could also disable the `font-synthesis` prop, but this approach is consistent with what we have for Exo)
