### PR TITLE
Add box alignment to front end drop box

### DIFF
--- a/src/IsaacApiTypes.tsx
+++ b/src/IsaacApiTypes.tsx
@@ -660,6 +660,7 @@ export interface FigureRegion {
     width: number;
     left: number;
     top: number;
+    boxAlign?: "left" | "center" | "right";
 }
 
 export type Stage = "year_7_and_8" | "year_9" | "gcse" | "a_level" | "further_a" | "university" | "scotland_national_5" | "scotland_higher" | "scotland_advanced_higher" | "foundation" | "core" | "advanced" | "post_18" | "all";

--- a/src/app/components/content/IsaacFigure.tsx
+++ b/src/app/components/content/IsaacFigure.tsx
@@ -67,6 +67,7 @@ export const IsaacFigure = ({doc}: IsaacFigureProps) => {
                         emptyHeight="100%"
                         rootElement={root || undefined}
                         skipPortalling={true}
+                        boxAlign={figureRegion.boxAlign}
                     />
                     : <InlineEntryZoneBase
                         inlineSpanId={parentId}
@@ -157,8 +158,8 @@ export const IsaacFigure = ({doc}: IsaacFigureProps) => {
                                         root: clozeDropRootElement.current, 
                                         style: (region: FigureRegion) => ({
                                             position: 'absolute',
-                                            left: `calc(${region.left}% - (max(${region.width}%, ${region.minWidth}) * ${(region.left)/100})`,
-                                            top: `calc(${region.top}% - (${regionHeight} * ${(region.top)/100})`,
+                                            left: `calc(${region.left}% - (max(${region.width}%, ${region.minWidth}) * ${(region.left)/100}))`,
+                                            top: `calc(${region.top}% - (${regionHeight} * ${(region.top)/100}))`,
                                             width: region.width ? `${region.width}%` : undefined,
                                             minWidth: region.minWidth,
                                             height: regionHeight,

--- a/src/app/components/elements/markup/portals/InlineDropZones.tsx
+++ b/src/app/components/elements/markup/portals/InlineDropZones.tsx
@@ -16,10 +16,11 @@ interface InlineDropRegionProps {
     emptyHeight?: string; // as above for height
     rootElement?: HTMLElement;
     skipPortalling?: boolean;
+    boxAlign?: "left" | "center" | "right";
 }
 
 // Inline droppables rendered for each registered drop region
-function InlineDropRegion({divId, zoneId, emptyWidth, emptyHeight, rootElement, skipPortalling}: InlineDropRegionProps) {
+function InlineDropRegion({divId, zoneId, emptyWidth, emptyHeight, rootElement, skipPortalling, boxAlign}: InlineDropRegionProps) {
     const dropRegionContext = useContext(DragAndDropRegionContext);
     const deviceSize = useDeviceSize();
     const [isOpen, setIsOpen] = useState<boolean>(false);
@@ -61,8 +62,13 @@ function InlineDropRegion({divId, zoneId, emptyWidth, emptyHeight, rootElement, 
     const width = (item || !emptyWidth) ? "auto" : emptyWidth;
 
     const draggableDropZone = <span
-        style={{minHeight: height, minWidth: width}}
-        className={classNames("d-inline-block cloze-drop-zone align-bottom", !item && `rounded bg-inline-question border ${isOver ? "border-dark" : "border-light"}`)}
+        style={{
+            minHeight: height,
+            minWidth: width,
+            // Only apply justifyContent if boxAlign is defined (figure drop zones), otherwise empty
+            ...(boxAlign ? {justifyContent: boxAlign === "right" ? "flex-end" : boxAlign === "center" ? "center" : "flex-start"} : {})
+        }}
+        className={classNames(boxAlign ? "d-flex" : "d-inline-block", "cloze-drop-zone align-bottom", !item && `rounded bg-inline-question border ${isOver ? "border-dark" : "border-light"}`)}
         ref={setNodeRef}
     >
         {item


### PR DESCRIPTION
Boxes are aligned based on the selection in the content. Defaults to left for backwards compatibility.