### PR TITLE
Fix `useHistoryState` race condition

### DIFF
--- a/src/app/services/history.ts
+++ b/src/app/services/history.ts
@@ -1,6 +1,7 @@
 import type {TypeGuard} from "@reduxjs/toolkit/dist/tsHelpers";
 import {useCallback, useEffect, useRef, useState} from "react";
 import {useLocation, useNavigate} from "react-router-dom";
+import isEqual from "lodash/isEqual";
 
 function prepareHash<T>(defaultState: T, typeGuard: TypeGuard<T>, hash: string) {
     const hashText = hash.replace("#", "");
@@ -41,21 +42,24 @@ export function useHistoryState<T>(key: string, initialValue: T, withoutLocation
     }, [location]);
 
     const setStateAndLocation = useCallback((value: React.SetStateAction<T>) => {
+        const existing = locationRef.current.state?.[key as keyof typeof locationRef.current.state] as T;
+        const calculated = typeof value === "function" ? (value as (prevState: T) => T)(existing) : value;
         if (!withoutLocationUpdate) {
             // don't do anything if the value is already set (would create a new state object and not be reference-equal inside useEffect deps)
-            if (value === locationRef.current.state?.[key as keyof typeof locationRef.current.state]) return; 
+            if (isEqual(calculated, existing)) return;
 
             void navigate({
                 ...locationRef.current,
             }, {
                 state: {
                     ...locationRef.current.state as Array<string>,
-                    [key]: value
+                    [key]: calculated
                 },
-                replace: true 
+                replace: true,
+                flushSync: true // ensures history state is updated immediately, so chained useHistoryState calls (with different keys) don't race and overwrite each other
             });
         }
-        setState(value);
+        setState(calculated);
 
         setLoadedFromHistory(false);
     }, [key, withoutLocationUpdate, navigate]);


### PR DESCRIPTION
The main fix here is the addition of `flushSync: true` inside the `navigate` call. 

Consider a scenario with two distinct values being managed by `useHistoryState` that update consecutively. In an ideal world, an initial location-state (i.e. the collection of all states at a given `history.location`) S1 is modified with an additional key from the first call, creating S2, which is then modified again with a second new key, creating S3. S3 is, of course, intended to have both new keys.

However, if a state change occurs to both states simultaneously*, since `navigate` is an asynchronous function it is possible for both `navigate` calls to start with a location-state reading of S1. This means S3 will not include the key created in S2, meaning not all state changes are recorded in the history.

> *In the issue that raised this, the second state was updated in a `useEffect` with a dependency on the first.

The `flushSync` option inside `navigate` forces an immediate DOM update after the navigation. This prevents batching of state updates, meaning the location is updated after **each state update**, preventing a situation where two calls can read the same stale state.

---

The remaining changes in the PR clean up the equality checking between two objects, ensuring that:
- If a state-changing function is passed in to `setHistoryState`, the computed value of this is used rather than the function itself;
- `isEqual` is preferred over `===`, providing better object equality checking.
