### PR TITLE
StyledTabPicker onChange cleanup

### DIFF
--- a/src/app/components/elements/inputs/StyledTabPicker.tsx
+++ b/src/app/components/elements/inputs/StyledTabPicker.tsx
@@ -24,6 +24,7 @@ export type StyledTabPickerProps = Omit<React.HTMLAttributes<HTMLElement>, 'onCh
     checked?: boolean;
     disabled?: boolean;
     onClick?: never;  // use onChange instead (supports non-clickable interactions, e.g. keyboard)
+    onKeyDown?: never; // use onChange instead
     onChange?: React.ChangeEventHandler<HTMLInputElement>;
     checkboxTitle: ReactNode;
     count?: number;

--- a/src/app/components/elements/inputs/StyledTabPicker.tsx
+++ b/src/app/components/elements/inputs/StyledTabPicker.tsx
@@ -23,9 +23,6 @@ import { Link } from "react-router-dom";
 export type StyledTabPickerProps = Omit<React.HTMLAttributes<HTMLElement>, 'onChange'> & {
     checked?: boolean;
     disabled?: boolean;
-    onClick?: never;  // use onChange instead (supports non-clickable interactions, e.g. keyboard)
-    onKeyDown?: never; // use onChange instead
-    onChange?: React.ChangeEventHandler<HTMLInputElement>;
     checkboxTitle: ReactNode;
     count?: number;
     indicatorPosition?: "left" | "right";
@@ -36,9 +33,14 @@ export type StyledTabPickerProps = Omit<React.HTMLAttributes<HTMLElement>, 'onCh
     }
 } & ({
     type?: "checkbox" | "radio";
+    // onClick / keyboard listeners can be used too (e.g. if clicking an already-selected tab should do something), but onChange is required.
+    // it can be undefined if the tab shouldn't do anything, but this is rare and should be explicit.
+    onChange: React.ChangeEventHandler<HTMLInputElement> | undefined;
     to?: never;
 } | {
     type: "link";
+    // onChange doesn't work for links. use onClick / keyboard listeners instead, if required
+    onChange?: never;
     to: string;
 })
 
