### PR TITLE
Use media-breakpoint-* mixins consistently (+ clean up mixins file in general)

### DIFF
--- a/src/app/components/pages/Equality.tsx
+++ b/src/app/components/pages/Equality.tsx
@@ -1,17 +1,16 @@
 import React, {ChangeEvent, lazy, Suspense, useLayoutEffect, useRef, useState} from "react";
-import {Button, Col, Container, Input, Label, Row} from "reactstrap";
+import {Col, Container, Input, Label, Row} from "reactstrap";
 import queryString from "query-string";
 import {ifKeyIsEnter, isStaff, siteSpecific, jsonHelper, useModalWithScroll} from "../../services";
 import katex from "katex";
 import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
 import {useLocation} from "react-router";
 import {Inequality, WidgetSpec} from 'inequality';
-import {openActiveModal, selectors, useAppDispatch, useAppSelector, useGetSegueEnvironmentQuery} from "../../state";
+import {selectors, useAppSelector, useGetSegueEnvironmentQuery} from "../../state";
 import {EditorMode, LogicSyntax} from "../elements/modals/inequality/constants";
 import { Loading } from "../handlers/IsaacSpinner";
 import { GeneralFormulaDTO, InequalityState, SymbolicTextInput } from "../elements/inputs/SymbolicTextInput";
 import { initialiseInequality, sanitiseInequalityState } from "../../services/inequalityUtils";
-import { loginOrSignUpModal } from "../elements/modals/LoginOrSignUpModal";
 
 const InequalityModal = lazy(() => import("../elements/modals/inequality/InequalityModal"));
 
@@ -39,8 +38,6 @@ const Equality = () => {
 
     const hiddenEditorRef = useRef<HTMLDivElement | null>(null);
     const sketchRef = useRef<Inequality | null | undefined>();
-
-    const dispatch = useAppDispatch();
 
     function updateState(state: InequalityState) {
         if (["maths", "logic"].includes(editorMode)) {
@@ -154,9 +151,6 @@ const Equality = () => {
                 </>}
             </Col>
         </Row>}
-        <Button onClick={() => dispatch(openActiveModal(loginOrSignUpModal))}>
-            Hello world
-        </Button>
     </Container>;
 };
 export default Equality;

--- a/src/app/components/pages/Equality.tsx
+++ b/src/app/components/pages/Equality.tsx
@@ -1,16 +1,17 @@
 import React, {ChangeEvent, lazy, Suspense, useLayoutEffect, useRef, useState} from "react";
-import {Col, Container, Input, Label, Row} from "reactstrap";
+import {Button, Col, Container, Input, Label, Row} from "reactstrap";
 import queryString from "query-string";
 import {ifKeyIsEnter, isStaff, siteSpecific, jsonHelper, useModalWithScroll} from "../../services";
 import katex from "katex";
 import {TitleAndBreadcrumb} from "../elements/TitleAndBreadcrumb";
 import {useLocation} from "react-router";
 import {Inequality, WidgetSpec} from 'inequality';
-import {selectors, useAppSelector, useGetSegueEnvironmentQuery} from "../../state";
+import {openActiveModal, selectors, useAppDispatch, useAppSelector, useGetSegueEnvironmentQuery} from "../../state";
 import {EditorMode, LogicSyntax} from "../elements/modals/inequality/constants";
 import { Loading } from "../handlers/IsaacSpinner";
 import { GeneralFormulaDTO, InequalityState, SymbolicTextInput } from "../elements/inputs/SymbolicTextInput";
 import { initialiseInequality, sanitiseInequalityState } from "../../services/inequalityUtils";
+import { loginOrSignUpModal } from "../elements/modals/LoginOrSignUpModal";
 
 const InequalityModal = lazy(() => import("../elements/modals/inequality/InequalityModal"));
 
@@ -38,6 +39,8 @@ const Equality = () => {
 
     const hiddenEditorRef = useRef<HTMLDivElement | null>(null);
     const sketchRef = useRef<Inequality | null | undefined>();
+
+    const dispatch = useAppDispatch();
 
     function updateState(state: InequalityState) {
         if (["maths", "logic"].includes(editorMode)) {
@@ -151,6 +154,9 @@ const Equality = () => {
                 </>}
             </Col>
         </Row>}
+        <Button onClick={() => dispatch(openActiveModal(loginOrSignUpModal))}>
+            Hello world
+        </Button>
     </Container>;
 };
 export default Equality;

--- a/src/scss/common/_mixins.scss
+++ b/src/scss/common/_mixins.scss
@@ -1,53 +1,115 @@
-// Helper for playing with pseudo element
-// $width: width of the pseudo element.
-// $height: height of the pseudo element.
-// $content: when playing with pseudo element, you mainly use `content: ""` (default value).
-// $position: when playing with pseudo element, you mainly use `position: absolute` (default value).
-// $display: when playing with pseudo element, you mainly use `display: block` (default value).
-@use "sass:math";
+@mixin pseudo-element($content: '', $position: absolute, $display: block) {
+  content: $content;
+  display: $display;
+  position: $position;
+}
 
-//
-//  MEDIA QUERIES
-//––––––––––––––––––––––––––––––––––––––––––––––––––
-// A map of breakpoints.
-// /!\ WARNING /!\ this is not the same as bootstraps $grid-breakpoints! (although it really should be!!!)
-$breakpoints: (
-  xs: 576px,
-  sm: 768px,
-  md: 992px,
-  lg: 1200px,
-  nav: 1256px
-); 
-
-
-
-//
-//  RESPOND BETWEEN
-//––––––––––––––––––––––––––––––––––––––––––––––––––
-// @include respond-between(sm, md) {}
-@mixin respond-between($lower, $upper) {
-  // If both the lower and upper breakpoints exist in the map.
-  @if map-has-key($breakpoints, $lower) and map-has-key($breakpoints, $upper) {
-    // Get the lower and upper breakpoints.
-    $lower-breakpoint: map-get($breakpoints, $lower);
-    $upper-breakpoint: map-get($breakpoints, $upper);
-    // Write the media query.
-    @media (min-width: $lower-breakpoint) and (max-width: ($upper-breakpoint - 1)) {
-      @content;
-    }
-    // If one or both of the breakpoints don't exist.
-  } @else {
-    // If lower breakpoint is invalid.
-    @if (map-has-key($breakpoints, $lower) == false) {
-      // Log a warning.
-      @warn 'Your lower breakpoint was invalid: #{$lower}.';
-    }
-    // If upper breakpoint is invalid.
-    @if (map-has-key($breakpoints, $upper) == false) {
-      // Log a warning.
-      @warn 'Your upper breakpoint was invalid: #{$upper}.';
-    }
+@mixin placeholder($colour: pink) {
+  /* Chrome, Firefox, Opera, Safari 10.1+ */
+  &::placeholder {
+    color: $colour !important;
+    /* Firefox */
+    opacity: 1;
   }
+  /* Some older WebKit based browsers */
+  &::-webkit-input-placeholder {
+    color: $colour !important;
+    opacity: 1;
+  }
+  /* Internet Explorer 10-11 */
+  &:-ms-input-placeholder {
+    color: $colour !important;
+  }
+  /* Microsoft Edge */
+  &::-ms-input-placeholder {
+    color: $colour !important;
+  }
+}
+
+@mixin aspect-ratio($width, $height) {
+  aspect-ratio: calc($width / $height);
+}
+
+// modified from https://css-tricks.com/books/greatest-css-tricks/scroll-shadows/
+@mixin vertical-scroll-shadow($background-color: white, $shadow-color: rgba(0, 0, 0, 0.2)) {
+  background:
+    linear-gradient(
+      $background-color 30%,
+      transparent
+    ) center top,
+    
+    linear-gradient(
+      transparent,
+      $background-color 70%
+    ) center bottom,
+
+    radial-gradient(
+      farthest-side at 50% 0,
+      $shadow-color,
+      transparent
+    ) center top,
+
+    radial-gradient(
+      farthest-side at 50% 100%,
+      $shadow-color,
+      transparent
+    ) center bottom;
+
+  background-repeat: no-repeat;
+  background-size: 100% 40px, 100% 40px, 100% 14px, 100% 14px;
+  background-attachment: local, local, scroll, scroll;
+}
+
+@mixin horizontal-scroll-shadow($background-color: white, $shadow-color: rgba(0, 0, 0, 0.2)) {
+  background:
+    linear-gradient(
+      to right,
+      $background-color 30%,
+      transparent
+    ) left center,
+    
+    linear-gradient(
+      to right,
+      transparent,
+      $background-color 70%
+    ) right center,
+
+    radial-gradient(
+      farthest-side at 0 50%,
+      $shadow-color,
+      transparent
+    ) left center,
+
+    radial-gradient(
+      farthest-side at 100% 50%,
+      $shadow-color,
+      transparent
+    ) right center;
+
+  background-repeat: no-repeat;
+  background-size: 40px 100%, 40px 100%, 14px 100%, 14px 100%;
+  background-attachment: local, local, scroll, scroll;
+}
+
+@mixin no-print {
+  @media not print {
+    @content;
+  }
+}
+
+@mixin only-print {
+  @media print {
+    @content;
+  }
+}
+
+@mixin fixed-text-height($line-height: 1.5rem, $lines: 2) {
+  max-height: calc(#{$line-height} * #{$lines});
+  overflow: hidden;
+  display: -webkit-box !important;
+  -webkit-line-clamp: $lines;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
 }
 
 // ICONS
@@ -168,118 +230,4 @@ $breakpoints: (
     --icon-foreground: #{$color} !important;
     --icon-background: #{$color} !important;
   }
-}
-
-@mixin aspect-ratio($width, $height) {
-  aspect-ratio: calc($width / $height);
-}
-
-@mixin placeholder($colour: pink) {
-  /* Chrome, Firefox, Opera, Safari 10.1+ */
-  &::placeholder {
-    color: $colour !important;
-    /* Firefox */
-    opacity: 1;
-  }
-  /* Some older WebKit based browsers */
-  &::-webkit-input-placeholder {
-    color: $colour !important;
-    opacity: 1;
-  }
-  /* Internet Explorer 10-11 */
-  &:-ms-input-placeholder {
-    color: $colour !important;
-  }
-  /* Microsoft Edge */
-  &::-ms-input-placeholder {
-    color: $colour !important;
-  }
-}
-
-// modified from https://css-tricks.com/books/greatest-css-tricks/scroll-shadows/
-@mixin vertical-scroll-shadow($background-color: white, $shadow-color: rgba(0, 0, 0, 0.2)) {
-  background:
-    linear-gradient(
-      $background-color 30%,
-      transparent
-    ) center top,
-    
-    linear-gradient(
-      transparent,
-      $background-color 70%
-    ) center bottom,
-
-    radial-gradient(
-      farthest-side at 50% 0,
-      $shadow-color,
-      transparent
-    ) center top,
-
-    radial-gradient(
-      farthest-side at 50% 100%,
-      $shadow-color,
-      transparent
-    ) center bottom;
-
-  background-repeat: no-repeat;
-  background-size: 100% 40px, 100% 40px, 100% 14px, 100% 14px;
-  background-attachment: local, local, scroll, scroll;
-}
-
-@mixin horizontal-scroll-shadow($background-color: white, $shadow-color: rgba(0, 0, 0, 0.2)) {
-  background:
-    linear-gradient(
-      to right,
-      $background-color 30%,
-      transparent
-    ) left center,
-    
-    linear-gradient(
-      to right,
-      transparent,
-      $background-color 70%
-    ) right center,
-
-    radial-gradient(
-      farthest-side at 0 50%,
-      $shadow-color,
-      transparent
-    ) left center,
-
-    radial-gradient(
-      farthest-side at 100% 50%,
-      $shadow-color,
-      transparent
-    ) right center;
-
-  background-repeat: no-repeat;
-  background-size: 40px 100%, 40px 100%, 14px 100%, 14px 100%;
-  background-attachment: local, local, scroll, scroll;
-}
-
-@mixin no-print {
-  @media not print {
-    @content;
-  }
-}
-
-@mixin only-print {
-  @media print {
-    @content;
-  }
-}
-
-@mixin fixed-text-height($line-height: 1.5rem, $lines: 2) {
-  max-height: calc(#{$line-height} * #{$lines});
-  overflow: hidden;
-  display: -webkit-box !important;
-  -webkit-line-clamp: $lines;
-  line-clamp: 2;
-  -webkit-box-orient: vertical;
-}
-
-@mixin pseudo-element($content: '', $position: absolute, $display: block) {
-  content: $content;
-  display: $display;
-  position: $position;
 }

--- a/src/scss/common/_mixins.scss
+++ b/src/scss/common/_mixins.scss
@@ -94,42 +94,6 @@ $breakpoints: (
   }
 }
 
-$viewport-sizes: (
-  25: 25%,
-  50: 50%,
-  75: 75%,
-  100: 100%,
-  auto: auto,
-);
-
-// Size / viewports -- (correctly) uses Bootstrap's breakpoints, NOT the ones declared in this file
-@each $bp, $bp-width in map-remove($grid-breakpoints, xs) {
-  @media (min-width: $bp-width) {
-    @each $size, $size-value in $viewport-sizes {
-      .w-#{$bp}-#{$size} {
-        width: #{$size-value} !important;
-      }
-      .h-#{$bp}-#{$size} {
-        height: #{$size-value} !important;
-      }
-    }
-  }
-}
-
-// Fixed sizes
-@for $size from 1 through 20 {
-  .wf-#{$size} {
-    width: #{$size}rem !important;
-  }
-  .hf-#{$size} {
-    height: #{$size}rem !important;
-  }
-}
-
-.mw-auto {
-  min-width: auto !important;
-}
-
 // ICONS
 @mixin svg-icon-raw($path, $width, $height, $background-size: none, $background-position: none) {
   // use this only for SVG icons that should not be recoloured; prefer @svg-icon in general

--- a/src/scss/common/_mixins.scss
+++ b/src/scss/common/_mixins.scss
@@ -11,25 +11,21 @@
   display: $display;
   position: $position;
 }
