### PR TITLE
More precisely specify extern links to prevent false positives

### DIFF
--- a/src/app/services/api.ts
+++ b/src/app/services/api.ts
@@ -35,7 +35,7 @@ export const apiHelper = {
         // Check if the image source is a fully qualified link (suggesting it is external to the Isaac site),
         // or else an asset link served by the APP, not the API. On the preview renderer only, also allow "data:"
         // in image sources, as the editor passes images to the renderer in a post message. 
-        if ((path.indexOf("http") > -1) || (path.indexOf("/assets/") > -1) || (EDITOR_PREVIEW && path.indexOf("data:") > -1)) {
+        if (path.startsWith("http://") || path.startsWith("https://") || (path.indexOf("/assets/") > -1) || (EDITOR_PREVIEW && path.startsWith("data:"))) {
             return path;
         } else {
             return `${IMAGE_PATH}/${path}`;


### PR DESCRIPTION
There was an issue with a (now-renamed :/) file called `network-http.svg` that was causing the `IMAGE_PATH` const not to be prefixed to the path.