### PR TITLE
Improvement/sticky sidebar

### DIFF
--- a/src/app/components/elements/layout/SidebarLayout.tsx
+++ b/src/app/components/elements/layout/SidebarLayout.tsx
@@ -65,11 +65,13 @@ export const ContentSidebar = (props: ContentSidebarProps) => {
     const sidebarContext = useContext(SidebarContext);
     if (!sidebarContext?.sidebarPresent) return <></>;
 
-    const { className, buttonTitle, hideButton, optionBar, ...rest } = props;
+    const { className, buttonTitle, hideButton, optionBar, children, ...rest } = props;
     return fullSidebarLayout
         ? siteSpecific(
-            <Col tag="aside" data-testid="sidebar" aria-label="Sidebar" lg={4} xl={3} {...rest} className={classNames("d-none d-lg-flex flex-column sidebar no-print ps-lg-3 py-lg-4 pe-lg-5 order-0", className)} />,
-            <Col tag="aside" data-testid="sidebar" aria-label="Sidebar" {...rest} className={classNames("flex-column sidebar no-print order-0", className)} />
+            <Col tag="aside" data-testid="sidebar" aria-label="Sidebar" lg={4} xl={3} {...rest} className={classNames("d-none d-lg-flex flex-column sidebar no-print ps-lg-3 pe-lg-5 order-0", className)}>
+                <div className="sidebar-inner py-lg-4">{children}</div>
+            </Col>,
+            <Col tag="aside" data-testid="sidebar" aria-label="Sidebar" {...rest} className={classNames("flex-column sidebar no-print order-0", className)}>{children}</Col>
         )
         : siteSpecific(
             <>
@@ -91,7 +93,7 @@ export const ContentSidebar = (props: ContentSidebarProps) => {
                     }/>
                     <OffcanvasBody>
                         <ContentSidebarContext.Provider value={{toggle: toggleMenu, close: closeMenu}}>
-                            <Col {...rest} className={classNames("sidebar p-4 pt-0", className)} />
+                            <Col {...rest} className={classNames("sidebar p-4 pt-0", className)}>{children}</Col>
                         </ContentSidebarContext.Provider>
                     </OffcanvasBody>
                 </Offcanvas>
@@ -103,7 +105,7 @@ export const ContentSidebar = (props: ContentSidebarProps) => {
                             <span className="fw-bold">{buttonTitle}</span>
                         </AccordionHeader>
                         <AccordionBody accordionId="myAda" className="accordion-flush-body">
-                            <Col {...rest} className={classNames("flex-column", className)} />
+                            <Col {...rest} className={classNames("flex-column", className)}>{children}</Col>
                         </AccordionBody>
                     </AccordionItem>
                 </Accordion>

--- a/src/app/components/elements/layout/SidebarLayout.tsx
+++ b/src/app/components/elements/layout/SidebarLayout.tsx
@@ -65,13 +65,11 @@ export const ContentSidebar = (props: ContentSidebarProps) => {
     const sidebarContext = useContext(SidebarContext);
     if (!sidebarContext?.sidebarPresent) return <></>;
 
-    const { className, buttonTitle, hideButton, optionBar, children, ...rest } = props;
+    const { className, buttonTitle, hideButton, optionBar, ...rest } = props;
     return fullSidebarLayout
         ? siteSpecific(
-            <Col tag="aside" data-testid="sidebar" aria-label="Sidebar" lg={4} xl={3} {...rest} className={classNames("d-none d-lg-flex flex-column sidebar no-print ps-lg-3 pe-lg-5 order-0", className)}>
-                <div className="sidebar-inner py-lg-4">{children}</div>
-            </Col>,
-            <Col tag="aside" data-testid="sidebar" aria-label="Sidebar" {...rest} className={classNames("flex-column sidebar no-print order-0", className)}>{children}</Col>
+            <Col tag="aside" data-testid="sidebar" aria-label="Sidebar" lg={4} xl={3} {...rest} className={classNames("d-none d-lg-flex flex-column sidebar no-print ps-lg-3 py-lg-4 pe-lg-5 order-0", className)} />,
+            <Col tag="aside" data-testid="sidebar" aria-label="Sidebar" {...rest} className={classNames("flex-column sidebar no-print order-0", className)} />
         )
         : siteSpecific(
             <>
@@ -93,7 +91,7 @@ export const ContentSidebar = (props: ContentSidebarProps) => {
                     }/>
                     <OffcanvasBody>
                         <ContentSidebarContext.Provider value={{toggle: toggleMenu, close: closeMenu}}>
-                            <Col {...rest} className={classNames("sidebar p-4 pt-0", className)}>{children}</Col>
+                            <Col {...rest} className={classNames("sidebar p-4 pt-0", className)} />
                         </ContentSidebarContext.Provider>
                     </OffcanvasBody>
                 </Offcanvas>
@@ -105,7 +103,7 @@ export const ContentSidebar = (props: ContentSidebarProps) => {
                             <span className="fw-bold">{buttonTitle}</span>
                         </AccordionHeader>
                         <AccordionBody accordionId="myAda" className="accordion-flush-body">
-                            <Col {...rest} className={classNames("flex-column", className)}>{children}</Col>
+                            <Col {...rest} className={classNames("flex-column", className)} />
                         </AccordionBody>
                     </AccordionItem>
                 </Accordion>

--- a/src/app/components/elements/layout/SidebarLayout.tsx
+++ b/src/app/components/elements/layout/SidebarLayout.tsx
@@ -39,10 +39,13 @@ export const NavigationSidebar = (props: SidebarProps) => {
     // A navigation sidebar is used for external links that are supplementary to the main content (e.g. related content);
     // the content in such a sidebar will collapse underneath the main content on smaller screens
     const sidebarContext = useContext(SidebarContext);
+    const fullSidebarLayout = useFullSidebarLayout();
     if (!sidebarContext?.sidebarPresent) return <></>; 
 
-    const { className, ...rest } = props;
-    return <Col tag="aside" aria-label="Sidebar" lg={4} xl={3} {...rest} className={classNames("sidebar no-print p-4 order-1 order-lg-0", {"ps-lg-2 py-lg-4 pe-lg-5": isPhy}, className)} />;
+    const { className, children, ...rest } = props;
+    return <Col tag="aside" aria-label="Sidebar" lg={4} xl={3} {...rest} className={classNames("sidebar no-print p-4 order-1 order-lg-0", {"ps-lg-2 py-lg-4 pe-lg-4": isPhy}, className)}>
+        <div key="sidebar_sticky" className={classNames({"sticky pe-lg-2": isPhy && fullSidebarLayout})}>{children}</div>
+    </Col>;
 };
 
 export interface ContentSidebarProps extends SidebarProps {
@@ -65,11 +68,14 @@ export const ContentSidebar = (props: ContentSidebarProps) => {
     const sidebarContext = useContext(SidebarContext);
     if (!sidebarContext?.sidebarPresent) return <></>;
 
-    const { className, buttonTitle, hideButton, optionBar, ...rest } = props;
+    const { className, buttonTitle, hideButton, optionBar, children, ...rest } = props;
+    const restWithChildren = {children, ...rest};
     return fullSidebarLayout
         ? siteSpecific(
-            <Col tag="aside" data-testid="sidebar" aria-label="Sidebar" lg={4} xl={3} {...rest} className={classNames("d-none d-lg-flex flex-column sidebar no-print ps-lg-3 py-lg-4 pe-lg-5 order-0", className)} />,
-            <Col tag="aside" data-testid="sidebar" aria-label="Sidebar" {...rest} className={classNames("flex-column sidebar no-print order-0", className)} />
+            <Col tag="aside" data-testid="sidebar" aria-label="Sidebar" lg={4} xl={3} {...rest} className={classNames("d-none d-lg-flex flex-column sidebar no-print ps-lg-3 py-lg-4 pe-lg-4 order-0", className)}>
+                <div key="sidebar_sticky" className="sticky pe-lg-2">{children}</div>
+            </Col>,
+            <Col tag="aside" data-testid="sidebar" aria-label="Sidebar" {...restWithChildren} className={classNames("flex-column sidebar no-print order-0", className)} />
         )
         : siteSpecific(
             <>
@@ -91,7 +97,7 @@ export const ContentSidebar = (props: ContentSidebarProps) => {
                     }/>
                     <OffcanvasBody>
                         <ContentSidebarContext.Provider value={{toggle: toggleMenu, close: closeMenu}}>
-                            <Col {...rest} className={classNames("sidebar p-4 pt-0", className)} />
+                            <Col {...restWithChildren} className={classNames("sidebar p-4 pt-0", className)} />
                         </ContentSidebarContext.Provider>
                     </OffcanvasBody>
                 </Offcanvas>
@@ -103,7 +109,7 @@ export const ContentSidebar = (props: ContentSidebarProps) => {
                             <span className="fw-bold">{buttonTitle}</span>
                         </AccordionHeader>
                         <AccordionBody accordionId="myAda" className="accordion-flush-body">
-                            <Col {...rest} className={classNames("flex-column", className)} />
+                            <Col {...restWithChildren} className={classNames("flex-column", className)} />
                         </AccordionBody>
                     </AccordionItem>
                 </Accordion>

--- a/src/scss/common/elements.scss
+++ b/src/scss/common/elements.scss
@@ -309,6 +309,7 @@ iframe.email-html {
 }
 
 .collapsible-body {
+  position: relative;
   @include reduced-motion-compliant-animation {
     transition: max-height 0.3s ease-in-out, height 0.3s ease-in-out;
   }

--- a/src/scss/common/elements.scss
+++ b/src/scss/common/elements.scss
@@ -309,6 +309,7 @@ iframe.email-html {
 }
 
 .collapsible-body {
+  // this prevents the height of a collapsed container adding to the height of the nearest parent's scroll container 
   position: relative;
   @include reduced-motion-compliant-animation {
     transition: max-height 0.3s ease-in-out, height 0.3s ease-in-out;

--- a/src/scss/phy/sidebar.scss
+++ b/src/scss/phy/sidebar.scss
@@ -1,4 +1,11 @@
 .sidebar {
+  .sticky {
+    position: sticky;
+    top: 0;
+    max-height: 100vh;
+    overflow: auto;
+  }
+
   ul {
     list-style: none;
     list-style-image: none;

--- a/src/scss/phy/sidebar.scss
+++ b/src/scss/phy/sidebar.scss
@@ -1,4 +1,16 @@
+.sidebar-layout {
+  align-items: flex-start;
+}
+
+.sidebar-inner {
+  overflow-y: auto;
+  max-height: 100vh;
+}
+
 .sidebar {
+  position: sticky;
+  top: -50px;
+
   ul {
     list-style: none;
     list-style-image: none;

--- a/src/scss/phy/sidebar.scss
+++ b/src/scss/phy/sidebar.scss
@@ -3,7 +3,7 @@
     position: sticky;
     top: 0;
     max-height: 100vh;
-    overflow-y: auto;
+    overflow: auto;
     // reserve 5px for elements to overflow (eg. button outlines when selected, on question finder).
     // preserve original layout by compensating for added padding using negative margin. 
     padding-left: 5px;

--- a/src/scss/phy/sidebar.scss
+++ b/src/scss/phy/sidebar.scss
@@ -3,7 +3,13 @@
     position: sticky;
     top: 0;
     max-height: 100vh;
-    overflow: auto;
+    overflow-y: auto;
+    // reserve 5px for elements to overflow (eg. button outlines when selected, on question finder).
+    // preserve original layout by compensating for added padding using negative margin. 
+    padding-left: 5px;
+    margin-left: -5px;
+    padding-bottom: 5px;
+    margin-bottom: -5px;
   }
 
   ul {

--- a/src/scss/phy/sidebar.scss
+++ b/src/scss/phy/sidebar.scss
@@ -1,16 +1,4 @@
-.sidebar-layout {
-  align-items: flex-start;
-}
-
-.sidebar-inner {
-  overflow-y: auto;
-  max-height: 100vh;
-}
-
 .sidebar {
-  position: sticky;
-  top: -50px;
-
   ul {
     list-style: none;
     list-style-image: none;


### PR DESCRIPTION
This implements sticky sidebars.

Here are some controversial choices I made:


1) I prioritised the case when the sidebar is short enough there’s no need for a scrollbar. In such a case, the page looks exactly as it did before. When there is a scrollbar, the sidebar’s contents is now narrower, to acommodate the width of the scrollbar. Maybe the reviewer knows a way to have the scrollbar eat into the padding we already have on the page? Unfortunately I couldn’t do this easily (considered relying on `scrollbar-gutter: stable`, but whether this takes up any space still depends on whether the os shows scrollbars).
2) when the main content becomes shorter, we loose scroll position and there’s a big jump. This might happen, eg. [on the Question finder](https://dev.isaacscience.org/questions), see attached video. I don't think there's an easy fix for this one: the browser remembers we're on the bottom of the page, but with the page a lot shorter, the bottom of the page becomes the footer, which doesn't have the scrollbar.
https://github.com/user-attachments/assets/480366b2-1030-4f96-80a8-bbde4d359f3c
3) For simplicity, I made every sidebar sticky. There are a few pages, like  "[News](https://dev.isaacscience.org/news)", where sticky sidebars feel unnecessary, as the sidebar doesn't really contain anything meaningful in the first place.
