### PR TITLE
Prevent autotranslation of LaTeX content

### DIFF
--- a/src/app/components/elements/markup/latexRendering.ts
+++ b/src/app/components/elements/markup/latexRendering.ts
@@ -319,7 +319,7 @@ export function katexify(
                 }
 
                 // prevent browser auto-translation
-                katexRenderResult = katexRenderResult.replace('<span class="katex', '<span translate="no" class="katex');
+                katexRenderResult = katexRenderResult.replace('<span class="katex"', '<span class="katex" translate="no"');
 
                 output += katexRenderResult;
 

--- a/src/app/components/elements/markup/latexRendering.ts
+++ b/src/app/components/elements/markup/latexRendering.ts
@@ -319,7 +319,7 @@ export function katexify(
                 }
 
                 // prevent browser auto-translation
-                katexRenderResult = katexRenderResult.slice(0, 6) + ' translate="no" ' + katexRenderResult.slice(6);
+                katexRenderResult = katexRenderResult.replace('<span class="katex', '<span translate="no" class="katex');
 
                 output += katexRenderResult;
 

--- a/src/app/components/elements/markup/latexRendering.ts
+++ b/src/app/components/elements/markup/latexRendering.ts
@@ -318,6 +318,9 @@ export function katexify(
                         }"`);
                 }
 
+                // prevent browser auto-translation
+                katexRenderResult = katexRenderResult.slice(0, 6) + ' translate="no" ' + katexRenderResult.slice(6);
+
                 output += katexRenderResult;
 
                 index = match.index + match[0].length;


### PR DESCRIPTION
The `translate` attribute is applied to all children, so doesn't need to be nested.