### PR TITLE
Run workflows on all non vrt-headed PRs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,12 +4,13 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
   schedule:
     - cron: "52 3 * * 6"
 
 jobs:
   analyze:
+    if: ${{ !startsWith(github.head_ref, 'vrt/') }}
+
     name: Analyze
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -4,10 +4,11 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
 
 jobs:
   cypress-run:
+    if: ${{ !startsWith(github.head_ref, 'vrt/') }}
+
     runs-on: ubuntu-22.04
     container:
       # This must stay in sync with the image used by the test-{site}-visual scripts in package.json.

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -7,10 +7,11 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
 
 jobs:
   build-and-test:
+    if: ${{ !startsWith(github.head_ref, 'vrt/') }}
+
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
This was primarily inspired by the new GitHub stacked PRs, which should allow us to develop new features in conditional parts while reviewing those parts separately more easily/without conflicts (although it's probably helpful in other cases too, like when we used a lot of "suggestion" PRs during the redesign).

These stacked PRs are inconsistent about how they run workflows currently. e.g. If **PR (1/2)** is targeting main but unable to be merged (e.g. it is a draft), then **PR (2/2)** will also not run any workflows requiring it targets main, but will do otherwise (except that once it has been enabled to do it once, it will not disable that regardless of how the state of **(1/2)** then changes). For the point of easy development, running workflows based on the condition of earlier PRs in the stack gets in the way of things, and we'd rather these workflows just run consistently in the first place.

For `-react-app`, we don't want these workflows to run on `vrt/*` branches, since their content is the same as their parent except for the snapshot changes, so it creates unnecessary work (or unwanted looping for flaky VRTs). Unfortunately to achieve this the [branches-ignore](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onworkflow_runbranchesbranches-ignore) syntax is used only to refer to the base branch, so we need to use the slightly more complicated `if: ${{ !startsWith(github.head_ref, 'vrt/') }}` instead. This also means that the workflow is skipped but does show up in the list of checks, whereas branches-ignore would stop it showing up in the list in the first place 🤷‍♀️

These workflows and stacked PRs in general were tested at the fork https://github.com/sjd210/isaac-react-app, if you want to see them in action before merging.