@@ -59,12 +61,12 @@ const PickerContents = ({checkboxTitle, count, suffix, disabled}: Pick<StyledTab
  * @returns {JSX.Element}
  */
 export const StyledTabPicker = (props: StyledTabPickerProps): JSX.Element => {
-    const { checked, disabled, onChange, checkboxTitle, count, suffix, ...rest } = props;
+    const { checked, disabled, checkboxTitle, onChange, count, suffix, ...rest } = props;
     const id = checkboxTitle?.toString().replace(" ", "-");
     const type = props.type ?? "checkbox";
 
     if (type === "link") {
-        return <Link {...rest} id={props.id ?? id} className={classNames("d-flex align-items-center py-2 w-100 tab-picker", rest.className, {"checked": checked})}
+        return <Link {...rest as typeof rest & { type: "link" }} id={props.id ?? id} className={classNames("d-flex align-items-center py-2 w-100 tab-picker", rest.className, {"checked": checked})}
             to={rest.to as string}
         >
             <PickerContents checkboxTitle={checkboxTitle} count={count} suffix={suffix} disabled={disabled} />
@@ -72,7 +74,7 @@ export const StyledTabPicker = (props: StyledTabPickerProps): JSX.Element => {
     }
 
     return <Label {...rest} id={props.id ?? id} tabIndex={-1} className={classNames("d-flex align-items-center py-2 my-1 w-100 tab-picker", rest.className, {"checked": checked})}>
-        <Input type={type} checked={checked ?? false} onChange={onChange} readOnly={onChange === undefined} disabled={disabled} aria-labelledby={props.id ?? id} />
+        <Input type={type} checked={checked ?? false} onChange={onChange as React.ChangeEventHandler<HTMLInputElement> | undefined} readOnly={onChange === undefined} disabled={disabled} aria-labelledby={props.id ?? id} />
         <PickerContents checkboxTitle={checkboxTitle} count={count} suffix={suffix} disabled={disabled} />
     </Label>;
 };

--- a/src/app/components/elements/inputs/StyledTabPicker.tsx
+++ b/src/app/components/elements/inputs/StyledTabPicker.tsx
@@ -11,7 +11,7 @@ import { Link } from "react-router-dom";
  * @property {string} id - A unique identifier for the tab picker.
  * @property {boolean} [checked] - Whether the tab is checked.
  * @property {boolean} [disabled] - Whether the tab is disabled.
- * @property {React.ChangeEventHandler<HTMLInputElement>} [onInputChange] - The function to call when the tab is clicked.
+ * @property {React.ChangeEventHandler<HTMLInputElement>} [onChange] - The function to call when the tab is clicked.
  * @property {ReactNode} checkboxTitle - The title of the tab.
  * @property {number} [count] - The number to display on the tab.
  * @property {"left" | "right"} [indicatorPosition] - The position of the indicator.
@@ -20,10 +20,11 @@ import { Link } from "react-router-dom";
  * @property {string} [to] - The URL to navigate to when the tab is clicked (only for type "link").
  */
 
-type StyledTabPickerProps = React.HTMLAttributes<HTMLElement> & {
+export type StyledTabPickerProps = Omit<React.HTMLAttributes<HTMLElement>, 'onChange'> & {
     checked?: boolean;
     disabled?: boolean;
-    onInputChange?: React.ChangeEventHandler<HTMLInputElement> | undefined;
+    onClick?: never;  // use onChange instead (supports non-clickable interactions, e.g. keyboard)
+    onChange?: React.ChangeEventHandler<HTMLInputElement>;
     checkboxTitle: ReactNode;
     count?: number;
     indicatorPosition?: "left" | "right";
@@ -51,13 +52,13 @@ const PickerContents = ({checkboxTitle, count, suffix, disabled}: Pick<StyledTab
 
 /**
  * A StyledTabPicker component, used to render a list of selectable tabs, each with a title and optional counter (as to indicate how many options selecting that would provide).
- * This can work as either a radio button or a multi-select checkbox, depending on the functionality of onInputChange.
+ * This can work as either a radio button or a multi-select checkbox, depending on the functionality of onChange.
  *
  * @param {StyledTabPickerProps} props
  * @returns {JSX.Element}
  */
 export const StyledTabPicker = (props: StyledTabPickerProps): JSX.Element => {
-    const { checked, disabled, onInputChange, checkboxTitle, count, suffix, ...rest } = props;
+    const { checked, disabled, onChange, checkboxTitle, count, suffix, ...rest } = props;
     const id = checkboxTitle?.toString().replace(" ", "-");
     const type = props.type ?? "checkbox";
 
@@ -70,7 +71,7 @@ export const StyledTabPicker = (props: StyledTabPickerProps): JSX.Element => {
     }
 
     return <Label {...rest} id={props.id ?? id} tabIndex={-1} className={classNames("d-flex align-items-center py-2 my-1 w-100 tab-picker", rest.className, {"checked": checked})}>
-        <Input type={type} checked={checked ?? false} onChange={onInputChange} readOnly={onInputChange === undefined} disabled={disabled} aria-labelledby={props.id ?? id} />
+        <Input type={type} checked={checked ?? false} onChange={onChange} readOnly={onChange === undefined} disabled={disabled} aria-labelledby={props.id ?? id} />
         <PickerContents checkboxTitle={checkboxTitle} count={count} suffix={suffix} disabled={disabled} />
     </Label>;
 };

--- a/src/app/components/elements/sidebar/AnvilAppsListingSidebar.tsx
+++ b/src/app/components/elements/sidebar/AnvilAppsListingSidebar.tsx
@@ -15,7 +15,7 @@ export const AnvilAppsListingSidebar = (props: ContentSidebarProps) => {
             {isFullyDefinedContext(context) && Object.keys(VALID_APPS_CONTEXTS[context.subject] ?? {}).map((stage, index) => <li key={index}>
                 <StyledTabPicker
                     checkboxTitle={HUMAN_STAGES[stage as LearningStage]} checked={context?.stage?.includes(stage as LearningStage)}
-                    onClick={() => navigate(`/${context?.subject}/${stage}/tools`)}
+                    onChange={() => navigate(`/${context?.subject}/${stage}/tools`)}
                 />
             </li>)}
         </ul>

--- a/src/app/components/elements/sidebar/BooksOverviewSidebar.tsx
+++ b/src/app/components/elements/sidebar/BooksOverviewSidebar.tsx
@@ -11,7 +11,7 @@ export const BooksOverviewSidebar = (props: ContentSidebarProps) => {
         <h5>Our books</h5>
         <ul>
             {ISAAC_BOOKS.filter(book => book.hidden !== BookHiddenState.HIDDEN).map((book, index) => <li key={index}>
-                <StyledTabPicker checkboxTitle={book.title} checked={false} onClick={() => navigate(book.path)}/>
+                <StyledTabPicker checkboxTitle={book.title} checked={false} onChange={() => navigate(book.path)}/>
             </li>)}
         </ul>
     </ContentSidebar>;

--- a/src/app/components/elements/sidebar/ContentControlledSidebar.tsx
+++ b/src/app/components/elements/sidebar/ContentControlledSidebar.tsx
@@ -37,7 +37,7 @@ const SidebarEntries = ({ entry }: { entry: SidebarEntryDTO }) => {
                     <span className="flex-grow-1"><Markup encoding="latex">{entry.title}</Markup></span>
                 </div>}
                 checked={isActive}
-                onClick={(() => navigate(calculateSidebarLink(entry) ?? ""))}
+                onChange={(() => navigate(calculateSidebarLink(entry) ?? ""))}
             />
         </li>;
 };

--- a/src/app/components/elements/sidebar/GlossarySidebar.tsx
+++ b/src/app/components/elements/sidebar/GlossarySidebar.tsx
@@ -92,7 +92,7 @@ export const GlossarySidebar = (props: GlossarySidebarProps) => {
                         <li key={index}>
                             <StyledTabPicker
                                 checkboxTitle={HUMAN_STAGES[stage]} checked={pageContext.stage[0] === stage}
-                                onClick={() => navigate(`/${pageContext.subject}/${stage}/glossary`, { replace: true })}
+                                onChange={() => navigate(`/${pageContext.subject}/${stage}/glossary`, { replace: true })}
                             />
                         </li>
                     )}

--- a/src/app/components/elements/sidebar/MyAccountSidebar.tsx
+++ b/src/app/components/elements/sidebar/MyAccountSidebar.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { ContentSidebarContext } from "../../../../IsaacAppTypes";
-import { ACCOUNT_TAB, ACCOUNT_TABS, ifKeyIsEnter } from "../../../services";
+import { ACCOUNT_TAB, ACCOUNT_TABS } from "../../../services";
 import { StyledTabPicker } from "../inputs/StyledTabPicker";
 import { ContentSidebar, SidebarProps } from "../layout/SidebarLayout";
 

--- a/src/app/components/elements/sidebar/MyAccountSidebar.tsx
+++ b/src/app/components/elements/sidebar/MyAccountSidebar.tsx
@@ -22,8 +22,8 @@ export const MyAccountSidebar = (props: MyAccountSidebarProps) => {
                     <li key={tab}>
                         <ContentSidebarContext.Consumer>
                             {(context) =>
-                                <StyledTabPicker id={title} tabIndex={0} checkboxTitle={title} checked={activeTab === tab}
-                                    onClick={() => { setActiveTab(tab); context?.close(); }} onKeyDown={ifKeyIsEnter(() => { setActiveTab(tab); context?.close(); })}
+                                <StyledTabPicker id={title} type="radio" tabIndex={0} checkboxTitle={title} checked={activeTab === tab}
+                                    onChange={() => { setActiveTab(tab); context?.close(); }}
                                 />
                             }
                         </ContentSidebarContext.Consumer>

--- a/src/app/components/elements/sidebar/MyAccountSidebar.tsx
+++ b/src/app/components/elements/sidebar/MyAccountSidebar.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { ContentSidebarContext } from "../../../../IsaacAppTypes";
-import { ACCOUNT_TAB, ACCOUNT_TABS } from "../../../services";
+import { ACCOUNT_TAB, ACCOUNT_TABS, ifKeyIsEnter } from "../../../services";
 import { StyledTabPicker } from "../inputs/StyledTabPicker";
 import { ContentSidebar, SidebarProps } from "../layout/SidebarLayout";
 
@@ -23,7 +23,9 @@ export const MyAccountSidebar = (props: MyAccountSidebarProps) => {
                         <ContentSidebarContext.Consumer>
                             {(context) =>
                                 <StyledTabPicker id={title} type="radio" tabIndex={0} checkboxTitle={title} checked={activeTab === tab}
-                                    onChange={() => { setActiveTab(tab); context?.close(); }}
+                                    onChange={() => setActiveTab(tab)}
+                                    onClick={() => context?.close()}
+                                    onKeyDown={ifKeyIsEnter(() => context?.close())}
                                 />
                             }
                         </ContentSidebarContext.Consumer>

--- a/src/app/components/elements/sidebar/MyAdaSidebar.tsx
+++ b/src/app/components/elements/sidebar/MyAdaSidebar.tsx
@@ -3,7 +3,7 @@ import { ContentSidebar, ContentSidebarProps } from "../layout/SidebarLayout";
 import { StyledTabPicker } from "../inputs/StyledTabPicker";
 import classNames from "classnames";
 import { selectors, sidebarSlice, useAppDispatch, useAppSelector } from "../../../state";
-import { isStudent, isTeacherOrAbove, isTutorOrAbove, useFullSidebarLayout, useUserNotifications } from "../../../services";
+import { ifKeyIsEnter, isStudent, isTeacherOrAbove, isTutorOrAbove, useFullSidebarLayout, useUserNotifications } from "../../../services";
 import { Spacer } from "../Spacer";
 import { useLocation } from "react-router";
 
@@ -131,7 +131,8 @@ export const MyAdaSidebar = (props: ContentSidebarProps) => {
                         </div>}
                         checked={isActive}
                         className={classNames("nav-link my-ada-tab ps-1")}
-                        onChange={() => !fullSidebarLayout && isOpen && toggleSidebar()}
+                        onClick={() => !fullSidebarLayout && isOpen && toggleSidebar()}
+                        onKeyDown={ifKeyIsEnter(() => !fullSidebarLayout && isOpen && toggleSidebar())}
                         type="link"
                         to={tab.url}
                     />;

--- a/src/app/components/elements/sidebar/MyAdaSidebar.tsx
+++ b/src/app/components/elements/sidebar/MyAdaSidebar.tsx
@@ -131,7 +131,7 @@ export const MyAdaSidebar = (props: ContentSidebarProps) => {
                         </div>}
                         checked={isActive}
                         className={classNames("nav-link my-ada-tab ps-1")}
-                        onClick={() => !fullSidebarLayout && isOpen && toggleSidebar()}
+                        onChange={() => !fullSidebarLayout && isOpen && toggleSidebar()}
                         type="link"
                         to={tab.url}
                     />;

--- a/src/app/components/elements/sidebar/MyAssignmentsSidebar.tsx
+++ b/src/app/components/elements/sidebar/MyAssignmentsSidebar.tsx
@@ -7,10 +7,10 @@ import { filterAssignmentsByStatus, getSearchPlaceholder, ASSIGNMENT_STATE_MAP, 
 import { ShowLoadingQuery } from "../../handlers/ShowLoadingQuery";
 import { AssignmentState } from "../../pages/MyAssignments";
 import { ContentSidebarProps, ContentSidebar } from "../layout/SidebarLayout";
-import { StyledTabPicker } from "../inputs/StyledTabPicker";
+import { StyledTabPicker, StyledTabPickerProps } from "../inputs/StyledTabPicker";
 import { SearchInputWithIcon } from "../SearchInputs";
 
-interface AssignmentStatusCheckboxProps extends React.HTMLAttributes<HTMLLabelElement> {
+type AssignmentStatusCheckboxProps = Partial<StyledTabPickerProps> & {
     status: AssignmentState;
     statusFilter: AssignmentState[];
     setStatusFilter: React.Dispatch<React.SetStateAction<AssignmentState[]>>;
@@ -20,10 +20,12 @@ interface AssignmentStatusCheckboxProps extends React.HTMLAttributes<HTMLLabelEl
 const AssignmentStatusCheckbox = (props: AssignmentStatusCheckboxProps) => {
     const {status, statusFilter, setStatusFilter, count, ...rest} = props;
     return <StyledTabPicker
+        {...rest}
+        type="checkbox" to={undefined}
         id={status ?? ""} checkboxTitle={status}
-        onInputChange={() => !statusFilter.includes(status) ? setStatusFilter(c => [...c.filter(s => s !== AssignmentState.ALL), status]) : setStatusFilter(c => c.filter(s => s !== status))}
+        onChange={() => !statusFilter.includes(status) ? setStatusFilter(c => [...c.filter(s => s !== AssignmentState.ALL), status]) : setStatusFilter(c => c.filter(s => s !== status))}
         checked={statusFilter.includes(status)}
-        count={count} {...rest}
+        count={count}
     />;
 };
 
@@ -31,8 +33,10 @@ const AssignmentStatusAllCheckbox = (props: Omit<AssignmentStatusCheckboxProps, 
     const { statusFilter, setStatusFilter, count, ...rest } = props;
     const [previousFilters, setPreviousFilters] = useState<AssignmentState[]>([]);
     return <StyledTabPicker
+        {...rest}
+        type="checkbox" to={undefined}
         id="all" checkboxTitle="All"
-        onInputChange={(e) => {
+        onChange={(e) => {
             if (e.target.checked) {
                 setPreviousFilters(statusFilter);
                 setStatusFilter([AssignmentState.ALL]);
@@ -41,7 +45,7 @@ const AssignmentStatusAllCheckbox = (props: Omit<AssignmentStatusCheckboxProps, 
             }
         }}
         checked={statusFilter.includes(AssignmentState.ALL)}
-        count={count} {...rest}
+        count={count}
     />;
 };
 

--- a/src/app/components/elements/sidebar/MyQuizzesSidebar.tsx
+++ b/src/app/components/elements/sidebar/MyQuizzesSidebar.tsx
@@ -6,10 +6,10 @@ import { useGetQuizAssignmentsAssignedToMeQuery } from "../../../state";
 import { ShowLoadingQuery } from "../../handlers/ShowLoadingQuery";
 import { StyledDropdown } from "../inputs/DropdownInput";
 import { ContentSidebarProps, ContentSidebar } from "../layout/SidebarLayout";
-import { StyledTabPicker } from "../inputs/StyledTabPicker";
+import { StyledTabPicker, StyledTabPickerProps } from "../inputs/StyledTabPicker";
 import { SearchInputWithIcon } from "../SearchInputs";
 
-interface QuizStatusCheckboxProps extends React.HTMLAttributes<HTMLLabelElement> {
+type QuizStatusCheckboxProps = Partial<StyledTabPickerProps> & {
     status: QuizStatus;
     statusFilter: QuizStatus[];
     setStatusFilter: React.Dispatch<React.SetStateAction<QuizStatus[]>>;
@@ -19,19 +19,23 @@ interface QuizStatusCheckboxProps extends React.HTMLAttributes<HTMLLabelElement>
 const QuizStatusCheckbox = (props: QuizStatusCheckboxProps) => {
     const {status, statusFilter, setStatusFilter, count, ...rest} = props;
     return <StyledTabPicker
+        {...rest}
+        type="checkbox" to={undefined}
         id={status ?? ""} checkboxTitle={status}
-        onInputChange={() => !statusFilter.includes(status) ? setStatusFilter(c => [...c.filter(s => s !== QuizStatus.All), status]) : setStatusFilter(c => c.filter(s => s !== status))}
+        onChange={() => !statusFilter.includes(status) ? setStatusFilter(c => [...c.filter(s => s !== QuizStatus.All), status]) : setStatusFilter(c => c.filter(s => s !== status))}
         checked={statusFilter.includes(status)}
-        count={count} {...rest}
+        count={count}
     />;
 };
 
-const QuizStatusAllCheckbox = (props: Omit<QuizStatusCheckboxProps, "status">) => {
+const QuizStatusAllCheckbox = (props: Omit<QuizStatusCheckboxProps, "status" | "checkboxTitle">) => {
     const { statusFilter, setStatusFilter, count, ...rest } = props;
     const [previousFilters, setPreviousFilters] = useState<QuizStatus[]>([]);
     return <StyledTabPicker
+        {...rest}
+        type="checkbox" to={undefined}
         id="all" checkboxTitle="All"
-        onInputChange={(e) => {
+        onChange={(e) => {
             if (e.target.checked) {
                 setPreviousFilters(statusFilter);
                 setStatusFilter([QuizStatus.All]);
@@ -40,7 +44,7 @@ const QuizStatusAllCheckbox = (props: Omit<QuizStatusCheckboxProps, "status">) =
             }
         }}
         checked={statusFilter.includes(QuizStatus.All)}
-        count={count} {...rest}
+        count={count}
     />;
 };
 

--- a/src/app/components/elements/sidebar/PolicyPageSidebar.tsx
+++ b/src/app/components/elements/sidebar/PolicyPageSidebar.tsx
@@ -11,10 +11,10 @@ export const PolicyPageSidebar = (props: ContentSidebarProps) => {
         <div className="section-divider"/>
         <h5>Select a page</h5>
         <ul>
-            <li><StyledTabPicker checkboxTitle="Accessibility Statement" checked={path === "/accessibility" || path === "/pages/accessibility_statement"} onClick={() => navigate("/accessibility")}/></li>
-            <li><StyledTabPicker checkboxTitle="Privacy Policy" checked={path === "/privacy"  || path === "/pages/privacy_policy"} onClick={() => navigate("/privacy")}/></li>
-            <li><StyledTabPicker checkboxTitle="Cookie Policy" checked={path === "/cookies" || path === "/pages/cookie_policy"} onClick={() => navigate("/cookies")}/></li>
-            <li><StyledTabPicker checkboxTitle="Terms of Use" checked={path === "/terms" || path === "/pages/terms_of_use"} onClick={() => navigate("/terms")}/></li>
+            <li><StyledTabPicker checkboxTitle="Accessibility Statement" checked={path === "/accessibility" || path === "/pages/accessibility_statement"} onChange={() => navigate("/accessibility")}/></li>
+            <li><StyledTabPicker checkboxTitle="Privacy Policy" checked={path === "/privacy"  || path === "/pages/privacy_policy"} onChange={() => navigate("/privacy")}/></li>
+            <li><StyledTabPicker checkboxTitle="Cookie Policy" checked={path === "/cookies" || path === "/pages/cookie_policy"} onChange={() => navigate("/cookies")}/></li>
+            <li><StyledTabPicker checkboxTitle="Terms of Use" checked={path === "/terms" || path === "/pages/terms_of_use"} onChange={() => navigate("/terms")}/></li>
         </ul>
     </ContentSidebar>;
 };

--- a/src/app/components/elements/sidebar/ProgrammesSidebar.tsx
+++ b/src/app/components/elements/sidebar/ProgrammesSidebar.tsx
@@ -22,7 +22,7 @@ export const ProgrammesSidebar = ({programmes, ...rest}: ProgrammesSidebarProps)
                         key={programme.id}
                         checkboxTitle={programme.title}
                         checked={false}
-                        onClick={() => {
+                        onChange={() => {
                             if (programme.id) {
                                 void navigate({pathname: location.pathname, hash: `${programme.id.slice(programme.id.indexOf("_") + 1)}`}, {replace: true});
                                 document.getElementById(programme.id.slice(programme.id.indexOf("_") + 1))?.scrollIntoView({behavior: "smooth"});

--- a/src/app/components/elements/sidebar/QuestionDecksSidebar.tsx
+++ b/src/app/components/elements/sidebar/QuestionDecksSidebar.tsx
@@ -34,7 +34,7 @@ export const QuestionDecksSidebar = (props: QuestionDecksSidebarProps) => {
                             checkboxTitle={HUMAN_STAGES[stage]}
                             checked={context.stage.includes(stage)}
                             disabled={!isValidStage(stage)}
-                            onClick={() => isValidStage(stage) && navigate(`/${context.subject}/${stage}/question_decks`)}
+                            onChange={() => isValidStage(stage) && navigate(`/${context.subject}/${stage}/question_decks`)}
                         />
                     </li>
                 )}
@@ -49,7 +49,7 @@ export const QuestionDecksSidebar = (props: QuestionDecksSidebarProps) => {
                                 checkboxTitle={HUMAN_SUBJECTS[subject]}
                                 checked={context.subject === subject}
                                 disabled={!isValidSubject(stages)}
-                                onClick={() => isValidSubject(stages) && navigate(`/${subject}/${context.stage}/question_decks`)}
+                                onChange={() => isValidSubject(stages) && navigate(`/${subject}/${context.stage}/question_decks`)}
                             />
                         </li>
                     )

--- a/src/app/components/elements/sidebar/SidebarElements.tsx
+++ b/src/app/components/elements/sidebar/SidebarElements.tsx
@@ -78,8 +78,8 @@ export const FilterCheckbox = (props : FilterCheckboxProps) => {
                 label={<span>{tag.title} {tagCounts && isDefined(tagCounts[tag.id]) && <span className="text-muted">({tagCounts[tag.id]})</span>}</span>}
                 partial={partial}
             />
-            : <StyledTabPicker {...rest} id={tag.id} checked={checked}
-                onInputChange={(e: ChangeEvent<HTMLInputElement>) => handleCheckboxChange(e.target.checked)}
+            : <StyledTabPicker className={rest.className} id={tag.id} checked={checked}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => handleCheckboxChange(e.target.checked)}
                 checkboxTitle={tag.title} count={tagCounts && isDefined(tagCounts[tag.id]) ? tagCounts[tag.id] : undefined}
             />
         }
@@ -87,13 +87,14 @@ export const FilterCheckbox = (props : FilterCheckboxProps) => {
 };
 
 export const AllFiltersCheckbox = (props: Omit<FilterCheckboxProps, "tag"> & {forceEnabled?: boolean}) => {
-    const { conceptFilters, setConceptFilters, tagCounts, baseTag, forceEnabled, ...rest } = props;
+    const { conceptFilters, setConceptFilters, tagCounts, baseTag, forceEnabled, className } = props;
     const [previousFilters, setPreviousFilters] = useState<Tag[]>([]);
     const pageContext = useAppSelector(selectors.pageContext.context);
 
-    return <StyledTabPicker {...rest}
+    return <StyledTabPicker
         id="all" checked={forceEnabled || !conceptFilters.length}
         checkboxTitle="All"
+        className={className}
         count={tagCounts &&
             (baseTag
                 ? tagCounts[baseTag.id] + (pageContext?.subject && pageContext?.stage?.length === 1
@@ -102,7 +103,7 @@ export const AllFiltersCheckbox = (props: Omit<FilterCheckboxProps, "tag"> & {fo
                 : Object.values(tagCounts).reduce((a, b) => a + b, 0)
             )
         }
-        onInputChange={(e) => {
+        onChange={(e) => {
             if (forceEnabled) {
                 setConceptFilters([]);
                 return;

--- a/src/app/components/elements/sidebar/SignupSidebar.tsx
+++ b/src/app/components/elements/sidebar/SignupSidebar.tsx
@@ -19,8 +19,8 @@ export const SignupSidebar = ({activeTab} : {activeTab: number}) => {
         {/* Tabs are clickable iff their page could be reached with a Back button */}
         <StyledTabPicker checkboxTitle={"Sign-up method"} checked={activeTab === 0} disabled={activeTab > 2} onChange={() => (activeTab === 1 || activeTab === 2) && goBack("/register")}/>
         <StyledTabPicker checkboxTitle={"Age verification"} checked={activeTab === 1} disabled={activeTab < 1 || activeTab > 2} onChange={() => activeTab === 2 && goBack("/age")}/>
-        <StyledTabPicker checkboxTitle={"Account details"} checked={activeTab === 2} disabled={activeTab !== 2}/>
-        <StyledTabPicker checkboxTitle={"Join a group"} checked={activeTab === 4} disabled={activeTab !== 4}/>
-        <StyledTabPicker checkboxTitle={"Preferences"} checked={activeTab === 3} disabled={activeTab !== 3}/>
+        <StyledTabPicker checkboxTitle={"Account details"} checked={activeTab === 2} disabled={activeTab !== 2} onChange={undefined}/>
+        <StyledTabPicker checkboxTitle={"Join a group"} checked={activeTab === 4} disabled={activeTab !== 4} onChange={undefined}/>
+        <StyledTabPicker checkboxTitle={"Preferences"} checked={activeTab === 3} disabled={activeTab !== 3} onChange={undefined}/>
     </ContentSidebar>;
 };

--- a/src/app/components/elements/sidebar/SignupSidebar.tsx
+++ b/src/app/components/elements/sidebar/SignupSidebar.tsx
@@ -17,8 +17,8 @@ export const SignupSidebar = ({activeTab} : {activeTab: number}) => {
         <div className="section-divider mt-4"/>
         <h5 className="mt-1">Create an account</h5>
         {/* Tabs are clickable iff their page could be reached with a Back button */}
-        <StyledTabPicker checkboxTitle={"Sign-up method"} checked={activeTab === 0} disabled={activeTab > 2} onClick={() => (activeTab === 1 || activeTab === 2) && goBack("/register")}/>
-        <StyledTabPicker checkboxTitle={"Age verification"} checked={activeTab === 1} disabled={activeTab < 1 || activeTab > 2} onClick={() => activeTab === 2 && goBack("/age")}/>
+        <StyledTabPicker checkboxTitle={"Sign-up method"} checked={activeTab === 0} disabled={activeTab > 2} onChange={() => (activeTab === 1 || activeTab === 2) && goBack("/register")}/>
+        <StyledTabPicker checkboxTitle={"Age verification"} checked={activeTab === 1} disabled={activeTab < 1 || activeTab > 2} onChange={() => activeTab === 2 && goBack("/age")}/>
         <StyledTabPicker checkboxTitle={"Account details"} checked={activeTab === 2} disabled={activeTab !== 2}/>
         <StyledTabPicker checkboxTitle={"Join a group"} checked={activeTab === 4} disabled={activeTab !== 4}/>
         <StyledTabPicker checkboxTitle={"Preferences"} checked={activeTab === 3} disabled={activeTab !== 3}/>

--- a/src/app/components/pages/Groups.tsx
+++ b/src/app/components/pages/Groups.tsx
@@ -525,7 +525,7 @@ export const GroupSelector = ({user, groups, allGroups, selectedGroup, setSelect
                             ? <li key={g.id} className="d-flex align-items-center group-item" data-testid={"group-item"}>
                                 <StyledTabPicker
                                     id={g.groupName} checkboxTitle={g.groupName} checked={selectedGroup && selectedGroup.id === g.id}
-                                    onInputChange={() => setSelectedGroupId(id => g.id === id ? undefined : g.id)} data-testid={"select-group"}
+                                    onChange={() => setSelectedGroupId(id => g.id === id ? undefined : g.id)} data-testid={"select-group"}
                                     suffix={showArchived ? {icon: "icon icon-close", action: (e) => {e.stopPropagation(); confirmDeleteGroup(dispatch, deleteGroup, user, g);}, info: "Delete group"} : undefined}
                                 />
                             </li>

--- a/src/app/components/pages/Support.tsx
+++ b/src/app/components/pages/Support.tsx
@@ -148,7 +148,7 @@ export const Support = () => {
                 {Object.values(section.categories).map((category, index) => 
                     <StyledTabPicker
                         key={index} id={category.category} tabIndex={0} checkboxTitle={category.title} checked={categoryIndex === index}
-                        onClick={() => activeTabChanged(index)} onKeyDown={ifKeyIsEnter(() => activeTabChanged(index))}
+                        onChange={() => activeTabChanged(index)} onKeyDown={ifKeyIsEnter(() => activeTabChanged(index))}
                     />
                 )}
             </FAQSidebar>,

--- a/src/app/components/pages/Support.tsx
+++ b/src/app/components/pages/Support.tsx
@@ -148,7 +148,7 @@ export const Support = () => {
                 {Object.values(section.categories).map((category, index) => 
                     <StyledTabPicker
                         key={index} id={category.category} tabIndex={0} checkboxTitle={category.title} checked={categoryIndex === index}
-                        onChange={() => activeTabChanged(index)} onKeyDown={ifKeyIsEnter(() => activeTabChanged(index))}
+                        onChange={() => activeTabChanged(index)}
                     />
                 )}
             </FAQSidebar>,


### PR DESCRIPTION
See https://github.com/isaacphysics/isaac-react-app/pull/2255#discussion_r3615576153; this makes all usages of `StyledTabPicker` consistent such that they all use `onChange` when the tab is changed.