### PR TITLE
Fix isDobOverN date validation logic

### DIFF
--- a/src/app/services/validation.ts
+++ b/src/app/services/validation.ts
@@ -30,14 +30,14 @@ export const isValidGameboardId = (gameboardId?: string) => {
 };
 
 const isDobOverN = (n: number, dateOfBirth?: Date | number) => {
-    if (dateOfBirth) {
-        const today = new Date();
-        const nYearsAgo = new Date(today.getFullYear() - n, today.getMonth(), today.getDate());
-        const hundredAndTwentyYearsAgo = new Date(today.getFullYear() - 120, today.getMonth(), today.getDate());
-        return hundredAndTwentyYearsAgo <= dateOfBirth && dateOfBirth <= nYearsAgo;
-    } else {
-        return false;
-    }
+    if (!dateOfBirth) return false;
+
+    const dob = new Date(dateOfBirth);
+    if (Number.isNaN(dob.getTime())) return false;
+
+    const today = new Date();
+    const nYearsAgo = new Date(today.getFullYear() - n, today.getMonth(), today.getDate());
+    return dob <= nYearsAgo;
 };
 
 export const isDobOverThirteen = (dateOfBirth?: Date | number) => isDobOverN(13, dateOfBirth);


### PR DESCRIPTION
Just changed it to return early, and then check today's date minus n with the date of birth.

Leap years would normalise to the next day so in this super niche scenario it would still work (if today is 29th of Feb, ten years ago wasn't a leap year, so it would normalise to 1st of March)