### PR TITLE
Fix bad save deck state caching on detail pages

### DIFF
--- a/src/app/components/elements/Book.tsx
+++ b/src/app/components/elements/Book.tsx
@@ -62,6 +62,7 @@ export const Book = () => {
                     ? <ShowLoadingQuery
                         query={bookDetailPageQuery}
                         defaultErrorTitle="Unable to load book page"
+                        maintainOnRefetch
                         thenRender={(bookDetailPage) => {
                             return <WithFigureNumbering doc={bookDetailPage}>
                                 <BookPage page={bookDetailPage} />

--- a/src/app/components/pages/RevisionDetailPage.tsx
+++ b/src/app/components/pages/RevisionDetailPage.tsx
@@ -35,9 +35,13 @@ export const RevisionPage = () => {
         <ShowLoadingQuery
             query={revisionPageQuery}
             defaultErrorTitle="Unable to load revision page."
-            maintainOnRefetch // allows keeping sidebar content intact while refetching
+            maintainOnRefetch
             thenRender={(page, isStale) => {
-                return isStale ? <LoadingPlaceholder /> : <RevisionPageInternal page={page} />;
+                // show the loading placeholder only if the page itself is changing (to give instant click feedback).
+                // if the content on a single page is changing (e.g. gameboard save status updates), we don't want a jarring full-page loading placeholder; okay to show stale content.
+                return isStale && (page.id !== pageId) 
+                    ? <LoadingPlaceholder />
+                    : <RevisionPageInternal page={page} />;
             }}
         />
     </PageContainer>;

--- a/src/app/components/pages/SubjectOverviewPage.tsx
+++ b/src/app/components/pages/SubjectOverviewPage.tsx
@@ -7,8 +7,9 @@ import { PageContextState } from "../../../IsaacAppTypes";
 import { convertToALVIGameboard, CustomListViewItemProps, ListView, ListViewCards, transformItemsForCustomListView } from "../elements/list-groups/ListView";
 import { LandingPageFooter } from "./SubjectLandingPage";
 import { DifficultyIcon } from "../elements/svg/DifficultyIcons";
-import { GameboardDTO } from "../../../IsaacApiTypes";
 import { PageMetadata } from "../elements/PageMetadata";
+import { useGetGameboardByIdQuery } from "../../state";
+import { ShowLoadingQuery } from "../handlers/ShowLoadingQuery";
 
 const SubjectCards = ({context}: { context: PageContextState }) => {
     const deviceSize = useDeviceSize();
@@ -76,26 +77,21 @@ const SubjectCards = ({context}: { context: PageContextState }) => {
 };
 
 const ExampleQuestions = ({ subject, className }: { subject: Subject, className: string }) => {
-    const items: { [key in Subject]: GameboardDTO[] } = {
-        maths: [{
-            title: "Sample Maths Questions",
-            id: "sample_maths_questions",
-        }],
-        physics: [{
-            title: "Sample Physics Questions",
-            id: "sample_phy_questions",
-        }],
-        chemistry: [{
-            title: "Sample Chemistry Questions",
-            id: "sample_chem_questions",
-        }],
-        biology: [{
-            title: "Sample Biology Questions",
-            id: "sample_bio_questions",
-        }],
+    const gameboard_ids: { [key in Subject]: string } = {
+        maths: "sample_maths_questions",
+        physics: "sample_phy_questions",
+        chemistry: "sample_chem_questions",
+        biology: "sample_bio_questions"
     };
 
-    return items[subject].length > 0 ? <ListView className={className} type="gameboard" items={items[subject].map(convertToALVIGameboard)} /> : null;
+    const gameboardByIdQuery = useGetGameboardByIdQuery(gameboard_ids[subject]);
+
+    return gameboard_ids[subject]
+        ? <ShowLoadingQuery
+            query={gameboardByIdQuery}
+            defaultErrorTitle="Unable to load example questions"
+            thenRender={(gameboard) => <ListView className={className} type="gameboard" items={[convertToALVIGameboard(gameboard)]} />}/> 
+        : null;
 };
 
 export const SubjectOverviewPage = () => {

--- a/src/app/components/pages/SubjectOverviewPage.tsx
+++ b/src/app/components/pages/SubjectOverviewPage.tsx
@@ -10,6 +10,8 @@ import { DifficultyIcon } from "../elements/svg/DifficultyIcons";
 import { PageMetadata } from "../elements/PageMetadata";
 import { useGetGameboardByIdQuery } from "../../state";
 import { ShowLoadingQuery } from "../handlers/ShowLoadingQuery";
+import { skipToken } from "@reduxjs/toolkit/query";
+import { RenderNothing } from "../elements/RenderNothing";
 
 const SubjectCards = ({context}: { context: PageContextState }) => {
     const deviceSize = useDeviceSize();
@@ -84,15 +86,16 @@ const ExampleQuestions = ({ subject, className }: { subject: Subject, className:
         biology: "sample_bio_questions"
     };
 
-    const gameboardByIdQuery = useGetGameboardByIdQuery(gameboard_ids[subject]);
+    const gameboardByIdQuery = useGetGameboardByIdQuery(gameboard_ids[subject] ?? skipToken);
 
-    return gameboard_ids[subject]
-        ? <ShowLoadingQuery
-            query={gameboardByIdQuery}
-            defaultErrorTitle="Unable to load example questions"
-            maintainOnRefetch
-            thenRender={(gameboard) => <ListView className={className} type="gameboard" items={[convertToALVIGameboard(gameboard)]} />}/> 
-        : null;
+    return <ShowLoadingQuery
+        query={gameboardByIdQuery}
+        defaultErrorTitle="Unable to load example questions"
+        ifNotFound={RenderNothing}
+        uninitializedPlaceholder={RenderNothing}
+        maintainOnRefetch
+        thenRender={(gameboard) => <ListView className={className} type="gameboard" items={[convertToALVIGameboard(gameboard)]}/>}
+    />;
 };
 
 export const SubjectOverviewPage = () => {

--- a/src/app/components/pages/SubjectOverviewPage.tsx
+++ b/src/app/components/pages/SubjectOverviewPage.tsx
@@ -90,6 +90,7 @@ const ExampleQuestions = ({ subject, className }: { subject: Subject, className:
         ? <ShowLoadingQuery
             query={gameboardByIdQuery}
             defaultErrorTitle="Unable to load example questions"
+            maintainOnRefetch
             thenRender={(gameboard) => <ListView className={className} type="gameboard" items={[convertToALVIGameboard(gameboard)]} />}/> 
         : null;
 };

--- a/src/app/state/slices/api/booksApi.ts
+++ b/src/app/state/slices/api/booksApi.ts
@@ -21,8 +21,11 @@ const booksApi = isaacApi.injectEndpoints({
             onQueryStarted: onQueryLifecycleEvents({
                 errorTitle: "Unable to fetch book page."
             }),
-            keepUnusedDataFor: 60,
-            providesTags: ["AllGameboards"], // required to refetch decks inside the detail page if saved status is updated 
+            providesTags: (page) => {
+                const mainBoards = page?.gameboards?.map((gb) => ({type: "Gameboard" as const, id: gb.id})) || [];
+                const extensionBoards = page?.extensionGameboards?.map((gb) => ({type: "Gameboard" as const, id: gb.id})) || [];
+                return ["AllGameboards", "AllSetAssignments", ...mainBoards, ...extensionBoards]; // required to refetch decks inside the detail page if saved status is updated 
+            }
         })
 
     })

--- a/src/app/state/slices/api/booksApi.ts
+++ b/src/app/state/slices/api/booksApi.ts
@@ -24,7 +24,7 @@ const booksApi = isaacApi.injectEndpoints({
             providesTags: (page) => {
                 const mainBoards = page?.gameboards?.map((gb) => ({type: "Gameboard" as const, id: gb.id})) || [];
                 const extensionBoards = page?.extensionGameboards?.map((gb) => ({type: "Gameboard" as const, id: gb.id})) || [];
-                return ["AllGameboards", "AllSetAssignments", ...mainBoards, ...extensionBoards]; // required to refetch decks inside the detail page if saved status is updated 
+                return [...mainBoards, ...extensionBoards]; // required to refetch decks inside the detail page if saved status is updated 
             }
         })
 

--- a/src/app/state/slices/api/booksApi.ts
+++ b/src/app/state/slices/api/booksApi.ts
@@ -21,7 +21,8 @@ const booksApi = isaacApi.injectEndpoints({
             onQueryStarted: onQueryLifecycleEvents({
                 errorTitle: "Unable to fetch book page."
             }),
-            keepUnusedDataFor: 60
+            keepUnusedDataFor: 60,
+            providesTags: ["AllGameboards"], // required to refetch decks inside the detail page if saved status is updated 
         })
 
     })

--- a/src/app/state/slices/api/revisionApi.ts
+++ b/src/app/state/slices/api/revisionApi.ts
@@ -11,7 +11,10 @@ const revisionApi = isaacApi.injectEndpoints({
             onQueryStarted: onQueryLifecycleEvents({
                 errorTitle: "Unable to fetch revision page."
             }),
-            keepUnusedDataFor: 60
+            providesTags: (page) => {
+                const boards = page?.gameboards?.map((gb) => ({type: "Gameboard" as const, id: gb.id})) || [];
+                return [...boards]; // required to refetch decks inside the detail page if saved status is updated
+            }
         }),
     })
 });


### PR DESCRIPTION
Uses correct `rtkq` caching tags in book detail and revision detail pages. Paired with the API etag PR, this fixes issues with not appearing to save / unsave decks on these pages.