-// Detect IE10 and IE11
-@mixin ie() {
-  @media screen and (-ms-high-contrast: active),
-  screen and (-ms-high-contrast: none) {
-    @content;
-  }
-}
+
 //
 //  MEDIA QUERIES
 //––––––––––––––––––––––––––––––––––––––––––––––––––
 // A map of breakpoints.
 // /!\ WARNING /!\ this is not the same as bootstraps $grid-breakpoints! (although it really should be!!!)
 $breakpoints: (
-        xs: 576px,
-        sm: 768px,
-        md: 992px,
-        lg: 1200px,
-        nav: 1256px
-); //
+  xs: 576px,
+  sm: 768px,
+  md: 992px,
+  lg: 1200px,
+  nav: 1256px
+); 
+
+//
 //  RESPOND ABOVE
 //––––––––––––––––––––––––––––––––––––––––––––––––––
 // @include respond-above(sm) {}
@@ -48,6 +44,7 @@ $breakpoints: (
     @warn 'Invalid breakpoint: #{$breakpoint}.';
   }
 }
+
 //
 //  RESPOND BELOW
 //––––––––––––––––––––––––––––––––––––––––––––––––––
@@ -67,6 +64,7 @@ $breakpoints: (
     @warn 'Invalid breakpoint: #{$breakpoint}.';
   }
 }
+
 //
 //  RESPOND BETWEEN
 //––––––––––––––––––––––––––––––––––––––––––––––––––
@@ -93,31 +91,6 @@ $breakpoints: (
       // Log a warning.
       @warn 'Your upper breakpoint was invalid: #{$upper}.';
     }
