### PR TITLE
Require defined segue environment before redirecting

### DIFF
--- a/src/app/components/navigation/UserAuthentication.tsx
+++ b/src/app/components/navigation/UserAuthentication.tsx
@@ -17,7 +17,7 @@ type RequireAuthProps = {
 
 export const RequireAuth = ({auth, element}: RequireAuthProps) => {
     const user = useAppSelector(selectors.user.orNull);
-    const {data: segueEnvironment} = useGetSegueEnvironmentQuery();
+    const {data: segueEnvironment, isLoading: isEnvironmentLoading} = useGetSegueEnvironmentQuery();
     const userNeedsToBeTutorOrTeacher = auth && [isTutorOrAbove.name, isTeacherOrAbove.name].includes(auth.name); // TODO we should try to find a more robust way than this
 
     if (!isDefined(user)) {
@@ -26,6 +26,10 @@ export const RequireAuth = ({auth, element}: RequireAuthProps) => {
 
     if (isTeacherPending(user) && auth.name) {
         return <Navigate to="/verifyemail" />;
+    };
+
+    if (isEnvironmentLoading) {
+        return <ShowLoading until={segueEnvironment} />;
     }
 
     if (user && element && auth(user, segueEnvironment || "")) {


### PR DESCRIPTION
Requests the Segue environment be defined before redirecting when inside an authenticated component.

While this does create a new request on each new tab load / first visit and so may appear to slow things down, the current user object is being requested at the same time; i.e., these two requests are occurring in parallel so there should in theory be no noticeable slowdown.