### PR TITLE
Feature/skills on my progress

### DIFF
--- a/src/IsaacApiTypes.tsx
+++ b/src/IsaacApiTypes.tsx
@@ -410,6 +410,7 @@ export interface AnvilAppDTO extends ContentDTO {
 export interface SkillsAppDTO extends ContentDTO {
     anvilApp?: AnvilAppDTO
 }
+
 export interface ChemicalFormulaDTO extends ChoiceDTO {
     mhchemExpression?: string;
 }
@@ -868,6 +869,9 @@ export interface AnsweredQuestionsByDate {
     [date: string]: number;
 }
 
+export interface SkillAttemptsByDate {
+    'mental_maths_overall': AnsweredQuestionsByDate
+}
 export interface TOTPSharedSecretDTO {
     userId: number;
     sharedSecret: string;

--- a/src/app/components/elements/Tabs.tsx
+++ b/src/app/components/elements/Tabs.tsx
@@ -25,6 +25,7 @@ interface TabsProps {
     singleLine?: boolean;
     style?: TabStyle;
     dataTestId?: string;
+    renderHiddenTabs?: boolean;
 }
 
 function callOrString(stringOrTabFunction: StringOrTabFunction | undefined, tabTitle: string, tabIndex: number) {
@@ -110,10 +111,23 @@ const CardsNavbar = ({children, activeTab, changeTab, tabTitleClass="", dataTest
     </div>;
 };
 
+const PrintOnlyTabNav = ({tabProps, tabIndex, changeTab}: {tabProps: TabsProps, tabIndex: number, changeTab: (i: number) => void}) => {
+    const {style, children, tabContentClass} = tabProps;
+    return style === "tabs" ?
+        <TabNavbar {...tabProps} className={classNames("d-none d-print-flex mb-3 mt-2", {"mt-n4": tabIndex === 1 && tabContentClass?.includes("pt-4")})} activeTab={tabIndex} changeTab={changeTab}>
+            {children}
+        </TabNavbar> :
+        style === "dropdowns" && isPhy && 
+        <DropdownNavbar {...tabProps} className={classNames("d-none d-print-flex mb-3 mt-2", {"mt-n4": tabIndex === 1 && tabContentClass?.includes("pt-4")})} activeTab={tabIndex} changeTab={changeTab}>
+            {children}
+        </DropdownNavbar>;
+};
+
 export const Tabs = (props: TabsProps) => {
     const {
         className, tabContentClass, tabNavbarClass, children, activeTabOverride, onActiveTabChange,
         deselectable=undefined, refreshHash, expandable, style=(siteSpecific("dropdowns", "tabs")),
+        renderHiddenTabs=true
     } = props;
     const [activeTab, setActiveTab] = useState(activeTabOverride || 1);
 
@@ -156,19 +170,14 @@ export const Tabs = (props: TabsProps) => {
                     {Object.entries(children).map(([tabTitle, tabBody], mapIndex) => {
                         const tabIndex = mapIndex + 1;
                         return <React.Fragment key={tabTitle}>
-                            {/* This navbar exists only when printing so each tab has its own heading */}
-                            {style === "tabs" ?
-                                <TabNavbar {...props} className={classNames("d-none d-print-flex mb-3 mt-2", {"mt-n4": mapIndex === 0 && tabContentClass?.includes("pt-4")})} activeTab={tabIndex} changeTab={changeTab}>
-                                    {children}
-                                </TabNavbar> :
-                                style === "dropdowns" && isPhy && 
-                                <DropdownNavbar {...props} className={classNames("d-none d-print-flex mb-3 mt-2", {"mt-n4": mapIndex === 0 && tabContentClass?.includes("pt-4")})} activeTab={tabIndex} changeTab={changeTab}>
-                                    {children}
-                                </DropdownNavbar>
-                            }
-                            <TabPane key={tabTitle} tabId={tabIndex} data-testid={tabIndex === activeTab ? "active-tab-pane" : undefined}>
-                                {tabBody as ReactNode}
-                            </TabPane>
+                            {(renderHiddenTabs || tabIndex === activeTab) && <>
+                                {/* include a print-only navbar so each tab appears to have its own heading when printing */}
+                                <PrintOnlyTabNav tabProps={props} tabIndex={tabIndex} changeTab={changeTab}/>
+
+                                <TabPane key={tabTitle} tabId={tabIndex} data-testid={tabIndex === activeTab ? "active-tab-pane" : undefined}>
+                                    {tabBody as ReactNode}
+                                </TabPane>
+                            </>}
                         </React.Fragment>;
                     })}
                 </TabContent>

--- a/src/app/components/elements/views/ActivityGraph.tsx
+++ b/src/app/components/elements/views/ActivityGraph.tsx
@@ -1,7 +1,8 @@
-import React, {useEffect, useMemo} from 'react';
+import React, {useEffect, useMemo, useRef} from 'react';
 import {areaSpline, bb, zoom} from "billboard.js";
 import {AnsweredQuestionsByDate} from "../../../../IsaacApiTypes";
 import {formatISODateOnly} from "../DateString";
+import throttle from 'lodash/throttle';
 
 type ActivityGraphProps = {
     id: string, // unique ID for the graph, so that multiple graphs can be rendered on the same page
@@ -12,6 +13,8 @@ type ActivityGraphProps = {
 };
 
 export const ActivityGraph = ({ id, answeredQuestionsByDate, caption, colour, emptyText }: ActivityGraphProps) => {
+    const graphRef = useRef<HTMLDivElement>(null);
+
     const selectedDates = useMemo(() => {
         const foundDates = answeredQuestionsByDate ? Object.keys(answeredQuestionsByDate) : [];
         if (foundDates && foundDates.length > 0) {
@@ -23,47 +26,61 @@ export const ActivityGraph = ({ id, answeredQuestionsByDate, caption, colour, em
         return [];
     }, [answeredQuestionsByDate]);
 
-    useEffect(() => {
-        if (selectedDates.length === 0) {
-            return;
-        }
-        let minDate, maxDate;
-        let nTicks = selectedDates.length;
-        if (selectedDates.length === 1) {
-            // If only one datapoint, Billboard shows a decade of time on the x-axis. Truncate to one month each side:
-            const firstDate = new Date(selectedDates[0]);
-            minDate = formatISODateOnly(new Date(firstDate.getFullYear(), firstDate.getMonth()-1, 1));
-            maxDate = formatISODateOnly(new Date(firstDate.getFullYear(), firstDate.getMonth()+1, 1));
-            nTicks = 3;  // For one month, we need 3 labels for symmetry else label ends up in wrong place.
-        }
-        bb.generate({
-            data: {
-                x: "x",
-                columns: [
-                    ["x", ...selectedDates],
-                    [caption, ...selectedDates.map((date) => answeredQuestionsByDate ? answeredQuestionsByDate[date] || 0 : 0)]
-                ],
-                types: {[caption]: areaSpline()},
-                colors: {[caption]: colour},
-                xFormat: "%Y-%m-%d",
-            },
-            axis: {
-                x: {
-                    type: "timeseries",
-                    tick: {fit: false, format: '%b %Y', count: Math.min(8, nTicks)},
-                    min: minDate,  // If these are undefined, then the values from the data will be used.
-                    max: maxDate,
-                }
-            },
-            zoom: {enabled: zoom()},
-            legend: {show: false},
-            spline: {interpolation: {type: "monotone-x"}},
-            bindto: `#activity-graph-${id}`,
-            padding: {top: 0, right: 30, bottom: 30, left: 35}  // Pad sides to avoid tick labels being truncated!
-        });
+    const regenerateGraph = useMemo(() => {
+        return throttle(() => {
+            if (selectedDates.length === 0) {
+                return;
+            }
+            let minDate, maxDate;
+            let nTicks = selectedDates.length;
+            if (selectedDates.length === 1) {
+                // If only one datapoint, Billboard shows a decade of time on the x-axis. Truncate to one month each side:
+                const firstDate = new Date(selectedDates[0]);
+                minDate = formatISODateOnly(new Date(firstDate.getFullYear(), firstDate.getMonth()-1, 1));
+                maxDate = formatISODateOnly(new Date(firstDate.getFullYear(), firstDate.getMonth()+1, 1));
+                nTicks = 3;  // For one month, we need 3 labels for symmetry else label ends up in wrong place.
+            }
+            bb.generate({
+                data: {
+                    x: "x",
+                    columns: [
+                        ["x", ...selectedDates],
+                        [caption, ...selectedDates.map((date) => answeredQuestionsByDate ? answeredQuestionsByDate[date] || 0 : 0)]
+                    ],
+                    types: {[caption]: areaSpline()},
+                    colors: {[caption]: colour},
+                    xFormat: "%Y-%m-%d",
+                },
+                axis: {
+                    x: {
+                        type: "timeseries",
+                        tick: {fit: false, format: '%b %Y', count: Math.min(8, nTicks)},
+                        min: minDate,  // If these are undefined, then the values from the data will be used.
+                        max: maxDate,
+                    }
+                },
+                zoom: {enabled: zoom()},
+                legend: {show: false},
+                spline: {interpolation: {type: "monotone-x"}},
+                bindto: `#activity-graph-${id}`,
+                padding: {top: 0, right: 30, bottom: 30, left: 35}  // Pad sides to avoid tick labels being truncated!
+            });
+        }, 250);
     }, [answeredQuestionsByDate, selectedDates, caption, colour, id]);
 
+    useEffect(() => {
+        // rerun the graph generation if any dependencies change
+        regenerateGraph();
+
+        // also reset the resizing listener, so that the correct update function is called if the window is resized
+        const handleResize = () => regenerateGraph();
+        window.addEventListener('resize', handleResize);
+        return () => window.removeEventListener('resize', handleResize);
+    }, [regenerateGraph]);
+
     return selectedDates.length > 0
-        ? <div id={`activity-graph-${id}`} key={`activity-graph-${id}`}/>
-        : <div key="graph-empty-state" className="text-center-width"><strong>No data{emptyText ? '.' : ''} {emptyText}</strong></div>;
+        ? <div id={`activity-graph-${id}`} key={`activity-graph-${id}`} ref={graphRef} />
+        : <div key="graph-empty-state" className="text-center-width">
+            <strong>No data{emptyText ? '.' : ''} {emptyText}</strong>
+        </div>;
 };

--- a/src/app/components/elements/views/ActivityGraph.tsx
+++ b/src/app/components/elements/views/ActivityGraph.tsx
@@ -4,7 +4,7 @@ import {AnsweredQuestionsByDate} from "../../../../IsaacApiTypes";
 import {formatISODateOnly} from "../DateString";
 
 export const ActivityGraph = ({ answeredQuestionsByDate, caption, colour }: ActivityGraphProps) => {
-
+    console.log('another render');
     let selectedDates: string[] = [];
     const foundDates = answeredQuestionsByDate ? Object.keys(answeredQuestionsByDate) : [];
     if (foundDates && foundDates.length > 0) {
@@ -15,6 +15,7 @@ export const ActivityGraph = ({ answeredQuestionsByDate, caption, colour }: Acti
     }
 
     useEffect(() => {
+        console.log('in useEffect');
         if (selectedDates.length === 0) {
             return;
         }
@@ -54,7 +55,9 @@ export const ActivityGraph = ({ answeredQuestionsByDate, caption, colour }: Acti
         });
     }, [answeredQuestionsByDate, selectedDates, caption, colour]);
 
-    return selectedDates.length > 0 ? <div id="activityGraph"/> : <div className="text-center-width"><strong>No data</strong></div>;
+    return selectedDates.length > 0
+        ? <div id="activityGraph" key="graph-with-data"/>
+        : <div key="graph-empty-state" className="text-center-width"><strong>No data</strong></div>;
 };
 
 type ActivityGraphProps = { answeredQuestionsByDate: AnsweredQuestionsByDate, caption: string, colour: string };

--- a/src/app/components/elements/views/ActivityGraph.tsx
+++ b/src/app/components/elements/views/ActivityGraph.tsx
@@ -2,9 +2,8 @@ import React, {useEffect} from 'react';
 import {areaSpline, bb, zoom} from "billboard.js";
 import {AnsweredQuestionsByDate} from "../../../../IsaacApiTypes";
 import {formatISODateOnly} from "../DateString";
-import {siteSpecific} from "../../../services";
 
-export const ActivityGraph = ({answeredQuestionsByDate}: {answeredQuestionsByDate: AnsweredQuestionsByDate}) => {
+export const ActivityGraph = ({ answeredQuestionsByDate, caption, colour }: ActivityGraphProps) => {
 
     let selectedDates: string[] = [];
     const foundDates = answeredQuestionsByDate ? Object.keys(answeredQuestionsByDate) : [];
@@ -33,10 +32,10 @@ export const ActivityGraph = ({answeredQuestionsByDate}: {answeredQuestionsByDat
                 x: "x",
                 columns: [
                     ["x", ...selectedDates],
-                    ["activity", ...selectedDates.map((date) => answeredQuestionsByDate ? answeredQuestionsByDate[date] || 0 : 0)]
+                    [caption, ...selectedDates.map((date) => answeredQuestionsByDate ? answeredQuestionsByDate[date] || 0 : 0)]
                 ],
-                types: {activity: areaSpline()},
-                colors: {activity: siteSpecific("#FEA102", "#FF4DC9")},
+                types: {[caption]: areaSpline()},
+                colors: {[caption]: colour},
                 xFormat: "%Y-%m-%d",
             },
             axis: {
@@ -53,7 +52,9 @@ export const ActivityGraph = ({answeredQuestionsByDate}: {answeredQuestionsByDat
             bindto: "#activityGraph",
             padding: {top: 0, right: 30, bottom: 30, left: 35}  // Pad sides to avoid tick labels being truncated!
         });
-    }, [answeredQuestionsByDate, selectedDates]);
+    }, [answeredQuestionsByDate, selectedDates, caption, colour]);
 
     return selectedDates.length > 0 ? <div id="activityGraph"/> : <div className="text-center-width"><strong>No data</strong></div>;
 };
+
+type ActivityGraphProps = { answeredQuestionsByDate: AnsweredQuestionsByDate, caption: string, colour: string };

--- a/src/app/components/elements/views/ActivityGraph.tsx
+++ b/src/app/components/elements/views/ActivityGraph.tsx
@@ -3,7 +3,7 @@ import {areaSpline, bb, zoom} from "billboard.js";
 import {AnsweredQuestionsByDate} from "../../../../IsaacApiTypes";
 import {formatISODateOnly} from "../DateString";
 
-export const ActivityGraph = ({ answeredQuestionsByDate, caption, colour }: ActivityGraphProps) => {
+export const ActivityGraph = ({ answeredQuestionsByDate, caption, colour, emptyText }: ActivityGraphProps) => {
     console.log('another render');
     let selectedDates: string[] = [];
     const foundDates = answeredQuestionsByDate ? Object.keys(answeredQuestionsByDate) : [];
@@ -57,7 +57,12 @@ export const ActivityGraph = ({ answeredQuestionsByDate, caption, colour }: Acti
 
     return selectedDates.length > 0
         ? <div id="activityGraph" key="graph-with-data"/>
-        : <div key="graph-empty-state" className="text-center-width"><strong>No data</strong></div>;
+        : <div key="graph-empty-state" className="text-center-width"><strong>No data{emptyText ? '.' : ''} {emptyText}</strong></div>;
 };
 
-type ActivityGraphProps = { answeredQuestionsByDate: AnsweredQuestionsByDate, caption: string, colour: string };
+type ActivityGraphProps = {
+    answeredQuestionsByDate: AnsweredQuestionsByDate,
+    caption: string,
+    colour: string,
+    emptyText?: React.JSX.Element
+};

--- a/src/app/components/elements/views/ActivityGraph.tsx
+++ b/src/app/components/elements/views/ActivityGraph.tsx
@@ -1,21 +1,29 @@
-import React, {useEffect} from 'react';
+import React, {useEffect, useMemo} from 'react';
 import {areaSpline, bb, zoom} from "billboard.js";
 import {AnsweredQuestionsByDate} from "../../../../IsaacApiTypes";
 import {formatISODateOnly} from "../DateString";
 
-export const ActivityGraph = ({ answeredQuestionsByDate, caption, colour, emptyText }: ActivityGraphProps) => {
-    console.log('another render');
-    let selectedDates: string[] = [];
-    const foundDates = answeredQuestionsByDate ? Object.keys(answeredQuestionsByDate) : [];
-    if (foundDates && foundDates.length > 0) {
-        const nonZeroDates = foundDates.filter((date) => answeredQuestionsByDate && answeredQuestionsByDate[date] > 0);
-        if (nonZeroDates.length > 0) {
-            selectedDates = foundDates.sort();
+type ActivityGraphProps = {
+    id: string, // unique ID for the graph, so that multiple graphs can be rendered on the same page
+    answeredQuestionsByDate: AnsweredQuestionsByDate,
+    caption: string,
+    colour: string,
+    emptyText?: React.JSX.Element
+};
+
+export const ActivityGraph = ({ id, answeredQuestionsByDate, caption, colour, emptyText }: ActivityGraphProps) => {
+    const selectedDates = useMemo(() => {
+        const foundDates = answeredQuestionsByDate ? Object.keys(answeredQuestionsByDate) : [];
+        if (foundDates && foundDates.length > 0) {
+            const nonZeroDates = foundDates.filter((date) => answeredQuestionsByDate && answeredQuestionsByDate[date] > 0);
+            if (nonZeroDates.length > 0) {
+                return foundDates.sort();
+            }
         }
-    }
+        return [];
+    }, [answeredQuestionsByDate]);
 
     useEffect(() => {
-        console.log('in useEffect');
         if (selectedDates.length === 0) {
             return;
         }
@@ -50,19 +58,12 @@ export const ActivityGraph = ({ answeredQuestionsByDate, caption, colour, emptyT
             zoom: {enabled: zoom()},
             legend: {show: false},
             spline: {interpolation: {type: "monotone-x"}},
-            bindto: "#activityGraph",
+            bindto: `#activity-graph-${id}`,
             padding: {top: 0, right: 30, bottom: 30, left: 35}  // Pad sides to avoid tick labels being truncated!
         });
-    }, [answeredQuestionsByDate, selectedDates, caption, colour]);
+    }, [answeredQuestionsByDate, selectedDates, caption, colour, id]);
 
     return selectedDates.length > 0
-        ? <div id="activityGraph" key="graph-with-data"/>
+        ? <div id={`activity-graph-${id}`} key={`activity-graph-${id}`}/>
         : <div key="graph-empty-state" className="text-center-width"><strong>No data{emptyText ? '.' : ''} {emptyText}</strong></div>;
-};
-
-type ActivityGraphProps = {
-    answeredQuestionsByDate: AnsweredQuestionsByDate,
-    caption: string,
-    colour: string,
-    emptyText?: React.JSX.Element
 };

--- a/src/app/components/elements/views/ActivityGraph.tsx
+++ b/src/app/components/elements/views/ActivityGraph.tsx
@@ -8,11 +8,11 @@ type ActivityGraphProps = {
     id: string, // unique ID for the graph, so that multiple graphs can be rendered on the same page
     answeredQuestionsByDate: AnsweredQuestionsByDate,
     caption: string,
-    colour: string,
+    color: string,
     emptyText?: React.JSX.Element
 };
 
-export const ActivityGraph = ({ id, answeredQuestionsByDate, caption, colour, emptyText }: ActivityGraphProps) => {
+export const ActivityGraph = ({ id, answeredQuestionsByDate, caption, color, emptyText }: ActivityGraphProps) => {
     const graphRef = useRef<HTMLDivElement>(null);
 
     const selectedDates = useMemo(() => {
@@ -48,7 +48,7 @@ export const ActivityGraph = ({ id, answeredQuestionsByDate, caption, colour, em
                         [caption, ...selectedDates.map((date) => answeredQuestionsByDate ? answeredQuestionsByDate[date] || 0 : 0)]
                     ],
                     types: {[caption]: areaSpline()},
-                    colors: {[caption]: colour},
+                    colors: {[caption]: color},
                     xFormat: "%Y-%m-%d",
                 },
                 axis: {
@@ -66,7 +66,7 @@ export const ActivityGraph = ({ id, answeredQuestionsByDate, caption, colour, em
                 padding: {top: 0, right: 30, bottom: 30, left: 35}  // Pad sides to avoid tick labels being truncated!
             });
         }, 250);
-    }, [answeredQuestionsByDate, selectedDates, caption, colour, id]);
+    }, [answeredQuestionsByDate, selectedDates, caption, color, id]);
 
     useEffect(() => {
         // rerun the graph generation if any dependencies change

--- a/src/app/components/pages/MyProgress.tsx
+++ b/src/app/components/pages/MyProgress.tsx
@@ -191,7 +191,10 @@ const MyProgress = ({user}: MyProgressProps) => {
 
                     {isPhy
                         ? <QuestionAndSkillsAttemptsOverTime viewingOwnData={viewingOwnData} user={user} />
-                        : <QuestionAttemptsOverTime viewingOwnData={viewingOwnData} user={user} />}
+                        : <div className="mt-4">
+                            <h4> Question attempts over time</h4>
+                            <QuestionAttemptsOverTime viewingOwnData={viewingOwnData} user={user} />
+                        </div>}
 
                     <Row id="progress-questions">
                         {progress?.mostRecentQuestions && progress?.mostRecentQuestions.length > 0 && <Col md={12} lg={6} className="mt-4">
@@ -238,7 +241,8 @@ const QuestionAndSkillsAttemptsOverTime = ({viewingOwnData, user}: { viewingOwnD
                         // TODO: dynamic subject colouring once we support more apps
                         [ActiveAttemptsTabIndex.Skills]: <Row data-bs-theme="maths" className='flex-grow-1'> 
                             <Col md={9} className='d-flex align-items-center'>
-                                <ActivityGraph answeredQuestionsByDate={mentalMaths} caption="Overall Mental Maths" colour="var(--subject-color-300)"/>
+                                <ActivityGraph answeredQuestionsByDate={mentalMaths} caption="Overall Mental Maths" 
+                                    emptyText = <span><br/> <a href='/pages/app_page_mental_maths_overall' target='blank'>Click here</a> to try our mental maths skills practice.</span> colour="var(--subject-color-300)"/>
                             </Col>
                             {above['md'](deviceSize) && <div className='vr px-0' />}
                             <Col>
@@ -260,7 +264,7 @@ const QuestionAndSkillsAttemptsOverTime = ({viewingOwnData, user}: { viewingOwnD
 const QuestionAttemptsOverTime = ({viewingOwnData, user}: { viewingOwnData: boolean, user: PotentialUser}) => {
     const myAnsweredQuestionsByDate = useAppSelector(selectors.user.answeredQuestionsByDate);
     const userAnsweredQuestionsByDate = useAppSelector(selectors.teacher.userAnsweredQuestionsByDate);
-    const answeredQuestionsByDate = (!viewingOwnData && isTeacherOrAbove(user)) ? userAnsweredQuestionsByDate : myAnsweredQuestionsByDate;
+    const answeredQuestionsByDate = {}; //(!viewingOwnData && isTeacherOrAbove(user)) ? userAnsweredQuestionsByDate : myAnsweredQuestionsByDate;
     
     return answeredQuestionsByDate && <ActivityGraph
         answeredQuestionsByDate={answeredQuestionsByDate}
@@ -275,8 +279,8 @@ enum ActiveAttemptsTabIndex {
 const useGetUserSkillsAttempts = (): Record<string | number | symbol, AnsweredQuestionsByDate> => {
     return {
         mentalMaths: {
-            ["2026-06-01"]: 60,
-            ["2026-07-01"]: 20
+            // ["2026-06-01"]: 60,
+            // ["2026-07-01"]: 20
         }
     };
 };

--- a/src/app/components/pages/MyProgress.tsx
+++ b/src/app/components/pages/MyProgress.tsx
@@ -239,21 +239,24 @@ const QuestionAndSkillsAttemptsOverTime = ({viewingOwnData, user}: { viewingOwnD
                     {{
                         [ActiveAttemptsTabIndex.Questions]: <QuestionAttemptsOverTime viewingOwnData={viewingOwnData} user={user}/>,
                         // TODO: dynamic subject colouring once we support more apps
-                        [ActiveAttemptsTabIndex.Skills]: <Row data-bs-theme="maths" className='flex-grow-1'> 
-                            <Col md={9} className='d-flex align-items-center'>
+                        [ActiveAttemptsTabIndex.Skills]: <div data-bs-theme="maths" className={`flex-grow-1 ${above['md'](deviceSize) ? 'row': 'd-flex flex-column'}`}> 
+                            <div className={`d-flex align-items-center ${above['md'](deviceSize) ? 'col-md-9' : 'flex-grow-1'}`}>
                                 <ActivityGraph answeredQuestionsByDate={mentalMaths} caption="Overall Mental Maths" 
-                                    emptyText = <span><br/> <a href='/pages/app_page_mental_maths_overall' target='blank'>Click here</a> to try our mental maths skills practice.</span> colour="var(--subject-color-300)"/>
-                            </Col>
+                                    emptyText = <span><br/>
+                                        <a href='/pages/app_page_mental_maths_overall' target='blank'>Click here</a>
+                                        to try our mental maths skills practice.
+                                    </span> colour="var(--subject-color-300)"/>
+                            </div>
                             {above['md'](deviceSize) && <div className='vr px-0' />}
-                            <Col>
-                                <div className='mb-2'>
+                            <div id="legend" className={above['md'](deviceSize) ? 'col' : 'order-first align-self-center'}>
+                                <div className='mb-md-2'>
                                     <strong>Subjects</strong> 
                                     <i className="icon icon-chevron-right icon-inline icon-color-black" />
                                     <strong>Maths</strong>
                                 </div>
                                 <div className='legend-item'>Overall Mental Maths</div>
-                            </Col>
-                        </Row>
+                            </div>
+                        </div>
                     }[activeTabIndex]}
                 </div>
             </div>

--- a/src/app/components/pages/MyProgress.tsx
+++ b/src/app/components/pages/MyProgress.tsx
@@ -224,7 +224,7 @@ const MyProgress = ({user}: MyProgressProps) => {
 };
 
 const QuestionAndSkillsAttemptsOverTime = ({viewingOwnData, user, userIdOfInterest}: UserProps) => {
-    return <Card className="mt-4 attempts-over-time">
+    return <Card className="mt-4 attempts-min-height">
         <CardBody className='h-100 d-flex flex-column'>
             <h4>Attempts over time</h4>
             <div className='flex-grow-1 d-flex flex-column'>
@@ -250,7 +250,7 @@ const SkillsAttemptsOverTime = ({ viewingOwnData, user, userIdOfInterest }: User
     const query = useGetUserSkillsAttemptsQuery(userId);
 
     return <Row data-bs-theme="maths" className="flex-row-reverse flex-md-row row-gap-3">
-        <Col md={9} className="d-flex align-items-center order-1 order-md-0">
+        <Col md={9} className="d-flex align-items-center order-1 order-md-0 graph-min-height">
             <ShowLoadingQuery 
                 query={query}
                 defaultErrorTitle='Failed to load skills attempts.'

--- a/src/app/components/pages/MyProgress.tsx
+++ b/src/app/components/pages/MyProgress.tsx
@@ -248,7 +248,7 @@ const QuestionAndSkillsAttemptsOverTime = ({viewingOwnData, user}: { viewingOwnD
                                     </span> colour="var(--subject-color-300)"/>
                             </div>
                             {above['md'](deviceSize) && <div className='vr px-0' />}
-                            <div id="legend" className={above['md'](deviceSize) ? 'col' : 'order-first align-self-center'}>
+                            <div id="legend" className={above['md'](deviceSize) ? 'col' : 'order-first mb-2 align-self-center'}>
                                 <div className='mb-md-2'>
                                     <strong>Subjects</strong> 
                                     <i className="icon icon-chevron-right icon-inline icon-color-black" />

--- a/src/app/components/pages/MyProgress.tsx
+++ b/src/app/components/pages/MyProgress.tsx
@@ -36,6 +36,7 @@ import { PageContainer } from '../elements/layout/PageContainer';
 import { MyAdaSidebar } from '../elements/sidebar/MyAdaSidebar';
 import { RevisionChallengeStats } from '../elements/panels/RevisionChallengeStats';
 import { AnsweredQuestionsByDate } from '../../../IsaacApiTypes';
+import classNames from 'classnames';
 
 const siteSpecificStats: {questionCountByBookTag: {[bookTag in keyof typeof ISAAC_BOOKS_BY_TAG]?: number}, questionTypeStatsList: string[]} = siteSpecific(
     // Physics
@@ -189,7 +190,7 @@ const MyProgress = ({user}: MyProgressProps) => {
                     </div>}
 
                     {isPhy
-                        ? <PhyAttemptsOverTime viewingOwnData={viewingOwnData} user={user} />
+                        ? <QuestionAndSkillsAttemptsOverTime viewingOwnData={viewingOwnData} user={user} />
                         : <QuestionAttemptsOverTime viewingOwnData={viewingOwnData} user={user} />}
 
                     <Row id="progress-questions">
@@ -218,7 +219,7 @@ const MyProgress = ({user}: MyProgressProps) => {
     </PageContainer>;
 };
 
-const PhyAttemptsOverTime = ({viewingOwnData, user}: { viewingOwnData: boolean, user: PotentialUser}) => {
+const QuestionAndSkillsAttemptsOverTime = ({viewingOwnData, user}: { viewingOwnData: boolean, user: PotentialUser}) => {
     const deviceSize = useDeviceSize();
     
     const [activeTabIndex, setActiveTabIndex] = useState(ActiveAttemptsTabIndex.Questions);
@@ -231,24 +232,26 @@ const PhyAttemptsOverTime = ({viewingOwnData, user}: { viewingOwnData: boolean, 
                 <Tabs style="tabs" tabContentClass='mt-4' activeTabOverride={activeTabIndex} onActiveTabChange={setActiveTabIndex}>
                     {{"Questions": undefined, "Skills": undefined}}
                 </Tabs>
-                {{
-                    [ActiveAttemptsTabIndex.Questions]: <QuestionAttemptsOverTime viewingOwnData={viewingOwnData} user={user} />,
-                    // TODO: dynamic subject colouring once we support more apps
-                    [ActiveAttemptsTabIndex.Skills]: <Row data-bs-theme="maths" className='flex-grow-1'> 
-                        <Col md={9}>
-                            <ActivityGraph answeredQuestionsByDate={mentalMaths} caption="Overall Mental Maths" colour="var(--subject-color-300)"/>
-                        </Col>
-                        {above['md'](deviceSize) && <div className='vr px-0'/>}
-                        <Col>
-                            <div className='mb-2'>
-                                <strong>Subjects</strong> 
-                                <i className="icon icon-chevron-right icon-inline icon-color-black" />
-                                <strong>Maths</strong>
-                            </div>
-                            <div className='legend-item'>Overall Mental Maths</div>
-                        </Col>
-                    </Row>
-                }[activeTabIndex]}
+                <div className={`flex-grow-1 d-flex ${classNames({'align-items-center': activeTabIndex === ActiveAttemptsTabIndex.Questions})}`}>
+                    {{
+                        [ActiveAttemptsTabIndex.Questions]: <QuestionAttemptsOverTime viewingOwnData={viewingOwnData} user={user}/>,
+                        // TODO: dynamic subject colouring once we support more apps
+                        [ActiveAttemptsTabIndex.Skills]: <Row data-bs-theme="maths" className='flex-grow-1'> 
+                            <Col md={9} className='d-flex align-items-center'>
+                                <ActivityGraph answeredQuestionsByDate={mentalMaths} caption="Overall Mental Maths" colour="var(--subject-color-300)"/>
+                            </Col>
+                            {above['md'](deviceSize) && <div className='vr px-0' />}
+                            <Col>
+                                <div className='mb-2'>
+                                    <strong>Subjects</strong> 
+                                    <i className="icon icon-chevron-right icon-inline icon-color-black" />
+                                    <strong>Maths</strong>
+                                </div>
+                                <div className='legend-item'>Overall Mental Maths</div>
+                            </Col>
+                        </Row>
+                    }[activeTabIndex]}
+                </div>
             </div>
         </CardBody>
     </Card>;

--- a/src/app/components/pages/MyProgress.tsx
+++ b/src/app/components/pages/MyProgress.tsx
@@ -11,6 +11,7 @@ import {
 import { TitleAndBreadcrumb } from "../elements/TitleAndBreadcrumb";
 import { Card, CardBody, Col, Row } from "reactstrap";
 import {
+    above,
     BookHiddenState,
     HUMAN_QUESTION_TYPES,
     ISAAC_BOOKS_BY_TAG,
@@ -218,24 +219,26 @@ const MyProgress = ({user}: MyProgressProps) => {
 };
 
 const PhyAttemptsOverTime = ({viewingOwnData, user}: { viewingOwnData: boolean, user: PotentialUser}) => {
+    const deviceSize = useDeviceSize();
+    
     const [activeTabIndex, setActiveTabIndex] = useState(ActiveAttemptsTabIndex.Questions);
     const { mentalMaths } = useGetUserSkillsAttempts();
 
-    return <Card className="mt-4">
-        <CardBody>
+    return <Card className="mt-4 attempts-over-time">
+        <CardBody className='h-100 d-flex flex-column'>
             <h4>Attempts over time</h4>
-            <div>
+            <div className='flex-grow-1 d-flex flex-column'>
                 <Tabs style="tabs" tabContentClass='mt-4' activeTabOverride={activeTabIndex} onActiveTabChange={setActiveTabIndex}>
                     {{"Questions": undefined, "Skills": undefined}}
                 </Tabs>
                 {{
                     [ActiveAttemptsTabIndex.Questions]: <QuestionAttemptsOverTime viewingOwnData={viewingOwnData} user={user} />,
                     // TODO: dynamic subject colouring once we support more apps
-                    [ActiveAttemptsTabIndex.Skills]: <Row data-bs-theme="maths"> 
+                    [ActiveAttemptsTabIndex.Skills]: <Row data-bs-theme="maths" className='flex-grow-1'> 
                         <Col md={9}>
                             <ActivityGraph answeredQuestionsByDate={mentalMaths} caption="Overall Mental Maths" colour="var(--subject-color-300)"/>
                         </Col>
-                        <div className='vr px-0'/>
+                        {above['md'](deviceSize) && <div className='vr px-0'/>}
                         <Col>
                             <div className='mb-2'>
                                 <strong>Subjects</strong> 

--- a/src/app/components/pages/MyProgress.tsx
+++ b/src/app/components/pages/MyProgress.tsx
@@ -264,7 +264,7 @@ const QuestionAndSkillsAttemptsOverTime = ({viewingOwnData, user}: { viewingOwnD
 const QuestionAttemptsOverTime = ({viewingOwnData, user}: { viewingOwnData: boolean, user: PotentialUser}) => {
     const myAnsweredQuestionsByDate = useAppSelector(selectors.user.answeredQuestionsByDate);
     const userAnsweredQuestionsByDate = useAppSelector(selectors.teacher.userAnsweredQuestionsByDate);
-    const answeredQuestionsByDate = {}; //(!viewingOwnData && isTeacherOrAbove(user)) ? userAnsweredQuestionsByDate : myAnsweredQuestionsByDate;
+    const answeredQuestionsByDate = (!viewingOwnData && isTeacherOrAbove(user)) ? userAnsweredQuestionsByDate : myAnsweredQuestionsByDate;
     
     return answeredQuestionsByDate && <ActivityGraph
         answeredQuestionsByDate={answeredQuestionsByDate}
@@ -279,8 +279,8 @@ enum ActiveAttemptsTabIndex {
 const useGetUserSkillsAttempts = (): Record<string | number | symbol, AnsweredQuestionsByDate> => {
     return {
         mentalMaths: {
-            // ["2026-06-01"]: 60,
-            // ["2026-07-01"]: 20
+            ["2026-06-01"]: 60,
+            ["2026-07-01"]: 20
         }
     };
 };

--- a/src/app/components/pages/MyProgress.tsx
+++ b/src/app/components/pages/MyProgress.tsx
@@ -282,6 +282,14 @@ enum ActiveAttemptsTabIndex {
 const useGetUserSkillsAttempts = (): Record<string | number | symbol, AnsweredQuestionsByDate> => {
     return {
         mentalMaths: {
+            ["2025-10-01"]: 60,
+            ["2025-11-01"]: 140,
+            ["2025-12-01"]: 0,
+            ["2026-01-01"]: 0,
+            ["2026-02-01"]: 30,
+            ["2026-03-01"]: 0,
+            ["2026-04-01"]: 0,
+            ["2026-05-01"]: 0,
             ["2026-06-01"]: 60,
             ["2026-07-01"]: 20
         }

--- a/src/app/components/pages/MyProgress.tsx
+++ b/src/app/components/pages/MyProgress.tsx
@@ -224,22 +224,16 @@ const MyProgress = ({user}: MyProgressProps) => {
 };
 
 const QuestionAndSkillsAttemptsOverTime = ({viewingOwnData, user, userIdOfInterest}: UserProps) => {
-    const [activeTabIndex, setActiveTabIndex] = useState(ActiveAttemptsTabIndex.Questions);
-
     return <Card className="mt-4 attempts-over-time">
         <CardBody className='h-100 d-flex flex-column'>
             <h4>Attempts over time</h4>
             <div className='flex-grow-1 d-flex flex-column'>
-                <Tabs style="tabs" tabContentClass='mt-4' activeTabOverride={activeTabIndex} onActiveTabChange={setActiveTabIndex}>
-                    {{"Questions": undefined, "Skills": undefined}}
-                </Tabs>
-                <div className={`flex-grow-1 d-flex ${classNames({'align-items-center': activeTabIndex === ActiveAttemptsTabIndex.Questions})}`}>
+                <Tabs style="tabs" tabContentClass='mt-4' renderHiddenTabs={false}>
                     {{
-                        [ActiveAttemptsTabIndex.Questions]: <QuestionAttemptsOverTime viewingOwnData={viewingOwnData} user={user}/>,
-                        // TODO: dynamic subject colouring once we support more apps
-                        [ActiveAttemptsTabIndex.Skills]: <SkillsAttemptsOverTime user={user} viewingOwnData={viewingOwnData} userIdOfInterest={userIdOfInterest} />
-                    }[activeTabIndex]}
-                </div>
+                        "Questions": <QuestionAttemptsOverTime viewingOwnData={viewingOwnData} user={user}/>,
+                        "Skills": <SkillsAttemptsOverTime user={user} viewingOwnData={viewingOwnData} userIdOfInterest={userIdOfInterest} />
+                    }}
+                </Tabs>
             </div>
         </CardBody>
     </Card>;

--- a/src/app/components/pages/MyProgress.tsx
+++ b/src/app/components/pages/MyProgress.tsx
@@ -75,8 +75,6 @@ const MyProgress = ({user}: MyProgressProps) => {
     const dispatch = useAppDispatch();
     const myProgress = useAppSelector(selectors.user.progress);
     const userProgress = useAppSelector(selectors.teacher.userProgress);
-    const myAnsweredQuestionsByDate = useAppSelector(selectors.user.answeredQuestionsByDate);
-    const userAnsweredQuestionsByDate = useAppSelector(selectors.teacher.userAnsweredQuestionsByDate);
     const [chartTab, setChartTab] = useState<"correct" | "attempted">("correct");
     const deviceSize = useDeviceSize();
 
@@ -99,7 +97,6 @@ const MyProgress = ({user}: MyProgressProps) => {
     }
 
     const progress = (!viewingOwnData && isTeacherOrAbove(user)) ? userProgress : myProgress;
-    const answeredQuestionsByDate = (!viewingOwnData && isTeacherOrAbove(user)) ? userAnsweredQuestionsByDate : myAnsweredQuestionsByDate;
 
     const userName = `${progress?.userDetails?.givenName || ""}${progress?.userDetails?.givenName ? " " : ""}${progress?.userDetails?.familyName || ""}`;
     const pageTitle = viewingOwnData ? siteSpecific("My progress", "Progress") : `Progress for ${userName || "user"}`;
@@ -189,12 +186,7 @@ const MyProgress = ({user}: MyProgressProps) => {
                         </Row>
                     </div>}
 
-                    {answeredQuestionsByDate && <div className="mt-4">
-                        <h4>Question attempts over time</h4>
-                        <div>
-                            <ActivityGraph answeredQuestionsByDate={answeredQuestionsByDate} />
-                        </div>
-                    </div>}
+                    <AttemptsOverTime viewingOwnData={viewingOwnData} user={user}/>
                     <Row id="progress-questions">
                         {progress?.mostRecentQuestions && progress?.mostRecentQuestions.length > 0 && <Col md={12} lg={6} className="mt-4">
                             <h4>Most recently answered questions</h4>
@@ -220,4 +212,23 @@ const MyProgress = ({user}: MyProgressProps) => {
         </Card>
     </PageContainer>;
 };
+
+const AttemptsOverTime = ({viewingOwnData, user}: { viewingOwnData: boolean, user: PotentialUser}) => {
+    const myAnsweredQuestionsByDate = useAppSelector(selectors.user.answeredQuestionsByDate);
+    const userAnsweredQuestionsByDate = useAppSelector(selectors.teacher.userAnsweredQuestionsByDate);
+    const answeredQuestionsByDate = (!viewingOwnData && isTeacherOrAbove(user)) ? userAnsweredQuestionsByDate : myAnsweredQuestionsByDate;
+
+    return answeredQuestionsByDate && <Card className="mt-4">
+        <CardBody>
+            <h4>Attempts over time</h4>
+            <div>
+                <Tabs style="tabs" tabContentClass='mt-4'>
+                    {{"Questions": undefined, "Skills": undefined}}
+                </Tabs>
+                <ActivityGraph answeredQuestionsByDate={answeredQuestionsByDate} />
+            </div>
+        </CardBody>
+    </Card>;
+};
+
 export default MyProgress;

--- a/src/app/components/pages/MyProgress.tsx
+++ b/src/app/components/pages/MyProgress.tsx
@@ -275,6 +275,7 @@ const QuestionAttemptsOverTime = ({ viewingOwnData, user }: { viewingOwnData: bo
     const answeredQuestionsByDate = (!viewingOwnData && isTeacherOrAbove(user)) ? userAnsweredQuestionsByDate : myAnsweredQuestionsByDate;
     
     return answeredQuestionsByDate && <ActivityGraph
+        id="question-attempts"
         answeredQuestionsByDate={answeredQuestionsByDate}
         caption={siteSpecific("Question attempts", "activity")}
         colour={siteSpecific("#FEA102",  "#FF4DC9")}/>;

--- a/src/app/components/pages/MyProgress.tsx
+++ b/src/app/components/pages/MyProgress.tsx
@@ -263,7 +263,7 @@ const SkillsAttemptsOverTime = ({ viewingOwnData, user, userIdOfInterest }: User
                             <br/>
                             <a href='/pages/app_page_mental_maths_overall' target='blank'>Click here</a> to try our mental maths skills practice.
                         </span>}
-                        colour="var(--subject-color-300)"
+                        color="var(--subject-color-300)"
                     />;
                 }}
             />
@@ -288,7 +288,7 @@ const QuestionAttemptsOverTime = ({ viewingOwnData, user }: { viewingOwnData: bo
         id="question-attempts"
         answeredQuestionsByDate={answeredQuestionsByDate}
         caption={siteSpecific("Question attempts", "activity")}
-        colour={siteSpecific("#FEA102",  "#FF4DC9")}/>;
+        color={siteSpecific("#FEA102",  "#FF4DC9")}/>;
 };
 
 type UserProps = { viewingOwnData: boolean, user: PotentialUser, userIdOfInterest: string }

--- a/src/app/components/pages/MyProgress.tsx
+++ b/src/app/components/pages/MyProgress.tsx
@@ -217,18 +217,26 @@ const AttemptsOverTime = ({viewingOwnData, user}: { viewingOwnData: boolean, use
     const myAnsweredQuestionsByDate = useAppSelector(selectors.user.answeredQuestionsByDate);
     const userAnsweredQuestionsByDate = useAppSelector(selectors.teacher.userAnsweredQuestionsByDate);
     const answeredQuestionsByDate = (!viewingOwnData && isTeacherOrAbove(user)) ? userAnsweredQuestionsByDate : myAnsweredQuestionsByDate;
+    const [activeTab, setActiveTab] = useState(ActiveAttemptsTab.Questions);
 
-    return answeredQuestionsByDate && <Card className="mt-4">
+    return <Card className="mt-4">
         <CardBody>
             <h4>Attempts over time</h4>
             <div>
-                <Tabs style="tabs" tabContentClass='mt-4'>
+                <Tabs style="tabs" tabContentClass='mt-4' activeTabOverride={activeTab} onActiveTabChange={setActiveTab}>
                     {{"Questions": undefined, "Skills": undefined}}
                 </Tabs>
-                <ActivityGraph answeredQuestionsByDate={answeredQuestionsByDate} />
+                {{
+                    [ActiveAttemptsTab.Questions]: answeredQuestionsByDate && <ActivityGraph answeredQuestionsByDate={answeredQuestionsByDate} />,
+                    [ActiveAttemptsTab.Skills]: <></>
+                }[activeTab]}
             </div>
         </CardBody>
     </Card>;
 };
+
+enum ActiveAttemptsTab {
+    Questions = 1, Skills = 2
+}
 
 export default MyProgress;

--- a/src/app/components/pages/MyProgress.tsx
+++ b/src/app/components/pages/MyProgress.tsx
@@ -187,7 +187,10 @@ const MyProgress = ({user}: MyProgressProps) => {
                         </Row>
                     </div>}
 
-                    <AttemptsOverTime viewingOwnData={viewingOwnData} user={user}/>
+                    {isPhy
+                        ? <PhyAttemptsOverTime viewingOwnData={viewingOwnData} user={user} />
+                        : <QuestionAttemptsOverTime viewingOwnData={viewingOwnData} user={user} />}
+
                     <Row id="progress-questions">
                         {progress?.mostRecentQuestions && progress?.mostRecentQuestions.length > 0 && <Col md={12} lg={6} className="mt-4">
                             <h4>Most recently answered questions</h4>
@@ -214,30 +217,52 @@ const MyProgress = ({user}: MyProgressProps) => {
     </PageContainer>;
 };
 
-const AttemptsOverTime = ({viewingOwnData, user}: { viewingOwnData: boolean, user: PotentialUser}) => {
-    const myAnsweredQuestionsByDate = useAppSelector(selectors.user.answeredQuestionsByDate);
-    const userAnsweredQuestionsByDate = useAppSelector(selectors.teacher.userAnsweredQuestionsByDate);
-    const answeredQuestionsByDate = (!viewingOwnData && isTeacherOrAbove(user)) ? userAnsweredQuestionsByDate : myAnsweredQuestionsByDate;
-    const [activeTab, setActiveTab] = useState(ActiveAttemptsTab.Questions);
+const PhyAttemptsOverTime = ({viewingOwnData, user}: { viewingOwnData: boolean, user: PotentialUser}) => {
+    const [activeTabIndex, setActiveTabIndex] = useState(ActiveAttemptsTabIndex.Questions);
     const { mentalMaths } = useGetUserSkillsAttempts();
 
     return <Card className="mt-4">
         <CardBody>
             <h4>Attempts over time</h4>
             <div>
-                <Tabs style="tabs" tabContentClass='mt-4' activeTabOverride={activeTab} onActiveTabChange={setActiveTab}>
+                <Tabs style="tabs" tabContentClass='mt-4' activeTabOverride={activeTabIndex} onActiveTabChange={setActiveTabIndex}>
                     {{"Questions": undefined, "Skills": undefined}}
                 </Tabs>
                 {{
-                    [ActiveAttemptsTab.Questions]: answeredQuestionsByDate && <ActivityGraph answeredQuestionsByDate={answeredQuestionsByDate} />,
-                    [ActiveAttemptsTab.Skills]: <ActivityGraph answeredQuestionsByDate={mentalMaths} />
-                }[activeTab]}
+                    [ActiveAttemptsTabIndex.Questions]: <QuestionAttemptsOverTime viewingOwnData={viewingOwnData} user={user} />,
+                    // TODO: dynamic subject colouring once we support more apps
+                    [ActiveAttemptsTabIndex.Skills]: <Row data-bs-theme="maths"> 
+                        <Col md={9}>
+                            <ActivityGraph answeredQuestionsByDate={mentalMaths} caption="Overall Mental Maths" colour="var(--subject-color-300)"/>
+                        </Col>
+                        <div className='vr px-0'/>
+                        <Col>
+                            <div className='mb-2'>
+                                <strong>Subjects</strong> 
+                                <i className="icon icon-chevron-right icon-inline icon-color-black" />
+                                <strong>Maths</strong>
+                            </div>
+                            <div className='legend-item'>Overall Mental Maths</div>
+                        </Col>
+                    </Row>
+                }[activeTabIndex]}
             </div>
         </CardBody>
     </Card>;
 };
 
-enum ActiveAttemptsTab {
+const QuestionAttemptsOverTime = ({viewingOwnData, user}: { viewingOwnData: boolean, user: PotentialUser}) => {
+    const myAnsweredQuestionsByDate = useAppSelector(selectors.user.answeredQuestionsByDate);
+    const userAnsweredQuestionsByDate = useAppSelector(selectors.teacher.userAnsweredQuestionsByDate);
+    const answeredQuestionsByDate = (!viewingOwnData && isTeacherOrAbove(user)) ? userAnsweredQuestionsByDate : myAnsweredQuestionsByDate;
+    
+    return answeredQuestionsByDate && <ActivityGraph
+        answeredQuestionsByDate={answeredQuestionsByDate}
+        caption={siteSpecific("Question attempts", "activity")}
+        colour={siteSpecific("#FEA102",  "#FF4DC9")}/>;
+};
+
+enum ActiveAttemptsTabIndex {
     Questions = 1, Skills = 2
 }
 

--- a/src/app/components/pages/MyProgress.tsx
+++ b/src/app/components/pages/MyProgress.tsx
@@ -243,8 +243,8 @@ const QuestionAndSkillsAttemptsOverTime = ({viewingOwnData, user}: { viewingOwnD
                             <div className={`d-flex align-items-center ${above['md'](deviceSize) ? 'col-md-9' : 'flex-grow-1'}`}>
                                 <ActivityGraph answeredQuestionsByDate={mentalMaths} caption="Overall Mental Maths" 
                                     emptyText = <span><br/>
-                                        <a href='/pages/app_page_mental_maths_overall' target='blank'>Click here</a>
-                                        to try our mental maths skills practice.
+                                        <a href='/pages/app_page_mental_maths_overall' target='blank'>Click here</a> to
+                                        try our mental maths skills practice.
                                     </span> colour="var(--subject-color-300)"/>
                             </div>
                             {above['md'](deviceSize) && <div className='vr px-0' />}
@@ -282,16 +282,16 @@ enum ActiveAttemptsTabIndex {
 const useGetUserSkillsAttempts = (): Record<string | number | symbol, AnsweredQuestionsByDate> => {
     return {
         mentalMaths: {
-            ["2025-10-01"]: 60,
-            ["2025-11-01"]: 140,
-            ["2025-12-01"]: 0,
-            ["2026-01-01"]: 0,
-            ["2026-02-01"]: 30,
-            ["2026-03-01"]: 0,
-            ["2026-04-01"]: 0,
-            ["2026-05-01"]: 0,
-            ["2026-06-01"]: 60,
-            ["2026-07-01"]: 20
+            // ["2025-10-01"]: 60,
+            // ["2025-11-01"]: 140,
+            // ["2025-12-01"]: 0,
+            // ["2026-01-01"]: 0,
+            // ["2026-02-01"]: 30,
+            // ["2026-03-01"]: 0,
+            // ["2026-04-01"]: 0,
+            // ["2026-05-01"]: 0,
+            // ["2026-06-01"]: 60,
+            // ["2026-07-01"]: 20
         }
     };
 };

--- a/src/app/components/pages/MyProgress.tsx
+++ b/src/app/components/pages/MyProgress.tsx
@@ -36,8 +36,8 @@ import { ListView } from '../elements/list-groups/ListView';
 import { PageContainer } from '../elements/layout/PageContainer';
 import { MyAdaSidebar } from '../elements/sidebar/MyAdaSidebar';
 import { RevisionChallengeStats } from '../elements/panels/RevisionChallengeStats';
-import classNames from 'classnames';
 import { skipToken } from '@reduxjs/toolkit/query';
+import { ShowLoadingQuery } from '../handlers/ShowLoadingQuery';
 
 const siteSpecificStats: {questionCountByBookTag: {[bookTag in keyof typeof ISAAC_BOOKS_BY_TAG]?: number}, questionTypeStatsList: string[]} = siteSpecific(
     // Physics
@@ -247,26 +247,36 @@ const SkillsAttemptsOverTime = ({ viewingOwnData, user, userIdOfInterest }: User
     } else if (isTeacherOrAbove(user)) {
         userId = userIdOfInterest;
     }
-    const { data, isSuccess } = useGetUserSkillsAttemptsQuery(userId);
+    const query = useGetUserSkillsAttemptsQuery(userId);
 
-    return <div data-bs-theme="maths" className={`flex-grow-1 ${above['md'](deviceSize) ? 'row': 'd-flex flex-column'}`}> 
-        <div className={`d-flex align-items-center ${above['md'](deviceSize) ? 'col-md-9' : 'flex-grow-1'}`}>
-            <ActivityGraph answeredQuestionsByDate={isSuccess && data ? data.mental_maths_overall : {}} caption="Overall Mental Maths" 
-                emptyText = <span><br/>
-                    <a href='/pages/app_page_mental_maths_overall' target='blank'>Click here</a> to
-                    try our mental maths skills practice.
-                </span> colour="var(--subject-color-300)"/>
-        </div>
-        {above['md'](deviceSize) && <div className='vr px-0' />}
-        <div id="legend" className={above['md'](deviceSize) ? 'col' : 'order-first mb-2 align-self-center'}>
+    return <Row data-bs-theme="maths" className="flex-row-reverse flex-md-row row-gap-2">
+        <Col md={9} className="d-flex align-items-center">
+            <ShowLoadingQuery 
+                query={query}
+                defaultErrorTitle='Failed to load skills attempts.'
+                thenRender={(data) => {
+                    return <ActivityGraph
+                        id="skills-attempts"
+                        answeredQuestionsByDate={data ? data.mental_maths_overall : {}} 
+                        caption="Overall Mental Maths" 
+                        emptyText={<span>
+                            <br/>
+                            <a href='/pages/app_page_mental_maths_overall' target='blank'>Click here</a> to try our mental maths skills practice.
+                        </span>}
+                        colour="var(--subject-color-300)"
+                    />;
+                }}
+            />
+        </Col>
+        <Col md={3} id="legend" className={above['md'](deviceSize) ? "border-start" : ""}>
             <div className='mb-md-2'>
                 <strong>Subjects</strong> 
                 <i className="icon icon-chevron-right icon-inline icon-color-black" />
                 <strong>Maths</strong>
             </div>
             <div className='legend-item'>Overall Mental Maths</div>
-        </div>
-    </div>;
+        </Col>
+    </Row>;
 };
 
 const QuestionAttemptsOverTime = ({ viewingOwnData, user }: { viewingOwnData: boolean, user: PotentialUser}) => {
@@ -280,10 +290,6 @@ const QuestionAttemptsOverTime = ({ viewingOwnData, user }: { viewingOwnData: bo
         caption={siteSpecific("Question attempts", "activity")}
         colour={siteSpecific("#FEA102",  "#FF4DC9")}/>;
 };
-
-enum ActiveAttemptsTabIndex {
-    Questions = 1, Skills = 2
-}
 
 type UserProps = { viewingOwnData: boolean, user: PotentialUser, userIdOfInterest: string }
 export default MyProgress;

--- a/src/app/components/pages/MyProgress.tsx
+++ b/src/app/components/pages/MyProgress.tsx
@@ -249,8 +249,8 @@ const SkillsAttemptsOverTime = ({ viewingOwnData, user, userIdOfInterest }: User
     }
     const query = useGetUserSkillsAttemptsQuery(userId);
 
-    return <Row data-bs-theme="maths" className="flex-row-reverse flex-md-row row-gap-2">
-        <Col md={9} className="d-flex align-items-center">
+    return <Row data-bs-theme="maths" className="flex-row-reverse flex-md-row row-gap-3">
+        <Col md={9} className="d-flex align-items-center order-1 order-md-0">
             <ShowLoadingQuery 
                 query={query}
                 defaultErrorTitle='Failed to load skills attempts.'

--- a/src/app/components/pages/MyProgress.tsx
+++ b/src/app/components/pages/MyProgress.tsx
@@ -6,7 +6,8 @@ import {
     getUserProgress,
     selectors,
     useAppDispatch,
-    useAppSelector
+    useAppSelector,
+    useGetUserSkillsAttemptsQuery
 } from "../../state";
 import { TitleAndBreadcrumb } from "../elements/TitleAndBreadcrumb";
 import { Card, CardBody, Col, Row } from "reactstrap";
@@ -35,8 +36,8 @@ import { ListView } from '../elements/list-groups/ListView';
 import { PageContainer } from '../elements/layout/PageContainer';
 import { MyAdaSidebar } from '../elements/sidebar/MyAdaSidebar';
 import { RevisionChallengeStats } from '../elements/panels/RevisionChallengeStats';
-import { AnsweredQuestionsByDate } from '../../../IsaacApiTypes';
 import classNames from 'classnames';
+import { skipToken } from '@reduxjs/toolkit/query';
 
 const siteSpecificStats: {questionCountByBookTag: {[bookTag in keyof typeof ISAAC_BOOKS_BY_TAG]?: number}, questionTypeStatsList: string[]} = siteSpecific(
     // Physics
@@ -190,7 +191,7 @@ const MyProgress = ({user}: MyProgressProps) => {
                     </div>}
 
                     {isPhy
-                        ? <QuestionAndSkillsAttemptsOverTime viewingOwnData={viewingOwnData} user={user} />
+                        ? <QuestionAndSkillsAttemptsOverTime viewingOwnData={viewingOwnData} user={user} userIdOfInterest={userIdOfInterest} />
                         : <div className="mt-4">
                             <h4> Question attempts over time</h4>
                             <QuestionAttemptsOverTime viewingOwnData={viewingOwnData} user={user} />
@@ -222,11 +223,8 @@ const MyProgress = ({user}: MyProgressProps) => {
     </PageContainer>;
 };
 
-const QuestionAndSkillsAttemptsOverTime = ({viewingOwnData, user}: { viewingOwnData: boolean, user: PotentialUser}) => {
-    const deviceSize = useDeviceSize();
-    
+const QuestionAndSkillsAttemptsOverTime = ({viewingOwnData, user, userIdOfInterest}: UserProps) => {
     const [activeTabIndex, setActiveTabIndex] = useState(ActiveAttemptsTabIndex.Questions);
-    const { mentalMaths } = useGetUserSkillsAttempts();
 
     return <Card className="mt-4 attempts-over-time">
         <CardBody className='h-100 d-flex flex-column'>
@@ -239,24 +237,7 @@ const QuestionAndSkillsAttemptsOverTime = ({viewingOwnData, user}: { viewingOwnD
                     {{
                         [ActiveAttemptsTabIndex.Questions]: <QuestionAttemptsOverTime viewingOwnData={viewingOwnData} user={user}/>,
                         // TODO: dynamic subject colouring once we support more apps
-                        [ActiveAttemptsTabIndex.Skills]: <div data-bs-theme="maths" className={`flex-grow-1 ${above['md'](deviceSize) ? 'row': 'd-flex flex-column'}`}> 
-                            <div className={`d-flex align-items-center ${above['md'](deviceSize) ? 'col-md-9' : 'flex-grow-1'}`}>
-                                <ActivityGraph answeredQuestionsByDate={mentalMaths} caption="Overall Mental Maths" 
-                                    emptyText = <span><br/>
-                                        <a href='/pages/app_page_mental_maths_overall' target='blank'>Click here</a> to
-                                        try our mental maths skills practice.
-                                    </span> colour="var(--subject-color-300)"/>
-                            </div>
-                            {above['md'](deviceSize) && <div className='vr px-0' />}
-                            <div id="legend" className={above['md'](deviceSize) ? 'col' : 'order-first mb-2 align-self-center'}>
-                                <div className='mb-md-2'>
-                                    <strong>Subjects</strong> 
-                                    <i className="icon icon-chevron-right icon-inline icon-color-black" />
-                                    <strong>Maths</strong>
-                                </div>
-                                <div className='legend-item'>Overall Mental Maths</div>
-                            </div>
-                        </div>
+                        [ActiveAttemptsTabIndex.Skills]: <SkillsAttemptsOverTime user={user} viewingOwnData={viewingOwnData} userIdOfInterest={userIdOfInterest} />
                     }[activeTabIndex]}
                 </div>
             </div>
@@ -264,7 +245,37 @@ const QuestionAndSkillsAttemptsOverTime = ({viewingOwnData, user}: { viewingOwnD
     </Card>;
 };
 
-const QuestionAttemptsOverTime = ({viewingOwnData, user}: { viewingOwnData: boolean, user: PotentialUser}) => {
+const SkillsAttemptsOverTime = ({ viewingOwnData, user, userIdOfInterest }: UserProps) => {
+    const deviceSize = useDeviceSize();
+    let userId: string | typeof skipToken = skipToken;
+    if (viewingOwnData && user.loggedIn && user.id) {
+        userId = user.id.toString();
+    } else if (isTeacherOrAbove(user)) {
+        userId = userIdOfInterest;
+    }
+    const { data, isSuccess } = useGetUserSkillsAttemptsQuery(userId);
+
+    return <div data-bs-theme="maths" className={`flex-grow-1 ${above['md'](deviceSize) ? 'row': 'd-flex flex-column'}`}> 
+        <div className={`d-flex align-items-center ${above['md'](deviceSize) ? 'col-md-9' : 'flex-grow-1'}`}>
+            <ActivityGraph answeredQuestionsByDate={isSuccess && data ? data.mental_maths_overall : {}} caption="Overall Mental Maths" 
+                emptyText = <span><br/>
+                    <a href='/pages/app_page_mental_maths_overall' target='blank'>Click here</a> to
+                    try our mental maths skills practice.
+                </span> colour="var(--subject-color-300)"/>
+        </div>
+        {above['md'](deviceSize) && <div className='vr px-0' />}
+        <div id="legend" className={above['md'](deviceSize) ? 'col' : 'order-first mb-2 align-self-center'}>
+            <div className='mb-md-2'>
+                <strong>Subjects</strong> 
+                <i className="icon icon-chevron-right icon-inline icon-color-black" />
+                <strong>Maths</strong>
+            </div>
+            <div className='legend-item'>Overall Mental Maths</div>
+        </div>
+    </div>;
+};
+
+const QuestionAttemptsOverTime = ({ viewingOwnData, user }: { viewingOwnData: boolean, user: PotentialUser}) => {
     const myAnsweredQuestionsByDate = useAppSelector(selectors.user.answeredQuestionsByDate);
     const userAnsweredQuestionsByDate = useAppSelector(selectors.teacher.userAnsweredQuestionsByDate);
     const answeredQuestionsByDate = (!viewingOwnData && isTeacherOrAbove(user)) ? userAnsweredQuestionsByDate : myAnsweredQuestionsByDate;
@@ -279,21 +290,5 @@ enum ActiveAttemptsTabIndex {
     Questions = 1, Skills = 2
 }
 
-const useGetUserSkillsAttempts = (): Record<string | number | symbol, AnsweredQuestionsByDate> => {
-    return {
-        mentalMaths: {
-            // ["2025-10-01"]: 60,
-            // ["2025-11-01"]: 140,
-            // ["2025-12-01"]: 0,
-            // ["2026-01-01"]: 0,
-            // ["2026-02-01"]: 30,
-            // ["2026-03-01"]: 0,
-            // ["2026-04-01"]: 0,
-            // ["2026-05-01"]: 0,
-            // ["2026-06-01"]: 60,
-            // ["2026-07-01"]: 20
-        }
-    };
-};
-
+type UserProps = { viewingOwnData: boolean, user: PotentialUser, userIdOfInterest: string }
 export default MyProgress;

--- a/src/app/components/pages/MyProgress.tsx
+++ b/src/app/components/pages/MyProgress.tsx
@@ -34,6 +34,7 @@ import { ListView } from '../elements/list-groups/ListView';
 import { PageContainer } from '../elements/layout/PageContainer';
 import { MyAdaSidebar } from '../elements/sidebar/MyAdaSidebar';
 import { RevisionChallengeStats } from '../elements/panels/RevisionChallengeStats';
+import { AnsweredQuestionsByDate } from '../../../IsaacApiTypes';
 
 const siteSpecificStats: {questionCountByBookTag: {[bookTag in keyof typeof ISAAC_BOOKS_BY_TAG]?: number}, questionTypeStatsList: string[]} = siteSpecific(
     // Physics
@@ -218,6 +219,7 @@ const AttemptsOverTime = ({viewingOwnData, user}: { viewingOwnData: boolean, use
     const userAnsweredQuestionsByDate = useAppSelector(selectors.teacher.userAnsweredQuestionsByDate);
     const answeredQuestionsByDate = (!viewingOwnData && isTeacherOrAbove(user)) ? userAnsweredQuestionsByDate : myAnsweredQuestionsByDate;
     const [activeTab, setActiveTab] = useState(ActiveAttemptsTab.Questions);
+    const { mentalMaths } = useGetUserSkillsAttempts();
 
     return <Card className="mt-4">
         <CardBody>
@@ -228,7 +230,7 @@ const AttemptsOverTime = ({viewingOwnData, user}: { viewingOwnData: boolean, use
                 </Tabs>
                 {{
                     [ActiveAttemptsTab.Questions]: answeredQuestionsByDate && <ActivityGraph answeredQuestionsByDate={answeredQuestionsByDate} />,
-                    [ActiveAttemptsTab.Skills]: <></>
+                    [ActiveAttemptsTab.Skills]: <ActivityGraph answeredQuestionsByDate={mentalMaths} />
                 }[activeTab]}
             </div>
         </CardBody>
@@ -238,5 +240,14 @@ const AttemptsOverTime = ({viewingOwnData, user}: { viewingOwnData: boolean, use
 enum ActiveAttemptsTab {
     Questions = 1, Skills = 2
 }
+
+const useGetUserSkillsAttempts = (): Record<string | number | symbol, AnsweredQuestionsByDate> => {
+    return {
+        mentalMaths: {
+            ["2026-06-01"]: 60,
+            ["2026-07-01"]: 20
+        }
+    };
+};
 
 export default MyProgress;

--- a/src/app/state/slices/api/skillsApi.ts
+++ b/src/app/state/slices/api/skillsApi.ts
@@ -1,9 +1,17 @@
-import { AnvilMarkingRequestDTO } from "../../../../IsaacApiTypes";
+import { AnvilMarkingRequestDTO, SkillAttemptsByDate } from "../../../../IsaacApiTypes";
 import {isaacApi} from "./baseApi";
 import { onQueryLifecycleEvents } from "./utils";
 
 export const skillsApi = isaacApi.injectEndpoints({
     endpoints: (build) => ({
+        getUserSkillsAttempts: build.query<SkillAttemptsByDate, string>({
+            query: (userId: string) => ({
+                url: `/skills/attempts/${userId}`
+            }),
+            onQueryStarted: onQueryLifecycleEvents({
+                errorTitle: "Unable to load skills questions",
+            }),
+        }),
         postSkillsAnswer: build.mutation<void, { appId: string, body: AnvilMarkingRequestDTO}>({
             query: ({ appId, body }) => ({
                 url: `skills/${appId}/answer`,
@@ -17,4 +25,4 @@ export const skillsApi = isaacApi.injectEndpoints({
     })
 });
 
-export const { usePostSkillsAnswerMutation } = skillsApi;
+export const { useGetUserSkillsAttemptsQuery, usePostSkillsAnswerMutation } = skillsApi;

--- a/src/app/state/store.tsx
+++ b/src/app/state/store.tsx
@@ -18,10 +18,10 @@ export const middleware: Middleware[] = [
     notificationCheckerMiddleware
 ];
 const defaultMiddlewareOptions = {
-    // serializableCheck: process.env.NODE_ENV !== 'test',
+    serializableCheck: process.env.NODE_ENV !== 'test',
     // Make local dev actually responsive?
-    serializableCheck: false,
-    immutableCheck: false,
+    // serializableCheck: false,
+    // immutableCheck: false,
 };
 
 export const store = configureStore({

--- a/src/app/state/store.tsx
+++ b/src/app/state/store.tsx
@@ -18,10 +18,10 @@ export const middleware: Middleware[] = [
     notificationCheckerMiddleware
 ];
 const defaultMiddlewareOptions = {
-    serializableCheck: process.env.NODE_ENV !== 'test',
+    // serializableCheck: process.env.NODE_ENV !== 'test',
     // Make local dev actually responsive?
-    // serializableCheck: false,
-    // immutableCheck: false,
+    serializableCheck: false,
+    immutableCheck: false,
 };
 
 export const store = configureStore({

--- a/src/scss/phy/my-progress.scss
+++ b/src/scss/phy/my-progress.scss
@@ -13,6 +13,10 @@
   }
 }
 
+.attempts-over-time {
+  min-height: 470px;
+}
+
 .legend-item {
   &::before {
     content: '';

--- a/src/scss/phy/my-progress.scss
+++ b/src/scss/phy/my-progress.scss
@@ -14,7 +14,7 @@
 }
 
 .attempts-over-time {
-  min-height: 470px;
+  min-height: 480px;
 }
 
 .legend-item {

--- a/src/scss/phy/my-progress.scss
+++ b/src/scss/phy/my-progress.scss
@@ -12,3 +12,21 @@
     font-weight: 700;
   }
 }
+
+.legend-item {
+  &::before {
+    content: '';
+    margin-right: 8px;
+    height: 10px;
+    width: 10px;
+    background-color: var(--subject-color-300);
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  display: flex;
+  align-items: center;
+  background-color: var(--color-neutral-50);
+  padding: 4px 8px 4px 8px;
+  border-radius: 5px;
+}

--- a/src/scss/phy/my-progress.scss
+++ b/src/scss/phy/my-progress.scss
@@ -13,8 +13,12 @@
   }
 }
 
-.attempts-over-time {
+.attempts-min-height {
   min-height: 480px;
+}
+
+.graph-min-height {
+  min-height: 320px;
 }
 
 .legend-item {


### PR DESCRIPTION
Starts showing skills attempts on my progress. I'll deploy this, as well as the necessary backend changes to dev, so you can try this.

Key considerations, for now:
- just shows results from the mental maths app, which is hardcoded
- only loads skills attempts when the skills tab has been selected, and each time the tabs are toggled, it fetches again. There's no spinner yet.
- there's an empty state for when there haven't been any attempts. It tells users about the maths practice app.
- should look nice on mobile as well as desktop!