-  }
-}
-// outline helper
-@mixin out($colour: pink, $width: 1px) {
-  outline: $width solid $colour;
-}
-@mixin placeholder($colour: pink) {
-  /* Chrome, Firefox, Opera, Safari 10.1+ */
-  &::placeholder {
-    color: $colour !important;
-    /* Firefox */
-    opacity: 1;
-  }
-  /* Some older WebKit based browsers */
-  &::-webkit-input-placeholder {
-    color: $colour !important;
-    opacity: 1;
-  }
-  /* Internet Explorer 10-11 */
-  &:-ms-input-placeholder {
-    color: $colour !important;
-  }
-  /* Microsoft Edge */
-  &::-ms-input-placeholder {
-    color: $colour !important;
   }
 }
 
@@ -157,10 +130,7 @@ $viewport-sizes: (
   min-width: auto !important;
 }
 
-@mixin aspect-ratio($width, $height) {
-  aspect-ratio: calc($width / $height);
-}
-
+// ICONS
 @mixin svg-icon-raw($path, $width, $height, $background-size: none, $background-position: none) {
   // use this only for SVG icons that should not be recoloured; prefer @svg-icon in general
   display: inline-block;
@@ -280,6 +250,32 @@ $viewport-sizes: (
   }
 }
 
+@mixin aspect-ratio($width, $height) {
+  aspect-ratio: calc($width / $height);
+}
+
+@mixin placeholder($colour: pink) {
+  /* Chrome, Firefox, Opera, Safari 10.1+ */
+  &::placeholder {
+    color: $colour !important;
+    /* Firefox */
+    opacity: 1;
+  }
+  /* Some older WebKit based browsers */
+  &::-webkit-input-placeholder {
+    color: $colour !important;
+    opacity: 1;
+  }
+  /* Internet Explorer 10-11 */
+  &:-ms-input-placeholder {
+    color: $colour !important;
+  }
+  /* Microsoft Edge */
+  &::-ms-input-placeholder {
+    color: $colour !important;
+  }
+}
+
 // modified from https://css-tricks.com/books/greatest-css-tricks/scroll-shadows/
 @mixin vertical-scroll-shadow($background-color: white, $shadow-color: rgba(0, 0, 0, 0.2)) {
   background:
@@ -351,13 +347,6 @@ $viewport-sizes: (
   @media print {
     @content;
   }
-}
-
-@mixin table-sticky() {
-  position: sticky !important;
-  position: -webkit-sticky !important;
-  background-clip:  padding-box !important;
-  z-index: 2;
 }
 
 @mixin fixed-text-height($line-height: 1.5rem, $lines: 2) {

--- a/src/scss/common/_mixins.scss
+++ b/src/scss/common/_mixins.scss
@@ -20,25 +20,6 @@ $breakpoints: (
 ); 
 
 
-//
-//  RESPOND BELOW
-//––––––––––––––––––––––––––––––––––––––––––––––––––
-// @include respond-below(sm) {}
-@mixin respond-below($breakpoint) {
-  // If the breakpoint exists in the map.
-  @if map-has-key($breakpoints, $breakpoint) {
-    // Get the breakpoint value.
-    $breakpoint-value: map-get($breakpoints, $breakpoint);
-    // Write the media query.
-    @media (max-width: ($breakpoint-value - 1)) {
-      @content;
-    }
-    // If the breakpoint doesn't exist in the map.
-  } @else {
-    // Log a warning.
-    @warn 'Invalid breakpoint: #{$breakpoint}.';
-  }
-}
 
 //
 //  RESPOND BETWEEN

--- a/src/scss/common/_mixins.scss
+++ b/src/scss/common/_mixins.scss
@@ -6,12 +6,6 @@
 // $display: when playing with pseudo element, you mainly use `display: block` (default value).
 @use "sass:math";
 
-@mixin pseudo-element($content: '', $position: absolute, $display: block) {
-  content: $content;
-  display: $display;
-  position: $position;
-}
-
 //
 //  MEDIA QUERIES
 //––––––––––––––––––––––––––––––––––––––––––––––––––
@@ -320,4 +314,10 @@ $breakpoints: (
   -webkit-line-clamp: $lines;
   line-clamp: 2;
   -webkit-box-orient: vertical;
+}
+
+@mixin pseudo-element($content: '', $position: absolute, $display: block) {
+  content: $content;
+  display: $display;
+  position: $position;
 }

--- a/src/scss/common/_mixins.scss
+++ b/src/scss/common/_mixins.scss
@@ -19,25 +19,6 @@ $breakpoints: (
   nav: 1256px
 ); 
 
-//
-//  RESPOND ABOVE
-//––––––––––––––––––––––––––––––––––––––––––––––––––
-// @include respond-above(sm) {}
-@mixin respond-above($breakpoint) {
-  // If the breakpoint exists in the map.
-  @if map-has-key($breakpoints, $breakpoint) {
-    // Get the breakpoint value.
-    $breakpoint-value: map-get($breakpoints, $breakpoint);
-    // Write the media query.
-    @media (min-width: $breakpoint-value) {
-      @content;
-    }
-    // If the breakpoint doesn't exist in the map.
-  } @else {
-    // Log a warning.
-    @warn 'Invalid breakpoint: #{$breakpoint}.';
-  }
-}
 
 //
 //  RESPOND BELOW

--- a/src/scss/common/_utils.scss
+++ b/src/scss/common/_utils.scss
@@ -130,25 +130,13 @@
   }
 }
 
-$viewport-sizes: (
-  25: 25%,
-  50: 50%,
-  75: 75%,
-  100: 100%,
-  auto: auto,
-);
+@each $name, $size in $element-sizes {
+  .w-#{$name} {
+    width: $size !important;
+  }
 
-// Size / viewports -- (correctly) uses Bootstrap's breakpoints, NOT the ones declared in this file
-@each $bp, $bp-width in map-remove($grid-breakpoints, xs) {
-  @media (min-width: $bp-width) {
-    @each $size, $size-value in $viewport-sizes {
-      .w-#{$bp}-#{$size} {
-        width: #{$size-value} !important;
-      }
-      .h-#{$bp}-#{$size} {
-        height: #{$size-value} !important;
-      }
-    }
+  .h-#{$name} {
+    height: $size !important;
   }
 }
 
@@ -159,5 +147,27 @@ $viewport-sizes: (
   }
   .hf-#{$size} {
     height: #{$size}rem !important;
+  }
+}
+
+$viewport-sizes: (
+  25: 25%,
+  50: 50%,
+  75: 75%,
+  100: 100%,
+  auto: auto,
+);
+
+// Size / viewports -- uses Bootstrap's breakpoints
+@each $bp, $bp-width in map-remove($grid-breakpoints, xs) {
+  @media (min-width: $bp-width) {
+    @each $size, $size-value in $viewport-sizes {
+      .w-#{$bp}-#{$size} {
+        width: #{$size-value} !important;
+      }
+      .h-#{$bp}-#{$size} {
+        height: #{$size-value} !important;
+      }
+    }
   }
 }

--- a/src/scss/common/_utils.scss
+++ b/src/scss/common/_utils.scss
@@ -49,6 +49,10 @@
   width: max-content !important;
 }
 
+.mw-auto {
+  min-width: auto !important;
+}
+
 .mw-max-content {
   min-width: max-content !important;
 }

--- a/src/scss/common/_utils.scss
+++ b/src/scss/common/_utils.scss
@@ -129,3 +129,35 @@
     z-index: calc(1000 + $i * 10) !important;
   }
 }
