### PR TITLE
Add accessibility warnings to several new places

### DIFF
--- a/src/app/components/elements/list-groups/AbstractListViewItem.tsx
+++ b/src/app/components/elements/list-groups/AbstractListViewItem.tsx
@@ -228,16 +228,14 @@ export const AbstractListViewItem = ({title, icon, subject, subtitle, breadcrumb
                                     <Markup encoding="latex">{title}</Markup>
                                 </span>
                             }
-                        </>
-                        {isItem && <>
-                            {typedProps.quizTag && <span className="quiz-level-1-tag ms-sm-2">{typedProps.quizTag}</span>}
-                            <ContentPropertyTags 
+                            {isItem && typedProps.quizTag && <span className="quiz-level-1-tag ms-sm-2">{typedProps.quizTag}</span>}
+                            {(isItem || isBuilder) && <ContentPropertyTags 
                                 className={classNames("justify-self-end", {"ms-2": !wrapTitleTags})}
                                 deprecated={typedProps.deprecated}
                                 supersededByPath={typedProps.supersededByPath}
                                 tags={tags}
-                            />
-                        </>}
+                            />}
+                        </>
                     </div>
                     {!flatLayout && <>
                         {subtitle && <div className="small text-muted text-wrap">

--- a/src/app/components/elements/list-groups/TopicSummaryLinks.tsx
+++ b/src/app/components/elements/list-groups/TopicSummaryLinks.tsx
@@ -5,12 +5,8 @@ import {
     audienceStyle,
     DOCUMENT_TYPE,
     documentTypePathPrefix,
-    isAda,
-    isPhy,
     isIntendedAudience,
     makeIntendedAudienceComparator,
-    notRelevantMessage,
-    siteSpecific,
     stringifyAudience,
     useDeviceSize,
     useUserViewingContext
@@ -19,7 +15,7 @@ import {Link} from "react-router-dom";
 import {selectors, useAppSelector} from "../../../state";
 import classNames from "classnames";
 import {Markup} from "../markup";
-import { ListGroup, ListGroupItem, Button, UncontrolledTooltip } from "reactstrap";
+import { ListGroup, ListGroupItem, Button } from "reactstrap";
 import { Spacer } from "../Spacer";
 
 export function TopicSummaryLinks({items, search}: {items: ContentSummaryDTO[]; search?: string}) {
@@ -29,9 +25,8 @@ export function TopicSummaryLinks({items, search}: {items: ContentSummaryDTO[]; 
 
     return <ListGroup className="mt-4 link-list list-group-links">
         {items
-            // For CS we want relevant sections to appear first
+            // We want relevant sections to appear first
             .sort((itemA, itemB) => {
-                if (!isAda) {return 0;}
                 return makeIntendedAudienceComparator(user, userContext)(itemA, itemB);
             })
 
@@ -42,7 +37,7 @@ export function TopicSummaryLinks({items, search}: {items: ContentSummaryDTO[]; 
             })
 
             // Render items
-            .map((item, index) => {
+            .map((item) => {
                 const audienceString = stringifyAudience(
                     item.audience, userContext,
                     isIntendedAudience(item.audience, userContext, user)
@@ -53,13 +48,9 @@ export function TopicSummaryLinks({items, search}: {items: ContentSummaryDTO[]; 
                         tag={Link} to={{pathname: `/${documentTypePathPrefix[DOCUMENT_TYPE.CONCEPT]}/${item.id}`, search}}
                         block color="link" className={"d-flex align-items-stretch " + classNames({"de-emphasised": item.deEmphasised})}
                     >
-                        <div className={"stage-label d-flex align-items-center justify-content-center " + classNames({[audienceStyle(audienceString)]: isAda})}>
-                            {siteSpecific(
-                                audienceString,
-                                above["sm"](deviceSize) ? audienceString : audienceString.replaceAll(",", "\n")
-                            ).split("\n").map((line, i, arr) => <>
-                                {line}{i < arr.length && <br/>}
-                            </>)}
+                        <div className={classNames("stage-label d-flex align-items-center justify-content-center", audienceStyle(audienceString))}>
+                            {above["sm"](deviceSize) ? audienceString : audienceString.replaceAll(",", "\n").split("\n").map((line, i, arr) => 
+                                <>{line}{i < arr.length && <br/>}</>)}
                         </div>
                         <div className="title ps-3 d-flex">
                             <div className="p-3">
@@ -67,12 +58,6 @@ export function TopicSummaryLinks({items, search}: {items: ContentSummaryDTO[]; 
                                     {item.title}
                                 </Markup>
                             </div>
-                            {isPhy && item.deEmphasised && <div className="ms-auto me-3 d-flex align-items-center">
-                                <i id={`audience-help-${index}`} className="icon icon-info icon-color-grey" />
-                                <UncontrolledTooltip placement="bottom" target={`audience-help-${index}`}>
-                                    {`This content has ${notRelevantMessage(userContext)}.`}
-                                </UncontrolledTooltip>
-                            </div>}
                         </div>
                         <Spacer />
                         <div className="d-flex align-items-center">

--- a/src/app/components/elements/list-groups/TopicSummaryLinks.tsx
+++ b/src/app/components/elements/list-groups/TopicSummaryLinks.tsx
@@ -43,9 +43,11 @@ export function TopicSummaryLinks({items, search}: {items: ContentSummaryDTO[]; 
                     isIntendedAudience(item.audience, userContext, user)
                 );
 
+                const documentType = (item.type && ["isaacQuestionPage", "isaacFastTrackQuestionPage"].includes(item.type)) ? DOCUMENT_TYPE.QUESTION : DOCUMENT_TYPE.CONCEPT;
+
                 return <ListGroupItem key={item.id} className="topic-summary-link">
                     <Button
-                        tag={Link} to={{pathname: `/${documentTypePathPrefix[DOCUMENT_TYPE.CONCEPT]}/${item.id}`, search}}
+                        tag={Link} to={{pathname: `/${documentTypePathPrefix[documentType]}/${item.id}`, search}}
                         block color="link" className={"d-flex align-items-stretch " + classNames({"de-emphasised": item.deEmphasised})}
                     >
                         <div className={classNames("stage-label d-flex align-items-center justify-content-center", audienceStyle(audienceString))}>

--- a/src/app/components/elements/list-groups/TopicSummaryLinks.tsx
+++ b/src/app/components/elements/list-groups/TopicSummaryLinks.tsx
@@ -17,6 +17,7 @@ import classNames from "classnames";
 import {Markup} from "../markup";
 import { ListGroup, ListGroupItem, Button } from "reactstrap";
 import { Spacer } from "../Spacer";
+import { ContentPropertyTags } from "../ContentPropertyTags";
 
 export function TopicSummaryLinks({items, search}: {items: ContentSummaryDTO[]; search?: string}) {
     const userContext = useUserViewingContext();
@@ -54,12 +55,14 @@ export function TopicSummaryLinks({items, search}: {items: ContentSummaryDTO[]; 
                             {above["sm"](deviceSize) ? audienceString : audienceString.replaceAll(",", "\n").split("\n").map((line, i, arr) => 
                                 <>{line}{i < arr.length && <br/>}</>)}
                         </div>
-                        <div className="title ps-3 d-flex">
-                            <div className="p-3">
-                                <Markup encoding={"latex"}>
-                                    {item.title}
-                                </Markup>
-                            </div>
+                        <div className="title p-3 ps-6 d-block d-sm-flex">
+                            <Markup encoding={"latex"}>
+                                {item.title}
+                            </Markup>
+                            <ContentPropertyTags 
+                                className="ps-sm-2"
+                                tags={item.tags}
+                            />
                         </div>
                         <Spacer />
                         <div className="d-flex align-items-center">

--- a/src/app/components/elements/list-groups/TopicSummaryLinks.tsx
+++ b/src/app/components/elements/list-groups/TopicSummaryLinks.tsx
@@ -61,6 +61,8 @@ export function TopicSummaryLinks({items, search}: {items: ContentSummaryDTO[]; 
                             </Markup>
                             <ContentPropertyTags 
                                 className="ps-sm-2"
+                                deprecated={item.deprecated}
+                                supersededByPath={item.supersededBy ? `/questions/${item.supersededBy}` : undefined}
                                 tags={item.tags}
                             />
                         </div>

--- a/src/app/components/elements/list-groups/TopicSummaryLinks.tsx
+++ b/src/app/components/elements/list-groups/TopicSummaryLinks.tsx
@@ -44,11 +44,11 @@ export function TopicSummaryLinks({items, search}: {items: ContentSummaryDTO[]; 
                     isIntendedAudience(item.audience, userContext, user)
                 );
 
-                const documentType = (item.type && ["isaacQuestionPage", "isaacFastTrackQuestionPage"].includes(item.type)) ? DOCUMENT_TYPE.QUESTION : DOCUMENT_TYPE.CONCEPT;
+                const documentPrefix = documentTypePathPrefix[item.type as DOCUMENT_TYPE];
 
                 return <ListGroupItem key={item.id} className="topic-summary-link">
                     <Button
-                        tag={Link} to={{pathname: `/${documentTypePathPrefix[documentType]}/${item.id}`, search}}
+                        tag={Link} to={{pathname: `/${documentPrefix}/${item.id}`, search}}
                         block color="link" className={"d-flex align-items-stretch " + classNames({"de-emphasised": item.deEmphasised})}
                     >
                         <div className={classNames("stage-label d-flex align-items-center justify-content-center", audienceStyle(audienceString))}>
@@ -62,7 +62,7 @@ export function TopicSummaryLinks({items, search}: {items: ContentSummaryDTO[]; 
                             <ContentPropertyTags 
                                 className="ps-sm-2"
                                 deprecated={item.deprecated}
-                                supersededByPath={item.supersededBy ? `/questions/${item.supersededBy}` : undefined}
+                                supersededByPath={item.supersededBy ? `/${documentPrefix}/${item.supersededBy}` : undefined}
                                 tags={item.tags}
                             />
                         </div>

--- a/src/app/components/pages/Generic.tsx
+++ b/src/app/components/pages/Generic.tsx
@@ -25,6 +25,8 @@ import { GenericPageSidebar } from "../elements/sidebar/GenericPageSidebar";
 import { PolicyPageSidebar } from "../elements/sidebar/PolicyPageSidebar";
 import { GenericSidebarWithRelatedContent } from "../elements/sidebar/RelatedContentSidebar";
 import { PageContainer } from "../elements/layout/PageContainer";
+import { getAccessibilityTags, useAccessibilitySettings } from "../../services/accessibility";
+import { InaccessibleContentWarningAlert } from "../elements/alerts/InaccessibleContentWarningAlert";
 
 interface GenericPageComponentProps {
     pageIdOverride?: string;
@@ -59,6 +61,7 @@ const SciSidebar = ({pageId, tags, gameboard, relatedContent, ...sidebarProps}: 
 
 export const Generic = ({pageIdOverride}: GenericPageComponentProps) => {
     const params = useParams();
+    const accessibilitySettings = useAccessibilitySettings();
     const pageId = pageIdOverride || params.pageId || "";
 
     const pageQuery = useGetGenericPageQuery(pageId);
@@ -113,6 +116,8 @@ export const Generic = ({pageIdOverride}: GenericPageComponentProps) => {
                     ? <PageMetadata doc={doc} />
                     : <PageMetadata doc={{...doc, subtitle: undefined}} title={doc.subtitle} noTitle={!doc.subtitle} />
                 }
+
+                {accessibilitySettings?.SHOW_INACCESSIBLE_WARNING && getAccessibilityTags(doc.tags).map(tag => <InaccessibleContentWarningAlert key={tag} type={tag} />)}
 
                 <Row className="generic-content-container">
                     <Col className={classNames("pb-4 generic-panel", {"mw-760": isAda && !CS_FULL_WIDTH_OVERRIDE[pageId], "pt-4": isAda})}>

--- a/src/app/components/pages/Topic.tsx
+++ b/src/app/components/pages/Topic.tsx
@@ -7,7 +7,6 @@ import {
     ALL_TOPICS_CRUMB,
     atLeastOne,
     getRelatedDocs,
-    isAda,
     PATHS,
 } from "../../services";
 import {Button, Card, CardBody, CardTitle, Col, Container, Row} from "reactstrap";
@@ -39,7 +38,7 @@ export const Topic = () => {
                     <div className="d-flex justify-content-end">
                         <UserContextPicker />
                     </div>
-                    {isAda && <IntendedAudienceWarningAlert doc={topicPage} />}
+                    <IntendedAudienceWarningAlert doc={topicPage} />
                     {topicPage.children && topicPage.children.map((child, index) =>
                         <IsaacContent key={index} doc={child}/>)
                     }

--- a/src/scss/common/topic.scss
+++ b/src/scss/common/topic.scss
@@ -4,7 +4,7 @@
   border-top: 1px solid $shadow-08 !important;
   padding: 0;
   &:first-of-type {border-top: 0;}
-  a {
+  > a {
     border-radius: 0;
     font-family: $secondary-font;
     font-weight: 600;


### PR DESCRIPTION
Accessibility warnings should now be on:
- Generic pages
- Gameboard builder ALVIs
- TopicSummaryLinks (links ON topic pages, not links TO topic pages)

when the associated page has `access:warning` or `access:motor`. This also allows other content summary tags like `nofilter` or `deprecated` to show, which is also generally useful.

Also does some very minor cleanup to `TopicSummaryLinks.tsx` and `Topic.tsx` by removing all site-specific references since these components are already Ada-specific.