### PR TITLE
Improve consistency of button styling

### DIFF
--- a/src/app/components/content/IsaacQuestion.tsx
+++ b/src/app/components/content/IsaacQuestion.tsx
@@ -56,11 +56,11 @@ const FastTrackSubmissionButtons = ({fastTrackPrimaryAction, fastTrackSecondaryA
     return <>
         {fastTrackSecondaryAction && <div
             className={classNames("m-auto pb-1 w-100 w-sm-100 w-md-50 w-lg-50", {"pe-sm-2 pe-lg-3 pb-3": fastTrackPrimaryAction})}>
-            <input {...fastTrackSecondaryAction} className="h-100 btn btn-outline-primary w-100"/>
+            <input {...fastTrackSecondaryAction} className="h-100 btn btn-keyline w-100"/>
         </div>}
         {fastTrackPrimaryAction && <div
             className={classNames("m-auto w-100 w-sm-100 w-md-50 w-lg-50", siteSpecific("pb-3", "pb-1"), {"ps-sm-2 ps-lg-3": fastTrackSecondaryAction})}>
-            <input {...fastTrackPrimaryAction} className="h-100 btn btn-secondary w-100"/>
+            <input {...fastTrackPrimaryAction} className="h-100 btn btn-solid w-100"/>
         </div>}
     </>;
 };

--- a/src/app/components/content/IsaacQuickQuestion.tsx
+++ b/src/app/components/content/IsaacQuickQuestion.tsx
@@ -37,10 +37,10 @@ function FastTrackOptions({isVisible, toggle, doc, fastTrackInfo}: OptionsProps)
         className={"d-flex align-items-stretch flex-column-reverse flex-sm-row flex-md-column-reverse flex-lg-row"}>
         {secondaryAction &&
         <div className={"m-auto pt-3 pb-1 w-100 w-sm-50 w-md-100 w-lg-50 pe-sm-2 pe-md-0 pe-lg-3"}>
-            <input {...secondaryAction} className="h-100 btn btn-outline-primary w-100"/>
+            <input {...secondaryAction} className="h-100 btn btn-keyline w-100"/>
         </div>}
         <div className={"m-auto pt-3 pb-1 w-100 w-sm-50 w-md-100 w-lg-50 ps-sm-2 ps-md-0 ps-lg-3"}>
-            <Button color="secondary" block className={classNames({"active": isVisible})} onClick={toggle} id={`toggle-${elemID(doc)}`}>
+            <Button color="solid" block className={classNames({"active": isVisible})} onClick={toggle} id={`toggle-${elemID(doc)}`}>
                 {isVisible ? "Hide answer" : "Show answer"}
             </Button>
         </div>

--- a/src/app/components/elements/inputs/ConfidenceQuestions.tsx
+++ b/src/app/components/elements/inputs/ConfidenceQuestions.tsx
@@ -159,7 +159,7 @@ export const ConfidenceQuestions = ({state, setState, validationPending, setVali
         {state === "initial" && <div className={"d-flex"}>
             <h4 className={classNames({"text-muted": disabled && isAda})}>{confidenceVariables?.title}</h4>
             <div className="ms-2 mt-n1 not-mobile">
-                <Button outline={isPhy} color="solid" className={"confidence-help"} size="sm"
+                <Button color="solid" className={"confidence-help"} size="sm"
                     onClick={() => dispatch(confidenceInformationModal())}
                 >
                     {

--- a/src/app/components/elements/modals/GroupsModalCreators.tsx
+++ b/src/app/components/elements/modals/GroupsModalCreators.tsx
@@ -103,7 +103,7 @@ const CurrentGroupInviteModal = ({firstTime, group}: CurrentGroupInviteModalProp
                     <p>Students can scan a QR code on their device to join your group:</p>
                     {showQR
                         ? <GroupQRPanel link={`${location.origin}/account?authToken=${token?.token}`} groupName={group.groupName} />
-                        : <Button color={siteSpecific("primary", "keyline")} onClick={() => {
+                        : <Button color={"keyline"} onClick={() => {
                             startTransition(() => {
                                 setShowQR(true);
                             });
@@ -130,7 +130,7 @@ const GroupInvitationModalButtons = ({firstTime, group, user}: {firstTime: boole
 
     return <Row key={0} className="w-100">
         <Col className="pb-0 pb-md-2 pb-lg-0" xs={siteSpecific(undefined, 12)} lg={siteSpecific(undefined, "auto")}>
-            <Button block color="primary" className={siteSpecific("btn-keyline", "text-nowrap mb-3")} onClick={() => {
+            <Button block color="solid" className={siteSpecific("", "mb-3")} onClick={() => {
                 store.dispatch(closeActiveModal());
                 void navigate(PATHS.SET_ASSIGNMENTS);
             }}>
@@ -139,7 +139,7 @@ const GroupInvitationModalButtons = ({firstTime, group, user}: {firstTime: boole
         </Col>
         {/* Only teachers are allowed to add additional managers to a group. */}
         {firstTime && isTeacherOrAbove(user) && <Col className="pb-0 pb-md-2 pb-lg-0" xs={siteSpecific(undefined, 12)} lg={siteSpecific(undefined, "auto")}>
-            <Button outline block color="secondary" className={siteSpecific("btn-keyline", "text-nowrap mb-3")} onClick={() => {
+            <Button block color="keyline" className={siteSpecific("", "mb-3")} onClick={() => {
                 void store.dispatch(closeActiveModal());
                 void store.dispatch(showGroupManagersModal({group, user}));
             }}>
@@ -288,11 +288,11 @@ Are you sure you want to promote this manager to group owner?\n
                     )}
                     <span>{manager.givenName} {manager.familyName} {user.id === manager.id && <span className={"text-muted"}>(you)</span>} ({manager.email})</span>
                     <Spacer />
-                    {userIsOwner && <Button className="d-none d-lg-inline" size="sm" color={siteSpecific("tertiary", "keyline")} onClick={() => promoteManager(manager)}>
+                    {userIsOwner && <Button className="d-none d-lg-inline" size="sm" color={"keyline"} onClick={() => promoteManager(manager)}>
                         Make owner
                     </Button>}
                     {(userIsOwner || user?.id === manager.id || group.additionalManagerPrivileges) && !(userIsOwner && below["md"](deviceSize)) &&
-                        <Button className="d-inline ms-2" size="sm" color={siteSpecific("tertiary", "secondary")}
+                        <Button className="d-inline ms-2" size="sm" color={"solid"}
                             onClick={() => user?.id === manager.id ? removeSelf(manager) : removeManager(manager)}
                         >
                             Remove

--- a/src/app/components/elements/panels/ManageExistingBookings.tsx
+++ b/src/app/components/elements/panels/ManageExistingBookings.tsx
@@ -228,7 +228,7 @@ export const ManageExistingBookings = ({user, eventId, eventBookings, userIdToSc
 
             <div className="mt-3 text-end">
                 <ButtonDropdown isOpen={dropdownOpen} toggle={toggle}>
-                    <DropdownToggle caret color="primary" outline className="me-3 mt-1">
+                    <DropdownToggle caret color="keyline" className="me-3 mt-1">
                         Email Users
                     </DropdownToggle>
                     <DropdownMenu>

--- a/src/app/components/elements/quiz/QuizContentsComponent.tsx
+++ b/src/app/components/elements/quiz/QuizContentsComponent.tsx
@@ -188,7 +188,7 @@ export function QuizRubricButton({rubric}: {rubric?: ContentDTO}) {
     };
 
     if (rubric) {
-        return <Button color={siteSpecific("keyline", "tertiary")} outline={isAda} className={siteSpecific("btn-lg text-nowrap", "mb-4 bg-light")}
+        return <Button color={"keyline"} className={siteSpecific("btn-lg text-nowrap", "mb-4 bg-light")}
             title="Show instructions in a modal" onClick={openQuestionModal}
         >
             Show instructions

--- a/src/app/components/pages/Groups.tsx
+++ b/src/app/components/pages/Groups.tsx
@@ -365,16 +365,15 @@ const GroupEditor = ({group, allGroups, user, ...rest}: GroupEditorProps) => {
                                     <Button
                                         disabled={group.archived}
                                         className={"d-inline-block text-nowrap w-100 w-sm-auto"}
-                                        color="primary"
+                                        color="solid"
                                         onClick={() => dispatch(showGroupInvitationModal({group, user, firstTime: false}))}
                                     >
-                                            Invite users
+                                        Invite users
                                     </Button>
                                     {canEmailUsers && usersInGroup.length > 0 &&
                                                 <Button
                                                     className={"d-inline-block text-nowrap w-100 w-sm-auto"}
-                                                    color="secondary"
-                                                    outline
+                                                    color="keyline"
                                                     onClick={() => dispatch(showGroupEmailModal(usersInGroup))}
                                                 >
                                                     Email users
@@ -385,14 +384,13 @@ const GroupEditor = ({group, allGroups, user, ...rest}: GroupEditorProps) => {
                             <div>
                                 <StyledCheckbox
                                     id="self-removal"
-                                    color={siteSpecific("primary", "")}
                                     onChange={toggleSelfRemoval}
                                     checked={!!group.selfRemoval}
                                     label={<span>Allow students to remove themselves from this group</span>}
                                 />
                             </div>
                             <div>
-                                        This group has {group.members.length} member{group.members.length != 1 ? 's' : ''}.
+                                This group has {group.members.length} member{group.members.length != 1 ? 's' : ''}.
                                 {bigGroup && !isExpanded &&
                                             <ButtonDropdown className="float-end" toggle={() => setExpanded(true)}>
                                                 <DropdownToggle caret>Show</DropdownToggle>

--- a/src/app/components/pages/QuestionFinder.tsx
+++ b/src/app/components/pages/QuestionFinder.tsx
@@ -624,7 +624,7 @@ export const QuestionFinder = () => {
                                                 setPageCount(c => c + 1);
                                             }}
                                             disabled={!moreResultsAvailable || isStale}
-                                            outline={isAda}
+                                            color={"keyline"}
                                         >
                                             Load more
                                         </Button>

--- a/src/app/components/pages/SetAssignments.tsx
+++ b/src/app/components/pages/SetAssignments.tsx
@@ -231,19 +231,19 @@ const PhyAddGameboardButtonsSetAssignments = ({className, redirectBackTo}: { cla
                 <Button role={"link"} onClick={() => {
                     setAssignBoardPath(redirectBackTo);
                     void dispatch(openIsaacBooksModal());
-                }} color="secondary" block className="px-3">
+                }} color="keyline" block className="px-3">
                     our books
                 </Button>
             </Col>
             <Col md={6} lg={4} className="pt-1">
                 <Button tag={Link} to={"/physics/a_level/question_decks"}
-                    onClick={() => setAssignBoardPath(redirectBackTo)} color="secondary" block>
+                    onClick={() => setAssignBoardPath(redirectBackTo)} color="keyline" block>
                     our topic question decks
                 </Button>
             </Col>
             <Col md={12} lg={4} className="pt-1">
                 <Button tag={Link} to={PATHS.GAMEBOARD_BUILDER} onClick={() => setAssignBoardPath(redirectBackTo)}
-                    color="secondary" block>
+                    color="keyline" block>
                     create a question deck
                 </Button>
             </Col>

--- a/src/app/components/pages/SetAssignments.tsx
+++ b/src/app/components/pages/SetAssignments.tsx
@@ -430,7 +430,7 @@ export const SetAssignments = () => {
                         Create a quiz
                     </Button>
                     <Button className={"w-100 w-lg-auto mt-2 mt-lg-auto mx-auto mx-lg-2"} tag={Link}
-                        to={"/pages/revision_quizzes"} color={"secondary"} outline>
+                        to={"/pages/revision_quizzes"} color={"keyline"}>
                         View pre-made quizzes
                     </Button>
                 </div>

--- a/src/scss/phy/button.scss
+++ b/src/scss/phy/button.scss
@@ -289,27 +289,6 @@ a.btn {
     font-size: initial;
     font-weight: initial;
   }
-
-  &.btn-outline-tertiary {
-    border-color: $gray-118;
-    border-width: 2px;
-    color: $black;
-
-    &:hover {
-      background-color: transparent;
-    }
-
-    &:not(:disabled):not(.disabled):active {
-      background-color: $gray-136;
-      border-color: $gray-136;
-    }
-
-    &.disabled,
-    &:disabled {
-      border-color: $gray-107;
-      color: $gray-107;
-    }
-  }
 }
 
 .btn, input.btn {
@@ -322,29 +301,6 @@ a.btn {
   &.btn-positive {
     background-color: $a11y_green;
   }
-  
-  //Button - Secondary Outline
-  &.btn-outline-secondary {
-    background-color: $black;
-    border-color: $black;
-    border-width: 2px;
-    color: $white;
-
-    &:not(:disabled):not(.disabled):active {
-      background-color: $gray-118;
-      border-color: $gray-118;
-    }
-
-    &.disabled,
-    &:disabled {
-      border-color: $gray-160;
-      color: $gray-160;
-    }
-  }
-}
-
-.btn-green {
-  @include button-variant($a11y_green, $a11y_green);
 }
 
 .quick-question-options {

--- a/src/scss/phy/button.scss
+++ b/src/scss/phy/button.scss
@@ -253,28 +253,6 @@
     }
   }
 
-  //Button - Primary Outline
-  &.btn-outline-primary {
-    border-color: $black;
-    border-width: 2px;
-    color: $black;
-
-    &:hover {
-      background-color: transparent;
-    }
-
-    &:not(:disabled):not(.disabled):active {
-      background-color: $gray-118;
-      border-color: $gray-118;
-    }
-
-    &.disabled,
-    &:disabled {
-      border-color: $gray-136;
-      color: $gray-136;
-    }
-  }
-
   &.btn-xl {
     width: 100%;
     white-space: nowrap;
@@ -344,11 +322,7 @@ a.btn {
   &.btn-positive {
     background-color: $a11y_green;
   }
-
-  &.btn-outline-primary:not(:disabled):not(.disabled):active {
-    color: black;
-  }
-
+  
   //Button - Secondary Outline
   &.btn-outline-secondary {
     background-color: $black;


### PR DESCRIPTION
- Restyle fasttrack buttons such that the secondary action button is legible in dark mode.

- Use `solid`/`keyline` in more places, to simplify some site-specific styling & remove all instances of `outline` buttons on sci. In most cases there is no visual impact; where there is a visual change, the buttons should now follow the convention of main action = `solid`, alternative action = `keyline`.

- Remove CSS for sci `outline` buttons.