### PR TITLE
Hide town where school name contains its town

### DIFF
--- a/src/app/services/user.ts
+++ b/src/app/services/user.ts
@@ -87,7 +87,7 @@ export function extractTeacherName(teacher: {readonly givenName?: string; readon
 
 export function schoolNameWithTownAndPostcode(schoolResult: School): string | undefined {
     let schoolName = schoolResult.schoolName;
-    if (schoolResult.town) {
+    if (schoolResult.town && !schoolResult.schoolName.includes(schoolResult.town)) {
         schoolName += ", " + schoolResult.town;
     }
     if (schoolResult.postalCode) {

--- a/src/app/services/user.ts
+++ b/src/app/services/user.ts
@@ -87,7 +87,7 @@ export function extractTeacherName(teacher: {readonly givenName?: string; readon
 
 export function schoolNameWithTownAndPostcode(schoolResult: School): string | undefined {
     let schoolName = schoolResult.schoolName;
-    if (schoolResult.town && !schoolResult.schoolName.includes(schoolResult.town)) {
+    if (schoolResult.town && !schoolName.includes(schoolResult.town)) {
         schoolName += ", " + schoolResult.town;
     }
     if (schoolResult.postalCode) {


### PR DESCRIPTION
Avoid displaying a school's town name where it already appears in the school name (so "University of Cambridge,  Cambridge, CB2 1TN" becomes "University of Cambridge,  CB2 1TN").