### PR TITLE
Stop using subjectId as a secondary source of context

### DIFF
--- a/src/IsaacAppTypes.tsx
+++ b/src/IsaacAppTypes.tsx
@@ -724,10 +724,6 @@ export interface Tag extends BaseTag {
     level: number;
 }
 
-export interface DocumentSubject {
-    subjectId?: string;
-}
-
 export interface Choice extends ChoiceDTO {
     correct?: boolean;
     explanation?: ContentBase;

--- a/src/app/components/elements/QuestionMetadata.tsx
+++ b/src/app/components/elements/QuestionMetadata.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Col } from "reactstrap";
 import { IsaacQuestionPageDTO } from "../../../IsaacApiTypes";
-import { DocumentSubject, ViewingContext } from "../../../IsaacAppTypes";
+import { ViewingContext } from "../../../IsaacAppTypes";
 import { stageLabelMap, difficultyShortLabelMap, isPhy, TAG_ID, tags } from "../../services";
 import { MetadataContainer } from "./panels/MetadataContainer";
 import { StageAndDifficultySummaryIcons } from "./StageAndDifficultySummaryIcons";
@@ -18,7 +18,7 @@ function getTags(docTags?: string[]) {
 }
 
 interface QuestionMetaDataProps {
-    doc: IsaacQuestionPageDTO & DocumentSubject;
+    doc: IsaacQuestionPageDTO;
     audienceViews: ViewingContext[];
     allQuestionsCorrect: boolean;
     allQuestionsAttempted: boolean;

--- a/src/app/components/elements/list-groups/ListView.tsx
+++ b/src/app/components/elements/list-groups/ListView.tsx
@@ -257,7 +257,7 @@ export const GenericListViewItem = ({item, ...rest}: GenericListViewItemProps) =
     const audienceViews: ViewingContext[] = determineAudienceViews(item.audience);
     const itemSubject = tags.getSpecifiedTag(TAG_LEVEL.subject, item.tags as TAG_ID[])?.id as Subject;
     const url = `/${documentTypePathPrefix[DOCUMENT_TYPE.GENERIC]}/${item.id}`;
-    const icon: TitleIconProps & {icon: IconProps} = {type: "icon", icon: {name: "icon-info", size: "lg", color: "secondary"}};
+    const icon: TitleIconProps & {icon: IconProps} = {type: "icon", icon: {name: "icon-info", size: "lg"}};
 
     if (isAda) {
         icon.label = "Info";

--- a/src/app/components/pages/Concept.tsx
+++ b/src/app/components/pages/Concept.tsx
@@ -4,7 +4,7 @@ import {selectors, useAppSelector, useGetGameboardByIdQuery} from "../../state";
 import {Col, Row} from "reactstrap";
 import {IsaacContent} from "../content/IsaacContent";
 import {IsaacConceptPageDTO} from "../../../IsaacApiTypes";
-import {Subject, usePreviousPageContext, isAda, useNavigation, siteSpecific, useUserViewingContext, isFullyDefinedContext, isSingleStageContext, LEARNING_STAGE_TO_STAGES, isDefined, showWildcard} from "../../services";
+import {usePreviousPageContext, isAda, useNavigation, siteSpecific, useUserViewingContext, isFullyDefinedContext, isSingleStageContext, LEARNING_STAGE_TO_STAGES, isDefined, showWildcard} from "../../services";
 import {DocumentSubject, GameboardContext} from "../../../IsaacAppTypes";
 import {RelatedContent} from "../elements/RelatedContent";
 import {WithFigureNumbering} from "../elements/WithFigureNumbering";

--- a/src/app/components/pages/Concept.tsx
+++ b/src/app/components/pages/Concept.tsx
@@ -75,7 +75,7 @@ export const Concept = ({conceptIdOverride, preview}: ConceptPageProps) => {
         thenRender={supertypedDoc => {
             const doc = supertypedDoc as IsaacConceptPageDTO & DocumentSubject;
             return <GameboardContext.Provider value={navigation.currentGameboard}>
-                <PageContainer data-bs-theme={doc.subjectId ?? pageContext?.subject}
+                <PageContainer data-bs-theme={pageContext?.subject ?? doc.subjectId}
                     pageTitle={<>
                         <TitleAndBreadcrumb
                             intermediateCrumbs={navigation.breadcrumbHistory}
@@ -84,7 +84,7 @@ export const Concept = ({conceptIdOverride, preview}: ConceptPageProps) => {
                             collectionType={navigation.collectionType}
                             subTitle={doc.subtitle}
                             preview={preview}
-                            icon={{type: "icon", subject: doc.subjectId as Subject, icon: "icon-concept"}}
+                            icon={{type: "icon", icon: "icon-concept"}}
                         />
                         {!preview && <>
                             <MetaDescription description={doc.summary} />

--- a/src/app/components/pages/Concept.tsx
+++ b/src/app/components/pages/Concept.tsx
@@ -3,9 +3,8 @@ import {useLocation, useParams} from "react-router-dom";
 import {selectors, useAppSelector, useGetGameboardByIdQuery} from "../../state";
 import {Col, Row} from "reactstrap";
 import {IsaacContent} from "../content/IsaacContent";
-import {IsaacConceptPageDTO} from "../../../IsaacApiTypes";
 import {usePreviousPageContext, isAda, useNavigation, siteSpecific, useUserViewingContext, isFullyDefinedContext, isSingleStageContext, LEARNING_STAGE_TO_STAGES, isDefined, showWildcard} from "../../services";
-import {DocumentSubject, GameboardContext} from "../../../IsaacAppTypes";
+import {GameboardContext} from "../../../IsaacAppTypes";
 import {RelatedContent} from "../elements/RelatedContent";
 import {WithFigureNumbering} from "../elements/WithFigureNumbering";
 import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
@@ -72,10 +71,9 @@ export const Concept = ({conceptIdOverride, preview}: ConceptPageProps) => {
         query={conceptQuery}
         defaultErrorTitle="Unable to load concept"
         ifNotFound={<NotFound />}
-        thenRender={supertypedDoc => {
-            const doc = supertypedDoc as IsaacConceptPageDTO & DocumentSubject;
+        thenRender={doc => {
             return <GameboardContext.Provider value={navigation.currentGameboard}>
-                <PageContainer data-bs-theme={pageContext?.subject ?? doc.subjectId}
+                <PageContainer data-bs-theme={pageContext?.subject}
                     pageTitle={<>
                         <TitleAndBreadcrumb
                             intermediateCrumbs={navigation.breadcrumbHistory}

--- a/src/app/components/pages/Generic.tsx
+++ b/src/app/components/pages/Generic.tsx
@@ -2,7 +2,7 @@ import React, {useEffect} from "react";
 import {Col, Row} from "reactstrap";
 import {ContentSummaryDTO, GameboardDTO} from "../../../IsaacApiTypes";
 import {IsaacContent} from "../content/IsaacContent";
-import {isAda, isPhy, showWildcard, siteSpecific, useUrlHashValue} from "../../services";
+import {isAda, isPhy, showWildcard, siteSpecific, useContextFromContentObjectTags, useUrlHashValue} from "../../services";
 import {useParams} from "react-router-dom";
 import {RelatedContent} from "../elements/RelatedContent";
 import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
@@ -64,6 +64,7 @@ export const Generic = ({pageIdOverride}: GenericPageComponentProps) => {
     const pageId = pageIdOverride || params.pageId || "";
 
     const pageQuery = useGetGenericPageQuery(pageId);
+    const pageContext = useContextFromContentObjectTags(pageQuery.currentData);
 
     const hash = useUntilFound(pageQuery.currentData, useUrlHashValue());
 
@@ -94,7 +95,7 @@ export const Generic = ({pageIdOverride}: GenericPageComponentProps) => {
                     undefined
                 );
 
-            return <PageContainer data-bs-theme={"biology"}
+            return <PageContainer data-bs-theme={pageContext?.subject}
                 pageTitle={
                     <TitleAndBreadcrumb 
                         currentPageTitle={doc.title as string} 

--- a/src/app/components/pages/Generic.tsx
+++ b/src/app/components/pages/Generic.tsx
@@ -1,11 +1,10 @@
 import React, {useEffect} from "react";
 import {Col, Row} from "reactstrap";
-import {ContentSummaryDTO, GameboardDTO, SeguePageDTO} from "../../../IsaacApiTypes";
+import {ContentSummaryDTO, GameboardDTO} from "../../../IsaacApiTypes";
 import {IsaacContent} from "../content/IsaacContent";
 import {isAda, isPhy, showWildcard, siteSpecific, useUrlHashValue} from "../../services";
 import {useParams} from "react-router-dom";
 import {RelatedContent} from "../elements/RelatedContent";
-import {DocumentSubject} from "../../../IsaacAppTypes";
 import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
 import {WithFigureNumbering} from "../elements/WithFigureNumbering";
 import {MetaDescription} from "../elements/MetaDescription";
@@ -86,11 +85,8 @@ export const Generic = ({pageIdOverride}: GenericPageComponentProps) => {
         query={pageQuery}
         defaultErrorTitle="Unable to load page"
         ifNotFound={<NotFound />}
-        thenRender={supertypedDoc => {
-            const doc = supertypedDoc as SeguePageDTO & DocumentSubject;
-
+        thenRender={doc => {
             const isNews = doc.tags?.includes("news") || false;
-
             const sidebar = doc.sidebar
                 ? <ContentControlledSidebar sidebar={doc.sidebar} />
                 : siteSpecific(
@@ -98,7 +94,7 @@ export const Generic = ({pageIdOverride}: GenericPageComponentProps) => {
                     undefined
                 );
 
-            return <PageContainer data-bs-theme={doc.subjectId}
+            return <PageContainer data-bs-theme={"biology"}
                 pageTitle={
                     <TitleAndBreadcrumb 
                         currentPageTitle={doc.title as string} 

--- a/src/app/components/pages/Question.tsx
+++ b/src/app/components/pages/Question.tsx
@@ -103,7 +103,7 @@ export const Question = ({questionIdOverride, preview}: QuestionPageProps) => {
                             intermediateCrumbs={navigation.breadcrumbHistory}
                             collectionType={navigation.collectionType}
                             audienceViews={determineAudienceViews(doc.audience, navigation.creationContext)}
-                            preview={preview} icon={{type: "icon", subject: doc.subjectId as Subject, icon: "icon-question"}}
+                            preview={preview} icon={{type: "icon", icon: "icon-question"}}
                         />
                     }
                     sidebar={siteSpecific(

--- a/src/app/components/pages/Question.tsx
+++ b/src/app/components/pages/Question.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import {Button, Col, Row} from "reactstrap";
 import {useLocation, useParams} from "react-router-dom";
 import {goToSupersededByQuestion, selectors, useAppDispatch, useAppSelector, useGetGameboardByIdQuery, useGetMyAssignmentsQuery, useGetQuestionQuery} from "../../state";
-import {IsaacQuestionPageDTO} from "../../../IsaacApiTypes";
 import {
     determineAudienceViews,
     DOCUMENT_TYPE,
@@ -21,7 +20,7 @@ import {WithFigureNumbering} from "../elements/WithFigureNumbering";
 import {IsaacContent} from "../content/IsaacContent";
 import {NavigationLinks} from "../elements/NavigationLinks";
 import {RelatedContent} from "../elements/RelatedContent";
-import {DocumentSubject, GameboardContext} from "../../../IsaacAppTypes";
+import {GameboardContext} from "../../../IsaacAppTypes";
 import {Markup} from "../elements/markup";
 import {FastTrackProgress} from "../elements/FastTrackProgress";
 import queryString from "query-string";
@@ -87,13 +86,12 @@ export const Question = ({questionIdOverride, preview}: QuestionPageProps) => {
         query={questionQuery}
         defaultErrorTitle="Unable to load question"
         ifNotFound={<NotFound />}
-        thenRender={supertypedDoc => {
-            const doc = supertypedDoc as IsaacQuestionPageDTO & DocumentSubject;
+        thenRender={doc => {
             const isFastTrack = doc && doc.type === DOCUMENT_TYPE.FAST_TRACK_QUESTION;
             const audienceViews = determineAudienceViews(doc.audience, navigation.creationContext);
 
             return <GameboardContext.Provider value={navigation.currentGameboard}>
-                <PageContainer className="no-shadow" data-bs-theme={pageContext?.subject ?? doc.subjectId}
+                <PageContainer className="no-shadow" data-bs-theme={pageContext?.subject}
                     pageTitle={
                         <TitleAndBreadcrumb
                             currentPageTitle={generateQuestionTitle(doc)}

--- a/src/app/components/pages/Question.tsx
+++ b/src/app/components/pages/Question.tsx
@@ -13,7 +13,6 @@ import {
     isPhy,
     isStudent,
     siteSpecific,
-    Subject,
     useNavigation,
     isDefined,
     showWildcard} from "../../services";

--- a/src/app/components/pages/quizzes/QuizPreview.tsx
+++ b/src/app/components/pages/quizzes/QuizPreview.tsx
@@ -1,7 +1,7 @@
 import React, {useCallback, useMemo} from "react";
 import {openActiveModal, useAppDispatch, useGetQuizPreviewQuery} from "../../../state";
 import {Link, useParams} from "react-router-dom";
-import {getThemeFromTags, isDefined, isTeacherOrAbove, tags, useQuizQuestions, useQuizSections} from "../../../services";
+import {getThemeFromTags, isDefined, isTeacherOrAbove, useQuizQuestions, useQuizSections} from "../../../services";
 import {FullQuizInfo, myQuizzesCrumbs, QuizContentsComponent, QuizPagination, QuizProps} from "../../elements/quiz/QuizContentsComponent";
 import {IsaacQuizDTO, QuizAttemptDTO, RegisteredUserDTO} from "../../../../IsaacApiTypes";
 import {Spacer} from "../../elements/Spacer";
@@ -41,7 +41,7 @@ export const QuizPreview = ({user}: {user: RegisteredUserDTO}) => {
     const attempt = useMemo(() =>
         quiz
             ? {
-                quiz: tags.augmentDocWithSubject(quiz),
+                quiz,
                 quizId: quiz.id,
             }
             : undefined

--- a/src/app/components/pages/quizzes/QuizView.tsx
+++ b/src/app/components/pages/quizzes/QuizView.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import {useGetQuizRubricQuery} from "../../../state";
 import {Link, useParams} from "react-router-dom";
-import {getThemeFromTags, isDefined, tags} from "../../../services";
+import {getThemeFromTags, isDefined} from "../../../services";
 import {QuizContentsComponent, viewQuizzesCrumbs} from "../../elements/quiz/QuizContentsComponent";
 import {Button, Container} from "reactstrap";
 import {ShowLoadingQuery} from "../../handlers/ShowLoadingQuery";
@@ -27,7 +27,7 @@ export const QuizView = ({user}: {user: RegisteredUserDTO}) => {
     const {quizId} = useParams();
     const quizRubricQuery = useGetQuizRubricQuery(isDefined(quizId) ? quizId : skipToken);
     const view = {
-        quiz: quizRubricQuery.data && tags.augmentDocWithSubject(quizRubricQuery.data),
+        quiz: quizRubricQuery.data,
         quizId: quizRubricQuery.data?.id,
     };
 

--- a/src/app/services/pageContext.ts
+++ b/src/app/services/pageContext.ts
@@ -7,7 +7,7 @@ import { HUMAN_STAGES, HUMAN_SUBJECTS } from "./constants";
 import { pageContextSlice, selectors, useAppDispatch, useAppSelector } from "../state";
 import { useEffect, useState } from "react";
 
-const filterBySubjects = (tags: (TAG_ID | string)[]): SiteTheme[] => {
+export const filterBySubjects = (tags: (TAG_ID | string)[]): SiteTheme[] => {
     // filtering this const list against the passed-in tags maintains the order (and thus precedence) of the subjects
     return [TAG_ID.physics, TAG_ID.maths, TAG_ID.chemistry, TAG_ID.biology].filter(tag => tags.includes(tag)) as SiteTheme[];
 };

--- a/src/app/services/pageContext.ts
+++ b/src/app/services/pageContext.ts
@@ -7,7 +7,7 @@ import { HUMAN_STAGES, HUMAN_SUBJECTS } from "./constants";
 import { pageContextSlice, selectors, useAppDispatch, useAppSelector } from "../state";
 import { useEffect, useState } from "react";
 
-export const filterBySubjects = (tags: (TAG_ID | string)[]): SiteTheme[] => {
+const filterBySubjects = (tags: (TAG_ID | string)[]): SiteTheme[] => {
     // filtering this const list against the passed-in tags maintains the order (and thus precedence) of the subjects
     return [TAG_ID.physics, TAG_ID.maths, TAG_ID.chemistry, TAG_ID.biology].filter(tag => tags.includes(tag)) as SiteTheme[];
 };

--- a/src/app/services/quiz.ts
+++ b/src/app/services/quiz.ts
@@ -28,7 +28,6 @@ import {
     isQuestion,
     Item,
     matchesAllWordsInAnyOrder,
-    tags,
     toTuple,
     useQueryParams
 } from "./";
@@ -224,7 +223,7 @@ export function useQuizAttemptFeedback(quizAttemptId: number | undefined, quizAs
     // changes, this causes the quiz attempt to change, but that causes the quiz question attempt to change again, etc.
     const attemptWithQuizSubject = useMemo(() => {
         return attempt
-            ? {...attempt, quiz: attempt?.quiz && tags.augmentDocWithSubject(attempt.quiz)}
+            ? {...attempt, quiz: attempt?.quiz}
             : undefined;
     }, [attempt]);
 
@@ -252,17 +251,8 @@ export function useCurrentQuizAttempt() {
         ];
     }, [currentUserAttemptState]);
 
-    // Augment quiz object with subject id, propagating undefined-ness
-    // WARNING: This useMemo stops an infinite loop of re-renders - this is because when a quiz question attempt
-    // changes, this causes the quiz attempt to change, but that causes the quiz question attempt to change again, etc.
-    const attemptWithQuizSubject = useMemo(() => {
-        return attempt
-            ? {...attempt, quiz: attempt?.quiz && tags.augmentDocWithSubject(attempt.quiz)}
-            : undefined;
-    }, [attempt]);
-
-    const questions = useQuizQuestions(attemptWithQuizSubject);
-    const sections = useQuizSections(attemptWithQuizSubject);
+    const questions = useQuizQuestions(attempt);
+    const sections = useQuizSections(attempt);
 
     const dispatch = useAppDispatch();
     useEffect( () => {
@@ -272,7 +262,7 @@ export function useCurrentQuizAttempt() {
         return () => dispatch(deregisterQuestions(questions.map(q => q.id as string)));
     }, [dispatch, questions]);
 
-    return {attempt: attemptWithQuizSubject, error, questions, sections};
+    return {attempt, error, questions, sections};
 }
 
 // type QuizAttemptOrAssignment = (QuizAttemptDTO | QuizAssignmentDTO);

--- a/src/app/services/tagsAbstract.ts
+++ b/src/app/services/tagsAbstract.ts
@@ -1,11 +1,9 @@
 import {TAG_ID, TAG_LEVEL} from "./";
 import {BaseTag, Tag} from "../../IsaacAppTypes";
-import {ContentDTO, ContentSummaryDTO} from "../../IsaacApiTypes";
 
 export abstract class AbstractBaseTagService {
     abstract getTagHierarchy(): TAG_LEVEL[];
     abstract getBaseTags(): BaseTag[];
-    abstract augmentDocWithSubject<T extends ContentDTO | ContentSummaryDTO>(doc: T): T & {subjectId?: string};
 
     // Augment base allTags
     public allTags: Tag[] = this.getBaseTags().map((baseTag) => {

--- a/src/app/services/tagsCS.ts
+++ b/src/app/services/tagsCS.ts
@@ -1,6 +1,5 @@
-import {AbstractBaseTagService, STAGE, SUBJECTS, TAG_ID, TAG_LEVEL} from "./";
+import {AbstractBaseTagService, STAGE, TAG_ID, TAG_LEVEL} from "./";
 import {BaseTag} from "../../IsaacAppTypes";
-import {ContentDTO, ContentSummaryDTO} from "../../IsaacApiTypes";
 
 const GCSE_COMING_2022 = {[STAGE.GCSE]: {comingSoonDate: "2022"}};
 const GCSE_HIDDEN = {[STAGE.GCSE]: {hidden: true}};
@@ -109,7 +108,4 @@ export class CsTagService extends AbstractBaseTagService {
     ];
     public getTagHierarchy() {return CsTagService.tagHierarchy;}
     public getBaseTags() {return CsTagService.baseTags;}
-    public augmentDocWithSubject<T extends ContentDTO | ContentSummaryDTO>(doc: T) {
-        return {...doc, subjectId: SUBJECTS.CS};
-    }
 }

--- a/src/app/services/tagsPhy.ts
+++ b/src/app/services/tagsPhy.ts
@@ -1,4 +1,4 @@
-import {AbstractBaseTagService, getTagFromPath, TAG_ID, TAG_LEVEL} from "./";
+import {AbstractBaseTagService, filterBySubjects, getTagFromPath, TAG_ID, TAG_LEVEL} from "./";
 import {BaseTag, Tag} from "../../IsaacAppTypes";
 import {ContentDTO, ContentSummaryDTO} from "../../IsaacApiTypes";
 
@@ -187,22 +187,22 @@ export class PhysicsTagService extends AbstractBaseTagService {
     public getTagHierarchy() {return PhysicsTagService.tagHierarchy;}
     public getBaseTags() {return PhysicsTagService.baseTags;}
     public augmentDocWithSubject<T extends ContentDTO | ContentSummaryDTO>(doc: T) {
-        const documentSubject = this.getPageSubjectTag((doc.tags || []) as TAG_ID[]);
-        return {...doc, subjectId: documentSubject && documentSubject.id};
+        const documentSubject = this.getPageSubjectTagId((doc.tags || []) as TAG_ID[]);
+        return {...doc, subjectId: documentSubject};
     }
 
-    private getPageSubjectTag(tagArray: TAG_ID[]): Tag | undefined {
+    private getPageSubjectTagId(tagArray: TAG_ID[]): TAG_ID | undefined {
         // Extract the subject tag from a tag array,
         // defaulting to the current site subject if no tags
         // and intelligently choosing if more than one subject tag.
         const globalSubjectTagId = getTagFromPath();
         if (tagArray == null || tagArray.length == 0) {
-            return globalSubjectTagId ? this.getById(globalSubjectTagId) : undefined;
+            return globalSubjectTagId;
         }
 
-        const subjectTags = this.getSpecifiedTags(TAG_LEVEL.subject, tagArray, true);
+        const subjectTags = filterBySubjects(tagArray) as TAG_ID[];
         for (const i in subjectTags) {
-            if (subjectTags[i].id == globalSubjectTagId) {
+            if (subjectTags[i] == globalSubjectTagId) {
                 return subjectTags[i];
             }
         }

--- a/src/app/services/tagsPhy.ts
+++ b/src/app/services/tagsPhy.ts
@@ -1,6 +1,5 @@
-import {AbstractBaseTagService, filterBySubjects, getTagFromPath, TAG_ID, TAG_LEVEL} from "./";
+import {AbstractBaseTagService, TAG_ID, TAG_LEVEL} from "./";
 import {BaseTag} from "../../IsaacAppTypes";
-import {ContentDTO, ContentSummaryDTO} from "../../IsaacApiTypes";
 
 export const softHyphen = "\u00AD";
 
@@ -186,28 +185,6 @@ export class PhysicsTagService extends AbstractBaseTagService {
     ];
     public getTagHierarchy() {return PhysicsTagService.tagHierarchy;}
     public getBaseTags() {return PhysicsTagService.baseTags;}
-    public augmentDocWithSubject<T extends ContentDTO | ContentSummaryDTO>(doc: T) {
-        const documentSubject = this.getPageSubjectTagId((doc.tags || []) as TAG_ID[]);
-        return {...doc, subjectId: documentSubject};
-    }
-
-    private getPageSubjectTagId(tagArray: TAG_ID[]): TAG_ID | undefined {
-        // Extract the subject tag from a tag array,
-        // defaulting to the current site subject if no tags
-        // and intelligently choosing if more than one subject tag.
-        const globalSubjectTagId = getTagFromPath();
-        if (tagArray == null || tagArray.length == 0) {
-            return globalSubjectTagId;
-        }
-
-        const subjectTags = filterBySubjects(tagArray) as TAG_ID[];
-        for (const i in subjectTags) {
-            if (subjectTags[i] == globalSubjectTagId) {
-                return subjectTags[i];
-            }
-        }
-        return subjectTags[0];
-    }
 }
 
 

--- a/src/app/services/tagsPhy.ts
+++ b/src/app/services/tagsPhy.ts
@@ -1,5 +1,5 @@
 import {AbstractBaseTagService, filterBySubjects, getTagFromPath, TAG_ID, TAG_LEVEL} from "./";
-import {BaseTag, Tag} from "../../IsaacAppTypes";
+import {BaseTag} from "../../IsaacAppTypes";
 import {ContentDTO, ContentSummaryDTO} from "../../IsaacApiTypes";
 
 export const softHyphen = "\u00AD";

--- a/src/app/state/slices/api/conceptsApi.ts
+++ b/src/app/state/slices/api/conceptsApi.ts
@@ -1,6 +1,5 @@
 import { IsaacConceptPageDTO } from "../../../../IsaacApiTypes";
 import { Concepts } from "../../../../IsaacAppTypes";
-import { tags } from "../../../services";
 import { docSlice } from "../doc";
 import { isaacApi } from "./baseApi";
 import { onQueryLifecycleEvents } from "./utils";
@@ -21,9 +20,6 @@ export const conceptsApi = isaacApi.injectEndpoints({
             query: (id) => ({
                 url: `/pages/concepts/${encodeURIComponent(id)}`
             }),
-            transformResponse: (response: IsaacConceptPageDTO) => {
-                return tags.augmentDocWithSubject(response);
-            },
             onQueryStarted: onQueryLifecycleEvents({
                 errorTitle: "Unable to load concept",
                 onQueryStart: (_args, {dispatch}) => {

--- a/src/app/state/slices/api/genericApi.ts
+++ b/src/app/state/slices/api/genericApi.ts
@@ -1,5 +1,4 @@
 import { SeguePageDTO } from "../../../../IsaacApiTypes";
-import { tags } from "../../../services";
 import { docSlice } from "../doc";
 import { isaacApi } from "./baseApi";
 import { onQueryLifecycleEvents } from "./utils";
@@ -10,9 +9,6 @@ export const genericApi = isaacApi.injectEndpoints({
             query: (id) => ({
                 url: `/pages/${id}`
             }),
-            transformResponse: (response: SeguePageDTO) => {
-                return tags.augmentDocWithSubject(response);
-            },
             onQueryStarted: onQueryLifecycleEvents({
                 errorTitle: "Unable to load question",
                 onQueryStart: (_args, {dispatch}) => {

--- a/src/app/state/slices/api/questionsApi.ts
+++ b/src/app/state/slices/api/questionsApi.ts
@@ -1,6 +1,6 @@
 import { ContentSummaryDTO, IsaacQuestionPageDTO, SearchResultsWrapper } from "../../../../IsaacApiTypes";
 import { CanAttemptQuestionTypeDTO, QuestionSearchQuery } from "../../../../IsaacAppTypes";
-import { isDefined, SEARCH_RESULTS_PER_PAGE, tags } from "../../../services";
+import { isDefined, SEARCH_RESULTS_PER_PAGE } from "../../../services";
 import { docSlice } from "../doc";
 import { isaacApi } from "./baseApi";
 import { onQueryLifecycleEvents } from "./utils";
@@ -61,9 +61,6 @@ export const questionsApi = isaacApi.enhanceEndpoints({addTagTypes: ["CanAttempt
             query: (id) => ({
                 url: `/pages/questions/${encodeURIComponent(id)}`
             }),
-            transformResponse: (response: IsaacQuestionPageDTO) => {
-                return tags.augmentDocWithSubject(response);
-            },
             onQueryStarted: onQueryLifecycleEvents({
                 errorTitle: "Unable to load question",
                 onQueryStart: (_args, {dispatch}) => {


### PR DESCRIPTION
~~Pages are augmented with a `subjectId` when their tags are processed, however previously in cases of multiple subject tags (and for which there was no subject in the url), the ID would be whichever is the first in the `doc`'s tag list. The order of this tag list should not matter (and indeed does not appear to be preserved when indexed) - instead we should use the subject priority that is already used for `pageContext`: **[physics -> maths -> chemistry -> biology]**~~

~~This was leading to mismatched page and title icon themes, although this could have also been avoided with a consistent order of `pageContext?.subject ?? doc.subjectId` (rather than the other way around), or by not re-stating the subject unnecessarily in the `TitleAndBreadcrumb`. To help avoid anything similar coming up again, these have both also been addressed.~~

(Kept for posterity, but no longer relevant)

---

An old system for determining the subject that should be associated with a page was by calculating it when processing tags, then augmenting the doc with a `subjectId` corresponding to that calculated subject. This system was not at all sufficient for the redesigned Sci site with the `pageContext` system mostly replacing it, but we never fully got rid of this old system.

The specific issue that this is trying to solve is a mismatch between page theme and title hex theme. For question pages, the page theme had been determined by `pageContext`, whereas the hex theme was determined by `subjectId` - however `subjectId` did not have the subject prioritisation of `pageContext` for multi-subject pages, leading to this mismatch. Rather than make `subjectId` work properly and maintain both systems, I replaced any remaining uses of `subjectId` and removed all associated code to clean up the codebase. 

(+ allows subject colouring to work properly with the `icon-info` used on generic page ALVIs in Sci search)