### PR TITLE
Reorder `RootLayout` providers to surround `ActiveModals`

### DIFF
--- a/src/app/components/navigation/IsaacApp.tsx
+++ b/src/app/components/navigation/IsaacApp.tsx
@@ -9,7 +9,7 @@ import {
     useAppDispatch,
     useAppSelector,
 } from "../../state";
-import {createBrowserRouter, createRoutesFromElements, Navigate, Outlet, Route, RouterProvider} from "react-router-dom";
+import {createBrowserRouter, createRoutesFromElements, Navigate, Outlet, Route, RouterProvider, useLocation} from "react-router-dom";
 import {Question} from "../pages/Question";
 import {Concept} from "../pages/Concept";
 import {Contact} from "../pages/Contact";
@@ -85,7 +85,10 @@ const GameboardBuilder = lazy(() => import('../pages/GameboardBuilder'));
 
 const RootLayout = () => {
     const mainContentRef = useRef(null);
+    const location = useLocation();
 
+    // Needs two ErrorBoundaries, since the outer one would trigger on any error, and the footer/header would not be rendered
+    // Inner one also gets reset on route change, as if you had an error, and clicked on a link in the footer, it would not reset the error state
     return <ErrorBoundary FallbackComponent={ChunkOrClientError}>
         <FeatureFlagProvider>
             <FigureNumberingProvider>
@@ -95,9 +98,11 @@ const RootLayout = () => {
                 <SiteBanners />
                 <OnPageLoad />
                 <main ref={mainContentRef} id="main" data-testid="main" role="main" className="flex-fill content-body">
-                    <Suspense fallback={<Loading/>}>
-                        <Outlet />
-                    </Suspense>
+                    <ErrorBoundary FallbackComponent={ChunkOrClientError} resetKeys={[location.pathname, location.search]}>
+                        <Suspense fallback={<Loading/>}>
+                            <Outlet />
+                        </Suspense>
+                    </ErrorBoundary>
                 </main>
                 <ScrollToTop mainContent={mainContentRef}/>
                 <SiteSpecific.Footer />

--- a/src/app/components/navigation/IsaacApp.tsx
+++ b/src/app/components/navigation/IsaacApp.tsx
@@ -86,24 +86,24 @@ const GameboardBuilder = lazy(() => import('../pages/GameboardBuilder'));
 const RootLayout = () => {
     const mainContentRef = useRef(null);
 
-    return <FeatureFlagProvider>
-        <SiteSpecific.Header />
-        <Toasts />
-        <ActiveModals />
-        <SiteBanners />
-        <OnPageLoad />
-        <main ref={mainContentRef} id="main" data-testid="main" role="main" className="flex-fill content-body">
-            <ErrorBoundary FallbackComponent={ChunkOrClientError}>
-                <FigureNumberingProvider>
+    return <ErrorBoundary FallbackComponent={ChunkOrClientError}>
+        <FeatureFlagProvider>
+            <FigureNumberingProvider>
+                <SiteSpecific.Header />
+                <Toasts />
+                <ActiveModals />
+                <SiteBanners />
+                <OnPageLoad />
+                <main ref={mainContentRef} id="main" data-testid="main" role="main" className="flex-fill content-body">
                     <Suspense fallback={<Loading/>}>
                         <Outlet />
                     </Suspense>
-                </FigureNumberingProvider>
-            </ErrorBoundary>
-        </main>
-        <ScrollToTop mainContent={mainContentRef}/>
-        <SiteSpecific.Footer />
-    </FeatureFlagProvider>;
+                </main>
+                <ScrollToTop mainContent={mainContentRef}/>
+                <SiteSpecific.Footer />
+            </FigureNumberingProvider>
+        </FeatureFlagProvider>
+    </ErrorBoundary>;
 };
 
 // Render


### PR DESCRIPTION
This ensures an active `FigureNumberingProvider` is available from inside an ActiveModal, for e.g. hints. Pulling out the error boundary to a wider group of elements also seems like a good idea, while we're here.