+
+$viewport-sizes: (
+  25: 25%,
+  50: 50%,
+  75: 75%,
+  100: 100%,
+  auto: auto,
+);
+
+// Size / viewports -- (correctly) uses Bootstrap's breakpoints, NOT the ones declared in this file
+@each $bp, $bp-width in map-remove($grid-breakpoints, xs) {
+  @media (min-width: $bp-width) {
+    @each $size, $size-value in $viewport-sizes {
+      .w-#{$bp}-#{$size} {
+        width: #{$size-value} !important;
+      }
+      .h-#{$bp}-#{$size} {
+        height: #{$size-value} !important;
+      }
+    }
+  }
+}
+
+// Fixed sizes
+@for $size from 1 through 20 {
+  .wf-#{$size} {
+    width: #{$size}rem !important;
+  }
+  .hf-#{$size} {
+    height: #{$size}rem !important;
+  }
+}

--- a/src/scss/common/accordions.scss
+++ b/src/scss/common/accordions.scss
@@ -36,7 +36,7 @@
 
   padding: 0 4px;
 
-  @include media-breakpoint-below(lg) {
+  @include media-breakpoint-down(lg) {
     padding-left: 0px;
     padding-right: 0px;
   }

--- a/src/scss/common/accordions.scss
+++ b/src/scss/common/accordions.scss
@@ -36,9 +36,9 @@
 
   padding: 0 4px;
 
-  @media (max-width: 991px) {
-      padding-left: 0px;
-      padding-right: 0px;
+  @include media-breakpoint-below(lg) {
+    padding-left: 0px;
+    padding-right: 0px;
   }
 }
 

--- a/src/scss/common/assignment-progress.scss
+++ b/src/scss/common/assignment-progress.scss
@@ -359,7 +359,7 @@ $failed-bg-size: 25%;
 .progress-header {
   text-align: center;
   padding: 0.5rem 0;
-  @include respond-above(sm) {
+  @include media-breakpoint-up(md) {
     font-size: 1.1rem;
   }
 }
@@ -368,7 +368,7 @@ $failed-bg-size: 25%;
   border-top: 1px solid $gray-118;
   display: flex;
   justify-content: space-between;
-  @include respond-above(sm) {
+  @include media-breakpoint-up(md) {
     font-size: 1.2rem;
   }
   align-items: center;
@@ -438,7 +438,7 @@ $failed-bg-size: 25%;
     }
   }
 
-  @include respond-above(sm) {
+  @include media-breakpoint-up(md) {
     font-size: 17px;
     tbody td, tbody th {
       min-width: 85px;
@@ -516,7 +516,7 @@ $failed-bg-size: 25%;
   }
 
   .sticky-ca-col {
-    @include respond-above(lg) {
+    @include media-breakpoint-up(xl) {
       position: sticky;
       z-index: 2;
       &:nth-child(2) {

--- a/src/scss/common/assignment-progress.scss
+++ b/src/scss/common/assignment-progress.scss
@@ -389,16 +389,6 @@ $failed-bg-size: 25%;
   }
 }
 
-@mixin after-border() {
-  content: '';
-  position: absolute;
-  margin: -0.5px -0.5px;
-  left: 0;
-  top: 0;
-  right: 0;
-  bottom: 0;
-}
-
 .single-download {
   position: relative;
   text-align: right;

--- a/src/scss/common/assignment-progress.scss
+++ b/src/scss/common/assignment-progress.scss
@@ -428,7 +428,7 @@ $failed-bg-size: 25%;
     right: 50px;
   }
 
-  @include respond-between(xs, sm) {
+  @include media-breakpoint-between(sm, md) {
     font-size: 14px;
     tbody td, tbody th {
       min-width: 65px;
@@ -507,9 +507,6 @@ $failed-bg-size: 25%;
   }
 
   .progress-table-header-footer .correct-attempted-header {
-    @include respond-between(sm, sm) {
-      font-size: 0.9rem;
-    }
     width: var(--correct-attempted-width);
     min-width: var(--correct-attempted-width);
     max-width: var(--correct-attempted-width);

--- a/src/scss/common/assignment-progress.scss
+++ b/src/scss/common/assignment-progress.scss
@@ -1,6 +1,6 @@
 @use "sass:math";
 
-@include respond-below(sm) {
+@include media-breakpoint-down(md) {
   .assignment-progress-gameboard {
     padding-left: 0 !important;
     padding-right: 0 !important;
@@ -456,7 +456,7 @@ $failed-bg-size: 25%;
     box-shadow: inset 0 1px 0 $gray-118;
   }
 
-  @include respond-below(xs) {
+  @include media-breakpoint-down(sm) {
     button.sort {
       display: none;
     }
@@ -487,7 +487,7 @@ $failed-bg-size: 25%;
     --correct-attempted-width: 7rem;
   }
 
-  @include respond-below(md) {
+  @include media-breakpoint-down(lg) {
     --student-name-width: 12rem;
 
     &:has(thead tr th.narrow-header) {
@@ -495,7 +495,7 @@ $failed-bg-size: 25%;
     }
   }
 
-  @include respond-below(sm) {
+  @include media-breakpoint-down(md) {
     --correct-attempted-width: 8rem;
     --student-name-width: 8rem;
   }

--- a/src/scss/common/boards.scss
+++ b/src/scss/common/boards.scss
@@ -6,7 +6,7 @@ tr.board-card {
 }
 .board-card {
   min-width: 30%;
-  @include media-breakpoint-below(md) {
+  @include media-breakpoint-down(md) {
     min-width: 50%;
   }
   margin-top: 25px;

--- a/src/scss/common/boards.scss
+++ b/src/scss/common/boards.scss
@@ -6,7 +6,7 @@ tr.board-card {
 }
 .board-card {
   min-width: 30%;
-  @media (max-width: map-get($breakpoints, sm)) {
+  @include media-breakpoint-below(md) {
     min-width: 50%;
   }
   margin-top: 25px;

--- a/src/scss/common/boards.scss
+++ b/src/scss/common/boards.scss
@@ -80,13 +80,6 @@ tr.board-card {
   }
 }
 
-.input-align {
-  @media only screen and (min-resolution: 192dpi) {
-    width: 100%;
-    align-self: center;
-  }
-}
-
 .table-button {
   background: none!important;
   border: none;
@@ -96,14 +89,6 @@ tr.board-card {
 
 .my-gameboard-table {
   min-width: 870px;
-}
-
-.input-options {
-  float: right;
-  @media only screen and (max-width:800px) {
-    float: unset !important;
-    flex-direction: column;
-  }
 }
 
 .table-share-link, .card-share-link {

--- a/src/scss/common/breadcrumbs.scss
+++ b/src/scss/common/breadcrumbs.scss
@@ -2,7 +2,7 @@
 .bread {
   background-color: $white;
   box-shadow: 0 2px 30px 0 $shadow-08;
-  @include respond-above(xs) {
+  @include media-breakpoint-up(sm) {
     background-color: transparent;
     box-shadow: none;
   }

--- a/src/scss/common/button.scss
+++ b/src/scss/common/button.scss
@@ -25,7 +25,7 @@
 }
 
 // When reactstrap hides the warning text
-@media (max-width:575px) {
+@include media-breakpoint-below(sm) {
     .manage-tests-btns {
         display: flex;
         flex-direction: column;

--- a/src/scss/common/button.scss
+++ b/src/scss/common/button.scss
@@ -25,7 +25,7 @@
 }
 
 // When reactstrap hides the warning text
-@include media-breakpoint-below(sm) {
+@include media-breakpoint-down(sm) {
     .manage-tests-btns {
         display: flex;
         flex-direction: column;

--- a/src/scss/common/cards.scss
+++ b/src/scss/common/cards.scss
@@ -7,7 +7,7 @@
   box-shadow: 0 2px 13px 0 $shadow-08;
   width: 100%;
 
-  @include respond-above(sm) {
+  @include media-breakpoint-up(md) {
     box-shadow: 0 2px 30px 0 $shadow-08;
   }
   .event-card-image img {

--- a/src/scss/common/elements.scss
+++ b/src/scss/common/elements.scss
@@ -77,7 +77,7 @@ button.btn.btn-link.login-b,
   text-transform: uppercase;
 
   &:hover {
-    @include respond-above(sm) {
+    @include media-breakpoint-up(md) {
       text-decoration: underline;
     }
   }
@@ -95,7 +95,7 @@ button.btn.btn-link.login-b,
 .signup {
   display: none;
 
-  @include respond-above(sm) {
+  @include media-breakpoint-up(md) {
     display: block;
   }
 
@@ -109,7 +109,7 @@ button.btn.btn-link.login-b,
     display: block;
 
     &:hover {
-      @include respond-above(sm) {
+      @include media-breakpoint-up(md) {
         text-decoration: underline;
       }
     }
@@ -126,7 +126,7 @@ button.btn.btn-link.login-b,
   text-transform: uppercase;
 
   &:hover {
-    @include respond-above(sm) {
+    @include media-breakpoint-up(md) {
       text-decoration: underline;
     }
   }
@@ -156,7 +156,7 @@ button.btn.btn-link.login-b,
   display: unset !important;
 
   &:hover {
-    @include respond-above(sm) {
+    @include media-breakpoint-up(md) {
       text-decoration: underline;
     }
   }
@@ -178,7 +178,7 @@ button.btn.btn-link.login-b,
 .logout {
   display: none;
 
-  @include respond-above(sm) {
+  @include media-breakpoint-up(md) {
     display: inline-block;
   }
 
@@ -190,7 +190,7 @@ button.btn.btn-link.login-b,
     display: unset !important;
 
     &:hover {
-      @include respond-above(sm) {
+      @include media-breakpoint-up(md) {
         text-decoration: underline;
       }
     }
@@ -240,7 +240,7 @@ iframe.email-html {
 //      height: 24px;
 //      width: 24px;
 //
-//      @include respond-above(sm) {
+//      @include media-breakpoint-up(md) {
 //        display: none;
 //      }
 //    }
@@ -257,7 +257,7 @@ iframe.email-html {
 //      width: 1px;
 //
 //
-//      @include respond-above(sm) {
+//      @include media-breakpoint-up(md) {
 //        clip: initial;
 //        height: initial;
 //        position: relative;

--- a/src/scss/common/elements.scss
+++ b/src/scss/common/elements.scss
@@ -198,7 +198,7 @@ button.btn.btn-link.login-b,
 }
 
 .not-mobile {
-  @include respond-below(sm) {
+  @include media-breakpoint-down(md) {
     display: none !important;
   }
 }

--- a/src/scss/common/elements.scss
+++ b/src/scss/common/elements.scss
@@ -211,16 +211,6 @@ button.btn.btn-link.login-b,
   cursor: grab;
 }
 
-@each $name, $size in $element-sizes {
-  .w-#{$name} {
-    width: $size !important;
-  }
-
-  .h-#{$name} {
-    height: $size !important;
-  }
-}
-
 .overflow-visible {
   overflow: visible !important;
 }

--- a/src/scss/common/finder.scss
+++ b/src/scss/common/finder.scss
@@ -40,13 +40,13 @@
   }
 
   .finder-filters {
-    @include respond-above(sm) {
+    @include media-breakpoint-up(md) {
       justify-content: flex-end;
     }
   }
 
   .finder-filters label {
-    @include respond-above(xs) {
+    @include media-breakpoint-up(sm) {
       margin-left: 0.5rem;
     }
     @include respond-below(xs) {

--- a/src/scss/common/finder.scss
+++ b/src/scss/common/finder.scss
@@ -49,7 +49,7 @@
     @include media-breakpoint-up(sm) {
       margin-left: 0.5rem;
     }
-    @include respond-below(xs) {
+    @include media-breakpoint-down(sm) {
       margin-right: 0.5rem;
     }
   }

--- a/src/scss/common/footer.scss
+++ b/src/scss/common/footer.scss
@@ -48,7 +48,7 @@
   }
 
   .logo-col {
-    @include respond-below(sm) {
+    @include media-breakpoint-down(md) {
       padding: 1rem;
     }
     a {

--- a/src/scss/common/footer.scss
+++ b/src/scss/common/footer.scss
@@ -14,12 +14,12 @@
       font-size: 13px;
       color: #000000;
     }
-    @include respond-above(md) {
+    @include media-breakpoint-up(lg) {
       width: 40%;
     }
   }
   .footer-bottom-logos {
-    @include respond-above(md) {
+    @include media-breakpoint-up(lg) {
       width: 40%;
       margin-left: 17%;
     }
@@ -66,7 +66,7 @@
     background-repeat: no-repeat;
     height: 100%;
 
-    @include respond-above(md) {
+    @include media-breakpoint-up(lg) {
       background-position: left 100% bottom 15%;
     }
   }
@@ -88,12 +88,12 @@
       font-size: 13px;
       color: #000000;
     }
-    @include respond-above(md) {
+    @include media-breakpoint-up(lg) {
       width: 40%;
     }
   }
   .footer-bottom-logos {
-    @include respond-above(md) {
+    @include media-breakpoint-up(lg) {
       width: 40%;
       margin-left: 17%;
     }

--- a/src/scss/common/forms.scss
+++ b/src/scss/common/forms.scss
@@ -246,7 +246,7 @@ input[type=date]::-webkit-outer-spin-button {
   margin-top: 0;
 }
 
-@media (min-width: 576px) {
+@include media-breakpoint-above(sm) {
   .form-inline label {
     display: flex;
     align-items: center;

--- a/src/scss/common/forms.scss
+++ b/src/scss/common/forms.scss
@@ -246,7 +246,7 @@ input[type=date]::-webkit-outer-spin-button {
   margin-top: 0;
 }
 
-@include media-breakpoint-above(sm) {
+@include media-breakpoint-up(sm) {
   .form-inline label {
     display: flex;
     align-items: center;

--- a/src/scss/common/forms.scss
+++ b/src/scss/common/forms.scss
@@ -97,7 +97,7 @@ textarea {
   height: 2.6rem;
   padding: initial 40px initial 1rem;
 
-  @include respond-above(sm) {
+  @include media-breakpoint-up(md) {
     max-width: 220px;
   }
 

--- a/src/scss/common/gameboard.scss
+++ b/src/scss/common/gameboard.scss
@@ -1,12 +1,3 @@
-@mixin after-border() {
-  content:'';
-  position:absolute;
-  left: 0px;
-  top: 0px;
-  right: 0px;
-  bottom: 0px;
-}
-
 .list-gameboard {
   .gameboard-item-icon {
     max-width: 2rem;

--- a/src/scss/common/glossary.scss
+++ b/src/scss/common/glossary.scss
@@ -44,7 +44,7 @@
         }
       }
 
-      @include respond-below(sm) {
+      @include media-breakpoint-down(md) {
         display: none;
       }
     }
@@ -55,7 +55,7 @@
     flex-direction: row;
     justify-content: space-evenly;
 
-    @include respond-below(sm) {
+    @include media-breakpoint-down(md) {
       flex-direction: column;
       position: fixed;
       right: 0vw;

--- a/src/scss/common/graph-sketcher-modal.scss
+++ b/src/scss/common/graph-sketcher-modal.scss
@@ -405,81 +405,83 @@
             }
         }
 
-        @media screen and (orientation:landscape) and (max-height: 575px) {
-            $button-size: 61px;
-            $button-spacing: 8px;
+        @media (orientation:landscape) {
+            @include media-breakpoint-down(sm) {
+                $button-size: 61px;
+                $button-spacing: 8px;
 
-            #graph-sketcher-ui-debug-window {
-                display: none;
-                top: 2 * $button-spacing;
-                left: 3 * $button-spacing + $button-size;
-            }
-
-            .button {
-                width: $button-size;
-                height: $button-size;
-
-                &#graph-sketcher-ui-trash-button {
+                #graph-sketcher-ui-debug-window {
+                    display: none;
                     top: 2 * $button-spacing;
-                    right: 2 * $button-spacing;
-                }
-
-                &#graph-sketcher-ui-reset-button {
-                    top: 3 * $button-spacing + $button-size;
-                    right: 2 * $button-spacing;
-                }
-
-                &#graph-sketcher-ui-question-button {
-                    bottom: 3 * $button-spacing + $button-size;
-                    left: 2 * $button-spacing;
-                }
-
-                &#graph-sketcher-ui-undo-button {
-                    bottom: 2 * $button-spacing;
-                    left: 2 * $button-spacing;
-                }
-
-                &#graph-sketcher-ui-redo-button {
-                    bottom: 2 * $button-spacing;
                     left: 3 * $button-spacing + $button-size;
                 }
 
-                &#graph-sketcher-ui-submit-button {
-                    bottom: 2 * $button-spacing;
-                    right: 2 * $button-spacing;
-                }
-
-                &#graph-sketcher-ui-help-button {
-                    bottom: 3 * $button-spacing + $button-size;
-                    right: 2 * $button-spacing;
-                }
-
-                &#graph-sketcher-ui-debug-button {
-                    display: none;
-                    top: unset;
-                    bottom: 3 * $button-spacing + $button-size;
-                    left: 2 * $button-spacing;
-                }
-
-                &#graph-sketcher-ui-bezier-button {
-                    top: 3 * $button-spacing + $button-size;
-                    left: 2 * $button-spacing;
-                }
-
-                &#graph-sketcher-ui-linear-button {
-                    top: 2 * $button-spacing;
-                    left: 2 * $button-spacing;
-                }
-            }
-
-            div#graph-sketcher-ui-color-select-hexagons {
-                top: 2 * $button-spacing;
-                left: 3 * $button-spacing + $button-size;
-                width: $button-size;
-                height: $button-size;
-                svg {
+                .button {
                     width: $button-size;
-                    height: $button-size;                        
+                    height: $button-size;
+
+                    &#graph-sketcher-ui-trash-button {
+                        top: 2 * $button-spacing;
+                        right: 2 * $button-spacing;
+                    }
+
+                    &#graph-sketcher-ui-reset-button {
+                        top: 3 * $button-spacing + $button-size;
+                        right: 2 * $button-spacing;
+                    }
+
+                    &#graph-sketcher-ui-question-button {
+                        bottom: 3 * $button-spacing + $button-size;
+                        left: 2 * $button-spacing;
+                    }
+
+                    &#graph-sketcher-ui-undo-button {
+                        bottom: 2 * $button-spacing;
+                        left: 2 * $button-spacing;
+                    }
+
+                    &#graph-sketcher-ui-redo-button {
+                        bottom: 2 * $button-spacing;
+                        left: 3 * $button-spacing + $button-size;
+                    }
+
+                    &#graph-sketcher-ui-submit-button {
+                        bottom: 2 * $button-spacing;
+                        right: 2 * $button-spacing;
+                    }
+
+                    &#graph-sketcher-ui-help-button {
+                        bottom: 3 * $button-spacing + $button-size;
+                        right: 2 * $button-spacing;
+                    }
+
+                    &#graph-sketcher-ui-debug-button {
+                        display: none;
+                        top: unset;
+                        bottom: 3 * $button-spacing + $button-size;
+                        left: 2 * $button-spacing;
+                    }
+
+                    &#graph-sketcher-ui-bezier-button {
+                        top: 3 * $button-spacing + $button-size;
+                        left: 2 * $button-spacing;
+                    }
+
+                    &#graph-sketcher-ui-linear-button {
+                        top: 2 * $button-spacing;
+                        left: 2 * $button-spacing;
+                    }
+                }
+
+                div#graph-sketcher-ui-color-select-hexagons {
+                    top: 2 * $button-spacing;
+                    left: 3 * $button-spacing + $button-size;
+                    width: $button-size;
+                    height: $button-size;
+                    svg {
+                        width: $button-size;
+                        height: $button-size;                        
+                    }
                 }
             }
         }

--- a/src/scss/common/graph-sketcher-modal.scss
+++ b/src/scss/common/graph-sketcher-modal.scss
@@ -249,7 +249,7 @@
         }
 
         @media (orientation:portrait) {
-            @include respond-below(xs) {
+            @include media-breakpoint-down(sm) {
                 $button-size: 61px;
                 $button-spacing: 8px;
 

--- a/src/scss/common/graph-sketcher-modal.scss
+++ b/src/scss/common/graph-sketcher-modal.scss
@@ -176,7 +176,7 @@
             }
         }
 
-        @include respond-above(lg) {
+        @include media-breakpoint-up(xl) {
             $button-size: 90px;
             $button-spacing: 10px;
 
@@ -328,7 +328,7 @@
             }
         }
 
-        @include respond-above(xs) {
+        @include media-breakpoint-up(sm) {
             $button-size: 90px;
             $button-spacing: 10px;
 

--- a/src/scss/common/header.scss
+++ b/src/scss/common/header.scss
@@ -26,7 +26,7 @@
     top: 20px;
     right: 20px;
   }
-  @include respond-above(sm) {
+  @include media-breakpoint-up(md) {
     top: 98px;
     right: 98px;
   }

--- a/src/scss/common/header.scss
+++ b/src/scss/common/header.scss
@@ -10,10 +10,10 @@
   border-bottom: solid 1px rgba($gray-blue, 0.6);
 }
 .banner-button {
-  @include respond-below(sm) {
+  @include media-breakpoint-down(md) {
     width: 100%;
   }
-  @include respond-below(lg) {
+  @include media-breakpoint-down(xl) {
     min-width: 150px;
   }
   //border-color: $purple !important;
@@ -22,7 +22,7 @@
 
 .toasts-container {
   position: fixed;
-  @include respond-below(sm) {
+  @include media-breakpoint-down(md) {
     top: 20px;
     right: 20px;
   }

--- a/src/scss/common/inequality-modal.scss
+++ b/src/scss/common/inequality-modal.scss
@@ -41,13 +41,13 @@
     }
 }
 
-@media screen and (orientation: portrait) {
+@media (orientation: portrait) {
     .question-reminder {
         display: none;
     }
 }
 
-@media screen and (max-width: 1023px) {
+@include media-breakpoint-down(lg) {
     .question-reminder {
         left: 100px;
         right: 100px;
@@ -74,7 +74,7 @@
         z-index: 255 !important;
     }
 
-    @media screen and (orientation: landscape) {
+    @media (orientation: landscape) {
         .orientation-warning {
             display: none;
         }

--- a/src/scss/common/login.scss
+++ b/src/scss/common/login.scss
@@ -11,16 +11,13 @@
     background: transparent;
   }
   #login-modal-form {
-    max-height: 800px;
-    @media (min-height: 800px) {
-      max-height: 90vh;
-    }
     padding: 100px 30px 30px;
+
     @include media-breakpoint-down(lg) {
-      max-height: unset;
       padding-top: 20px;
       padding-bottom: 30px;
     }
+    
     .password-reset-col {
       max-width: 8em;
     }

--- a/src/scss/common/media.scss
+++ b/src/scss/common/media.scss
@@ -20,7 +20,7 @@ figure {
   font-weight: bold;
 }
 
-@include respond-above(md) {
+@include media-breakpoint-up(lg) {
   .align-start {
     float: left;
     width: 300px;
@@ -42,7 +42,7 @@ figure {
 
 .text-center-column {
   text-align: left;
-  @include respond-above(sm) {
+  @include media-breakpoint-up(md) {
     padding-left: 20%;
     padding-right: 20%;
   }

--- a/src/scss/common/modals.scss
+++ b/src/scss/common/modals.scss
@@ -34,7 +34,7 @@
   }
 
   .modal-footer {
-    @include respond-below(sm) {
+    @include media-breakpoint-down(md) {
       button, a {
         font-family: $secondary-font;
         margin: 0 0.25rem 1rem;

--- a/src/scss/common/my-account.scss
+++ b/src/scss/common/my-account.scss
@@ -43,7 +43,7 @@
 
 .account-dropdown {
   flex: 1 1 0px;
-  @include respond-above(xs) {
+  @include media-breakpoint-up(sm) {
     min-width: 140px;
   }
 }
@@ -73,7 +73,7 @@
     border-bottom-left-radius: $border-radius;
     border-bottom-right-radius: $border-radius;
 
-    @include respond-above(sm) {
+    @include media-breakpoint-up(md) {
       background-color: $white;
       box-shadow: 0 20px 30px 0 $shadow-08;
       top: 5rem;

--- a/src/scss/common/questions.scss
+++ b/src/scss/common/questions.scss
@@ -746,7 +746,7 @@ p > .katex, .katex-display {
       color: inherit;
       min-width: 176px;
       flex-basis: 100%;
-      @media (max-width: 768px) {
+      @include media-breakpoint-up(md) {
         min-width: 0;
       }
       &:hover {

--- a/src/scss/common/search.scss
+++ b/src/scss/common/search.scss
@@ -9,13 +9,13 @@
   }
 
   .search-filters {
-    @include respond-above(sm) {
+    @include media-breakpoint-up(md) {
       justify-content: flex-end;
     }
   }
 
   .search-filters label {
-    @include respond-above(xs) {
+    @include media-breakpoint-up(sm) {
       margin-left: 0.5rem;
     }
     @include respond-below(xs) {
@@ -33,7 +33,7 @@ nav.search {
   top: 0;
   width: 100%;
 
-  @include respond-above(sm) {
+  @include media-breakpoint-up(md) {
     align-items: center;
     height: 100%;
   }
@@ -52,7 +52,7 @@ nav.search {
       right: 19%;
       top: 19px;
     }
-    @include respond-above(xs) {
+    @include media-breakpoint-up(sm) {
       right: 90px;
       top: 19px;
     }
@@ -61,7 +61,7 @@ nav.search {
   .search--main-group {
     width: 100%;
 
-    @include respond-above(sm) {
+    @include media-breakpoint-up(md) {
       margin: auto;
     }
   }
@@ -69,7 +69,7 @@ nav.search {
   .navbar-nav {
     padding-top: 0.5rem;
 
-    @include respond-above(sm) {
+    @include media-breakpoint-up(md) {
       padding-top: 0;
     }
 
@@ -77,7 +77,7 @@ nav.search {
       border-top: 1px solid $white;
       padding-top: 0.6rem;
 
-      @include respond-above(sm) {
+      @include media-breakpoint-up(md) {
         border-width: 0;
         padding: 0;
       }

--- a/src/scss/common/search.scss
+++ b/src/scss/common/search.scss
@@ -18,7 +18,7 @@
     @include media-breakpoint-up(sm) {
       margin-left: 0.5rem;
     }
-    @include respond-below(xs) {
+    @include media-breakpoint-down(sm) {
       margin-right: 0.5rem;
     }
   }
@@ -48,7 +48,7 @@ nav.search {
     border-width: 0;
     position: absolute;
 
-    @include respond-below(xs) {
+    @include media-breakpoint-down(sm) {
       right: 19%;
       top: 19px;
     }

--- a/src/scss/common/tabs.scss
+++ b/src/scss/common/tabs.scss
@@ -59,7 +59,7 @@
       font-size: 1rem;
       cursor: pointer;
       text-decoration: underline;
-      @include respond-above(sm) {
+      @include media-breakpoint-up(md) {
         font-size: 1.25rem;
       }
     }
@@ -81,7 +81,7 @@
   .feattab-image & {
     border-width: 0;
 
-    @include respond-above(sm) {
+    @include media-breakpoint-up(md) {
       margin-top: 6rem;
     }
     .btn-link {
@@ -93,7 +93,7 @@
 .feattab-image {
   padding: 7rem 0;
   position: relative;
-  @include respond-above(sm) {
+  @include media-breakpoint-up(md) {
     padding: 0;
   }
 
@@ -110,7 +110,7 @@
   .question-hints {
     position: absolute;
     top: 0;
-    @include respond-above(sm) {
+    @include media-breakpoint-up(md) {
       position: relative;
     }
   }

--- a/src/scss/common/tabs.scss
+++ b/src/scss/common/tabs.scss
@@ -98,7 +98,7 @@
   }
 
   img {
-    @include respond-below(sm) {
+    @include media-breakpoint-down(md) {
       position: absolute;
       bottom: -84px;
       left: 0;

--- a/src/scss/common/topic.scss
+++ b/src/scss/common/topic.scss
@@ -44,7 +44,7 @@
         color: white;
       }
 
-      @include respond-below(xs) {
+      @include media-breakpoint-down(sm) {
         min-width: 105px;
         max-width: 105px;
       }

--- a/src/scss/cs/assignment-progress.scss
+++ b/src/scss/cs/assignment-progress.scss
@@ -53,7 +53,7 @@
 }
 
 .progress-table {
-  @include respond-above(sm) {
+  @include media-breakpoint-up(md) {
     tbody td, tbody th {
       min-width: 77px; // fits 10 questions on screen at once
     }

--- a/src/scss/cs/breadcrumbs.scss
+++ b/src/scss/cs/breadcrumbs.scss
@@ -6,13 +6,13 @@
   margin-left: -1 * math.div($grid-gutter-width, 2);
   margin-right: -1 * math.div($grid-gutter-width, 2);
   position: relative;
-  @include respond-above(sm) {
+  @include media-breakpoint-up(md) {
     margin: 0;
   }
 
   .breadcrumb {
     padding: 0.75rem 0 0.75rem 1rem;
-    @include respond-above(sm) {
+    @include media-breakpoint-up(md) {
       padding-left: 0;
     }
   }

--- a/src/scss/cs/finder.scss
+++ b/src/scss/cs/finder.scss
@@ -1,6 +1,6 @@
 @import "../common/finder";
 
-@media (min-width: 992px) {
+@include media-breakpoint-up(lg) {
   .finder-panel::before {
     position: absolute;
     content: "";

--- a/src/scss/cs/logo.scss
+++ b/src/scss/cs/logo.scss
@@ -2,14 +2,14 @@
 .header-logo {
   float: left;
 
-  @include respond-above(lg) {
+  @include media-breakpoint-up(nav) {
     float: none;
   }
 
   img {
     width: auto;
     height: 3rem;
-    @include respond-above(lg) {
+    @include media-breakpoint-up(nav) {
       height: 4rem;
       float: none;
     }

--- a/src/scss/cs/logo.scss
+++ b/src/scss/cs/logo.scss
@@ -2,14 +2,14 @@
 .header-logo {
   float: left;
 
-  @include respond-above(nav) {
+  @include respond-above(lg) {
     float: none;
   }
 
   img {
     width: auto;
     height: 3rem;
-    @include respond-above(nav) {
+    @include respond-above(lg) {
       height: 4rem;
       float: none;
     }

--- a/src/scss/phy/assignment-progress.scss
+++ b/src/scss/phy/assignment-progress.scss
@@ -81,7 +81,7 @@
       box-shadow: inset 0 -1px var(--table-selected-border);
     }
     thead th.correct-attempted-header {
-      @include respond-above(lg) {
+      @include media-breakpoint-up(xl) {
         box-shadow: inset 0 -1px var(--table-selected-border);
       }
     }

--- a/src/scss/phy/button.scss
+++ b/src/scss/phy/button.scss
@@ -279,7 +279,7 @@
     width: 100%;
     white-space: nowrap;
 
-    @include respond-above(md) {
+    @include media-breakpoint-up(lg) {
       padding-right: 5rem;
       padding-left: 5rem;
       width: auto;

--- a/src/scss/phy/forms.scss
+++ b/src/scss/phy/forms.scss
@@ -34,7 +34,7 @@
 .search--main-group {
   &.form-group {
     &:has(#header-search) {
-      @media (min-width: 768px) and (max-width: 1199px) {
+      @include media-breakpoint-between(md, xl) {
         width: 130px;
       }
     }

--- a/src/scss/phy/header.scss
+++ b/src/scss/phy/header.scss
@@ -47,7 +47,7 @@ header {
   }
 
   > .container {
-    @include respond-below(sm) {
+    @include media-breakpoint-down(md) {
       max-width: 100% !important;
     }
   }

--- a/src/scss/phy/hints.scss
+++ b/src/scss/phy/hints.scss
@@ -22,6 +22,6 @@
 .isaac-accordion .tabbed-hints {
   margin-bottom: 0;
   margin-top: 1rem;
-  @include respond-above(sm) {margin-top: 1.25rem;}
-  @include respond-above(md) {margin-top: 1.5rem;}
+  @include media-breakpoint-up(md) {margin-top: 1.25rem;}
+  @include media-breakpoint-up(lg) {margin-top: 1.5rem;}
 }

--- a/src/scss/phy/hints.scss
+++ b/src/scss/phy/hints.scss
@@ -2,8 +2,8 @@
   margin-top: 1rem;
   margin-bottom: 2rem;
   ul li {
-    @include respond-below(lg) {padding-left: 0.5rem !important; padding-right: 0.5rem !important;}
-    @include respond-below(xs) {padding-left: 0 !important; padding-right: 0 !important;}
+    @include media-breakpoint-down(xl) {padding-left: 0.5rem !important; padding-right: 0.5rem !important;}
+    @include media-breakpoint-down(sm) {padding-left: 0 !important; padding-right: 0 !important;}
   }
 
   li {

--- a/src/scss/phy/homepage.scss
+++ b/src/scss/phy/homepage.scss
@@ -265,7 +265,7 @@ a:has(.assignment-card) {
   }
 }
 
-@media (min-width: 992px) and (max-width: 1199px) {
+@include media-breakpoint-between(lg, xl) {
   .row-cols-lg-8 > *{
     flex: 0 0 auto;
     width: 12.5%;

--- a/src/scss/phy/logo.scss
+++ b/src/scss/phy/logo.scss
@@ -2,7 +2,7 @@
 .header-logo {
   float: left;
 
-  @include respond-above(xs) {
+  @include media-breakpoint-up(sm) {
     float: none;
   }
 
@@ -14,7 +14,7 @@
       width: 9rem;
     }
 
-    @include respond-above(lg) {
+    @include media-breakpoint-up(xl) {
       width: 12rem;
     }
 

--- a/src/scss/phy/logo.scss
+++ b/src/scss/phy/logo.scss
@@ -10,7 +10,7 @@
     width: 45px;
     vertical-align: top;
 
-    @include respond-between(xs, lg) {
+    @include media-breakpoint-between(sm, xl) {
       width: 9rem;
     }
 

--- a/src/scss/phy/menu-page-phy.scss
+++ b/src/scss/phy/menu-page-phy.scss
@@ -194,13 +194,13 @@
 }
 
 .hexagon-offset {
-  @include respond-above(lg) {
+  @include media-breakpoint-up(xl) {
     margin-left: -250px;
   }
 }
 
 .hexagon-offset-large {
-  @include respond-above(lg) {
+  @include media-breakpoint-up(xl) {
     margin-top: -55px;
   }
 }

--- a/src/scss/phy/questions.scss
+++ b/src/scss/phy/questions.scss
@@ -11,7 +11,7 @@
   font-weight: 400;
 }
 
-@include respond-above(xs) {
+@include media-breakpoint-up(sm) {
   :not(.generic-panel):not(.concept-panel):not(.question-panel) > .content-chunk > .figure-panel {
     // if a figure is in the top level of a content block that is not the top level of a page (i.e. preamble), indent it. otherwise (i.e. when inside a layout component), leave it for that component to handle
     // TODO: move the padding from this to the layout component (usually accordions!)
@@ -32,7 +32,7 @@
 
     // content directly inside an accordion on a question page is indented to match that inside a question-component
     > .content-chunk > .content-value {
-      @include respond-above(xs) {
+      @include media-breakpoint-up(sm) {
         padding-left: 1.625rem;
         padding-right: 1.625rem;
       }
@@ -52,7 +52,7 @@
       @include respond-below(md) {
         padding: 0.5rem 1.5rem;
       }
-      @include respond-above(md) {
+      @include media-breakpoint-up(lg) {
         padding: 0.5rem 2rem;
       }
     }

--- a/src/scss/phy/questions.scss
+++ b/src/scss/phy/questions.scss
@@ -49,7 +49,7 @@
     padding-top: 1rem;
 
     > div:not(.quick-question):first-child {
-      @include respond-below(md) {
+      @include media-breakpoint-down(lg) {
         padding: 0.5rem 1.5rem;
       }
       @include media-breakpoint-up(lg) {

--- a/src/scss/phy/typography.scss
+++ b/src/scss/phy/typography.scss
@@ -85,10 +85,10 @@ ul {
 @mixin dynamic-font-size($mobile, $tablet, $desktop) {
   font-size: $mobile;
   line-height: 1.14;
-  @include respond-above(sm) {
+  @include media-breakpoint-up(md) {
     font-size: $tablet;
   }
-  @include respond-above(md) {
+  @include media-breakpoint-up(lg) {
     font-size: $desktop;
   }
 }
@@ -149,7 +149,7 @@ h5 {
   padding-top: 62px;
   position: relative;
   margin-left: 0;
-  @include respond-above(md) {
+  @include media-breakpoint-up(lg) {
     padding-top: 0;
     padding-left: 62px;
     margin-left: -62px;
@@ -170,7 +170,7 @@ h5 {
     text-align: center;
     width: 42px;
 
-    @include respond-above(sm) {
+    @include media-breakpoint-up(md) {
       top: 5px;
     }
   }
@@ -206,7 +206,7 @@ h5 {
     right: 0;
     width: 32%;
 
-    @include respond-above(sm) {
+    @include media-breakpoint-up(md) {
       max-width: 380px;
     }
   }
@@ -245,7 +245,7 @@ a {
   &.x-lrg-text {
     font-size: 1.25rem;
 
-    @include respond-above(sm) {
+    @include media-breakpoint-up(md) {
       font-size: 1.625rem;
     }
   }


### PR DESCRIPTION
We had three different ways of conditionally applying styling rules according to breakpoint values in the codebase:
- `@media (min-width: $VALUE)`
- `@include respond-above($bp)`
- `@include media-breakpoint-up($bp)`
(and equivalents for below and between)

Firstly, the `@media (min-width: $VALUE)` version does not adapt at all to our adjusted breakpoints for sidebar width on Ada, so are causing odd behaviour on pages such as the question finder. Similarly, `respond-above` COULD adapt to our adjusted breakpoints except it uses a separate list of values from the `$grid-breakpoints` list in `isaac.scss` which hasn't been adjusted, so may also cause problems.

Secondly, this inconsistency just makes it slightly harder to maneuver the codebase (e.g. searching for what styles change when switching from a sm to a md breakpoint, maintaining files with multiple different types of rules).

Thus, this PR replaces all instances of `@media (min-width: $VALUE)` and `@include respond-above($bp)` with the bootstrap-provided `@include media-breakpoint-up($bp)` (and equivalents).

> _The only complicated cases were:_
> - _The login/sign up modal - for which a min-height rule was used, but is no longer having an effect so could just be removed_
> - _The equality/graph sketcher modals - for which a non-breakpoint width was used for the question reminder box and has been replaced with the closest breakpoint, and some unnecessary `@media screen` rules were removed_

---

While removing the `media-breakpoint-*` rules from _mixins, some more light cleaning was done by finding and removing other unused mixins - specifically `ie()`, `out($colour, $width)`, `table-sticky()`, and `after-border()`.
I also moved the non-mixins calculated classes of `w(-{$bp})-{$size}` and `h(-{$bp})-{$size}` to a unified spot in `_utils`, where I think they are more suitably placed.