### PR TITLE
Hide unnecessary sidebar element on Ada quiz feedback

### DIFF
--- a/src/app/components/pages/quizzes/QuizAttemptFeedback.tsx
+++ b/src/app/components/pages/quizzes/QuizAttemptFeedback.tsx
@@ -81,7 +81,7 @@ export const QuizAttemptFeedback = ({user}: {user: RegisteredUserDTO}) => {
             {isDefined(attempt) && <>
                 <QuizContentsComponent {...subProps} />
                 <SidebarLayout show={isPhy}>
-                    <Col lg={4} xl={3} className={classNames("d-none d-lg-flex flex-column sidebar p-4 order-0")} />
+                    {isPhy && <Col lg={4} xl={3} className={classNames("d-none d-lg-flex flex-column sidebar p-4 order-0")} />}
                     <MainContent>
                         {attempt.feedbackMode === 'DETAILED_FEEDBACK' && <QuizAttemptFeedbackFooter {...subProps} />}
                     </MainContent>


### PR DESCRIPTION
We need this for indenting the attempt footer properly on sci (since the rest of the page has a sidebar) but it isn't needed on Ada and just shows up as a white box.