### PR TITLE
attempt to stabilize `MyGameboards`

### DIFF
--- a/cypress/support/commands.tsx
+++ b/cypress/support/commands.tsx
@@ -59,12 +59,12 @@ declare global {
 import React, {ReactNode} from "react";
 import {Provider} from "react-redux";
 import {store} from "../../src/app/state";
-import {createBrowserRouter, createRoutesFromElements, Route, To} from "react-router";
+import {createMemoryRouter, createRoutesFromElements, Route, To} from "react-router";
 import { RouterProvider } from 'react-router-dom';
 import { ACTION_TYPE } from '../../src/app/services';
 
 Cypress.Commands.add('mountWithStoreAndRouter', (component, routes, initialRoute=routes?.[0], user, mountOptions) => {
-    const router = createBrowserRouter(createRoutesFromElements(<>
+    const router = createMemoryRouter(createRoutesFromElements(<>
         {routes?.length
             ? routes.map(route => <Route key={route} element={component} path={route} />)
             : <Route path="*" element={component} />


### PR DESCRIPTION
The `My Gameboards` VRT is still flaky ([here's ](https://github.com/isaacphysics/isaac-react-app/actions/runs/31611042300/attempts/1)a random failure). Interestingly, the part that fails is in `createBrowserRouter`, a method provided by `reactRouter`. We call this from our custom `mountWithStoreAndRouter` function.

```
My Gameboards
    ✓ should have no visual regressions in table view (2983ms)
    1) should have no visual regressions in card view


  1 passing (3s)
  1 failing

  1) My Gameboards
       should have no visual regressions in card view:
     TypeError: Cannot read properties of null (reading 'history')
      at getUrlBasedHistory (http://localhost:5173/node_modules/.vite/deps/chunk-IU74XXAH.js?v=bd399ecb:720:31)
      at createBrowserHistory (http://localhost:5173/node_modules/.vite/deps/chunk-IU74XXAH.js?v=bd399ecb:593:10)
      at createBrowserRouter (http://localhost:5173/node_modules/.vite/deps/chunk-IU74XXAH.js?v=bd399ecb:10740:14)
      at Context.<anonymous> (http://localhost:5173/cypress/support/commands.tsx:9:18)
```

I have no idea what cypress is doing to the browser in the background that might make this fail. However, I thought since the tests seem fine with that too, we can just try using the more lightweight `createMemoryRouter` instead. This doesn't use any browser APIs, and is therefore less likely to be affected by whatever cypress is doing.