### PR TITLE
Fix print layout and pagination across browsers

### DIFF
--- a/src/app/components/elements/EditContentButton.tsx
+++ b/src/app/components/elements/EditContentButton.tsx
@@ -12,7 +12,7 @@ export interface EditContentButtonProps {
 export const EditContentButton = ({doc, className}: EditContentButtonProps) => {
     const {data: segueEnvironment} = useGetSegueEnvironmentQuery();
     if (segueEnvironment === "DEV" && doc?.canonicalSourceFile) {
-        return <div className="not-mobile">
+        return <div className="not-mobile no-print">
             <span className="h4">
                 <ExternalLink href={EDITOR_URL + doc.canonicalSourceFile} className={className}>
                     {doc.published ? "Published" : "Unpublished"} ✎

--- a/src/scss/common/print.scss
+++ b/src/scss/common/print.scss
@@ -1,9 +1,9 @@
+// Fix for Safari printing from a wide window
+$print-container-padding: 30px;
+
 @media print {
 
-  @page {
-    // min-width of 992px, scaled to 1:sqrt(2), plus 1in default padding on each side
-    size: calc(992px + 1in) calc(992px * sqrt(2) + 1in);
-  }
+  // Leave the page size to the print dialog so the layout can adapt to the selected paper.
 
   body {
     min-width: unset !important;
@@ -49,8 +49,13 @@
   }
 
   .isaac-accordion {
-    page-break-inside: avoid;
+
     box-shadow: none;
+    
+    // Keep accordion headings with the following content.
+    > .accordion-header {
+      break-after: avoid;
+    }
   }
 
   .content-body {
@@ -64,6 +69,23 @@
   .container {
     max-width: none;
     min-width: unset !important;
+    // Fixed gutters prevent Safari from collapsing print content in wide windows.
+    padding-left: $print-container-padding;
+    padding-right: $print-container-padding;
+  }
+
+  .container-override {
+    // Match full-width children to the fixed print gutters.
+    margin-left: -$print-container-padding;
+    margin-right: -$print-container-padding;
+    padding-left: $print-container-padding;
+    padding-right: $print-container-padding;
+  }
+
+  #page-content {
+    // Use the full width when the sidebar is hidden for printing.
+    width: 100%;
+    max-width: 100%;
   }
 
   figure {
@@ -89,6 +111,7 @@
     padding: 0 !important;
     margin-bottom: 1rem;
     box-shadow: none;
+    break-inside: avoid;
   }
 
   .expanded-layout {
@@ -109,6 +132,7 @@
     .card {
       padding-left: 1rem;
       padding-right: 1rem;
+      display: block;
     }
   }
 


### PR DESCRIPTION
Printing on Safari on a bigger screen was broken, as it would print the content in a thin line:

<img width="3586" height="1756" alt="image" src="https://github.com/user-attachments/assets/0ab32a0c-4562-4e9b-b07c-cda66e2cff93" />

The main fix was adding padding and margin to the page.

<img width="3586" height="1756" alt="image" src="https://github.com/user-attachments/assets/08bf10c7-53da-4a5a-87b9-793a6f73f57a" />

After fixing that, I realised there was a lot of empty space in some questions, depending on how you print it - fixed by making  the accordion body a block and removed the page break inside, so it prefers to be printed continuously, made the questions also preferably continuous, and removed the `@page` calculation altogether, as that made pages look too big (as per the live version of the screenshot).

I tested it mainly on Isaac, and a bit on Ada afterwards.