### PR TITLE
Make gender dropdown keyboard-accessible in Firefox

### DIFF
--- a/src/app/components/elements/inputs/GenderInput.tsx
+++ b/src/app/components/elements/inputs/GenderInput.tsx
@@ -38,7 +38,7 @@ export const GenderInput = ({className, userToUpdate, setUserToUpdate, submissio
                 setUserToUpdate(Object.assign({}, userToUpdate, {gender: e.target.value}))
             }
         >
-            <option value="UNKNOWN" disabled hidden></option>
+            <option value="UNKNOWN" disabled className="d-none"></option>
             <option value="FEMALE">Female</option>
             <option value="MALE">Male</option>
             <option value="OTHER">Other gender identity</option>


### PR DESCRIPTION
Having a `hidden` option prevents this dropdown from working properly in Firefox (it works fine with enter followed by arrow keys to scroll options, but if you press the spacebar to open the dropdown then it's impossible to select an option). For accessibility, this dropdown should work the same way as the others on this page.