### PR TITLE
Attempt My Gameboards VRT fix

### DIFF
--- a/cypress/support/commands.tsx
+++ b/cypress/support/commands.tsx
@@ -63,11 +63,14 @@ import {store} from "../../src/app/state";
 import {createBrowserRouter, createRoutesFromElements, Route, To} from "react-router";
 import { RouterProvider } from 'react-router-dom';
 import { ACTION_TYPE } from '../../src/app/services';
+import {v4 as uuid_v4} from "uuid";
 
 Cypress.Commands.add('mountWithStoreAndRouter', (component, routes, initialRoute=routes?.[0], user, mountOptions) => {
+    const uuid = uuid_v4();
+
     const router = createBrowserRouter(createRoutesFromElements(<>
         {routes?.length
-            ? routes.map(route => <Route key={route} element={component} path={route} />)
+            ? routes.map(route => <Route key={`${uuid}-${route}`} element={component} path={route} />)
             : <Route path="*" element={component} />
         }
     </>));
@@ -80,7 +83,7 @@ Cypress.Commands.add('mountWithStoreAndRouter', (component, routes, initialRoute
     
     mount(
         <Provider store={store}>
-            <RouterProvider router={router} />
+            <RouterProvider key={uuid} router={router} />
         </Provider>,
         mountOptions
     );

--- a/cypress/support/commands.tsx
+++ b/cypress/support/commands.tsx
@@ -63,30 +63,33 @@ import {store} from "../../src/app/state";
 import {createBrowserRouter, createRoutesFromElements, Route, To} from "react-router";
 import { RouterProvider } from 'react-router-dom';
 import { ACTION_TYPE } from '../../src/app/services';
-import {v4 as uuid_v4} from "uuid";
 
 Cypress.Commands.add('mountWithStoreAndRouter', (component, routes, initialRoute=routes?.[0], user, mountOptions) => {
-    const uuid = uuid_v4();
+    cy.window().then(window => {
+        // createBrowserRouter errors with `TypeError: Cannot read properties of null (reading 'history')` if the global window is not defined.
+        // this seems to happen randomly with certain test setups (MyGameboards.cy.tsx has faced this a lot), but the exact reason remains unknown.
+        // my best guess is something regarding having two tests that mountWithStoreAndRouter the same component?
 
-    const router = createBrowserRouter(createRoutesFromElements(<>
-        {routes?.length
-            ? routes.map(route => <Route key={`${uuid}-${route}`} element={component} path={route} />)
-            : <Route key={`${uuid}-*`} element={component} path="*" />
+        const router = createBrowserRouter(createRoutesFromElements(<>
+            {routes?.length
+                ? routes.map(route => <Route key={route} element={component} path={route} />)
+                : <Route element={component} path="*" />
+            }
+        </>), { window });
+
+        if (user) {
+            void store.dispatch({type: ACTION_TYPE.CURRENT_USER_RESPONSE_SUCCESS, user});
         }
-    </>));
 
-    if (user) {
-        void store.dispatch({type: ACTION_TYPE.CURRENT_USER_RESPONSE_SUCCESS, user});
-    }
-
-    void router.navigate(initialRoute || '/');
-    
-    mount(
-        <Provider store={store}>
-            <RouterProvider key={uuid} router={router} />
-        </Provider>,
-        mountOptions
-    );
+        void router.navigate(initialRoute || '/');
+        
+        mount(
+            <Provider store={store}>
+                <RouterProvider router={router} />
+            </Provider>,
+            mountOptions
+        );
+    });
 });
 
 import "@frsource/cypress-plugin-visual-regression-diff/dist/support";

--- a/cypress/support/commands.tsx
+++ b/cypress/support/commands.tsx
@@ -68,8 +68,11 @@ import { v4 as uuid_v4 } from 'uuid';
 Cypress.Commands.add('mountWithStoreAndRouter', (component, routes, initialRoute=routes?.[0], user, mountOptions) => {
     cy.window().then(window => {
         // createBrowserRouter errors with `TypeError: Cannot read properties of null (reading 'history')` if the global window is not defined.
-        // this seems to happen randomly with certain test setups (MyGameboards.cy.tsx has faced this a lot), but the exact reason remains unknown.
-        // my best guess is something regarding having two tests that mountWithStoreAndRouter the same component?
+        // this seems to fatally affect test setups where the "same" component is mounted across multiple tests (c.f. MyGameboards.cy.tsx),
+        // presumably because there is some state that is not correctly flushed across the tests' teardown/setup.
+        // 
+        // wrapping the router creation in a `cy.window().then` seems to fix the issue issue with the global window not being defined;
+        // passing a rerender key to the mount function fixes the issue with stale mounted components being used across tests.
         const uuid = uuid_v4();
 
         const router = createBrowserRouter(createRoutesFromElements(<>

--- a/cypress/support/commands.tsx
+++ b/cypress/support/commands.tsx
@@ -63,12 +63,14 @@ import {store} from "../../src/app/state";
 import {createBrowserRouter, createRoutesFromElements, Route, To} from "react-router";
 import { RouterProvider } from 'react-router-dom';
 import { ACTION_TYPE } from '../../src/app/services';
+import { v4 as uuid_v4 } from 'uuid';
 
 Cypress.Commands.add('mountWithStoreAndRouter', (component, routes, initialRoute=routes?.[0], user, mountOptions) => {
     cy.window().then(window => {
         // createBrowserRouter errors with `TypeError: Cannot read properties of null (reading 'history')` if the global window is not defined.
         // this seems to happen randomly with certain test setups (MyGameboards.cy.tsx has faced this a lot), but the exact reason remains unknown.
         // my best guess is something regarding having two tests that mountWithStoreAndRouter the same component?
+        const uuid = uuid_v4();
 
         const router = createBrowserRouter(createRoutesFromElements(<>
             {routes?.length
@@ -87,7 +89,8 @@ Cypress.Commands.add('mountWithStoreAndRouter', (component, routes, initialRoute
             <Provider store={store}>
                 <RouterProvider router={router} />
             </Provider>,
-            mountOptions
+            mountOptions,
+            uuid
         );
     });
 });

--- a/cypress/support/commands.tsx
+++ b/cypress/support/commands.tsx
@@ -71,7 +71,7 @@ Cypress.Commands.add('mountWithStoreAndRouter', (component, routes, initialRoute
     const router = createBrowserRouter(createRoutesFromElements(<>
         {routes?.length
             ? routes.map(route => <Route key={`${uuid}-${route}`} element={component} path={route} />)
-            : <Route path="*" element={component} />
+            : <Route key={`${uuid}-*`} element={component} path="*" />
         }
     </>));
 


### PR DESCRIPTION
There are two fixes here that work together and do seem to be working consistently. There are 5 successful consecutive runs [here](https://github.com/isaacphysics/isaac-react-app/actions/runs/33773522883).

First, this wraps the `mountWithStoreAndRouter` command with a `cy.window().then(window => ...);`. This ensures a global window is necessarily defined before `createBrowserRouter` gets called; this was causing the `Cannot read properties of null (reading 'history')` error we love. The reason the window was _not_ defined in the first place is slightly more tricky, and indeed this fix alone does not solve the issue.

If we fix the window issue, the next error seen (from [this run](https://github.com/isaacphysics/isaac-react-app/actions/runs/33772123147/job/100706862989)) helps find the root cause – this reads `queue.insert must be called with a valid index - the index (1) is out of bounds`. Similar stack traces occur when Cypress commands occur outside of the standard test lifecycle order. In this case, my presumption is that:

- Cypress mounts the first My Gameboards test component, a `<MyGameboards user={mockUser} />` wrapped in a store `<Provider />` and a `<RouterProvider />`;
- This test completes fine;
- Cypress unmounts this component.
- Cypress mounts the next My Gameboards test component, _again_ the exact same thing;
- Since the underlying React _has not rendered in this time_, from its perspective _the same component_ is still there so all the state on this component is reused;
- Somewhere inside this state is a reference to _something_ from Cypress' runner – I can't tell exactly what, but it belongs to the old test and so is stale;
- Attempting to queue up operations here inserts the operation into the wrong queue, hence this error.

The fix is therefore to ensure that the component passed into the tests cannot be recognised as the same by React. We solve this with `key`s; my first attempt at doing this manually did not seem to work, but the `mount` function takes an explicit `rerenderKey` that seems to be for precisely this purpose, so I'm using a random string unique to a given test.

These two things together seem to fix things!