### PR TITLE
Set / manage work fixes

### DIFF
--- a/src/app/components/elements/sidebar/ManageAssignmentsSidebar.tsx
+++ b/src/app/components/elements/sidebar/ManageAssignmentsSidebar.tsx
@@ -1,5 +1,5 @@
 import { ContentSidebar } from "../layout/SidebarLayout";
-import { above, isTeacherOrAbove, Item, itemise, reactSelectDarkModeStyles, selectOnChange, Subjects, useDeviceSize } from "../../../services";
+import { above, isTeacherOrAbove, Item, itemise, reactSelectDarkModeStyles, selectOnChange, useDeviceSize } from "../../../services";
 import { sortBy } from "lodash";
 import React from "react";
 import { Button, ButtonGroup, Input } from "reactstrap";
@@ -24,7 +24,7 @@ interface HeaderProps {
     collapse: () => void;
 } 
 
-export const ManageAssignmentsSidebar = ({groups, assignmentsSetByMe, viewBy, setViewBy, setGroupsToInclude, groupsToInclude, workTypesToInclude, setWorkTypesToInclude, setSubjectsToInclude, subjectsToInclude, workTitleToInclude, setWorkTitleToInclude, collapse}: HeaderProps) => {
+export const ManageAssignmentsSidebar = ({groups, assignmentsSetByMe, viewBy, setViewBy, setGroupsToInclude, groupsToInclude, workTypesToInclude, setWorkTypesToInclude, workTitleToInclude, setWorkTitleToInclude, collapse}: HeaderProps) => {
     const user = useAppSelector(selectors.user.orNull);
     const deviceSize = useDeviceSize();
 

--- a/src/app/components/elements/sidebar/ManageAssignmentsSidebar.tsx
+++ b/src/app/components/elements/sidebar/ManageAssignmentsSidebar.tsx
@@ -69,7 +69,10 @@ export const ManageAssignmentsSidebar = ({groups, assignmentsSetByMe, viewBy, se
             />
         </>}
 
-        <details>
+        <h5 className="mt-3">Filter by title</h5>
+        <Input type="text" placeholder="Search by title" value={workTitleToInclude} onChange={e => setWorkTitleToInclude(e.target.value)} />
+        {/* TODO swap the above title filter with the below filters pair, once subject information is available for assignments */}
+        {/* <details>
             <summary className="mt-3">More filters</summary>
 
             <h5 className="mt-3">Filter by title</h5>
@@ -82,7 +85,7 @@ export const ManageAssignmentsSidebar = ({groups, assignmentsSetByMe, viewBy, se
                 options={Subjects.map(s => itemise(s, s.charAt(0).toUpperCase() + s.slice(1)))}
                 styles={reactSelectDarkModeStyles}
             />
-        </details>
+        </details> */}
 
 
         <div className="section-divider" />

--- a/src/app/components/pages/ManageAssignments.tsx
+++ b/src/app/components/pages/ManageAssignments.tsx
@@ -463,6 +463,7 @@ export const ManageAssignments = ({user}: { user: LoggedInUser }) => {
                 ? combineQueries(assignmentsSetByMeQuery, testsSetByMeQuery, () => []) 
                 : assignmentsSetByMeQuery
             }
+            maintainOnRefetch
         >
             <ManageAssignmentsContext.Provider value={{groupsById, workByGroup, groups: groups ?? [], collapsed, setCollapsed, viewBy}}>
                 <div className="px-md-4 ps-2 pe-2 timeline-column mb-4 pt-2">

--- a/src/app/state/slices/api/gameboardApi.ts
+++ b/src/app/state/slices/api/gameboardApi.ts
@@ -98,7 +98,7 @@ export const gameboardApi = isaacApi.injectEndpoints({
                 method: "POST",
                 params: {title: newTitle},
             }),
-            invalidatesTags: (_, error, {boardId}) => error ? ["AllGameboards"] : ["AllGameboards", {type: "Gameboard", id: boardId}],
+            invalidatesTags: (_, _error, {boardId}) => ["AllGameboards", {type: "Gameboard", id: boardId}],
             onQueryStarted: onQueryLifecycleEvents({
                 errorTitle: `Linking the ${siteSpecific("deck", "quiz")} to your account failed`
             })
@@ -109,7 +109,8 @@ export const gameboardApi = isaacApi.injectEndpoints({
                 url: `gameboards/user_gameboards/${encodeURIComponent(boardId)}`,
                 method: "POST"
             }),
-            invalidatesTags: (_, error, boardId) => error ? ["AllGameboards"] : ["AllGameboards", {type: "Gameboard", id: boardId}],
+            // TODO requires invalidating AllSetAssignments as the assignment's gameboard can be updated by this and so should not be cached
+            invalidatesTags: (_, _error, boardId) => ["AllGameboards", "AllSetAssignments", {type: "Gameboard", id: boardId}],
             onQueryStarted: onQueryLifecycleEvents({
                 errorTitle: `Linking the ${siteSpecific("deck", "quiz")} to your account failed`
             })
@@ -120,7 +121,7 @@ export const gameboardApi = isaacApi.injectEndpoints({
                 url: `/gameboards/user_gameboards/${encodeURIComponent(boardId)}`,
                 method: "DELETE",
             }),
-            invalidatesTags: (_, error, boardId) => !error ? [{type: "Gameboard", id: boardId}] : [],
+            invalidatesTags: (_, _error, boardId) => ["AllGameboards", "AllSetAssignments", {type: "Gameboard", id: boardId}],
             onQueryStarted: onQueryLifecycleEvents({
                 successTitle: `${siteSpecific("Deck", "Quiz")} removed`,
                 successMessage: siteSpecific("The deck has been removed from your saved decks.", "You have successfully unlinked your account from this quiz."),


### PR DESCRIPTION
Fixes a couple of bugs found during regression testing.

I don't know that invalidating assignments on deck save is necessarily very clean, but fundamentally we do have two sources of gameboards that can be cached – either via any Gameboards endpoint or by mapping `(a => a.gameboard)` over any Assignments endpoint. Changing something about a deck necessarily requires invalidating both under this method; with a much larger overhaul we could not require this, but for now I see no easy way around it.