### PR TITLE
Fix print button so fonts are loaded before printing

### DIFF
--- a/src/app/components/elements/PrintButton.tsx
+++ b/src/app/components/elements/PrintButton.tsx
@@ -1,5 +1,5 @@
 import React, {useState} from "react";
-import {printingSettingsSlice, useAppDispatch} from "../../state";
+import {AppDispatch, printingSettingsSlice, useAppDispatch} from "../../state";
 import {Button} from "reactstrap";
 import { IconButton } from "./AffixButton";
 import { isAda, siteSpecific } from "../../services";
@@ -11,14 +11,23 @@ interface PrintProps {
 
 const FONT_LOAD_TIMEOUT = 2000;
 
-// Function that goes through all fonts on the page, waits for them to load/fail, and then prints the page
-async function printWithFontsReady() {
+async function printWithHintsAndLoadedFonts(dispatch: AppDispatch, withHints: boolean) {
+    dispatch(printingSettingsSlice.actions.enableHints(withHints));
 
-    const loads = Array.from(document.fonts).map(font => (font.status === "unloaded" ? font.load() : font.loaded ).catch(() => undefined));
-    
+    // Two animation frames, so that any hints we just toggled have been rendered before we look at them
+    await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+
+    // Ask for every font the page uses...
+    const fontsInUse = new Set<string>();
+    for (const element of document.body.querySelectorAll("*")) {
+        const {fontStyle, fontWeight, fontFamily} = getComputedStyle(element);
+        fontsInUse.add(`${fontStyle} ${fontWeight} 1em ${fontFamily}`);
+    }
+
+    //... and load them specifically
     await Promise.race([
-        Promise.all(loads).then(()=> document.fonts.ready),
-        new Promise(resolve => setTimeout(resolve,FONT_LOAD_TIMEOUT)),
+        Promise.all(Array.from(fontsInUse, font => document.fonts.load(font).catch(() => undefined))),
+        new Promise(resolve => setTimeout(resolve, FONT_LOAD_TIMEOUT)),
     ]);
 
     window.print();
@@ -38,10 +47,7 @@ export const PrintButton = ({questionPage}: PrintProps ) => {
                         color={"link"}
                         title={"Print with hints"}
                         className="a-alt"
-                        onClick={() => {
-                            dispatch(printingSettingsSlice.actions.enableHints(true));
-                            setTimeout(printWithFontsReady, 100);
-                        }}
+                        onClick={() => printWithHintsAndLoadedFonts(dispatch, true)}
                     ><span className="visually-hidden">Print{" "}</span>With hints
                     </Button>
                     |
@@ -50,10 +56,7 @@ export const PrintButton = ({questionPage}: PrintProps ) => {
                         color={"link"}
                         title={"Print without hints"}
                         className="a-alt"
-                        onClick={() => {
-                            dispatch(printingSettingsSlice.actions.enableHints(false));
-                            setTimeout(printWithFontsReady, 100);
-                        }}
+                        onClick={() => printWithHintsAndLoadedFonts(dispatch, false)}
                     ><span className="visually-hidden">Print{" "}</span>Without hints</Button>
                 </div>
             </div>}
@@ -75,9 +78,6 @@ export const PrintButton = ({questionPage}: PrintProps ) => {
             title="Print page"
             color={siteSpecific("tint", "primary")}
             data-bs-theme="neutral"
-            onClick={() => {
-                dispatch(printingSettingsSlice.actions.enableHints(false)); 
-                setTimeout(printWithFontsReady, 100);
-            }}
+            onClick={() => printWithHintsAndLoadedFonts(dispatch, false)}
         />;
 };

--- a/src/app/components/elements/PrintButton.tsx
+++ b/src/app/components/elements/PrintButton.tsx
@@ -9,6 +9,21 @@ interface PrintProps {
     questionPage?: boolean;
 }
 
+const FONT_LOAD_TIMEOUT = 2000;
+
+// Function that goes through all fonts on the page, waits for them to load/fail, and then prints the page
+async function printWithFontsReady() {
+
+    const loads = Array.from(document.fonts).map(font => (font.status === "unloaded" ? font.load() : font.loaded ).catch(() => undefined));
+    
+    await Promise.race([
+        Promise.all(loads).then(()=> document.fonts.ready),
+        new Promise(resolve => setTimeout(resolve,FONT_LOAD_TIMEOUT)),
+    ]);
+
+    window.print();
+}
+
 export const PrintButton = ({questionPage}: PrintProps ) => {
 
     const [questionPrintOpen, setQuestionPrintOpen] = useState(false);
@@ -25,7 +40,7 @@ export const PrintButton = ({questionPage}: PrintProps ) => {
                         className="a-alt"
                         onClick={() => {
                             dispatch(printingSettingsSlice.actions.enableHints(true));
-                            setTimeout(window.print, 100);
+                            setTimeout(printWithFontsReady, 100);
                         }}
                     ><span className="visually-hidden">Print{" "}</span>With hints
                     </Button>
@@ -37,7 +52,7 @@ export const PrintButton = ({questionPage}: PrintProps ) => {
                         className="a-alt"
                         onClick={() => {
                             dispatch(printingSettingsSlice.actions.enableHints(false));
-                            setTimeout(window.print, 100);
+                            setTimeout(printWithFontsReady, 100);
                         }}
                     ><span className="visually-hidden">Print{" "}</span>Without hints</Button>
                 </div>
@@ -62,7 +77,7 @@ export const PrintButton = ({questionPage}: PrintProps ) => {
             data-bs-theme="neutral"
             onClick={() => {
                 dispatch(printingSettingsSlice.actions.enableHints(false)); 
-                setTimeout(window.print, 100);
+                setTimeout(printWithFontsReady, 100);
             }}
         />;
 };


### PR DESCRIPTION
Basically, the problem was that the browser wouldn't load all fonts because they were in an accordion, and it loaded them lazily. When you clicked the print button, it opened the accordions, saw that they are not loaded, and sent a request, but the print function would execute before the request came back, thus sometimes some symbols would be missing, which is also why the second time you click "print" it worked.

What I did was just make a new function, that goes through all fonts, loads them, and then prints. There is a timeout that I have set at 2 seconds, could be less or more.  We might need to play with that as when I tested a fully loaded page, opened the network tools tab, set it to 3G, it couldn't load the fonts in time for 2 seconds, so it timed out. 

This also won't work if a user presses Control+P or does the in-browser print button - we could be just preloading the fonts at load anyway, if we care about that.