### PR TITLE
Gameboard builder visual enhancements

### DIFF
--- a/src/app/components/elements/GameboardBuilderTableRow.tsx
+++ b/src/app/components/elements/GameboardBuilderTableRow.tsx
@@ -57,7 +57,7 @@ const GameboardBuilderTableRow = (
             </td>
             <td rowSpan={arr.length} className={classNames(cellClasses, siteSpecific("w-40", "w-30"))}>
                 <div className="d-flex">
-                    {isDnd && <img src="/assets/common/icons/drag_indicator.svg" alt="Drag to reorder" className="me-1 grab-cursor" />}
+                    {isDnd && <i aria-label="Drag to reorder" className="ms-n1 me-1 grab-cursor icon icon-md icon-drag-indicator icon-color-black align-self-center" />}
                     <div>
                         <div className="d-flex">
                             <a className="text-wrap" href={`/questions/${question.id}`} target="_blank" rel="noopener noreferrer" title="Preview question in new tab">

--- a/src/app/components/elements/GameboardBuilderTableRow.tsx
+++ b/src/app/components/elements/GameboardBuilderTableRow.tsx
@@ -60,7 +60,7 @@ const GameboardBuilderTableRow = (
                     {isDnd && <i aria-label="Drag to reorder" className="ms-n1 me-1 grab-cursor icon icon-md icon-drag-indicator icon-color-black align-self-center" />}
                     <div>
                         <div className="d-flex">
-                            <a className="text-wrap" href={`/questions/${question.id}`} target="_blank" rel="noopener noreferrer" title="Preview question in new tab">
+                            <a className="text-wrap" href={`/questions/${question.id}`} target="_blank" rel="noopener noreferrer" title={`Preview question '${question.id}' in new tab`}>
                                 <Markup encoding="latex">{generateQuestionTitle(question)}</Markup>
                             </a>
                             <PreviewQuestionButton id={question.id} className="ms-2" />

--- a/src/app/components/elements/PreviewButton.tsx
+++ b/src/app/components/elements/PreviewButton.tsx
@@ -15,7 +15,7 @@ export const PreviewQuestionButton = ({id, className}: {id?: string, className?:
     if (!id) return null;
 
     return <button
-        type="button" title="Preview question in modal" className={classNames("d-flex pointer-cursor new-tab bg-transparent vertical-center", className)}
+        type="button" title={`Preview question '${id}' in modal`} className={classNames("d-flex pointer-cursor new-tab bg-transparent vertical-center", className)}
         aria-label="Preview question"
         onClick={() => id && openQuestionModal(id)}
     >

--- a/src/app/components/elements/list-groups/AbstractListViewItem.tsx
+++ b/src/app/components/elements/list-groups/AbstractListViewItem.tsx
@@ -228,16 +228,14 @@ export const AbstractListViewItem = ({title, icon, subject, subtitle, breadcrumb
                                     <Markup encoding="latex">{title}</Markup>
                                 </span>
                             }
-                        </>
-                        {isItem && <>
-                            {typedProps.quizTag && <span className="quiz-level-1-tag ms-sm-2">{typedProps.quizTag}</span>}
-                            <ContentPropertyTags 
+                            {isItem && typedProps.quizTag && <span className="quiz-level-1-tag ms-sm-2">{typedProps.quizTag}</span>}
+                            {(isItem || isBuilder) && <ContentPropertyTags 
                                 className={classNames("justify-self-end", {"ms-2": !wrapTitleTags})}
                                 deprecated={typedProps.deprecated}
                                 supersededByPath={typedProps.supersededByPath}
                                 tags={tags}
-                            />
-                        </>}
+                            />}
+                        </>
                     </div>
                     {!flatLayout && <>
                         {subtitle && <div className="small text-muted text-wrap">

--- a/src/app/components/elements/list-groups/AbstractListViewItem.tsx
+++ b/src/app/components/elements/list-groups/AbstractListViewItem.tsx
@@ -237,14 +237,12 @@ export const AbstractListViewItem = ({title, icon, subject, subtitle, breadcrumb
                             />}
                         </>
                     </div>
-                    {!flatLayout && <>
-                        {subtitle && <div className="small text-muted text-wrap">
-                            <Markup encoding="latex">{subtitle}</Markup>
-                        </div>}
-                        {breadcrumb && <span className="hierarchy-tags d-flex flex-wrap mw-auto">
-                            <Breadcrumb breadcrumb={breadcrumb}/>
-                        </span>}
-                    </>}
+                    {subtitle && <div className="small text-muted text-wrap">
+                        <Markup encoding="latex">{subtitle}</Markup>
+                    </div>}
+                    {!flatLayout && breadcrumb && <span className="hierarchy-tags d-flex flex-wrap mw-auto">
+                        <Breadcrumb breadcrumb={breadcrumb}/>
+                    </span>}
                     {(isItem || isBuilder) && stackedLayout && typedProps.audienceViews && <div className="d-flex mt-1"> 
                         <StageAndDifficultySummaryIcons audienceViews={typedProps.audienceViews} stack/> 
                     </div>}
@@ -272,14 +270,10 @@ export const AbstractListViewItem = ({title, icon, subject, subtitle, breadcrumb
             {!stackedLayout &&
                 <>
                     {isPhy && isItem && typedProps.status && typedProps.status !== CompletionState.ALL_CORRECT && <StatusDisplay status={typedProps.status} showText className="ms-2 me-3" />}
-                    {flatLayout && (subtitle || breadcrumb) && <div className="list-view-border wf-10 pe-3 d-flex align-items-center">
-                        {subtitle && <div className="small text-muted text-wrap">
-                            <Markup encoding="latex">{subtitle}</Markup>
-                        </div>}
-                        {/* additional `&& !subtitle` as compared to stacked, as flat layout only has room for one */}
-                        {breadcrumb && !subtitle && <span className="hierarchy-tags d-flex flex-wrap mw-auto">
+                    {flatLayout && breadcrumb && <div className="list-view-border wf-10 pe-3 d-flex align-items-center">
+                        <span className="hierarchy-tags d-flex flex-wrap mw-auto">
                             <Breadcrumb breadcrumb={breadcrumb}/>
-                        </span>}
+                        </span>
                     </div>}
                     {(isItem || isBuilder) && typedProps.audienceViews && <div className={classNames("d-none d-md-flex justify-content-end", siteSpecific("wf-13", "wf-16"), {"list-view-border": (isPhy || isBuilder) && typedProps.audienceViews.length > 0})}>
                         <StageAndDifficultySummaryIcons audienceViews={typedProps.audienceViews} stack className={siteSpecific("w-100", "py-3 pe-3")}/> 

--- a/src/app/components/elements/list-groups/ListView.tsx
+++ b/src/app/components/elements/list-groups/ListView.tsx
@@ -395,13 +395,14 @@ export const BuilderListViewItem = (props: BuilderListViewItemProps) => {
             componentTag={"div"}
             icon={deviceSize !== "xs" ? icon : undefined}
             title={item.title ?? ""}
+            subtitle={item.subtitle}
             subject={itemSubject !== "neutral" ? itemSubject : undefined}
             url={url}
             tags={item.tags}
             deprecated={item.deprecated}
             supersededByPath={item.supersededBy ? `/questions/${item.supersededBy}` : undefined}
             style="flat"
-            subtitle={topic}
+            breadcrumb={topic ? [topic] : undefined}
             audienceViews={audienceViews}
             className="flex-grow-1 align-content-center bg-transparent"
             questionPreviewId={item.id}

--- a/src/app/components/elements/list-groups/ListView.tsx
+++ b/src/app/components/elements/list-groups/ListView.tsx
@@ -384,7 +384,7 @@ export const BuilderListViewItem = (props: BuilderListViewItemProps) => {
                 <button type="button" title="Move question up" className="btn btn-blank p-0 m-0 border-0" onClick={() => onMove?.(item.id ?? "", -1)} disabled={index === 0}>
                     <i className={classNames("icon icon-chevron-up", index === 0 ? "icon-color-disabled" : "icon-color-muted-hoverable icon-color-theme-on-hover" )} />
                 </button>
-                <img src="/assets/common/icons/drag_indicator.svg" alt="Drag to reorder" className="mx-1 grab-cursor" />
+                <i aria-label="Drag to reorder" className="mx-1 grab-cursor icon icon-md icon-drag-indicator icon-color-black" />
                 <button type="button" title="Move question down" className="btn btn-blank p-0 m-0 border-0" onClick={() => onMove?.(item.id ?? "", 1)} disabled={!!(totalItems && index === totalItems - 1)}>
                     <i className={classNames("icon icon-chevron-down", totalItems && index === totalItems - 1 ? "icon-color-disabled" : "icon-color-muted-hoverable icon-color-theme-on-hover" )} />
                 </button>

--- a/src/app/components/elements/list-groups/TopicSummaryLinks.tsx
+++ b/src/app/components/elements/list-groups/TopicSummaryLinks.tsx
@@ -5,12 +5,8 @@ import {
     audienceStyle,
     DOCUMENT_TYPE,
     documentTypePathPrefix,
-    isAda,
-    isPhy,
     isIntendedAudience,
     makeIntendedAudienceComparator,
-    notRelevantMessage,
-    siteSpecific,
     stringifyAudience,
     useDeviceSize,
     useUserViewingContext
@@ -19,7 +15,7 @@ import {Link} from "react-router-dom";
 import {selectors, useAppSelector} from "../../../state";
 import classNames from "classnames";
 import {Markup} from "../markup";
-import { ListGroup, ListGroupItem, Button, UncontrolledTooltip } from "reactstrap";
+import { ListGroup, ListGroupItem, Button } from "reactstrap";
 import { Spacer } from "../Spacer";
 
 export function TopicSummaryLinks({items, search}: {items: ContentSummaryDTO[]; search?: string}) {
@@ -29,9 +25,8 @@ export function TopicSummaryLinks({items, search}: {items: ContentSummaryDTO[]; 
 
     return <ListGroup className="mt-4 link-list list-group-links">
         {items
-            // For CS we want relevant sections to appear first
+            // We want relevant sections to appear first
             .sort((itemA, itemB) => {
-                if (!isAda) {return 0;}
                 return makeIntendedAudienceComparator(user, userContext)(itemA, itemB);
             })
 
@@ -42,7 +37,7 @@ export function TopicSummaryLinks({items, search}: {items: ContentSummaryDTO[]; 
             })
 
             // Render items
-            .map((item, index) => {
+            .map((item) => {
                 const audienceString = stringifyAudience(
                     item.audience, userContext,
                     isIntendedAudience(item.audience, userContext, user)
@@ -53,13 +48,9 @@ export function TopicSummaryLinks({items, search}: {items: ContentSummaryDTO[]; 
                         tag={Link} to={{pathname: `/${documentTypePathPrefix[DOCUMENT_TYPE.CONCEPT]}/${item.id}`, search}}
                         block color="link" className={"d-flex align-items-stretch " + classNames({"de-emphasised": item.deEmphasised})}
                     >
-                        <div className={"stage-label d-flex align-items-center justify-content-center " + classNames({[audienceStyle(audienceString)]: isAda})}>
-                            {siteSpecific(
-                                audienceString,
-                                above["sm"](deviceSize) ? audienceString : audienceString.replaceAll(",", "\n")
-                            ).split("\n").map((line, i, arr) => <>
-                                {line}{i < arr.length && <br/>}
-                            </>)}
+                        <div className={classNames("stage-label d-flex align-items-center justify-content-center", audienceStyle(audienceString))}>
+                            {above["sm"](deviceSize) ? audienceString : audienceString.replaceAll(",", "\n").split("\n").map((line, i, arr) => 
+                                <>{line}{i < arr.length && <br/>}</>)}
                         </div>
                         <div className="title ps-3 d-flex">
                             <div className="p-3">
@@ -67,12 +58,6 @@ export function TopicSummaryLinks({items, search}: {items: ContentSummaryDTO[]; 
                                     {item.title}
                                 </Markup>
                             </div>
-                            {isPhy && item.deEmphasised && <div className="ms-auto me-3 d-flex align-items-center">
-                                <i id={`audience-help-${index}`} className="icon icon-info icon-color-grey" />
-                                <UncontrolledTooltip placement="bottom" target={`audience-help-${index}`}>
-                                    {`This content has ${notRelevantMessage(userContext)}.`}
-                                </UncontrolledTooltip>
-                            </div>}
                         </div>
                         <Spacer />
                         <div className="d-flex align-items-center">

--- a/src/app/components/elements/list-groups/TopicSummaryLinks.tsx
+++ b/src/app/components/elements/list-groups/TopicSummaryLinks.tsx
@@ -43,9 +43,11 @@ export function TopicSummaryLinks({items, search}: {items: ContentSummaryDTO[]; 
                     isIntendedAudience(item.audience, userContext, user)
                 );
 
+                const documentType = (item.type && ["isaacQuestionPage", "isaacFastTrackQuestionPage"].includes(item.type)) ? DOCUMENT_TYPE.QUESTION : DOCUMENT_TYPE.CONCEPT;
+
                 return <ListGroupItem key={item.id} className="topic-summary-link">
                     <Button
-                        tag={Link} to={{pathname: `/${documentTypePathPrefix[DOCUMENT_TYPE.CONCEPT]}/${item.id}`, search}}
+                        tag={Link} to={{pathname: `/${documentTypePathPrefix[documentType]}/${item.id}`, search}}
                         block color="link" className={"d-flex align-items-stretch " + classNames({"de-emphasised": item.deEmphasised})}
                     >
                         <div className={classNames("stage-label d-flex align-items-center justify-content-center", audienceStyle(audienceString))}>

--- a/src/app/components/elements/list-groups/TopicSummaryLinks.tsx
+++ b/src/app/components/elements/list-groups/TopicSummaryLinks.tsx
@@ -17,6 +17,7 @@ import classNames from "classnames";
 import {Markup} from "../markup";
 import { ListGroup, ListGroupItem, Button } from "reactstrap";
 import { Spacer } from "../Spacer";
+import { ContentPropertyTags } from "../ContentPropertyTags";
 
 export function TopicSummaryLinks({items, search}: {items: ContentSummaryDTO[]; search?: string}) {
     const userContext = useUserViewingContext();
@@ -54,12 +55,14 @@ export function TopicSummaryLinks({items, search}: {items: ContentSummaryDTO[]; 
                             {above["sm"](deviceSize) ? audienceString : audienceString.replaceAll(",", "\n").split("\n").map((line, i, arr) => 
                                 <>{line}{i < arr.length && <br/>}</>)}
                         </div>
-                        <div className="title ps-3 d-flex">
-                            <div className="p-3">
-                                <Markup encoding={"latex"}>
-                                    {item.title}
-                                </Markup>
-                            </div>
+                        <div className="title p-3 ps-6 d-block d-sm-flex">
+                            <Markup encoding={"latex"}>
+                                {item.title}
+                            </Markup>
+                            <ContentPropertyTags 
+                                className="ps-sm-2"
+                                tags={item.tags}
+                            />
                         </div>
                         <Spacer />
                         <div className="d-flex align-items-center">

--- a/src/app/components/elements/list-groups/TopicSummaryLinks.tsx
+++ b/src/app/components/elements/list-groups/TopicSummaryLinks.tsx
@@ -61,6 +61,8 @@ export function TopicSummaryLinks({items, search}: {items: ContentSummaryDTO[]; 
                             </Markup>
                             <ContentPropertyTags 
                                 className="ps-sm-2"
+                                deprecated={item.deprecated}
+                                supersededByPath={item.supersededBy ? `/questions/${item.supersededBy}` : undefined}
                                 tags={item.tags}
                             />
                         </div>

--- a/src/app/components/pages/Generic.tsx
+++ b/src/app/components/pages/Generic.tsx
@@ -25,6 +25,8 @@ import { GenericPageSidebar } from "../elements/sidebar/GenericPageSidebar";
 import { PolicyPageSidebar } from "../elements/sidebar/PolicyPageSidebar";
 import { GenericSidebarWithRelatedContent } from "../elements/sidebar/RelatedContentSidebar";
 import { PageContainer } from "../elements/layout/PageContainer";
+import { getAccessibilityTags, useAccessibilitySettings } from "../../services/accessibility";
+import { InaccessibleContentWarningAlert } from "../elements/alerts/InaccessibleContentWarningAlert";
 
 interface GenericPageComponentProps {
     pageIdOverride?: string;
@@ -59,6 +61,7 @@ const SciSidebar = ({pageId, tags, gameboard, relatedContent, ...sidebarProps}: 
 
 export const Generic = ({pageIdOverride}: GenericPageComponentProps) => {
     const params = useParams();
+    const accessibilitySettings = useAccessibilitySettings();
     const pageId = pageIdOverride || params.pageId || "";
 
     const pageQuery = useGetGenericPageQuery(pageId);
@@ -113,6 +116,8 @@ export const Generic = ({pageIdOverride}: GenericPageComponentProps) => {
                     ? <PageMetadata doc={doc} />
                     : <PageMetadata doc={{...doc, subtitle: undefined}} title={doc.subtitle} noTitle={!doc.subtitle} />
                 }
+
+                {accessibilitySettings?.SHOW_INACCESSIBLE_WARNING && getAccessibilityTags(doc.tags).map(tag => <InaccessibleContentWarningAlert key={tag} type={tag} />)}
 
                 <Row className="generic-content-container">
                     <Col className={classNames("pb-4 generic-panel", {"mw-760": isAda && !CS_FULL_WIDTH_OVERRIDE[pageId], "pt-4": isAda})}>

--- a/src/app/components/pages/Topic.tsx
+++ b/src/app/components/pages/Topic.tsx
@@ -7,7 +7,6 @@ import {
     ALL_TOPICS_CRUMB,
     atLeastOne,
     getRelatedDocs,
-    isAda,
     PATHS,
 } from "../../services";
 import {Button, Card, CardBody, CardTitle, Col, Container, Row} from "reactstrap";
@@ -39,7 +38,7 @@ export const Topic = () => {
                     <div className="d-flex justify-content-end">
                         <UserContextPicker />
                     </div>
-                    {isAda && <IntendedAudienceWarningAlert doc={topicPage} />}
+                    <IntendedAudienceWarningAlert doc={topicPage} />
                     {topicPage.children && topicPage.children.map((child, index) =>
                         <IsaacContent key={index} doc={child}/>)
                     }

--- a/src/scss/common/icons.scss
+++ b/src/scss/common/icons.scss
@@ -207,6 +207,10 @@ img[aria-disabled="true"] {
   }
 }
 
+.icon-drag-indicator {
+  @include svg-icon('/assets/common/icons/drag_indicator.svg', var(--icon-size), var(--icon-size), var(--mask-size, 60%));
+}
+
 // Icon sizing
 .icon {
   --icon-size: 16px;

--- a/src/scss/common/topic.scss
+++ b/src/scss/common/topic.scss
@@ -4,7 +4,7 @@
   border-top: 1px solid $shadow-08 !important;
   padding: 0;
   &:first-of-type {border-top: 0;}
-  a {
+  > a {
     border-radius: 0;
     font-family: $secondary-font;
     font-weight: 600;


### PR DESCRIPTION
Dependent on https://github.com/isaacphysics/isaac-react-app/pull/2240 to avoid merge issues with ALVI changes

Several small things:
- Allow subtitles to appear below title on `flatLayout` ALVIs (for the deck builder)
- Allow question ID to be checked using the deck builder preview button tooltip
  - I tried a few different ways for this. Including the ID directly or a new hover region was messy-looking, and adding a tooltip to the title was too distracting. This seemed best, and definitely works for the desired use-case
  - (I also changed the table builder row title tooltip to include it, so the tooltips still match)
- Use a css `icon` for drag-indicator so that it becomes white and hence visible in dark mode