### PR TITLE
Adjust spacing around `.almost` regions

### DIFF
--- a/src/app/components/content/IsaacQuestion.tsx
+++ b/src/app/components/content/IsaacQuestion.tsx
@@ -280,7 +280,7 @@ export const IsaacQuestion = ({doc}: {doc: ApiTypes.QuestionDTO}) => {
                         validationResponse={validationResponse}
                     />
                     : (!correct || canSubmit || (isFastTrack && (fastTrackPrimaryAction || fastTrackSecondaryAction))) && !locked &&
-                        <div className={classNames("submission-buttons d-flex align-items-stretch flex-column-reverse flex-sm-row flex-md-column-reverse flex-lg-row", {"mt-7 mb-n3": correct})}>
+                        <div className={classNames("submission-buttons d-flex align-items-stretch flex-column-reverse flex-sm-row flex-md-column-reverse flex-lg-row")}>
                             {isFastTrack 
                                 ? <FastTrackSubmissionButtons fastTrackPrimaryAction={fastTrackPrimaryAction} fastTrackSecondaryAction={fastTrackSecondaryAction} />
                                 : <Button {...checkAnswerButtonProps} className="mx-auto mt-3 w-100 w-sm-100 w-md-50 w-lg-50" type="submit">{submitButtonLabel}</Button>

--- a/src/scss/phy/questions.scss
+++ b/src/scss/phy/questions.scss
@@ -197,7 +197,7 @@ form:has(> .question-component), div.quiz-question-container:has(> .question-com
     background-color: initial;
   }
 
-  > .question-component:not(:has(> .validation-response-panel.correct, > .validation-response-panel.almost,
+  > .question-component:not(:has(> .validation-response-panel.correct,
     > .quick-question:is(.isaac-accordion *), + .tabbed-hints)) {
     padding-bottom: 1rem;
   }


### PR DESCRIPTION
Inline / other types with partial correctness lack spacing underneath when partially correct:
<img width="1200" height="85" alt="image" src="https://github.com/user-attachments/assets/a96d3d12-9a92-4b1e-aff4-339b4f4162d9" />

---

This also removes a related pair of conditional classes on `correct` regions, as these were being applied to correct-but-modified regions. They seem to have been designed for fasttrack, but doesn't work for that currently either; removing them fixes this too:

before:
<img width="710" height="385" alt="image" src="https://github.com/user-attachments/assets/c2494e42-fa25-4199-8054-dde9c25e7fb0" />

after:
<img width="710" height="385" alt="image" src="https://github.com/user-attachments/assets/6fdea527-6bf9-46c9-bc09-2fe09dacc161" />
