### PR TITLE
Re-hide fasttrack filter from non-staff

### DIFF
--- a/src/app/components/elements/modals/QuestionSearchModal.tsx
+++ b/src/app/components/elements/modals/QuestionSearchModal.tsx
@@ -312,7 +312,7 @@ export const QuestionSearchModal = (
                 }} />}
 
                 {isPhy && isStaff(user) && <>
-                    <StyledCheckbox color="primary" checked={searchFastTrack} label={<span>Show FastTrack questions</span>} onChange={e => {
+                    <StyledCheckbox color="primary" checked={searchFastTrack} label={<span>Show FastTrack only</span>} onChange={e => {
                         startTransition(() => {
                             setSearchFastTrack(e.target.checked);
                         });

--- a/src/app/components/elements/modals/QuestionSearchModal.tsx
+++ b/src/app/components/elements/modals/QuestionSearchModal.tsx
@@ -18,6 +18,7 @@ import {
     groupTagSelectionsByParent,
     isAda,
     isPhy,
+    isStaff,
     Item,
     logEvent,
     searchResultIsPublic,
@@ -310,7 +311,7 @@ export const QuestionSearchModal = (
                     });
                 }} />}
 
-                {isPhy && <>
+                {isPhy && isStaff(user) && <>
                     <StyledCheckbox color="primary" checked={searchFastTrack} label={<span>Show FastTrack questions</span>} onChange={e => {
                         startTransition(() => {
                             setSearchFastTrack(e.target.checked);


### PR DESCRIPTION
Also update the checkbox text to make it clear that this hides non-fasttrack questions (similarly to the bookmarks filter).