### PR TITLE
Increase max school search results to 5

### DIFF
--- a/src/app/state/slices/api/miscApi.ts
+++ b/src/app/state/slices/api/miscApi.ts
@@ -7,7 +7,7 @@ export const miscApi = isaacApi.enhanceEndpoints({
 }).injectEndpoints({
     endpoints: (build) => ({
         searchSchools: build.query<School[], { query: string, countryCode: string }>({
-            query: (args) => `/schools/?limit=3&query=${encodeURIComponent(args.query)}&countryCode=${encodeURIComponent(args.countryCode)}`,
+            query: (args) => `/schools/?limit=5&query=${encodeURIComponent(args.query)}&countryCode=${encodeURIComponent(args.countryCode)}`,
         }),
 
         getSchoolById: build.query<School[], string>({


### PR DESCRIPTION
Show up to 5 results, instead of always 3. To go with the API changes to filter out less-relevant results: https://github.com/isaacphysics/isaac-api/pull/834.