### PR TITLE
Use correct submission method for fasttrack inlines

### DIFF
--- a/src/app/components/content/IsaacQuestion.tsx
+++ b/src/app/components/content/IsaacQuestion.tsx
@@ -187,7 +187,7 @@ export const IsaacQuestion = ({doc}: {doc: ApiTypes.QuestionDTO}) => {
         <Form onSubmit={(event) => {
             if (event) {event.preventDefault();}
             if (isInlineQuestion) {
-                void submitInlineRegion(inlineContext, currentGameboard, currentUser, pageQuestions, dispatch, hidingAttempts)
+                void submitInlineRegion(inlineContext, currentGameboard, currentUser, pageQuestions, dispatch, hidingAttempts);
             } else {
                 void submitCurrentAttempt(questionPart, doc.id as string, doc.type as string, currentGameboard, currentUser, dispatch);
             }

--- a/src/app/components/content/IsaacQuestion.tsx
+++ b/src/app/components/content/IsaacQuestion.tsx
@@ -176,10 +176,6 @@ export const IsaacQuestion = ({doc}: {doc: ApiTypes.QuestionDTO}) => {
     const fastTrackPrimaryAction = isFastTrack ? determineFastTrackPrimaryAction(fastTrackInfo) : null;
     const fastTrackSecondaryAction = isFastTrack ? determineFastTrackSecondaryAction(fastTrackInfo) : null;
 
-    const checkAnswerButtonProps = isInlineQuestion 
-        ? {disabled: !canSubmit, onClick: () => submitInlineRegion(inlineContext, currentGameboard, currentUser, pageQuestions, dispatch, hidingAttempts)} 
-        : {disabled: !canSubmit || awaitingFeedback};
-
     const validationFeedback = invalidFormatError ? invalidFormatFeeback : tooManySigFigsError ? tooManySigFigsFeedback : tooFewSigFigsError ? tooFewSigFigsFeedback :
         <IsaacContent doc={validationResponse?.explanation as ContentDTO}/>;
 
@@ -190,7 +186,11 @@ export const IsaacQuestion = ({doc}: {doc: ApiTypes.QuestionDTO}) => {
     return <ConfidenceContext.Provider value={{recordConfidence}}>
         <Form onSubmit={(event) => {
             if (event) {event.preventDefault();}
-            void submitCurrentAttempt(questionPart, doc.id as string, doc.type as string, currentGameboard, currentUser, dispatch);
+            if (isInlineQuestion) {
+                void submitInlineRegion(inlineContext, currentGameboard, currentUser, pageQuestions, dispatch, hidingAttempts)
+            } else {
+                void submitCurrentAttempt(questionPart, doc.id as string, doc.type as string, currentGameboard, currentUser, dispatch);
+            }
             setHasSubmitted(true);
             setSentFeedback(false);
         }}>
@@ -276,7 +276,7 @@ export const IsaacQuestion = ({doc}: {doc: ApiTypes.QuestionDTO}) => {
                         <div className={classNames("submission-buttons d-flex align-items-stretch flex-column-reverse flex-sm-row flex-lg-row")}>
                             {isFastTrack 
                                 ? <FastTrackSubmissionButtons fastTrackPrimaryAction={fastTrackPrimaryAction} fastTrackSecondaryAction={fastTrackSecondaryAction} />
-                                : <Button {...checkAnswerButtonProps} className="mx-auto w-100 w-sm-100 w-md-50 w-lg-50" type="submit">{submitButtonLabel}</Button>
+                                : <Button disabled={!canSubmit || awaitingFeedback} className="mx-auto w-100 w-sm-100 w-md-50 w-lg-50" type="submit">{submitButtonLabel}</Button>
                             }
                         </div>
                 }


### PR DESCRIPTION
Inline questions should be submitted via `submitInlineRegion`; FastTrack questions were using a different submit button that did not have the `onClick` override that used to be in place for inline regions on the main button. This PR refactors the flow a little so all question attempts pass through the same `onSubmit` handler, ensuring both regular and FT inline questions submit using the same logic.